### PR TITLE
fix(modal): reduced spacing

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -62,23 +62,6 @@ cssPrefix: pf-c-modal-box
 {{/modal-box}}
 ```
 
-```hbs title=Roomy
-{{#> modal-box modal-box--modifier="pf-m-roomy" modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-   <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-    Modal header
-  {{/title}}
-  {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
-    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
-  {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
-    Modal footer
-  {{/modal-box-footer}}
-{{/modal-box}}
-```
-
 ```hbs title=Without-header
 {{#> modal-box modal-box--attribute='aria-label="Example of a modal without a header" aria-describedby="modal-no-header-description"'}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
@@ -105,26 +88,6 @@ cssPrefix: pf-c-modal-box
     A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
   {{/modal-box-description}}
   {{#> modal-box-body}}
-    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
-  {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
-    Modal footer
-  {{/modal-box-footer}}
-{{/modal-box}}
-```
-
-```hbs title=Roomy-with-description
-{{#> modal-box modal-box--modifier="pf-m-roomy" modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-   <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-    Modal header
-  {{/title}}
-  {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
-    A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
-  {{/modal-box-description}}
-  {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
   {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
@@ -160,5 +123,4 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |
 | `.pf-m-lg` | `.pf-c-modal-box` | Modifies for a large modal box width. |
-| `.pf-m-roomy` | `.pf-c-modal-box` | Modifies for more spacer between/around elements. |
 | `.pf-m-align-left` | `.pf-c-modal-box__foter` | Modifies for buttons in footer to be left aligned. **Required** |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -62,6 +62,23 @@ cssPrefix: pf-c-modal-box
 {{/modal-box}}
 ```
 
+```hbs title=Roomy
+{{#> modal-box modal-box--modifier="pf-m-roomy" modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
+  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+   <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+    Modal header
+  {{/title}}
+  {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
+    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
+  {{/modal-box-body}}
+  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+    Modal footer
+  {{/modal-box-footer}}
+{{/modal-box}}
+```
+
 ```hbs title=Without-header
 {{#> modal-box modal-box--attribute='aria-label="Example of a modal without a header" aria-describedby="modal-no-header-description"'}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
@@ -88,6 +105,26 @@ cssPrefix: pf-c-modal-box
     A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
   {{/modal-box-description}}
   {{#> modal-box-body}}
+    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
+  {{/modal-box-body}}
+  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+    Modal footer
+  {{/modal-box-footer}}
+{{/modal-box}}
+```
+
+```hbs title=Roomy-with-description
+{{#> modal-box modal-box--modifier="pf-m-roomy" modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
+  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+   <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+    Modal header
+  {{/title}}
+  {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
+    A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
+  {{/modal-box-description}}
+  {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
   {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
@@ -123,4 +160,5 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |
 | `.pf-m-lg` | `.pf-c-modal-box` | Modifies for a large modal box width. |
+| `.pf-m-roomy` | `.pf-c-modal-box` | Modifies for more spacer between/around elements. |
 | `.pf-m-align-left` | `.pf-c-modal-box__foter` | Modifies for buttons in footer to be left aligned. **Required** |

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -5,10 +5,6 @@
   --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--m-roomy--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--m-roomy--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--m-roomy--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--m-roomy--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
@@ -20,14 +16,11 @@
 
   // Description
   --pf-c-modal-box__c-title--description--MarginTop: var(--pf-global--spacer--xs);
-  --pf-c-modal-box--m-roomy__c-title--description--MarginTop: var(--pf-global--spacer--sm);
 
   // Body
   --pf-c-modal-box--body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
   --pf-c-modal-box__description--body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-modal-box--m-roomy__description--body--MarginTop: var(--pf-global--spacer--lg);
   --pf-c-modal-box--c-title--body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-modal-box--m-roomy--c-title--body--MarginTop: var(--pf-global--spacer--lg);
 
   // Close
   --pf-c-modal-box--c-button--Top: calc(var(--pf-c-modal-box--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
@@ -36,7 +29,6 @@
 
   // Footer
   --pf-c-modal-box__footer--MarginTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--m-roomy__footer--MarginTop: var(--pf-global--spacer--xl);
 
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
@@ -69,17 +61,6 @@
     @media screen and (min-width: $pf-global--breakpoint--xl) {
       --pf-c-modal-box--MaxWidth: var(--pf-c-modal-box--m-lg--lg--MaxWidth);
     }
-  }
-
-  &.pf-m-roomy {
-    --pf-c-modal-box--PaddingTop: var(--pf-c-modal-box--m-roomy--PaddingTop);
-    --pf-c-modal-box--PaddingRight: var(--pf-c-modal-box--m-roomy--PaddingRight);
-    --pf-c-modal-box--PaddingBottom: var(--pf-c-modal-box--m-roomy--PaddingBottom);
-    --pf-c-modal-box--PaddingLeft: var(--pf-c-modal-box--m-roomy--PaddingLeft);
-    --pf-c-modal-box--c-title--body--MarginTop: var(--pf-c-modal-box--m-roomy--c-title--body--MarginTop);
-    --pf-c-modal-box__c-title--description--MarginTop: var(--pf-c-modal-box--m-roomy__c-title--description--MarginTop);
-    --pf-c-modal-box__description--body--MarginTop: var(--pf-c-modal-box--m-roomy__description--body--MarginTop);
-    --pf-c-modal-box__footer--MarginTop: var(--pf-c-modal-box--m-roomy__footer--MarginTop);
   }
 
   // Close button

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,10 +1,14 @@
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-modal-box--BorderColor: transparent;
-  --pf-c-modal-box--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-modal-box--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--m-roomy--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-modal-box--m-roomy--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-modal-box--m-roomy--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-modal-box--m-roomy--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
@@ -15,12 +19,15 @@
   --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
   // Description
-  --pf-c-modal-box__c-title--description--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__c-title--description--MarginTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box--m-roomy__c-title--description--MarginTop: var(--pf-global--spacer--sm);
 
   // Body
   --pf-c-modal-box--body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
-  --pf-c-modal-box__description--body--MarginTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--c-title--body--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__description--body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box--m-roomy__description--body--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--c-title--body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box--m-roomy--c-title--body--MarginTop: var(--pf-global--spacer--lg);
 
   // Close
   --pf-c-modal-box--c-button--Top: calc(var(--pf-c-modal-box--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
@@ -28,7 +35,8 @@
   --pf-c-modal-box--c-button--sibling--MarginRight: var(--pf-global--spacer--xl);
 
   // Footer
-  --pf-c-modal-box__footer--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-modal-box__footer--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--m-roomy__footer--MarginTop: var(--pf-global--spacer--xl);
 
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
@@ -61,6 +69,17 @@
     @media screen and (min-width: $pf-global--breakpoint--xl) {
       --pf-c-modal-box--MaxWidth: var(--pf-c-modal-box--m-lg--lg--MaxWidth);
     }
+  }
+
+  &.pf-m-roomy {
+    --pf-c-modal-box--PaddingTop: var(--pf-c-modal-box--m-roomy--PaddingTop);
+    --pf-c-modal-box--PaddingRight: var(--pf-c-modal-box--m-roomy--PaddingRight);
+    --pf-c-modal-box--PaddingBottom: var(--pf-c-modal-box--m-roomy--PaddingBottom);
+    --pf-c-modal-box--PaddingLeft: var(--pf-c-modal-box--m-roomy--PaddingLeft);
+    --pf-c-modal-box--c-title--body--MarginTop: var(--pf-c-modal-box--m-roomy--c-title--body--MarginTop);
+    --pf-c-modal-box__c-title--description--MarginTop: var(--pf-c-modal-box--m-roomy__c-title--description--MarginTop);
+    --pf-c-modal-box__description--body--MarginTop: var(--pf-c-modal-box--m-roomy__description--body--MarginTop);
+    --pf-c-modal-box__footer--MarginTop: var(--pf-c-modal-box--m-roomy__footer--MarginTop);
   }
 
   // Close button


### PR DESCRIPTION
Part of the updates for https://github.com/patternfly/patternfly-next/issues/2653. This is a breaking change so shouldn't be merged to master.

@lboehling I also reduced the spacers used with the new "description" element. The space between the title -> description changed from sm (8px) to xs (4px), and the space between the description and body changed from lg (24px) to md (16px). Let me know if that works.

## Breaking changes
* Reduces default spacing:
  * outer padding from `--pf-global--spacer--xl` to `--pf-global--spacer--lg`
  * space between title and description from `--pf-global--spacer--sm` to `--pf-global--spacer--xs`
  * space between description and body from `--pf-global--spacer--lg` to `--pf-global--spacer--md`
  * space between title and body from `--pf-global--spacer--lg` to `--pf-global--spacer--md`
  * space above footer from `--pf-global--spacer--xl` to `--pf-global--spacer--lg`
