### PR TITLE
fix(button): add modifiers to position icon in button

### DIFF
--- a/src/patternfly/components/Button/button-text.hbs
+++ b/src/patternfly/components/Button/button-text.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-button__text{{#if button-text--modifier}} {{button-text--modifier}}{{/if}}"
-  {{#if button-text--attribute}}
-    {{{button-text--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -124,16 +124,6 @@
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 
-  .pf-c-button__icon {
-    &.pf-m-start {
-      margin-right: var(--pf-c-button__icon--m-start--MarginRight);
-    }
-
-    &.pf-m-end {
-      margin-left: var(--pf-c-button__icon--m-end--MarginLeft);
-    }
-  }
-
   &::after {
     position: absolute;
     top: 0;
@@ -431,6 +421,16 @@
 
       background-color: var(--pf-c-button--m-plain--disabled--BackgroundColor);
     }
+  }
+}
+
+.pf-c-button__icon {
+  &.pf-m-start {
+    margin-right: var(--pf-c-button__icon--m-start--MarginRight);
+  }
+
+  &.pf-m-end {
+    margin-left: var(--pf-c-button__icon--m-end--MarginLeft);
   }
 }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -109,8 +109,8 @@
   --pf-c-button--m-control--disabled--BackgroundColor: transparent;
 
   // Styles for an icon in button
-  --pf-c-button__icon--text--MarginLeft: var(--pf-global--spacer--xs);
-  --pf-c-button__text--icon--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-button__icon--m-start--MarginRight: var(--pf-global--spacer--xs);
+  --pf-c-button__icon--m-end--MarginLeft: var(--pf-global--spacer--xs);
 
   position: relative;
   display: inline-block;
@@ -124,12 +124,14 @@
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 
-  .pf-c-button__icon + .pf-c-button__text {
-    margin-left: var(--pf-c-button__icon--text--MarginLeft);
-  }
+  .pf-c-button__icon {
+    &.pf-m-start {
+      margin-right: var(--pf-c-button__icon--m-start--MarginRight);
+    }
 
-  .pf-c-button__text + .pf-c-button__icon {
-    margin-left: var(--pf-c-button__text--icon--MarginLeft);
+    &.pf-m-end {
+      margin-left: var(--pf-c-button__icon--m-end--MarginLeft);
+    }
   }
 
   &::after {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -109,7 +109,7 @@
   --pf-c-button--m-control--disabled--BackgroundColor: transparent;
 
   // Styles for an icon in button
-  --pf-c-button__icon--MarginRight: var(--pf-global--spacer--xs);
+  --pf-c-button__icon--text--MarginLeft: var(--pf-global--spacer--xs);
   --pf-c-button__text--icon--MarginLeft: var(--pf-global--spacer--xs);
 
   position: relative;
@@ -124,12 +124,11 @@
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 
-  .pf-c-button__icon {
-    margin-right: var(--pf-c-button__icon--MarginRight);
+  .pf-c-button__icon + .pf-c-button__text {
+    margin-left: var(--pf-c-button__icon--text--MarginLeft);
   }
 
   .pf-c-button__text + .pf-c-button__icon {
-    margin-right: 0;
     margin-left: var(--pf-c-button__text--icon--MarginLeft);
   }
 

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -26,19 +26,15 @@ import './Button.css'
 <br>
 <br>
 {{#> button button--modifier="pf-m-link"}}
-  {{#> button-icon}}
+  {{#> button-icon button-icon--modifier="pf-m-start"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  {{#> button-text}}
-    Link
-  {{/button-text}}
+  Link
 {{/button}}
 
 {{#> button button--modifier="pf-m-link"}}
-  {{#> button-text}}
-    Link
-  {{/button-text}}
-  {{#> button-icon}}
+  Link
+  {{#> button-icon button-icon--modifier="pf-m-end"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
 {{/button}}
@@ -127,39 +123,31 @@ import './Button.css'
 {{/button}}
 <br><br>
 {{#> button button--modifier="pf-m-link"}}
-  {{#> button-icon}}
+  {{#> button-icon button-icon--modifier="pf-m-start"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  {{#> button-text}}
-    Link
-  {{/button-text}}
+  Link
 {{/button}}
 
 {{#> button button--modifier="pf-m-link pf-m-focus"}}
-  {{#> button-icon}}
+  {{#> button-icon button-icon--modifier="pf-m-start"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  {{#> button-text}}
-    Link focus
-  {{/button-text}}
+  Link focus
 {{/button}}
 
 {{#> button button--modifier="pf-m-link pf-m-active"}}
-  {{#> button-icon}}
+  {{#> button-icon button-icon--modifier="pf-m-start"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  {{#> button-text}}
-    Link active
-  {{/button-text}}
+  Link active
 {{/button}}
 
 {{#> button button--modifier="pf-m-link" button--attribute="disabled"}}
-  {{#> button-icon}}
+  {{#> button-icon button-icon--modifier="pf-m-start"}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  {{#> button-text}}
-    Link disabled
-  {{/button-text}}
+  Link disabled
 {{/button}}
 <br>
 <br>
@@ -273,8 +261,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
-| `.pf-c-button__icon` | `<span>` | Applies right spacing to an icon inside of the button when the icon is followed by text. |
-| `.pf-c-button__text` | `<span>` | Applies left spacing to an icon inside of a button when the icon comes after text. **Required when using `pf-c-button__icon`** |
+| `.pf-c-button__icon` | `<span>` | Initiates a button icon. |
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |
@@ -288,3 +275,5 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-hover` | `.pf-c-button` | Forces display of the hover state of the button. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:hover` pseudo-class.  |
 | `.pf-m-active` | `.pf-c-button` | Forces display of the active state of the button. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:active` pseudo-class.  |
 | `.pf-m-focus` | `.pf-c-button` | Forces display of the focus state of the button. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:focus` pseudo-class.  |
+| `.pf-m-start` | `.pf-c-button__icon` | Applies right spacing to an icon inside of a button when the icon comes before text. |
+| `.pf-m-end` | `.pf-c-button__icon` | Applies left spacing to an icon inside of a button when the icon comes after text. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -130,28 +130,36 @@ import './Button.css'
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  Link
+  {{#> button-text}}
+    Link
+  {{/button-text}}
 {{/button}}
 
 {{#> button button--modifier="pf-m-link pf-m-focus"}}
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  Link focus
+  {{#> button-text}}
+    Link focus
+  {{/button-text}}
 {{/button}}
 
 {{#> button button--modifier="pf-m-link pf-m-active"}}
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  Link active
+  {{#> button-text}}
+    Link active
+  {{/button-text}}
 {{/button}}
 
 {{#> button button--modifier="pf-m-link" button--attribute="disabled"}}
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  Link disabled
+  {{#> button-text}}
+    Link disabled
+  {{/button-text}}
 {{/button}}
 <br>
 <br>
@@ -266,7 +274,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | -- | -- | -- |
 | `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
 | `.pf-c-button__icon` | `<span>` | Applies right spacing to an icon inside of the button when the icon is followed by text. |
-| `.pf-c-button__text` | `<span>` | Applies left spacing to an icon inside of a button when the icon comes after text. |
+| `.pf-c-button__text` | `<span>` | Applies left spacing to an icon inside of a button when the icon comes after text. **Required when using `pf-c-button__icon`** |
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |

--- a/src/patternfly/components/InlineEdit/inline-edit-dl.hbs
+++ b/src/patternfly/components/InlineEdit/inline-edit-dl.hbs
@@ -3,12 +3,10 @@
 {{/title}}
 {{#> inline-edit-toggle}}
   {{#> button button--modifier="pf-m-link" button--attribute=(concat 'id="' inline-edit--id '-edit-button" aria-labelledby="' inline-edit--id '-edit-button ' inline-edit--id '-label"')}}
-    {{#> button-icon}}
+    {{#> button-icon button-icon--modifier="pf-m-start"}}
       <i class="fas fa-pencil-alt" aria-hidden="true"></i>
     {{/button-icon}}
-    {{#> button-text}}
-      Edit
-    {{/button-text}}
+    Edit
   {{/button}}
 {{/inline-edit-toggle}}
 

--- a/src/patternfly/components/InlineEdit/inline-edit-dl.hbs
+++ b/src/patternfly/components/InlineEdit/inline-edit-dl.hbs
@@ -6,7 +6,9 @@
     {{#> button-icon}}
       <i class="fas fa-pencil-alt" aria-hidden="true"></i>
     {{/button-icon}}
-    Edit
+    {{#> button-text}}
+      Edit
+    {{/button-text}}
   {{/button}}
 {{/inline-edit-toggle}}
 

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -662,7 +662,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          10
+          {{#> button-text}}
+            10
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -670,7 +672,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
@@ -678,7 +682,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -725,7 +731,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          3
+          {{#> button-text}}
+            3
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -733,7 +741,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
@@ -741,7 +751,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          2
+          {{#> button-text}}
+            2
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -788,7 +800,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          70
+          {{#> button-text}}
+            70
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -796,7 +810,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          15
+          {{#> button-text}}
+            15
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
@@ -804,7 +820,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          12
+          {{#> button-text}}
+            12
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -659,32 +659,26 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            10
-          {{/button-text}}
+          10
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -728,32 +722,26 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            3
-          {{/button-text}}
+          3
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            2
-          {{/button-text}}
+          2
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -797,32 +785,26 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            70
-          {{/button-text}}
+          70
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            15
-          {{/button-text}}
+          15
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            12
-          {{/button-text}}
+          12
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}

--- a/src/patternfly/demos/Table/table-compound-expansion-table.hbs
+++ b/src/patternfly/demos/Table/table-compound-expansion-table.hbs
@@ -31,7 +31,9 @@
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          10
+          {{#> button-text}}
+            10
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -39,7 +41,9 @@
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
@@ -47,7 +51,9 @@
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -94,7 +100,9 @@
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          3
+          {{#> button-text}}
+            3
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -102,7 +110,9 @@
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          4
+          {{#> button-text}}
+            4
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
@@ -110,7 +120,9 @@
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          2
+          {{#> button-text}}
+            2
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -157,7 +169,9 @@
           {{#> button-icon}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          70
+          {{#> button-text}}
+            70
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
@@ -165,7 +179,9 @@
           {{#> button-icon}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          15
+          {{#> button-text}}
+            15
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
@@ -173,7 +189,9 @@
           {{#> button-icon}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          12
+          {{#> button-text}}
+            12
+          {{/button-text}}
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}

--- a/src/patternfly/demos/Table/table-compound-expansion-table.hbs
+++ b/src/patternfly/demos/Table/table-compound-expansion-table.hbs
@@ -28,32 +28,26 @@
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            10
-          {{/button-text}}
+          10
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -97,32 +91,26 @@
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            3
-          {{/button-text}}
+          3
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            4
-          {{/button-text}}
+          4
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            2
-          {{/button-text}}
+          2
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -166,32 +154,26 @@
       {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code-branch" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            70
-          {{/button-text}}
+          70
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-code" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            15
-          {{/button-text}}
+          15
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
         {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
-          {{#> button-icon}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
             <i class="fas fa-cube" aria-hidden="true"></i>
           {{/button-icon}}
-          {{#> button-text}}
-            12
-          {{/button-text}}
+          12
         {{/button}}
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}


### PR DESCRIPTION
closes #2574 

### Breaking changes
* Adds the modifiers `pf-m-start` and `pf-m-end` to position `pf-c-button__icon` in the button component depending on whether it comes before or after text. We made this change so that we could safely position the icon before or after text, without needing to introduce a new class that wraps the text.
* Removes `  --pf-c-button__icon--MarginRight` and `--pf-c-button__text--icon--MarginLeft`. These are no longer in use, and to modify the right margin on an icon at the beginning of the button, use `--pf-c-button__icon--m-start--MarginRight` now and `--pf-c-button__icon--m-end--MarginLeft` to modify the left margin of an icon at the end of a button.
* Removes the `.pf-c-button__text` element as it is no longer necessary. Any instance of this element or styling using this selector should be removed as it is no longer used in the button component.