### PR TITLE
Add pf-l-split

### DIFF
--- a/src/pages/layouts/split/index.js
+++ b/src/pages/layouts/split/index.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import Documentation from '@siteComponents/Documentation'
+import Example from '@siteComponents/Example'
+import Split, {Docs} from '@layouts/Split'
+
+export default () => {
+  return (
+    <Documentation docs={Docs} className="is-split-page">
+      <Example heading="Split Example - Default)">
+        <Split>
+          <div>
+            Secondary content area.
+          </div>
+          <div>
+            <p> Main Content Area. Expands to full-width of the container, minus the width of the secondary content area(s).</p>
+          </div>
+          <div>
+            Secondary content area.
+          </div>
+        </Split>
+      </Example>
+
+      <Example heading="Split Example - Explicit Content Areas">
+        <Split>
+          <div className="pf-l-split__main">
+            <p> Main Content Area. Expands to full-width of the container, minus the width of the secondary content area(s).</p>
+          </div>
+          <div className="pf-l-split__secondary">
+            Secondary content area.
+          </div>
+          <div className="pf-l-split__secondary">
+            Secondary content area.
+          </div>
+        </Split>
+      </Example>
+    </Documentation>
+  )
+}

--- a/src/patternfly/layouts/Split/docs.md
+++ b/src/patternfly/layouts/Split/docs.md
@@ -1,0 +1,17 @@
+# Split Layout
+
+## Overview
+
+Split layouts are meant for use in positioning child elements horizontally, with one of the children being used as primary content area, and the other(s) being used as a secondary content area.
+
+## Notes
+
+- Splits may contain at most 1 main content area.
+- Splits may contain 1 or more secondary content areas, but it is recommended not to exceed 2.
+- Splits are designed to always display the children horizontally, regardless of the device or viewport.
+
+## Usage
+
+- `.pf-l-split` **Applied to:** `<div>` |  **Outcome:** Established element as a split layout **Required:** Yes **Remarks:** None
+  - `.pf-l-split__main` **Applied to:** `<div>` |  **Outcome:** Explicitly sets a child element as the main content area  **Required:** No **Remarks:** If not applied, the main content area will be the second child.
+  - `.pf-l-split__secondary` **Applied to:** `<div>` | **Outcome:** Explicitly sets a child element as a secondary content area **Required:** No **Remarks:** If not applied, all children except the second child will be secondary content.

--- a/src/patternfly/layouts/Split/index.js
+++ b/src/patternfly/layouts/Split/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import docs from './docs.md'
+import './styles.scss'
+
+export const Docs = docs
+
+export default ({children, className = ''}) => {
+  return (
+    <div className={`pf-l-split ${className}`}>
+      {children}
+    </div>
+  )
+}

--- a/src/patternfly/layouts/Split/styles.scss
+++ b/src/patternfly/layouts/Split/styles.scss
@@ -1,0 +1,16 @@
+@import "../../patternfly-utilities";
+
+.pf-l-split {
+  display: flex;
+  padding: 0;
+  margin: 0;
+
+  > :nth-child(2),
+  > .pf-l-split__main {
+    flex: 1;
+  }
+  > .pf-l-split__secondary,
+  > .pf-l-split__secondary:nth-child(2) {
+    flex: 0 1 auto;
+  }
+}

--- a/src/workspace.scss
+++ b/src/workspace.scss
@@ -1,4 +1,7 @@
 /* stylelint-disable */
+// styles placed here are only meant for styling
+// the workspace or applying styles that are only
+// relevant inside of the workspace
 .layout {
   display: flex;
   flex-direction: column;
@@ -87,6 +90,7 @@
   padding-left: 1rem;
   padding-right: 1rem;
 }
+
 .gatsby-highlight {
   box-sizing: border-box;
   overflow: auto;
@@ -126,4 +130,11 @@
   }
 }
 
+.is-split-page {
+  .pf-l-split,
+  .pf-l-split > * {
+    border: 2px dashed #393f44;
+    padding: 0.5rem;
+  }
+}
 /* stylelint-enable */


### PR DESCRIPTION
This adds the the split layout.

Changes include:
- Adds layout
- Implements layout with default example
- Implements layout with an example explicit content areas
- Adds a description of the layout and it's behavior in the documentation

https://deploy-preview-7--pf-next.netlify.com/layouts/split/