### PR TITLE
feat(infrastructure): parse hbs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint:fix": "npm run lint:js --fix && npm run lint:styles --fix",
     "lint:sass": "stylelint 'src/**/*.scss'",
     "lint:js": "eslint .",
+    "lint:hbs": "node ./parseHbs --lint",
     "precommit": "lint-staged",
     "sassdoc": "sassdoc ./src/patternfly/**/*.scss --parse > sassdoc/data.json",
     "serve": "gatsby serve",

--- a/parseHbs.js
+++ b/parseHbs.js
@@ -1,0 +1,307 @@
+const path = require('path');
+const fse = require('fs-extra');
+const fs = require('fs');
+const glob = require('glob');
+const prettier = require('prettier');
+const Handlebars = require('handlebars');
+const { extractExamples } = require('gatsby-theme-patternfly-org/helpers/extractExamples');
+
+const mdx = require(`@mdx-js/mdx`);
+
+const srcDir = path.join('./src/patternfly');
+const mdFiles = glob.sync('**/*.md', {
+  cwd: srcDir
+});
+const hbsFiles = glob.sync('**/*.hbs', {
+  cwd: srcDir
+});
+
+const cliArgs = process.argv.slice(2);
+const erroredFiles = {};
+
+const createHandlebars = nodes => {
+  const instance = Handlebars.create();
+
+  // Add helpers
+  instance.registerHelper('concat', (...params) => {
+    // Ignore the object appended by handlebars.
+    if (typeof params[params.length - 1] === 'object') {
+      params.pop();
+    }
+    return params.join('');
+  });
+
+  // Add partials
+  nodes.forEach(({ fields }) =>
+    instance.registerPartial(
+      fields.name, // Partial name
+      fields.partial // Partial template
+    )
+  );
+
+  return instance;
+};
+
+// glob all .md files under src/patternfly
+// const hbsNodes = glob all .hbs files
+// const hbsInstance = createHandlebars(hbsNodes);
+
+// 1. loop through .md files
+// 2. for each .md files, get the mdxAst tree and the hbsInstance
+// -> in each loop iteration: const examples = extractExamples(mdxAST, hbsInstance, fileRelativePath);
+// now for each md examples file, we have an array of HTML examples?
+
+const individualExamples = [];
+const coreSnippets = [];
+
+function parseAllMd() {
+  const mdExamples = [];
+  const hbsNodes = [];
+  hbsFiles.forEach(file => {
+    const name = path.basename(file, '.hbs');
+    const from = path.join(srcDir, file);
+    const partial = fse.readFileSync(from).toString();
+    hbsNodes.push({
+      fields: {
+        file,
+        name,
+        partial
+      }
+    });
+  });
+  const hbsInstance = createHandlebars(hbsNodes);
+
+  mdFiles.forEach(file => {
+    const from = path.join(srcDir, file);
+    const sourceText = fse.readFileSync(from).toString();
+    const compiler = mdx.createMdxAstCompiler({
+      mdPlugins: null,
+      remarkPlugins: []
+    });
+    const mdxAST = compiler.parse(sourceText);
+    const name = path.basename(file, '.md');
+    const example = extractExamples(mdxAST, hbsInstance, name);
+    const type = file.split('/')[0];
+    mdExamples.push({
+      name,
+      file,
+      example,
+      type
+    });
+  });
+
+  for (let i = 0; i < mdExamples.length; i++) {
+    const { name, file, example, type } = mdExamples[i];
+    let typePrefix = '';
+    if (type === 'components') {
+      typePrefix = 'ex-c-';
+    } else if (type === 'layouts') {
+      typePrefix = 'ex-l-';
+    } else if (type === 'utilities') {
+      typePrefix = 'ex-u-';
+    } else if (type === 'demos') {
+      typePrefix = 'ex-d-';
+    }
+    Object.entries(example).forEach(([oneExample, html]) => {
+      let prettierHtml;
+      try {
+        prettierHtml = prettier.format(html, { parser: 'html' });
+        individualExamples.push({
+          mdName: name,
+          mdFile: file,
+          exampleName: oneExample,
+          exampleHtml: prettierHtml,
+          type,
+          fullName: `${typePrefix}${name}--${oneExample}`
+        });
+      } catch (error) {
+        if (!erroredFiles[file]) {
+          console.error();
+          console.error(`error parsing: ${file}`);
+          erroredFiles[file] = true;
+          // console.error(html);
+          console.error(error);
+        }
+      }
+    });
+  }
+
+  const fileDefaults = {
+    'form-control': {
+      controlType: 'input',
+      input: true
+    },
+    'input-group-text': {
+      inputGroupTextType: 'span'
+    }
+  };
+
+  hbsNodes.forEach(node => {
+    let template;
+    let compiledPartial;
+    const type = node.fields.file.split('/')[0];
+    let typePrefix = '';
+    if (type === 'components') {
+      typePrefix = 'c-';
+    } else if (type === 'layouts') {
+      typePrefix = 'l-';
+    } else if (type === 'utilities') {
+      typePrefix = 'u-';
+    } else if (type === 'demos') {
+      typePrefix = 'd-';
+    }
+    try {
+      template = hbsInstance.compile(node.fields.partial);
+      const templateContext = {
+        PLACEHOLDER: '$PLACEHOLDER',
+        ...fileDefaults[node.fields.name]
+      };
+      const partialsObj = {
+        '@partial-block': '{{PLACEHOLDER}}'
+      };
+      compiledPartial = template(templateContext, { partials: partialsObj });
+      let placeholderNum = 0;
+      compiledPartial = compiledPartial.replace(/"-[a-zA-Z]/g, match => `"\${${++placeholderNum}}${match.slice(1)}`);
+      compiledPartial = compiledPartial.replace(/\$PLACEHOLDER/g, () => `\${${++placeholderNum}}`);
+      const prettierHtml = prettier.format(compiledPartial, { parser: 'html' });
+      coreSnippets.push({
+        name: `${typePrefix}${node.fields.name}`,
+        type,
+        snippet: JSON.parse(JSON.stringify(prettierHtml.replace(/\t/g, '\\t'))),
+        file: node.fields.file
+      });
+    } catch (e) {
+      if (!erroredFiles[node.fields.file]) {
+        console.error();
+        console.error(`error parsing: ${node.fields.file}`);
+        erroredFiles[node.fields.file] = true;
+        // console.error(html);
+        console.error(e);
+      }
+    }
+  });
+}
+
+const renderSnippet = (snippet, tabtrigger, description) => {
+  // escape " with \"
+  // split lines by line-break
+  const separatedSnippet = snippet
+    .trim()
+    // .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .split('\n');
+  const separatedSnippetLength = separatedSnippet.length;
+  const lastLine = separatedSnippetLength - 1;
+
+  // add double quotes around each line apart from the last one
+  const newSnippet = separatedSnippet.map((line, index) => {
+    if (separatedSnippetLength === 1) {
+      return `"${line}"`;
+    }
+    // eslint-disable-next-line no-nested-ternary
+    return index === lastLine ? `\t\t\t"${line}"` : index === 0 ? `"${line}",` : `\t\t\t"${line}",`;
+  });
+  // prettier-ignore
+  return `{
+    "prefix": "${tabtrigger}",
+    "body": [
+      ${newSnippet.join('\n')}
+    ],
+    "description": "${description}"
+  }`;
+};
+
+const makeCodeFragments = () => {
+  const jsonSnippet = {
+    codeCategories: []
+  };
+  const getCategoryJson = category => ({
+    category,
+    codeFragments: []
+  });
+  const getFragmentJson = (label, content) => ({
+    label,
+    content
+  });
+  const componentsCategory = getCategoryJson('Components');
+  const layoutsCategory = getCategoryJson('Layouts');
+  const demosCategory = getCategoryJson('Demos');
+  const utilitiesCategory = getCategoryJson('Utilities');
+  const getCategory = filePath => {
+    // console.log(`filePath: ${filePath}`);
+    const filePathArr = filePath.split('/');
+    const type = filePathArr[0];
+    const group = filePathArr[1];
+    let fragment;
+    let category;
+    if (type === 'components') {
+      category = componentsCategory;
+    } else if (type === 'layouts') {
+      category = layoutsCategory;
+    } else if (type === 'utilities') {
+      category = utilitiesCategory;
+    } else if (type === 'demos') {
+      category = demosCategory;
+    }
+    // console.log(`category: ${JSON.stringify(category)}`)
+    fragment = category.codeFragments.find(f => f.group === group);
+    if (!fragment) {
+      fragment = {
+        group,
+        children: []
+      };
+      category.codeFragments.push(fragment);
+    }
+
+    return fragment.children;
+  };
+
+  individualExamples.forEach(node => {
+    const { mdFile, exampleHtml, fullName } = node;
+    const currentCategoryGroup = getCategory(mdFile);
+    currentCategoryGroup.push(getFragmentJson(fullName, exampleHtml));
+  });
+
+  coreSnippets.forEach(node => {
+    const { name, snippet, file } = node;
+    const currentCategoryGroup = getCategory(file);
+    currentCategoryGroup.push(getFragmentJson(name, snippet));
+  });
+
+  jsonSnippet.codeCategories.push(componentsCategory, layoutsCategory, utilitiesCategory, demosCategory);
+  fs.writeFileSync(path.join(srcDir, 'coreFragments.json'), JSON.stringify(jsonSnippet), 'utf-8');
+};
+
+async function getResults() {
+  // example snippets
+  let snippetsString = '{';
+  for (let i = 0; i < individualExamples.length; i++) {
+    const snippet = renderSnippet(
+      individualExamples[i].exampleHtml,
+      `@${individualExamples[i].fullName}`,
+      `${individualExamples[i].fullName}`
+    );
+    if (i === 0) {
+      snippetsString = `${snippetsString}\n\t"${individualExamples[i].fullName}": ${snippet}`;
+    } else {
+      snippetsString = `${snippetsString},\n\t"${individualExamples[i].fullName}": ${snippet}`;
+    }
+  }
+
+  // partials snippets
+  for (let i = 0; i < coreSnippets.length; i++) {
+    const snippet = renderSnippet(coreSnippets[i].snippet, `@${coreSnippets[i].name}`, `${coreSnippets[i].name}`);
+    snippetsString = `${snippetsString},\n\t"${coreSnippets[i].name}": ${snippet}`;
+  }
+
+  snippetsString = `${snippetsString}\n}`;
+
+  fs.writeFileSync(path.join(srcDir, 'coreSnippets.json'), snippetsString, 'utf-8');
+}
+
+parseAllMd();
+
+if (cliArgs.indexOf('--lint') === -1) {
+  makeCodeFragments();
+  getResults();
+}

--- a/src/patternfly/components/AppLauncher/app-launcher-group-title.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-group-title.hbs
@@ -2,5 +2,5 @@
   {{#if app-launcher-group-title--attribute}}
 	  {{{app-launcher-group-title--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </h1>

--- a/src/patternfly/components/AppLauncher/app-launcher-group.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-group.hbs
@@ -2,5 +2,5 @@
   {{#if app-launcher-group--attribute}}
 	  {{{app-launcher-group--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </section>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-icon.hbs
@@ -2,5 +2,5 @@
   {{#if app-launcher-menu-item-icon--attribute}}
 	  {{{app-launcher-menu-item-icon--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </span>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item.hbs
@@ -5,5 +5,5 @@
   {{#if app-launcher-menu-item--attribute}}
 	  {{{app-launcher-menu-item--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </{{# if app-launcher-menu-item--type}}{{app-launcher-menu-item--type}}{{else}}a{{/if}}>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-wrapper.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-wrapper.hbs
@@ -2,5 +2,5 @@
   {{#if app-launcher-menu-wrapper--attribute}}
 	  {{{app-launcher-menu-wrapper--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </li>

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -45,7 +45,7 @@ cssPrefix: pf-c-clipboard-copy
   {{#> clipboard-copy-group}}
     {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-toggle}}
-    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-copy}}
@@ -74,7 +74,7 @@ cssPrefix: pf-c-clipboard-copy
   {{#> clipboard-copy-group}}
     {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-toggle}}
-    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-copy}}

--- a/src/patternfly/components/DataToolbar/data-toolbar-item-separator.hbs
+++ b/src/patternfly/components/DataToolbar/data-toolbar-item-separator.hbs
@@ -1,1 +1,2 @@
 {{#> data-toolbar-item data-toolbar-item--attribute='aria-hidden="true"' data-toolbar-item--modifier=(concat 'pf-m-separator ' data-toolbar-item-separator--modifier)}}
+{{/data-toolbar-item}}

--- a/src/patternfly/components/Dropdown/dropdown-menu-item-icon.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu-item-icon.hbs
@@ -2,5 +2,5 @@
   {{#if dropdown-menu-item-icon--attribute}}
 	  {{{dropdown-menu-item-icon--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </span>

--- a/src/patternfly/components/Dropdown/dropdown-toggle-button.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-toggle-button.hbs
@@ -14,7 +14,7 @@
     {{{dropdown-toggle-button--attribute}}}
   {{/if}}>
   {{#if @partial-block}}
-    {{{@partial-block}}}
+    {{> @partial-block}}
   {{else}}
     <i class="fas fa-caret-down" aria-hidden="true"></i>
   {{/if}}

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -18,7 +18,7 @@ cssPrefix: pf-c-form-control
 {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute='type="text" value="Success" id="textInput4" aria-label="Success state input example"'}}
 {{/form-control}}
 <br /><br />
-{{#> form-control controlType="input" form-control--modifier="pf-m-search" form-control--attribute='type="search" id="search-input" name="search-input" aria-label="Search"'}}
+{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute='type="search" id="search-input" name="search-input" aria-label="Search"'}}
 {{/form-control}}
 <br /><br />
 {{#> form-control controlType="input" input="true" form-control--attribute='disabled type="text" value="Disabled" id="textInput5" aria-label="Disabled input example"'}}

--- a/src/patternfly/components/List/examples/List.md
+++ b/src/patternfly/components/List/examples/List.md
@@ -42,7 +42,6 @@ cssPrefix: pf-c-list
       <li>Cras gravida arcu at diam gravida gravida.</li>
       {{/list}}
     </li>
-    </li>
     {{/list}}
   <li>Aenean nec tortor orci.</li>
   <li>Quisque aliquam cursus urna, non bibendum massa viverra eget.</li>

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -34,11 +34,11 @@ cssPrefix: pf-c-login
           {{/form-helper-text}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
           {{#> check}}

--- a/src/patternfly/components/NotificationBadge/notification-badge.hbs
+++ b/src/patternfly/components/NotificationBadge/notification-badge.hbs
@@ -2,5 +2,5 @@
   {{#if notification-badge--attribute}}
     {{{notification-badge--attribute}}}
   {{/if}}>
-  {{{@partial-block}}}
+  {{> @partial-block}}
 </span>

--- a/src/patternfly/components/Select/select-checkbox-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-checked.hbs
@@ -9,7 +9,7 @@
     {{/select-menu-input}}
     {{#> divider}}{{/divider}}
   {{/if}}
-  {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id=""' id '-label"')}}
+  {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-label"')}}
     {{#> check check--type="label" check--attribute=(concat 'for="' id '-active"') check--modifier="pf-c-select__menu-item"}}
       {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-active" name="' id '-active"')}}{{/check-input}}
       {{#> check-label check-label--type="span"}}Active{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-checked.hbs
@@ -9,7 +9,7 @@
     {{/select-menu-input}}
     {{#> divider}}{{/divider}}
   {{/if}}
-  {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-label"')}}
+  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"'}}
     {{#> check check--type="label" check--attribute=(concat 'for="' id '-active"') check--modifier="pf-c-select__menu-item"}}
       {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-active" name="' id '-active"')}}{{/check-input}}
       {{#> check-label check-label--type="span"}}Active{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
@@ -40,7 +40,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-vendor"')}}
       Vendor
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat id '-group-vendor')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-vendor"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-dell"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-dell" name="dell"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Dell{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
+++ b/src/patternfly/components/Select/select-checkbox-groups-checked.hbs
@@ -10,10 +10,10 @@
     {{#> divider}}{{/divider}}
   {{/if}}
   {{#> select-menu-group}}
-    {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-label"')}}
+    {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-status"')}}
       Status
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-status"')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' id '-group-status"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-running"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-running" name="running"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Running{{/check-label}}
@@ -40,7 +40,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-vendor"')}}
       Vendor
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-vendor"')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' id '-group-vendor"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-dell"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-dell" name="dell"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Dell{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox-groups.hbs
+++ b/src/patternfly/components/Select/select-checkbox-groups.hbs
@@ -4,10 +4,10 @@
     {{{select-multi-attribute}}}
   {{/if}}>
   {{#> select-menu-group}}
-    {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-label"')}}
+    {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-status"')}}
       Status
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-status"')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' id '-group-status"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-running"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-running" name="running"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Running{{/check-label}}
@@ -34,7 +34,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-vendor"')}}
       Vendor
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-vendor"')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' id '-group-vendor"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-dell"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-dell" name="dell"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Dell{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox-groups.hbs
+++ b/src/patternfly/components/Select/select-checkbox-groups.hbs
@@ -7,7 +7,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-label"')}}
       Status
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat id '-group-status')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-status"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-running"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-running" name="running"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Running{{/check-label}}
@@ -34,7 +34,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' id '-group-vendor"')}}
       Vendor
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat id '-group-vendor')}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'id="' id '-group-vendor"')}}
       {{#> check check--type="label" check--attribute=(concat 'for="' id '-dell"') check--modifier="pf-c-select__menu-item"}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-dell" name="dell"')}}{{/check-input}}
         {{#> check-label check-label--type="span"}}Dell{{/check-label}}

--- a/src/patternfly/components/Select/select-checkbox.hbs
+++ b/src/patternfly/components/Select/select-checkbox.hbs
@@ -3,28 +3,26 @@
   {{#if select-multi--attribute}}
     {{{select-multi-attribute}}}
   {{/if}}>
-  {{#> form}}
-    {{#> form-fieldset form-fieldset--attribute=(concat 'aria-labelledby="' id '-label"')}}
-      {{#> check check--type="label" check--attribute=(concat 'for="' id '-active"') check--modifier="pf-c-select__menu-item"}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-active" name="' id '-active"')}}{{/check-input}}
-        {{#> check-label check-label--type="span"}}Active{{/check-label}}
-      {{/check}}
-      {{#> check check--type="label" check--attribute=(concat 'for="' id '-cancelled"')check--modifier="pf-c-select__menu-item"}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-cancelled" name="' id '-cancelled"')}}{{/check-input}}
-        {{#> check-label check-label--type="span"}}Cancelled{{/check-label}}
-      {{/check}}
-      {{#> check check--type="label" check--attribute=(concat 'for="' id '-paused"') check--modifier="pf-c-select__menu-item"}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-paused" name="' id '-paused"')}}{{/check-input}}
-        {{#> check-label check-label--type="span"}}Paused{{/check-label}}
-      {{/check}}
-      {{#> check check--type="label" check--attribute=(concat 'for="' id '-warning"') check--modifier="pf-c-select__menu-item"}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-warning" name="' id '-warning"')}}{{/check-input}}
-        {{#> check-label check-label--type="span"}}Warning{{/check-label}}
-      {{/check}}
-      {{#> check check--type="label" check--attribute=(concat 'for="' id '-restarted"') check--modifier="pf-c-select__menu-item"}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-restarted" name="' id '-restarted"')}}{{/check-input}}
-        {{#> check-label check-label--type="span"}}Restarted{{/check-label}}
-      {{/check}}
-    {{/form-fieldset}}
-  {{/form}}
+  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"'}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' id '-active"') check--modifier="pf-c-select__menu-item"}}
+      {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-active" name="' id '-active"')}}{{/check-input}}
+      {{#> check-label check-label--type="span"}}Active{{/check-label}}
+    {{/check}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' id '-cancelled"') check--modifier="pf-c-select__menu-item"}}
+      {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-cancelled" name="' id '-cancelled"')}}{{/check-input}}
+      {{#> check-label check-label--type="span"}}Cancelled{{/check-label}}
+    {{/check}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' id '-paused"') check--modifier="pf-c-select__menu-item"}}
+      {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-paused" name="' id '-paused"')}}{{/check-input}}
+      {{#> check-label check-label--type="span"}}Paused{{/check-label}}
+    {{/check}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' id '-warning"') check--modifier="pf-c-select__menu-item"}}
+      {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-warning" name="' id '-warning"')}}{{/check-input}}
+      {{#> check-label check-label--type="span"}}Warning{{/check-label}}
+    {{/check}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' id '-restarted"') check--modifier="pf-c-select__menu-item"}}
+      {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-restarted" name="' id '-restarted"')}}{{/check-input}}
+      {{#> check-label check-label--type="span"}}Restarted{{/check-label}}
+    {{/check}}
+  {{/select-menu-fieldset}}
 </div>

--- a/src/patternfly/components/Select/select-menu-search-input.hbs
+++ b/src/patternfly/components/Select/select-menu-search-input.hbs
@@ -1,2 +1,2 @@
-{{#> form-control controlType="input" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
+{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
 {{/form-control}}

--- a/src/patternfly/components/Select/select-typeahead.hbs
+++ b/src/patternfly/components/Select/select-typeahead.hbs
@@ -8,7 +8,7 @@
     <li><button type="button" class="pf-c-select__menu-item" aria-pressed="false">Alabama</button></li>
     <li><button type="button" class="pf-c-select__menu-item" aria-pressed="false">Florida</button></li>
   {{/unless}}
-  <li><button type="button" class="pf-c-select__menu-item" aria-pressed="false">{{#if select--IsCurrentlyTyping}}<mark class="pf-c-select__menu-item--match">{{/if}}New{{#if select--IsCurrentlyTyping}}</mark>{{/if}} Jersey</button type="button"></li>
+  <li><button type="button" class="pf-c-select__menu-item" aria-pressed="false">{{#if select--IsCurrentlyTyping}}<mark class="pf-c-select__menu-item--match">{{/if}}New{{#if select--IsCurrentlyTyping}}</mark>{{/if}} Jersey</button></li>
   {{#unless select--IsMultiSelect}}
     <li>
       <button type="button" class="pf-c-select__menu-item{{#if select--ItemIsSelected}} pf-m-selected{{/if}}"

--- a/src/patternfly/demos/AboutModal/examples/AboutModal.md
+++ b/src/patternfly/demos/AboutModal/examples/AboutModal.md
@@ -45,9 +45,7 @@ section: demos
           </dl>
           {{/content}}
           {{#> about-modal-box-strapline}}
-            {{#> title titleType="p" title--modifier="pf-m-md"}}
-              Trademark and copyright information here
-            {{/title}}
+            Trademark and copyright information here
           {{/about-modal-box-strapline}}
         {{/about-modal-box-content}}
       {{/about-modal-box}}

--- a/src/patternfly/utilities/Flex/examples/Flex.md
+++ b/src/patternfly/utilities/Flex/examples/Flex.md
@@ -41,7 +41,6 @@ import './Flex.css'
   {{#> flex-item}}Flex item 1{{/flex-item}}
   {{#> flex-item}}Flex item 2{{/flex-item}}
   {{#> flex-item}}Flex item 3{{/flex-item}}
-  </div>
 {{/display}}
 <br>
 {{#> title titleType="h2" title--modifier="pf-m-lg"}}


### PR DESCRIPTION
This adds a handlebars parser that is used to create snippet and fragment files for the VSCode pfsnippets extension. 
As a side effect, since it uses prettier to format the HTML, it will error if the resultant hbs -> HTML conversion has issues which is how I found most of the issues in the hbs files fixed in this PR.
The script is currently not run by default but invoked manually.