### PR TITLE
fix(page): reduce space between tertiary nav, breadcrumbs, main section

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -110,6 +110,7 @@
   --pf-c-page__main-section--m-no-padding-mobile--md--PaddingLeft: 0;
   --pf-c-page__main-section--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-page__main--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-page__main-breadcrumb--main-section--PaddingTop: var(--pf-global--spacer--md);
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--md--PaddingTop);
@@ -122,7 +123,6 @@
   --pf-c-page__main-nav--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-page__main-nav--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-page__main-nav--md--PaddingLeft: var(--pf-global--spacer--lg);
@@ -147,13 +147,10 @@
   --pf-c-page__main-breadcrumb--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-breadcrumb--PaddingBottom: 0;
   --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-breadcrumb--md--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-page__main-breadcrumb--md--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-page__main-breadcrumb--md--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-page__main-nav--main-breadcrumb--PaddingTop: 0;
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__main-breadcrumb--PaddingTop: var(--pf-c-page__main-breadcrumb--md--PaddingTop);
     --pf-c-page__main-breadcrumb--PaddingRight: var(--pf-c-page__main-breadcrumb--md--PaddingRight);
     --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-c-page__main-breadcrumb--md--PaddingLeft);
   }
@@ -423,7 +420,9 @@
 }
 
 .pf-c-page__main-nav {
-  padding: var(--pf-c-page__main-nav--PaddingTop) var(--pf-c-page__main-nav--PaddingRight) var(--pf-c-page__main-nav--PaddingBottom) var(--pf-c-page__main-nav--PaddingLeft);
+  padding-top: var(--pf-c-page__main-nav--PaddingTop);
+  padding-right: var(--pf-c-page__main-nav--PaddingRight);
+  padding-left: var(--pf-c-page__main-nav--PaddingLeft);
   background-color: var(--pf-c-page__main-nav--BackgroundColor);
 
   .pf-c-nav {
@@ -443,8 +442,8 @@
   padding: var(--pf-c-page__main-breadcrumb--PaddingTop) var(--pf-c-page__main-breadcrumb--PaddingRight) var(--pf-c-page__main-breadcrumb--PaddingBottom) var(--pf-c-page__main-breadcrumb--PaddingLeft);
   background-color: var(--pf-c-page__main-breadcrumb--BackgroundColor);
 
-  .pf-c-page__main-nav + & {
-    --pf-c-page__main-breadcrumb--PaddingTop: var(--pf-c-page__main-nav--main-breadcrumb--PaddingTop);
+  + .pf-c-page__main-section {
+    --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-breadcrumb--main-section--PaddingTop);
   }
 }
 


### PR DESCRIPTION
part of https://github.com/patternfly/patternfly-next/issues/2653

## Breaking changes
* removes `--pf-c-page__main-nav--PaddingBottom`
* removes `--pf-c-page__main-breadcrumb--md--PaddingTop`
* removes `--pf-c-page__main-nav--main-breadcrumb--PaddingTop`
* reduced spacer between breadcrumb and page section that is below it to `var(--pf-global--spacer--md)`