### PR TITLE
fix(table): update compact spacing

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -82,8 +82,13 @@
   --pf-c-table-cell--responsive--PaddingLeft: 0;
 
   // Compact table
-  --pf-c-table--m-compact-tr-td--responsive--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-tr-td--responsive--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact-tr--responsive--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact-tr--responsive--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact-tr-td--responsive--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-table--m-compact-tr-td--responsive--PaddingBottom: var(--pf-global--spacer--xs);
+  --pf-c-table--m-compact__action--responsive--MarginTop: calc(var(--pf-global--spacer--xs) * -1);
+  --pf-c-table--m-compact__action--responsive--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
+  --pf-c-table--m-compact__toggle--c-button--responsive--MarginBottom: calc(#{pf-size-prem(6px)} * -1);
 
   // Expandable row content
   --pf-c-table__expandable-row-content--responsive--PaddingRight: var(--pf-global--spacer--lg);
@@ -186,12 +191,20 @@
     }
   }
 
-  .pf-c-table.pf-m-compact {
-    tr {
-      & > * {
-        padding-top: var(--pf-c-table--m-compact-tr-td--responsive--PaddingTop);
-        padding-bottom: var(--pf-c-table--m-compact-tr-td--responsive--PaddingBottom);
-      }
+  &.pf-m-compact {
+    --pf-c-table-tr--responsive--PaddingTop: var(--pf-c-table--m-compact-tr--responsive--PaddingTop);
+    --pf-c-table-tr--responsive--PaddingBottom: var(--pf-c-table--m-compact-tr--responsive--PaddingBottom);
+    --pf-c-table-cell--responsive--PaddingTop: var(--pf-c-table--m-compact-tr-td--responsive--PaddingTop);
+    --pf-c-table-cell--responsive--PaddingBottom: var(--pf-c-table--m-compact-tr-td--responsive--PaddingBottom);
+    --pf-c-table__check--input--MarginTop: 0;
+
+    .pf-c-table__action {
+      margin-top: var(--pf-c-table--m-compact__action--responsive--MarginTop);
+      margin-bottom: var(--pf-c-table--m-compact__action--responsive--MarginTop);
+    }
+
+    .pf-c-table__toggle .pf-c-button {
+      margin-bottom: var(--pf-c-table--m-compact__toggle--c-button--responsive--MarginBottom);
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -114,8 +114,8 @@
   // ============================================================ //
 
   // Modifier - compact table
-  --pf-c-table--m-compact-th--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-table--m-compact-th--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-table--m-compact-th--PaddingTop: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--xs));
+  --pf-c-table--m-compact-th--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-table--m-compact-cell--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-table--m-compact-cell--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-table--m-compact-cell--PaddingBottom: var(--pf-global--spacer--sm);
@@ -502,14 +502,6 @@
     tbody {
       --pf-c-table--BorderWidth: 0;
       --pf-c-table--BorderColor: transparent;
-
-      tr:first-child > * {
-        --pf-c-table-cell--PaddingTop: calc(var(--pf-c-table--m-compact-cell--PaddingTop) * 2);
-      }
-
-      tr:last-child > * {
-        --pf-c-table-cell--PaddingBottom: calc(var(--pf-c-table--m-compact-cell--PaddingBottom) * 2);
-      }
     }
   }
 


### PR DESCRIPTION
part of https://github.com/patternfly/patternfly-next/issues/2653.

This just modifies the existing compact spacing and leaves the modifier and default behavior in place.

We're also not going to update the button alignment to center if the space below exceeds 8px. 

This also doesn't modify the pagination because that spacing is currently controlled by the old toolbar, and that toolbar isn't in use by anyone since it isn't a react component. So I think this spacing is something we'll need to discuss. That could potentially be a variation of the data-toolbar, but since we don't use the data-toolbar in demos yet (since it's still beta), I think it's OK to figure out how to best handle that spacing once the toolbar is promoted. I created an issue to address that in https://github.com/patternfly/patternfly-next/issues/2774

## Breaking changes
* Changed compact table's header spacing from `--pf-global--spacer--md` top and bottom padding to `calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--xs))` top padding and `var(--pf-global--spacer--sm)` bottom padding.
* Changed compact table's responsive/grid spacers. All values changed from the default table's responsive spacers:
  * `<tr>` top/bottom padding changed to `var(--pf-global--spacer--sm)`
  * `<td>` top/bottom padding changed to `var(--pf-global--spacer--xs)`
  * `.pf-c-table__action` top/bottom margin set to `calc(var(--pf-global--spacer--xs) * -1);` to better align in the grid layout.
  * The expandable row toggle button's (`.pf-c-table__toggle .pf-c-button`) bottom margin set to`calc(#{pf-size-prem(6px)} * -1);` to reduce gap between toggle and expandable row content.