### PR TITLE
fix(empty-state): center content, fix vars, adjust secondary margin

### DIFF
--- a/src/patternfly/components/EmptyState/empty-state-content.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-content.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-empty-state__content{{#if empty-state-content--modifier}} {{empty-state-content--modifier}}{{/if}}"
+  {{#if empty-state-content--attribute}}
+    {{{empty-state-content--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/EmptyState/empty-state.hbs
+++ b/src/patternfly/components/EmptyState/empty-state.hbs
@@ -2,5 +2,7 @@
   {{#if empty-state--attribute}}
     {{{empty-state--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#> empty-state-content}}
+    {{> @partial-block}}
+  {{/empty-state-content}}
 </div>

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -45,6 +45,10 @@
       font-size: var(--pf-c-empty-state--m-xl__body--FontSize);
     }
   }
+
+  &.pf-m-full-height {
+    height: 100%;
+  }
 }
 
 .pf-c-empty-state__content {

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -10,9 +10,9 @@
   --pf-c-empty-state__primary--secondary--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-empty-state__secondary--MarginTop: var(--pf-global--spacer--xl);
   --pf-c-empty-state__secondary--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
-  --pf-c-empty-state__secondary__c-button--MarginRight: calc(var(--pf-global--spacer--xs) / 2);
-  --pf-c-empty-state__secondary__c-button--MarginBottom: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__secondary__c-button--MarginLeft: calc(var(--pf-global--spacer--xs) / 2);
+  --pf-c-empty-state__secondary--child--MarginRight: calc(var(--pf-global--spacer--xs) / 2);
+  --pf-c-empty-state__secondary--child--MarginBottom: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__secondary--child--MarginLeft: calc(var(--pf-global--spacer--xs) / 2);
   --pf-c-empty-state--m-sm__content--MaxWidth: #{pf-size-prem(400px)};
   --pf-c-empty-state--m-lg__content--MaxWidth: #{pf-size-prem(600px)};
   --pf-c-empty-state--m-xl__body--FontSize: var(--pf-global--FontSize--xl);
@@ -77,10 +77,10 @@
   margin-top: var(--pf-c-empty-state__secondary--MarginTop);
   margin-bottom: var(--pf-c-empty-state__secondary--MarginBottom);
 
-  > .pf-c-button {
-    margin-right: var(--pf-c-empty-state__secondary__c-button--MarginRight);
-    margin-bottom: var(--pf-c-empty-state__secondary__c-button--MarginBottom);
-    margin-left: var(--pf-c-empty-state__secondary__c-button--MarginLeft);
+  > * {
+    margin-right: var(--pf-c-empty-state__secondary--child--MarginRight);
+    margin-bottom: var(--pf-c-empty-state__secondary--child--MarginBottom);
+    margin-left: var(--pf-c-empty-state__secondary--child--MarginLeft);
   }
 }
 

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,64 +1,54 @@
 .pf-c-empty-state {
   --pf-c-empty-state--Padding: var(--pf-global--spacer--xl);
+  --pf-c-empty-state__content--MaxWidth: none;
   --pf-c-empty-state__icon--MarginBottom: var(--pf-global--spacer--lg);
   --pf-c-empty-state__icon--FontSize: var(--pf-global--icon--FontSize--xl);
   --pf-c-empty-state__icon--Color: var(--pf-global--icon--Color--light);
   --pf-c-empty-state__body--MarginTop: var(--pf-global--spacer--md);
   --pf-c-empty-state__body--Color: var(--pf-global--Color--200);
-  --pf-c-empty-state--c-button--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state--c-button__secondary--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-empty-state__primary--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-empty-state__primary--secondary--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-empty-state__secondary--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state__secondary--MarginRight: calc(var(--pf-global--spacer--xs) * -1);
   --pf-c-empty-state__secondary--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
-  --pf-c-empty-state__secondary--c-button--MarginRight: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__secondary--c-button--MarginBottom: var(--pf-global--spacer--xs);
-  --pf-c-empty-state--m-sm--MaxWidth: #{pf-size-prem(400px)};
-  --pf-c-empty-state--m-lg--MaxWidth: #{pf-size-prem(600px)};
+  --pf-c-empty-state__secondary__c-button--MarginRight: calc(var(--pf-global--spacer--xs) / 2);
+  --pf-c-empty-state__secondary__c-button--MarginBottom: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__secondary__c-button--MarginLeft: calc(var(--pf-global--spacer--xs) / 2);
+  --pf-c-empty-state--m-sm__content--MaxWidth: #{pf-size-prem(400px)};
+  --pf-c-empty-state--m-lg__content--MaxWidth: #{pf-size-prem(600px)};
   --pf-c-empty-state--m-xl__body--FontSize: var(--pf-global--FontSize--xl);
   --pf-c-empty-state--m-xl__body--MarginTop: var(--pf-global--spacer--lg);
   --pf-c-empty-state--m-xl__icon--MarginBottom: var(--pf-global--spacer--xl);
   --pf-c-empty-state--m-xl__icon--FontSize: #{pf-size-prem(100px)};
   --pf-c-empty-state--m-xl--c-button__secondary--MarginTop: var(--pf-global--spacer--md);
 
+  display: flex;
+  justify-content: center;
   padding: var(--pf-c-empty-state--Padding);
   text-align: center;
 
-  // stylelint-disable
-  > .pf-c-button.pf-m-primary,
-  .pf-c-empty-state__primary {
-    margin-top: var(--pf-c-empty-state--c-button--MarginTop);
-
-    + .pf-c-empty-state__secondary {
-      margin-top: var(--pf-c-empty-state--c-button__secondary--MarginTop);
-    }
-  }
-
   &.pf-m-sm {
-    max-width: var(--pf-c-empty-state--m-sm--MaxWidth);
+    --pf-c-empty-state__content--MaxWidth: var(--pf-c-empty-state--m-sm__content--MaxWidth);
   }
 
   &.pf-m-lg {
-    max-width: var(--pf-c-empty-state--m-lg--MaxWidth);
+    --pf-c-empty-state__content--MaxWidth: var(--pf-c-empty-state--m-lg__content--MaxWidth);
   }
 
   &.pf-m-xl {
     --pf-c-empty-state__body--MarginTop: var(--pf-c-empty-state--m-xl__body--MarginTop);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xl__icon--MarginBottom);
     --pf-c-empty-state__icon--FontSize: var(--pf-c-empty-state--m-xl__icon--FontSize);
+    --pf-c-empty-state--c-button__secondary--MarginTop: var(--pf-c-empty-state--m-xl--c-button__secondary--MarginTop);
 
     .pf-c-empty-state__body {
       font-size: var(--pf-c-empty-state--m-xl__body--FontSize);
     }
-
-    > .pf-c-button.pf-m-primary,
-    .pf-c-empty-state__primary {
-      + .pf-c-empty-state__secondary {
-        --pf-c-empty-state--c-button__secondary--MarginTop: var(--pf-c-empty-state--m-xl--c-button__secondary--MarginTop);
-      }
-    }
   }
 }
-// stylelint-enable
+
+.pf-c-empty-state__content {
+  max-width: var(--pf-c-empty-state__content--MaxWidth);
+}
 
 .pf-c-empty-state__icon {
   margin-bottom: var(--pf-c-empty-state__icon--MarginBottom);
@@ -71,17 +61,26 @@
   color: var(--pf-c-empty-state__body--Color);
 }
 
+@at-root .pf-c-empty-state__content > .pf-c-button.pf-m-primary,
+.pf-c-empty-state__primary {
+  margin-top: var(--pf-c-empty-state__primary--MarginTop);
+
+  + .pf-c-empty-state__secondary {
+    margin-top: var(--pf-c-empty-state__primary--secondary--MarginTop);
+  }
+}
+
 .pf-c-empty-state__secondary {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   margin-top: var(--pf-c-empty-state__secondary--MarginTop);
-  margin-right: var(--pf-c-empty-state__secondary--MarginRight);
   margin-bottom: var(--pf-c-empty-state__secondary--MarginBottom);
 
   > .pf-c-button {
-    margin-right: var(--pf-c-empty-state__secondary--c-button--MarginRight);
-    margin-bottom: var(--pf-c-empty-state__secondary--c-button--MarginBottom);
+    margin-right: var(--pf-c-empty-state__secondary__c-button--MarginRight);
+    margin-bottom: var(--pf-c-empty-state__secondary__c-button--MarginBottom);
+    margin-left: var(--pf-c-empty-state__secondary__c-button--MarginLeft);
   }
 }
 

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -22,6 +22,7 @@
   --pf-c-empty-state--m-xl--c-button__secondary--MarginTop: var(--pf-global--spacer--md);
 
   display: flex;
+  align-items: center;
   justify-content: center;
   padding: var(--pf-c-empty-state--Padding);
   text-align: center;

--- a/src/patternfly/components/EmptyState/examples/EmptyState.md
+++ b/src/patternfly/components/EmptyState/examples/EmptyState.md
@@ -153,11 +153,13 @@ cssPrefix: pf-c-empty-state
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. **Required** |
+| `.pf-c-empty-state__content` | `<div>` |  Creates the content container. **Required** |
 | `.pf-c-empty-state__icon` | `<i>`, `<div>` |  Creates the empty state icon or icon container when used as a `<div>`. |
 | `.pf-c-title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Creates the empty state title. **Required** |
 | `.pf-c-empty-state__body` | `<div>` |  Creates the empty state body content. You can have more than one `.pf-c-empty-state__body` elements. |
 | `.pf-c-button.pf-m-primary` | `<button>` |  Creates the primary action button. |
 | `.pf-c-empty-state__primary` | `<div>` |  Container for primary actions. Can be used in lieu of using `.pf-c-button.pf-m-primary`. |
 | `.pf-c-empty-state__secondary` | `<div>` |  Container secondary actions. |
-| `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width |
-| `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width |
+| `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width. |
+| `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width. |
+| `.pf-m-xl` | `.pf-c-empty-state` | Modifies the empty state for a x-large max-width. |

--- a/src/patternfly/components/EmptyState/examples/EmptyState.md
+++ b/src/patternfly/components/EmptyState/examples/EmptyState.md
@@ -152,7 +152,7 @@ cssPrefix: pf-c-empty-state
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. **Required** |
+| `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. The empty state centers its content (`.pf-c-empty-state__content`) vertically and horizontally. **Required** |
 | `.pf-c-empty-state__content` | `<div>` |  Creates the content container. **Required** |
 | `.pf-c-empty-state__icon` | `<i>`, `<div>` |  Creates the empty state icon or icon container when used as a `<div>`. |
 | `.pf-c-title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Creates the empty state title. **Required** |
@@ -163,3 +163,4 @@ cssPrefix: pf-c-empty-state
 | `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width. |
 | `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width. |
 | `.pf-m-xl` | `.pf-c-empty-state` | Modifies the empty state for a x-large max-width. |
+| `.pf-m-full-height` | `.pf-c-empty-state` | Modifies the empty state to be `height: 100%`. If you need the empty state content to be centered vertically, you can use this modifier to make the empty state fill the height of its container, and center `.pf-c-empty-state__content`. **Note:** this modifier requires the parent of `.pf-c-empty-state` have an implicit or explicit `height` defined.  |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2568
fixes https://github.com/patternfly/patternfly/issues/2857

## Breaking changes
* Introduces a new element `.pf-c-empty-state__content` that wraps the contents of the empty state content. The `max-width` used for the size variations applies to `.pf-c-empty-state__content` instead of `.pf-c-empty-state`, and `.pf-c-empty-state__content` is centered horizontally and vertically in its parent, reducing the need for using a `.pf-l-bullseye` layout to center empty state content. If you're using the bullseye layout to center the empty state horizontally, you can remove that, though there is likely no harm in continuing to use it.
  * Adds `--pf-c-empty-state__content--MaxWidth` that is overridden with `.pf-m-sm` and `.pf-m-lg` via `--pf-c-empty-state--m-sm__content--MaxWidth` and `--pf-c-empty-state--m-lg__content--MaxWidth`
  * Adds a `.pf-m-full-height` variation to `.pf-c-empty-state` for use when the empty state component should be centered vertically in a container, and the empty state does not already consume the height of its container.
* Adjusts the left/right spacing on buttons in the secondary actions container so that instead of using a `margin-right` to space the buttons, we use a `margin-left` and `margin-right`, which allows us to get rid of the negative right margin on the secondary actions container. We're also styling all direct children of the secondary actions container instead of just `.pf-c-button` elements.
  * removes `--pf-c-empty-state__secondary--MarginRight`. This was just to offset the right margin on buttons in the `__secondary` container and is no longer necessary. No updates needed unless you were referencing that var.
  * renames `--pf-c-empty-state__secondary__c-button--MarginRight` to `--pf-c-empty-state__secondary--child--MarginRight` and `--pf-c-empty-state__secondary__c-button--MarginBottom` to `--pf-c-empty-state__secondary--child--MarginBottom`. Any references you may have to this var need to be updated to the new names.
  * adds `--pf-c-empty-state__secondary--child--MarginLeft`. The margin between secondary actions is now calculated from `--pf-c-empty-state__secondary--child--MarginLeft` and `--pf-c-empty-state__secondary--child--MarginRight` between adjacent buttons.
* Fixes vars. Any references to the old vars will need to be updated to use the new vars.
  * renames `--pf-c-empty-state--c-button--MarginTop` to `--pf-c-empty-state__primary--MarginTop`
  * renames `--pf-c-empty-state--c-button__secondary--MarginTop` to `--pf-c-empty-state__primary--secondary--MarginTop`