### PR TITLE
fix(card): renamed vars, updated docs

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -15,12 +15,12 @@
   --pf-c-card--m-compact--child--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-card--m-compact__header--not-last-child--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-card--m-compact__header--not--last-child--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-card--first-child--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-card__header--not--last-child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card__body--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__footer--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
@@ -75,7 +75,7 @@
     --pf-c-card--child--PaddingRight: var(--pf-c-card--m-compact--child--PaddingRight);
     --pf-c-card--child--PaddingBottom: var(--pf-c-card--m-compact--child--PaddingBottom);
     --pf-c-card--child--PaddingLeft: var(--pf-c-card--m-compact--child--PaddingLeft);
-    --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-c-card--m-compact__header--not-last-child--PaddingBottom);
+    --pf-c-card__header--not--last-child--PaddingBottom: var(--pf-c-card--m-compact__header--not--last-child--PaddingBottom);
   }
 }
 
@@ -120,7 +120,7 @@
 .pf-c-card__head,
 .pf-c-card__header {
   &:not(:last-child) {
-    padding-bottom: var(--pf-c-card__header--not-last-child--PaddingBottom);
+    padding-bottom: var(--pf-c-card__header--not--last-child--PaddingBottom);
   }
 }
 

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -74,7 +74,7 @@ cssPrefix: pf-c-card
     {{/card-actions}}
   {{/card-head}}
   {{#> card-body card-body--attribute=(concat 'id="' card--id '-check-label"')}}
-    This is the card body, there is only actions in the card head.
+    This is the card body, there are only actions in the card head.
   {{/card-body}}
 {{/card}}
 ```
@@ -235,14 +235,14 @@ A card is a generic rectangular container that can be used to build other compon
 ### Usage
 | Class | Applied | Outcome |
 | ---- | ---- | ---- |
-| `.pf-c-card` | `<div>` | Creates a card containing content. **Required** |
+| `.pf-c-card` | `<div>` | Creates a card component.  **Required** |
 | `.pf-c-card__header` | `<div>` | Creates the header of a card. |
 | `.pf-c-card__body` | `<div>` | Creates the body of a card. By default, the body element fills the available space in the card. You can use multiple `.pf-c-card__body` elements. |
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
 | `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
 | `.pf-c-card__head-main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
-| `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. |
+| `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |
 | `.pf-m-selectable` | `.pf-c-card` | Modifies a selectable card so that it is selectable. |


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-next/issues/2653.

Per @mceledonia we're going to leave this component as-is, and just make sure the documentation is clear that - Dashboards = compact, Larger content = regular

preview url is https://patternfly-pr-2759.surge.sh/documentation/core/components/card

## Breaking changes
* renames `--pf-c-card--m-compact__header--not-last-child--PaddingBottom` to `--pf-c-card--m-compact__header--not--last-child--PaddingBottom`
* renames `--pf-c-card__header--not-last-child--PaddingBottom` to `--pf-c-card__header--not--last-child--PaddingBottom`
* renames `--pf-c-card__header--not-last-child--PaddingBottom` to `--pf-c-card__header--not--last-child--PaddingBottom`