### PR TITLE
fix(box-shadow): update global shadows, add xl, update shadow utility

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -131,20 +131,25 @@
 
   // Shadows
   --pf-global--BoxShadow--sm: #{$pf-global--BoxShadow--sm};
-  --pf-global--BoxShadow--sm-right: #{$pf-global--BoxShadow--sm-right};
-  --pf-global--BoxShadow--sm-left: #{$pf-global--BoxShadow--sm-left};
-  --pf-global--BoxShadow--sm-bottom: #{$pf-global--BoxShadow--sm-bottom};
   --pf-global--BoxShadow--sm-top: #{$pf-global--BoxShadow--sm-top};
+  --pf-global--BoxShadow--sm-right: #{$pf-global--BoxShadow--sm-right};
+  --pf-global--BoxShadow--sm-bottom: #{$pf-global--BoxShadow--sm-bottom};
+  --pf-global--BoxShadow--sm-left: #{$pf-global--BoxShadow--sm-left};
   --pf-global--BoxShadow--md: #{$pf-global--BoxShadow--md};
-  --pf-global--BoxShadow--md-right: #{$pf-global--BoxShadow--md-right};
-  --pf-global--BoxShadow--md-left: #{$pf-global--BoxShadow--md-left};
-  --pf-global--BoxShadow--md-bottom: #{$pf-global--BoxShadow--md-bottom};
   --pf-global--BoxShadow--md-top: #{$pf-global--BoxShadow--md-top};
+  --pf-global--BoxShadow--md-right: #{$pf-global--BoxShadow--md-right};
+  --pf-global--BoxShadow--md-bottom: #{$pf-global--BoxShadow--md-bottom};
+  --pf-global--BoxShadow--md-left: #{$pf-global--BoxShadow--md-left};
   --pf-global--BoxShadow--lg: #{$pf-global--BoxShadow--lg};
-  --pf-global--BoxShadow--lg-right: #{$pf-global--BoxShadow--lg-right};
-  --pf-global--BoxShadow--lg-left: #{$pf-global--BoxShadow--lg-left};
-  --pf-global--BoxShadow--lg-bottom: #{$pf-global--BoxShadow--lg-bottom};
   --pf-global--BoxShadow--lg-top: #{$pf-global--BoxShadow--lg-top};
+  --pf-global--BoxShadow--lg-right: #{$pf-global--BoxShadow--lg-right};
+  --pf-global--BoxShadow--lg-bottom: #{$pf-global--BoxShadow--lg-bottom};
+  --pf-global--BoxShadow--lg-left: #{$pf-global--BoxShadow--lg-left};
+  --pf-global--BoxShadow--xl: #{$pf-global--BoxShadow--xl};
+  --pf-global--BoxShadow--xl-top: #{$pf-global--BoxShadow--xl-top};
+  --pf-global--BoxShadow--xl-right: #{$pf-global--BoxShadow--xl-right};
+  --pf-global--BoxShadow--xl-bottom: #{$pf-global--BoxShadow--xl-bottom};
+  --pf-global--BoxShadow--xl-left: #{$pf-global--BoxShadow--xl-left};
   --pf-global--BoxShadow--inset: #{$pf-global--BoxShadow--inset};
 
   // Fontpath

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -90,10 +90,10 @@ $pf-global--primary-color--dark-100:    $pf-color-blue-400 !default;
 // Shadows
 // small
 $pf-global--BoxShadow--sm: 0 pf-size-prem(1px) pf-size-prem(2px) 0 rgba($pf-color-black-1000, .12), 0 0 pf-size-prem(2px) 0 rgba($pf-color-black-1000, .06) !default;
-$pf-global--BoxShadow--sm-top: 0 pf-size-prem(-2px) pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-right: pf-size-prem(2px) 0 pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-bottom: 0 pf-size-prem(2px) pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-left: pf-size-prem(-2px) 0 pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
+$pf-global--BoxShadow--sm-top: 0 pf-size-prem(-2px) pf-size-prem(4px) pf-size-prem(-1px) rgba($pf-color-black-1000, .16) !default;
+$pf-global--BoxShadow--sm-right: pf-size-prem(2px) 0 pf-size-prem(4px) pf-size-prem(-1px) rgba($pf-color-black-1000, .16) !default;
+$pf-global--BoxShadow--sm-bottom: 0 pf-size-prem(2px) pf-size-prem(4px) pf-size-prem(-1px) rgba($pf-color-black-1000, .16) !default;
+$pf-global--BoxShadow--sm-left: pf-size-prem(-2px) 0 pf-size-prem(4px) pf-size-prem(-1px) rgba($pf-color-black-1000, .16) !default;
 
 // medium
 $pf-global--BoxShadow--md: 0 pf-size-prem(4px) pf-size-prem(8px) pf-size-prem(0) rgba($pf-color-black-1000, .12), 0 0 pf-size-prem(4px) 0 rgba($pf-color-black-1000, .06) !default;

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -89,25 +89,32 @@ $pf-global--primary-color--dark-100:    $pf-color-blue-400 !default;
 
 // Shadows
 // small
-$pf-global--BoxShadow--sm: 0 pf-size-prem(1) pf-size-prem(2) 0 rgba($pf-color-black-1000, .2) !default;
-$pf-global--BoxShadow--sm-right: pf-size-prem(4) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-left: pf-size-prem(-4) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-bottom: 0 pf-size-prem(4) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--sm-top: 0 pf-size-prem(-4) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;
+$pf-global--BoxShadow--sm: 0 pf-size-prem(1px) pf-size-prem(2px) 0 rgba($pf-color-black-1000, .12), 0 0 pf-size-prem(2px) 0 rgba($pf-color-black-1000, .06) !default;
+$pf-global--BoxShadow--sm-top: 0 pf-size-prem(-2px) pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
+$pf-global--BoxShadow--sm-right: pf-size-prem(2px) 0 pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
+$pf-global--BoxShadow--sm-bottom: 0 pf-size-prem(2px) pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
+$pf-global--BoxShadow--sm-left: pf-size-prem(-2px) 0 pf-size-prem(3px) pf-size-prem(-1px) rgba($pf-color-black-1000, .12) !default;
 
 // medium
-$pf-global--BoxShadow--md: 0 pf-size-prem(1) pf-size-prem(1) pf-size-prem(0) rgba($pf-color-black-1000, .05), 0 pf-size-prem(4) pf-size-prem(8) pf-size-prem(4) rgba($pf-color-black-1000, .06) !default;
-$pf-global--BoxShadow--md-right: pf-size-prem(5) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .25) !default;
-$pf-global--BoxShadow--md-left: pf-size-prem(-5) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .25) !default;
-$pf-global--BoxShadow--md-bottom: 0 pf-size-prem(5) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .25) !default;
-$pf-global--BoxShadow--md-top: 0 pf-size-prem(-5) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .25) !default;
+$pf-global--BoxShadow--md: 0 pf-size-prem(4px) pf-size-prem(8px) pf-size-prem(0) rgba($pf-color-black-1000, .12), 0 0 pf-size-prem(4px) 0 rgba($pf-color-black-1000, .06) !default;
+$pf-global--BoxShadow--md-top: 0 pf-size-prem(-8px) pf-size-prem(8px) pf-size-prem(-6px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--md-right: pf-size-prem(8px) 0 pf-size-prem(8px) pf-size-prem(-6px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--md-bottom: 0 pf-size-prem(8px) pf-size-prem(8px) pf-size-prem(-6px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--md-left: pf-size-prem(-8px) 0 pf-size-prem(8px) pf-size-prem(-6px) rgba($pf-color-black-1000, .18) !default;
 
 // large
-$pf-global--BoxShadow--lg: 0 pf-size-prem(3) pf-size-prem(7) pf-size-prem(3) rgba($pf-color-black-1000, .13), 0 pf-size-prem(11) pf-size-prem(24) pf-size-prem(16) rgba($pf-color-black-1000, .12) !default;
-$pf-global--BoxShadow--lg-right: pf-size-prem(12) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .07) !default;
-$pf-global--BoxShadow--lg-left: pf-size-prem(-12) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .07) !default;
-$pf-global--BoxShadow--lg-bottom: 0 pf-size-prem(12) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .07) !default;
-$pf-global--BoxShadow--lg-top: 0 pf-size-prem(-12) pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .07) !default;
+$pf-global--BoxShadow--lg: 0 pf-size-prem(8px) pf-size-prem(16px) 0 rgba($pf-color-black-1000, .16), 0 0 pf-size-prem(6px) 0 rgba($pf-color-black-1000, .08) !default;
+$pf-global--BoxShadow--lg-top: 0 pf-size-prem(-12px) pf-size-prem(12px) pf-size-prem(-8px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--lg-right: pf-size-prem(12px) 0 pf-size-prem(12px) pf-size-prem(-8px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--lg-bottom: 0 pf-size-prem(12px) pf-size-prem(12px) pf-size-prem(-8px) rgba($pf-color-black-1000, .18) !default;
+$pf-global--BoxShadow--lg-left: pf-size-prem(-12px) 0 pf-size-prem(12px) pf-size-prem(-8px) rgba($pf-color-black-1000, .18) !default;
+
+// x-large
+$pf-global--BoxShadow--xl: 0 pf-size-prem(16px) pf-size-prem(32px) 0 rgba($pf-color-black-1000, .16), 0 0 pf-size-prem(8px) 0 rgba($pf-color-black-1000, .1) !default;
+$pf-global--BoxShadow--xl-top: 0 pf-size-prem(-16px) pf-size-prem(16px) pf-size-prem(-8px) rgba($pf-color-black-1000, .2) !default;
+$pf-global--BoxShadow--xl-right: pf-size-prem(16px) 0 pf-size-prem(16px) pf-size-prem(-8px) rgba($pf-color-black-1000, .2) !default;
+$pf-global--BoxShadow--xl-bottom: 0 pf-size-prem(16px) pf-size-prem(16px) pf-size-prem(-8px) rgba($pf-color-black-1000, .2) !default;
+$pf-global--BoxShadow--xl-left: pf-size-prem(-16px) 0 pf-size-prem(16px) pf-size-prem(-8px) rgba($pf-color-black-1000, .2) !default;
 
 // inset
 $pf-global--BoxShadow--inset: inset 0 0 pf-size-prem(10) 0 rgba($pf-color-black-1000, .25) !default;

--- a/src/patternfly/utilities/BoxShadow/box-shadow.hbs
+++ b/src/patternfly/utilities/BoxShadow/box-shadow.hbs
@@ -1,4 +1,4 @@
-<div class="ws-core-box-shadow-box{{#if box-shadow--modifier}} {{box-shadow--modifier}}{{/if}}"
+<div class="{{#if box-shadow--modifier}} {{box-shadow--modifier}}{{/if}}"
   {{#if box-shadow--attribute}}
     {{{box-shadow--attribute}}}
   {{/if}}>

--- a/src/patternfly/utilities/BoxShadow/box-shadow.scss
+++ b/src/patternfly/utilities/BoxShadow/box-shadow.scss
@@ -1,27 +1,35 @@
 // stylelint-disable
 
 $pf-u-box-shadow-options: (
-  /* small*/
+  /* small */
   box-shadow-sm:        (box-shadow var(--pf-global--BoxShadow--sm)),
   box-shadow-sm-top:    (box-shadow var(--pf-global--BoxShadow--sm-top)),
   box-shadow-sm-right:  (box-shadow var(--pf-global--BoxShadow--sm-right)),
   box-shadow-sm-bottom: (box-shadow var(--pf-global--BoxShadow--sm-bottom)),
   box-shadow-sm-left:   (box-shadow var(--pf-global--BoxShadow--sm-left)),
 
-  /* medium*/
+  /* medium */
   box-shadow-md:        (box-shadow var(--pf-global--BoxShadow--md)),
   box-shadow-md-top:    (box-shadow var(--pf-global--BoxShadow--md-top)),
   box-shadow-md-right:  (box-shadow var(--pf-global--BoxShadow--md-right)),
   box-shadow-md-bottom: (box-shadow var(--pf-global--BoxShadow--md-bottom)),
   box-shadow-md-left:   (box-shadow var(--pf-global--BoxShadow--md-left)),
 
-  /* large*/
+  /* large */
   box-shadow-lg:        (box-shadow var(--pf-global--BoxShadow--lg)),
   box-shadow-lg-top:    (box-shadow var(--pf-global--BoxShadow--lg-top)),
   box-shadow-lg-right:  (box-shadow var(--pf-global--BoxShadow--lg-right)),
   box-shadow-lg-bottom: (box-shadow var(--pf-global--BoxShadow--lg-bottom)),
   box-shadow-lg-left:   (box-shadow var(--pf-global--BoxShadow--lg-left)),
 
+  /* x-large */
+  box-shadow-xl:        (box-shadow var(--pf-global--BoxShadow--xl)),
+  box-shadow-xl-top:    (box-shadow var(--pf-global--BoxShadow--xl-top)),
+  box-shadow-xl-right:  (box-shadow var(--pf-global--BoxShadow--xl-right)),
+  box-shadow-xl-bottom: (box-shadow var(--pf-global--BoxShadow--xl-bottom)),
+  box-shadow-xl-left:   (box-shadow var(--pf-global--BoxShadow--xl-left)),
+
+  /* inset */
   box-shadow-inset:     (box-shadow var(--pf-global--BoxShadow--inset))
 );
 

--- a/src/patternfly/utilities/BoxShadow/examples/BoxShadow.css
+++ b/src/patternfly/utilities/BoxShadow/examples/BoxShadow.css
@@ -1,4 +1,25 @@
-.ws-core-box-shadow-box {
-  padding: 24px;
-  margin: 60px 60px 32px 32px;
+.ws-core-u-box-shadow [class*="pf-u-box-shadow"],
+.ws-core-u-boxshadow [class*="pf-u-box-shadow"] {
+  padding: var(--pf-global--spacer--lg);
+  margin-bottom: var(--pf-global--spacer--md);
+}
+
+#ws-core-u-box-shadow-small [class*="pf-u-box-shadow"]:not(:last-child),
+#ws-core-u-boxshadow-small [class*="pf-u-box-shadow"]:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--lg);
+}
+
+#ws-core-u-box-shadow-medium [class*="pf-u-box-shadow"]:not(:last-child),
+#ws-core-u-boxshadow-medium [class*="pf-u-box-shadow"]:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--xl);
+}
+
+#ws-core-u-box-shadow-large [class*="pf-u-box-shadow"]:not(:last-child),
+#ws-core-u-boxshadow-large [class*="pf-u-box-shadow"]:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--2xl);
+}
+
+#ws-core-u-box-shadow-extra-large [class*="pf-u-box-shadow"]:not(:last-child),
+#ws-core-u-boxshadow-extra-large [class*="pf-u-box-shadow"]:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--3xl);
 }

--- a/src/patternfly/utilities/BoxShadow/examples/BoxShadow.md
+++ b/src/patternfly/utilities/BoxShadow/examples/BoxShadow.md
@@ -6,54 +6,81 @@ section: utilities
 import './BoxShadow.css'
 
 ## Examples
-```hbs title=Basic
+```hbs title=Small
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-sm"}}
-  Box shadow small
+  Regular
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-sm-top"}}
-  Box shadow small, top
+  Top
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-sm-right"}}
-  Box shadow small, right
+  Right
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-sm-bottom"}}
-  Box shadow small, bottom
+  Bottom
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-sm-left"}}
-  Box shadow small, left
+  Left
 {{/box-shadow}}
+```
+
+```hbs title=Medium
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-md"}}
-  Box shadow medium
+  Regular
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-md-top"}}
-  Box shadow medium, top
+  Top
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-md-right"}}
-  Box shadow medium, right
+  Right
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-md-bottom"}}
-  Box shadow medium, bottom
+  Bottom
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-md-left"}}
-  Box shadow medium, left
+  Left
 {{/box-shadow}}
+```
+
+```hbs title=Large
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-lg"}}
-  Box shadow large
+  Regular
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-lg-top"}}
-  Box shadow large, top
+  Top
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-lg-right"}}
-  Box shadow large, right
+  Right
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-lg-bottom"}}
-  Box shadow large, bottom
+  Bottom
 {{/box-shadow}}
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-lg-left"}}
-  Box shadow large, left
+  Left
 {{/box-shadow}}
+```
+
+```hbs title=Extra-large
+{{#> box-shadow box-shadow--modifier="pf-u-box-shadow-xl"}}
+  Regular
+{{/box-shadow}}
+{{#> box-shadow box-shadow--modifier="pf-u-box-shadow-xl-top"}}
+  Top
+{{/box-shadow}}
+{{#> box-shadow box-shadow--modifier="pf-u-box-shadow-xl-right"}}
+  Right
+{{/box-shadow}}
+{{#> box-shadow box-shadow--modifier="pf-u-box-shadow-xl-bottom"}}
+  Bottom
+{{/box-shadow}}
+{{#> box-shadow box-shadow--modifier="pf-u-box-shadow-xl-left"}}
+  Left
+{{/box-shadow}}
+```
+
+```hbs title=Inset
 {{#> box-shadow box-shadow--modifier="pf-u-box-shadow-inset"}}
-  Box shadow inset
+  Regular
 {{/box-shadow}}
 ```
 
@@ -79,3 +106,8 @@ Box shadow utility
 | `.pf-u-box-shadow-lg-right` | `*` |  Applies box-shadow large right. |
 | `.pf-u-box-shadow-lg-bottom` | `*` |  Applies box-shadow large bottom. |
 | `.pf-u-box-shadow-lg-left` | `*` |  Applies box-shadow large left. |
+| `.pf-u-box-shadow-xl` | `*` |  Applies box-shadow x-large. |
+| `.pf-u-box-shadow-xl-top` | `*` |  Applies box-shadow x-large top. |
+| `.pf-u-box-shadow-xl-right` | `*` |  Applies box-shadow x-large right. |
+| `.pf-u-box-shadow-xl-bottom` | `*` |  Applies box-shadow x-large bottom. |
+| `.pf-u-box-shadow-xl-left` | `*` |  Applies box-shadow x-large left. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2845

@lboehling looks like these shadows are built from absolute black. We don't use black anywhere else in patternfly. The previous shadows were built from `$pf-color-black-1000` (`#151515`). Will these shadows work using `$pf-color-black-1000` as the color used in the `rgba()` function?

PR Preview: https://patternfly-pr-2854.surge.sh/
* Any component that uses the existing box-shadow global variables will be updated in this preview.
* Link to the box-shadow utility class examples: https://patternfly-pr-2854.surge.sh/documentation/core/utilities/boxshadow