### PR TITLE
fix(select/contextselector): update name for menu search

### DIFF
--- a/src/patternfly/components/ContextSelector/context-selector-menu-input.hbs
+++ b/src/patternfly/components/ContextSelector/context-selector-menu-input.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-context-selector__menu-input{{#if context-selector-menu-input--modifier}} {{context-selector-menu-input--modifier}}{{/if}}"
-  {{#if context-selector-menu-input--attribute}}
-    {{{context-selector-menu-input--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/ContextSelector/context-selector-menu-search.hbs
+++ b/src/patternfly/components/ContextSelector/context-selector-menu-search.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-context-selector__menu-search{{#if context-selector-menu-search--modifier}} {{context-selector-menu-search--modifier}}{{/if}}"
+  {{#if context-selector-menu-search--attribute}}
+    {{{context-selector-menu-search--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -37,12 +37,12 @@
   --pf-c-context-selector__menu--BoxShadow: var(--pf-global--BoxShadow--md);
 
   // Menu input
-  --pf-c-context-selector__menu-input--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-context-selector__menu-input--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-context-selector__menu-input--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-context-selector__menu-input--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-context-selector__menu-input--BottomBorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-context-selector__menu-input--BottomBorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-context-selector__menu-search--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-context-selector__menu-search--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-context-selector__menu-search--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-context-selector__menu-search--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-context-selector__menu-search--BottomBorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-context-selector__menu-search--BottomBorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Menu menu item
   --pf-c-context-selector__menu-list--MaxHeight: #{pf-size-prem(200px)};
@@ -141,10 +141,10 @@
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
 }
 
-.pf-c-context-selector__menu-input {
+.pf-c-context-selector__menu-search {
   position: relative;
-  padding: var(--pf-c-context-selector__menu-input--PaddingTop) var(--pf-c-context-selector__menu-input--PaddingRight) var(--pf-c-context-selector__menu-input--PaddingBottom) var(--pf-c-context-selector__menu-input--PaddingLeft);
-  border-bottom: var(--pf-c-context-selector__menu-input--BottomBorderWidth) solid var(--pf-c-context-selector__menu-input--BottomBorderColor);
+  padding: var(--pf-c-context-selector__menu-search--PaddingTop) var(--pf-c-context-selector__menu-search--PaddingRight) var(--pf-c-context-selector__menu-search--PaddingBottom) var(--pf-c-context-selector__menu-search--PaddingLeft);
+  border-bottom: var(--pf-c-context-selector__menu-search--BottomBorderWidth) solid var(--pf-c-context-selector__menu-search--BottomBorderColor);
 }
 
 .pf-c-context-selector__menu-list {

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -41,8 +41,8 @@
   --pf-c-context-selector__menu-search--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-context-selector__menu-search--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-context-selector__menu-search--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-context-selector__menu-search--BottomBorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-context-selector__menu-search--BottomBorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-context-selector__menu-search--BorderBottomColor: var(--pf-global--BorderColor--100);
+  --pf-c-context-selector__menu-search--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
 
   // Menu menu item
   --pf-c-context-selector__menu-list--MaxHeight: #{pf-size-prem(200px)};
@@ -144,7 +144,7 @@
 .pf-c-context-selector__menu-search {
   position: relative;
   padding: var(--pf-c-context-selector__menu-search--PaddingTop) var(--pf-c-context-selector__menu-search--PaddingRight) var(--pf-c-context-selector__menu-search--PaddingBottom) var(--pf-c-context-selector__menu-search--PaddingLeft);
-  border-bottom: var(--pf-c-context-selector__menu-search--BottomBorderWidth) solid var(--pf-c-context-selector__menu-search--BottomBorderColor);
+  border-bottom: var(--pf-c-context-selector__menu-search--BorderBottomWidth) solid var(--pf-c-context-selector__menu-search--BorderBottomColor);
 }
 
 .pf-c-context-selector__menu-list {

--- a/src/patternfly/components/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/components/ContextSelector/examples/ContextSelector.md
@@ -16,7 +16,7 @@ import './ContextSelector.css'
     {{/context-selector-toggle-icon}}
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
-    {{#> context-selector-menu-input}}
+    {{#> context-selector-menu-search}}
       {{#> input-group}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
         {{/form-control}}
@@ -24,7 +24,7 @@ import './ContextSelector.css'
           <i class="fas fa-search" aria-hidden="true"></i>
         {{/button}}
       {{/input-group}}
-    {{/context-selector-menu-input}}
+    {{/context-selector-menu-search}}
     {{#> context-selector-menu-menu}}
       <li>
         {{#> context-selector-menu-menu-item}}
@@ -89,7 +89,7 @@ import './ContextSelector.css'
     {{/context-selector-toggle-icon}}
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
-    {{#> context-selector-menu-input}}
+    {{#> context-selector-menu-search}}
       {{#> input-group}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" placeholder="Search" id="textInput2" name="textInput2" aria-labelledby="' context-selector--id '-search-button"')}}
         {{/form-control}}
@@ -97,7 +97,7 @@ import './ContextSelector.css'
           <i class="fas fa-search" aria-hidden="true"></i>
         {{/button}}
       {{/input-group}}
-    {{/context-selector-menu-input}}
+    {{/context-selector-menu-search}}
     {{#> context-selector-menu-menu}}
       <li>
         {{#> context-selector-menu-menu-item}}
@@ -164,8 +164,8 @@ Added after React implementation.
 | `.pf-c-context-selector__toggle` | `<button>` | Initiates a toggle. |
 | `.pf-c-context-selector__toggle-text` | `<span>` | Initiates text inside the toggle. |
 | `.pf-c-context-selector__toggle-icon` | `<i>` | Inititiates icon inside the toggle. |
-| `.pf-c-context-selector__menu` | `<div>` | Initiaties a menu |
-| `.pf-c-context-selector__menu-input` | `<div>` | Initiates a container for the input group. |
+| `.pf-c-context-selector__menu` | `<div>` | Initiaties a menu. |
+| `.pf-c-context-selector__menu-search` | `<div>` | Initiates a container for the search input group. |
 | `.pf-c-context-selector__menu-list` | `<ul>` | Initiaties an unordered list of menu items that sits under the input container. |
 | `.pf-c-context-selector__menu-list-item` | `<li>` | Initiaties a menu item. |
 | `.pf-m-expanded` | `.pf-c-context-selector` | Modifies for the expanded state. |

--- a/src/patternfly/components/Select/examples/Select.md
+++ b/src/patternfly/components/Select/examples/Select.md
@@ -203,7 +203,7 @@ The checkbox select can select multiple items using checkboxes. The number of it
 | `.pf-c-select__menu-fieldset` | `<fieldset>` | Initiates a fieldset for the items in a checkbox select. |
 | `.pf-c-select__menu-group` | `<div>` | Initiates a group within a select menu. |
 | `.pf-c-select__menu-group-title` | `<div>` | Initiates a title for a group with a select menu. |
-| `.pf-c-select__menu-input` | `<div>` | Initiates a container for an input group. |
+| `.pf-c-select__menu-search` | `<div>` | Initiates a container for the search input group. |
 | `.pf-m-expanded` | `.pf-c-select` | Indicates the select is expanded. |
 | `.pf-m-typeahead` | `.pf-c-select__toggle` | Indicates the select has a typeahead. |
 

--- a/src/patternfly/components/Select/select-checkbox-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-checked.hbs
@@ -4,9 +4,9 @@
     {{{select-multi-attribute}}}
   {{/if}}>
   {{#if select--IsFilterable}}
-    {{#> select-menu-input}}
+    {{#> select-menu-search}}
       {{> select-menu-search-input}}
-    {{/select-menu-input}}
+    {{/select-menu-search}}
     {{#> divider}}{{/divider}}
   {{/if}}
   {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id=""' id '-label"')}}

--- a/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
@@ -4,9 +4,9 @@
     {{{select-multi-attribute}}}
   {{/if}}>
   {{#if select--IsFilterable}}
-    {{#> select-menu-input}}
+    {{#> select-menu-search}}
       {{> select-menu-search-input}}
-    {{/select-menu-input}}
+    {{/select-menu-search}}
     {{#> divider}}{{/divider}}
   {{/if}}
   {{#> select-menu-group}}

--- a/src/patternfly/components/Select/select-menu-input.hbs
+++ b/src/patternfly/components/Select/select-menu-input.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-select__menu-input{{#if select-menu-input--modifier}} {{select-menu-input--modifier}}{{/if}}"
-  {{#if select-menu-input--attribute}}
-    {{{select-menu-input--attribute}}}
-  {{/if}}>
-  {{>@partial-block}}
-</div>

--- a/src/patternfly/components/Select/select-menu-search.hbs
+++ b/src/patternfly/components/Select/select-menu-search.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-select__menu-search{{#if select-menu-search--modifier}} {{select-menu-search--modifier}}{{/if}}"
+  {{#if select-menu-search--attribute}}
+    {{{select-menu-search--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</div>

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -112,10 +112,10 @@
   --pf-c-select__menu-item--match--FontWeight: var(--pf-global--FontWeight--bold);
 
   // Menu group padding
-  --pf-c-select__menu-input--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-select__menu-input--PaddingRight: var(--pf-c-select__menu-item--PaddingRight);
-  --pf-c-select__menu-input--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-select__menu-input--PaddingLeft: var(--pf-c-select__menu-item--PaddingLeft);
+  --pf-c-select__menu-search--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-select__menu-search--PaddingRight: var(--pf-c-select__menu-item--PaddingRight);
+  --pf-c-select__menu-search--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-select__menu-search--PaddingLeft: var(--pf-c-select__menu-item--PaddingLeft);
 
   // Menu Item separator
   --pf-c-select__separator--Height: var(--pf-global--BorderWidth--sm);
@@ -449,8 +449,8 @@
   padding-top: var(--pf-c-select__menu-group--not--first-of-type--PaddingTop);
 }
 
-.pf-c-select__menu-input {
-  padding: var(--pf-c-select__menu-input--PaddingTop) var(--pf-c-select__menu-input--PaddingRight) var(--pf-c-select__menu-input--PaddingBottom) var(--pf-c-select__menu-input--PaddingLeft);
+.pf-c-select__menu-search {
+  padding: var(--pf-c-select__menu-search--PaddingTop) var(--pf-c-select__menu-search--PaddingRight) var(--pf-c-select__menu-search--PaddingBottom) var(--pf-c-select__menu-search--PaddingLeft);
 }
 
 .pf-c-select__menu-group-title {


### PR DESCRIPTION
closes #2438 

## Breaking Changes
* changes `pf-c-context-selector__menu-input` to `pf-c-context-selector__menu-search`
* changes `pf-c-select__menu-input` to `pf-c-select__menu-search`
* changes `--pf-c-context-selector__menu-input--PaddingTop` to `--pf-c-context-selector__menu-search--PaddingTop`
* changes `--pf-c-context-selector__menu-input--PaddingRight` to `--pf-c-context-selector__menu-search--PaddingRight`
* changes `--pf-c-context-selector__menu-input--PaddingBottom` to `--pf-c-context-selector__menu-search--PaddingBottom`
* changes `--pf-c-context-selector__menu-input--PaddingLeft` to `--pf-c-context-selector__menu-search--PaddingLeft`
*  changes `--pf-c-context-selector__menu-input--BottomBorderColor` to `--pf-c-context-selector__menu-search--BorderBottomColor`
* changes `--pf-c-context-selector__menu-input--BottomBorderWidth` to `--pf-c-context-selector__menu-search--BorderBottomWidth`
* changes `--pf-c-select__menu-input--PaddingTop` to `--pf-c-select__menu-search--PaddingTop`
* changes `--pf-c-select__menu-input--PaddingRight` to `--pf-c-select__menu-search--PaddingRight`
* changes `--pf-c-select__menu-input--PaddingBottom` to `--pf-c-select__menu-search--PaddingBottom`
* changes `--pf-c-select__menu-input--PaddingLeft` to `--pf-c-select__menu-search--PaddingLeft`

