### PR TITLE
fix(table): replaced expanded content box shadow with border

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -139,8 +139,7 @@
   --pf-c-table__compound-expansion-toggle--BorderBottom--BorderColor: var(--pf-global--BackgroundColor--light-100);
 
   // Modifier - expandable row expanded
-  --pf-c-table__expandable-row--m-expanded--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
-  --pf-c-table__expandable-row--m-expanded--BorderBottomColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-table__expandable-row--m-expanded--BorderBottomColor: var(--pf-global--BorderColor--100);
 
   // Modifier - sort
   --pf-c-table__sort--sorted--Color: var(--pf-global--active-color--100);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2850

## Breaking changes
* removes `--pf-c-table__expandable-row--m-expanded--BoxShadow`
* replaces expanded content box shadow with border