### PR TITLE
fix(modal): updated box shadow size

### DIFF
--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -6,7 +6,7 @@
   --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
-  --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-modal-box--Width: 100%;
   --pf-c-modal-box--MaxWidth: calc(100% - var(--pf-global--spacer--xl)); // Ensure modal has gutters at full width


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2848

## Breaking changes
* changes box shadow from lg to xl. This is a visual breaking change only. No further action required to consume this change.