### PR TITLE
style(BaseSCSSSpellingError): misspelling of the word shield.

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -1,4 +1,4 @@
-// CSS shild against PF 3
+// CSS shield against PF 3
 .pf-c-about-modal-box,
 .pf-c-alert,
 .pf-c-application-launcher,


### PR DESCRIPTION
fixes #1307.

Spell checking before beta launch. 