### PR TITLE
fix(tooltip): added box shadow

### DIFF
--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -1,6 +1,7 @@
 .pf-c-tooltip {
   // Component variables
   --pf-c-tooltip--MaxWidth: #{pf-size-prem(300px)};
+  --pf-c-tooltip--BoxShadow: var(--pf-global--BoxShadow--md);
 
   // Content variables
   --pf-c-tooltip__content--PaddingTop: var(--pf-global--spacer--sm);
@@ -21,6 +22,7 @@
 
   position: relative;
   max-width: var(--pf-c-tooltip--MaxWidth);
+  box-shadow: var(--pf-c-tooltip--BoxShadow);
 
   &.pf-m-top {
     .pf-c-tooltip__arrow {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2847

## Breaking changes
* adds medium box shadow to tooltip