### PR TITLE
fix(accordion): updated spacing, removed box shadow and shadow variation

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,16 +1,12 @@
 .pf-c-accordion {
   // accordion
   --pf-c-accordion--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-accordion--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-accordion--BoxShadow: var(--pf-global--BoxShadow--md);
-  --pf-c-accordion--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-accordion--PaddingBottom: var(--pf-global--spacer--xl);
 
   // accordion toggle
   --pf-c-accordion__toggle--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-accordion__toggle--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-accordion__toggle--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-accordion__toggle--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-accordion__toggle--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-accordion__toggle--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-accordion__toggle--BorderLeftColor: transparent;
   --pf-c-accordion__toggle--hover--BackgroundColor: var(--pf-global--BackgroundColor--150);
   --pf-c-accordion__toggle--focus--BackgroundColor: var(--pf-global--BackgroundColor--150);
@@ -36,9 +32,9 @@
 
   // accordion expanded content
   --pf-c-accordion__expanded-content-body--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-accordion__expanded-content-body--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-accordion__expanded-content-body--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-accordion__expanded-content-body--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-accordion__expanded-content-body--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-accordion__expanded-content--Color: var(--pf-global--secondary-color--100);
   --pf-c-accordion__expanded-content--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-accordion__expanded-content--BorderLeftColor: transparent;
@@ -49,14 +45,7 @@
   // This component always needs to be light
   @include pf-t-light;
 
-  padding-top: var(--pf-c-accordion--PaddingTop);
-  padding-bottom: var(--pf-c-accordion--PaddingBottom);
   background-color: var(--pf-c-accordion--BackgroundColor);
-  box-shadow: var(--pf-c-accordion--BoxShadow);
-
-  &.pf-m-no-box-shadow {
-    --pf-c-accordion--BoxShadow: none;
-  }
 }
 
 .pf-c-accordion__toggle {

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -139,50 +139,6 @@ cssPrefix: pf-c-accordion
 {{/accordion}}
 ```
 
-```hbs title=No-box-shadow
-{{#> accordion accordion--modifier="pf-m-no-box-shadow"}}
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expanded-content}}
-    This text is hidden
-  {{/accordion-expanded-content}}
-
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expanded-content}}
-    This text is hidden
-  {{/accordion-expanded-content}}
-
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expanded-content}}
-    This text is hidden
-  {{/accordion-expanded-content}}
-
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute='aria-expanded="true"'}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-  {{/accordion-expanded-content}}
-
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expanded-content}}
-    This text is hidden
-  {{/accordion-expanded-content}}
-{{/accordion}}
-```
-
 ## Documentation
 ### Overview
 There are two variations to build the accordion component:
@@ -209,7 +165,6 @@ In these examples `.pf-c-accordion` uses `<dl>`, `.pf-c-accordion__toggle` uses 
 | `.pf-c-accordion__toggle-icon` | `<i>` | Initiates the toggle icon. **Required** |
 | `.pf-c-accordion__expanded-content` | `<div>`, `<dd>` | Initiates expanded content. **Must be paired with a button** |
 | `.pf-c-accordion__expanded-content-body` | `<div>` | Initiates expanded content body. **Required** |
-| `.pf-m-no-box-shadow` | `.pf-c-accordion` | Modifies the accordion to remove the box shadow. |
 | `.pf-m-expanded` | `.pf-c-accordion__toggle`, `.pf-c-accordion__expanded-content` | Modifies the accordion button and expanded content for the expanded state. |
 | `.pf-m-hover` | `.pf-c-accordion__toggle` | Modifies the accordion button for the hover state. |
 | `.pf-m-active` | `.pf-c-accordion__toggle` | Modifies the accordion button for the active state. |


### PR DESCRIPTION
Part of the updates for https://github.com/patternfly/patternfly-next/issues/2653. Note this is a breaking change so we won't merge to master.

@mcarrano @lboehling @mceledonia I removed the box shadow and "no box shadow" variation. Let me know if that's OK.

## Breaking changes
* Reduces left/right padding from `--pf-global--spacer--xl` to `--pf-global--spacer--md`
* Removes the box shadow and outer padding. Removes vars:
  * `--pf-c-accordion--BorderWidth`
  * `--pf-c-accordion--BoxShadow`
  * `--pf-c-accordion--PaddingTop`
  * `--pf-c-accordion--PaddingBottom`
* Removes `.pf-m-no-box-shadow` variation