### PR TITLE
WIP: Fix table tr height + text wrapping control

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -310,8 +310,8 @@ cssPrefix: pf-c-table
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{concat table--id '-node1'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div id="{{table--id}}-node1">Node 1</div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 1" table-flexible-wrapper--example--id="node1"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -335,11 +335,8 @@ cssPrefix: pf-c-table
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node2">Node 2</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 2" table-flexible-wrapper--example--id="node2" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -363,11 +360,8 @@ cssPrefix: pf-c-table
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node3">Node 3</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 3" table-flexible-wrapper--example--id="node3" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -391,11 +385,8 @@ cssPrefix: pf-c-table
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node4">Node 4</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 4" table-flexible-wrapper--example--id="node4" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -464,11 +455,8 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{concat table--id '-node1'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node1">Node 1</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 1" table-flexible-wrapper--example--id="node1" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -503,11 +491,8 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node2">Node 2</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 2" table-flexible-wrapper--example--id="node2" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -540,11 +525,8 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node3">Node 3</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 3" table-flexible-wrapper--example--id="node3" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -576,11 +558,8 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node4">Node 4</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 4" table-flexible-wrapper--example--id="node4" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -632,7 +611,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{#> table table--id="table-compound-expansion" table--grid="true" table--modifier="pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Compound expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true" table-th--modifier="pf-m-width-30"}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true"}}
         Repositories
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}
@@ -654,32 +633,20 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr table-tr--expanded="true"}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--HasLink="true" table-flexible-wrapper--example--no-text="true"}}
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          10
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        10
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
-          {{#> button-icon}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
+        {{> button-icon button-icon--name="fas fa-cube"}}
+        4
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>20 minutes</span>
@@ -694,21 +661,21 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-1')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-2')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-3')}}
         {{/table-nested}}
       {{/table-td}}
@@ -717,32 +684,20 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--HasLink="true" table-flexible-wrapper--example--no-text="true"}}
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          3
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        3
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
-          {{#> button-icon}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          2
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
+        {{> button-icon button-icon--name="fas fa-cube"}}
+        2
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>1 day ago</span>
@@ -757,21 +712,21 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-4')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-5')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-6')}}
         {{/table-nested}}
       {{/table-td}}
@@ -780,32 +735,20 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-       {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--HasLink="true" table-flexible-wrapper--example--no-text="true"}}
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          70
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        70
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
-          {{#> button-icon}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          15
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
+        {{> button-icon button-icon--name="fas fa-code-branch"}}
+        15
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
-          {{#> button-icon}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          12
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--compound-expansion-toggle--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
+        {{> button-icon button-icon--name="fas fa-cube"}}
+        12
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>2 days ago</span>
@@ -820,21 +763,21 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-7')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-8')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding" table-td--no-wrapper="true"}}
         {{#> table-nested table--id=(concat table--id '-nested-table-9')}}
         {{/table-nested}}
       {{/table-td}}
@@ -889,8 +832,12 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{concat table--id "-name1"}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor"}}
-        <span id="{{concat table--id "-name1"}}">Sam Jones</span>
+      {{#> table-th table-th--data-label="Contributor" table-th--no-wrapper="true"}}
+        {{#> table-flexible-wrapper}}
+          {{#> table-text table-text--attribute=(concat 'id="' table--id '-name1"')}}
+            Sam Jones
+          {{/table-text}}
+        {{/table-flexible-wrapper}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         CSS guru
@@ -920,8 +867,12 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id "-name2"}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor"}}
-        <span id="{{concat table--id "-name2"}}">Amy Miller</span>
+      {{#> table-th table-th--data-label="Contributor" table-th--no-wrapper="true"}}
+        {{#> table-flexible-wrapper}}
+          {{#> table-text table-text--attribute=(concat 'id="' table--id '-name2"')}}
+            Amy Miller
+          {{/table-text}}
+        {{/table-flexible-wrapper}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         Visual design
@@ -951,8 +902,12 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id "-name3"}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor"}}
-        <span id="{{concat table--id "-name3"}}">Steve Wilson</span>
+      {{#> table-th table-th--data-label="Contributor" table-th--no-wrapper="true"}}
+        {{#> table-flexible-wrapper}}
+          {{#> table-text table-text--attribute=(concat 'id="' table--id '-name3"')}}
+            Steve Wilson
+          {{/table-text}}
+        {{/table-flexible-wrapper}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         Visual design lead
@@ -982,8 +937,12 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id "-name4"}}">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor name"}}
-        <span id="{{concat table--id "-name4"}}">Emma Jackson</span>
+      {{#> table-th table-th--data-label="Contributor" table-th--no-wrapper="true"}}
+        {{#> table-flexible-wrapper}}
+          {{#> table-text table-text--attribute=(concat 'id="' table--id '-name4"')}}
+            Emma Jackson
+          {{/table-text}}
+        {{/table-flexible-wrapper}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         Interaction design
@@ -1054,6 +1013,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--data-label="Contributor"}}
         <span id="{{concat table--id "-name1"}}">Sam Jones</span>
       {{/table-th}}
+
+
       {{#> table-td table-td--data-label="Position"}}
         CSS guru
       {{/table-td}}
@@ -1182,7 +1143,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{#> table table--id="table-compact-expandable" table--grid="true" table--modifier="pf-m-compact pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Compact expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td}}{{/table-td}}
+      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-check-all" aria-label="Select all rows">
       {{/table-td}}
@@ -1404,8 +1365,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{table--id}}-node1">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div id="{{table--id}}-node1">Node 1</div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 1" table-flexible-wrapper--example--id="node1"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1425,11 +1386,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{table--id}}-node2">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node2">Node 2</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 12" table-flexible-wrapper--example--id="node2" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1449,11 +1407,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{table--id}}-node3">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node3">Node 3</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 3" table-flexible-wrapper--example--id="node3" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1473,11 +1428,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{table--id}}-node4">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node4">Node 4</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 4" table-flexible-wrapper--example--id="node4" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1612,94 +1564,79 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-caption}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
+      {{#> table-th table-th--sortable="true" table-th--attribute='scope="col"'}}
+        This is a normal table header that truncates by default.
       {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
+      {{#> table-th table-th--sortable="true" table-th--attribute='scope="col"' table-text--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time, that is set to wrap.
       {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
+      {{#> table-th table-th--sortable="true" table-th--attribute='scope="col"' table-text--modifier="pf-m-wrap"}}
+        Thisisalongstring-thathassomespecialcharacters-andissettowrap
       {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
+      {{#> table-th table-th--attribute='scope="col"' table-text--modifier="pf-m-no-wrap"}}
+        No wrapping, be careful!
       {{/table-th}}
     {{/table-tr}}
   {{/table-thead}}
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a normal table header that truncates by default."}}
         Repository 1
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time, that is set to wrap."}}
         10
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="Consider a custom label."}}
         25
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="No wrapping, be careful!"}}
         5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a normal table header that truncates by default."}}
         Repository 2
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time, that is set to wrap."}}
         10
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="Consider a custom label."}}
         25
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="No wrapping, be careful!"}}
         5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a normal table header that truncates by default."}}
         Repository 3
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time, that is set to wrap."}}
         10
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="Consider a custom label."}}
         25
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="No wrapping, be careful!"}}
         5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a normal table header that truncates by default."}}
         Repository 4
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time, that is set to wrap."}}
         10
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="Consider a custom label."}}
         25
       {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+      {{#> table-td table-td--data-label="No wrapping, be careful!"}}
         5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/table-button.hbs
+++ b/src/patternfly/components/Table/table-button.hbs
@@ -1,0 +1,7 @@
+<button class="pf-c-table__button{{#if button-table--modifier}} {{table-button--modifier}}{{/if}}"
+  type="button"
+  {{#if button--attribute}}
+    {{{button--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</button>

--- a/src/patternfly/components/Table/table-flexible-wrapper.hbs
+++ b/src/patternfly/components/Table/table-flexible-wrapper.hbs
@@ -1,0 +1,19 @@
+<div class="pf-c-table__flexible-wrapper{{#if table-flexible-wrapper--modifier}} {{table-flexible-wrapper--modifier}}{{/if}}"
+  {{#if table-flexible-wrapper--attribute}}
+    {{{table-flexible-wrapper--attribute}}}
+  {{/if}}>
+  {{#if table-flexible-wrapper--example}}
+    {{#unless table-flexible-wrapper--example--no-text}}
+      {{#> table-text table-text--type="div" table-text--attribute=(concat 'id="' table--id '-' table-flexible-wrapper--example--id '"')}}
+        {{table-flexible-wrapper--example--text}}
+      {{/table-text}}
+    {{/unless}}
+    {{#if table-flexible-wrapper--example--HasLink}}
+      {{#> table-text table-text--type="a" table-text--attribute='href="#"'}}
+        siemur/test-space
+      {{/table-text}}
+    {{/if}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
+</div>

--- a/src/patternfly/components/Table/table-sort-indicator.hbs
+++ b/src/patternfly/components/Table/table-sort-indicator.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-table__sort-indicator{{#if table-sort-indicator--modifier}} {{table-sort-indicator--modifier}}{{/if}}"
+  {{#if table-sort-indicator--attribute}}
+    {{{table-sort-indicator--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -15,10 +15,31 @@
   {{#if table-td--data-label}}
     data-label="{{table-td--data-label}}"
   {{/if}}>
-  {{#if table-td--toggle}}
-    <button class="pf-c-button pf-m-plain{{#if table-tr--expanded}} pf-m-expanded{{/if}}" {{#if table-td--button--attribute}}{{{table-td--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
-      {{#> table-toggle-icon}}{{/table-toggle-icon}}
-    </button>
-  {{/if}}
-  {{> @partial-block}}
+  {{#unless table-td--IsEmpty}}
+    {{#if table-td--no-wrapper}}
+      {{> @partial-block}}
+    {{else if table-td--toggle}}
+      <button class="pf-c-button pf-m-plain{{#if table-tr--expanded}} pf-m-expanded{{/if}}" {{#if table-td--button--attribute}}{{{table-td--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
+        {{#> table-toggle-icon}}{{/table-toggle-icon}}
+      </button>
+    {{else if table-td--compound-expansion-toggle}}
+      <button class="pf-c-button pf-m-link{{#if table-td--compound-expansion-toggle--button--modifier}} {{table-td--compound-expansion-toggle--button--modifier}}{{/if}}" {{#if table-td--compound-expansion-toggle--button--attribute}}{{{table-td--compound-expansion-toggle--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
+        {{> @partial-block}}
+      </button>
+    {{else if table-td--check}}
+      {{> @partial-block}}
+    {{else if table-td--action}}
+      {{> @partial-block}}
+    {{else if table-td--icon}}
+      {{> @partial-block}}
+    {{else if table-tr--expandable}}
+      {{> @partial-block}}
+    {{else}}
+      {{#> table-flexible-wrapper}}
+        {{#> table-text}}
+          {{> @partial-block}}
+        {{/table-text}}
+      {{/table-flexible-wrapper}}
+    {{/if}}
+  {{/unless}}
 </td>

--- a/src/patternfly/components/Table/table-text.hbs
+++ b/src/patternfly/components/Table/table-text.hbs
@@ -1,0 +1,6 @@
+<{{# if table-text--type}}{{table-text--type}}{{else}}span{{/if}} class="pf-c-table__text{{#if table-text--modifier}} {{table-text--modifier}}{{/if}}"
+  {{#if table-text--attribute}}
+    {{{table-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{# if table-text--type}}{{table-text--type}}{{else}}span{{/if}}>

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -24,28 +24,38 @@
   {{#if table-th--attribute}}
     {{{table-th--attribute}}}
   {{/if}}>
-  {{#if table-th--sortable}}
-    {{#> button button--modifier="pf-m-plain"}}
-      {{#if table-th--sortable-wrap}}
-        <span class="pf-c-table__sort-text">
-          {{> @partial-block}}
-        </span>
-      {{else}}
-        {{> @partial-block}}
-      {{/if}}
-      <span class="pf-c-table__sort-indicator">
-        {{#if table-th--selected}}
-          {{#if table-th--asc}}
-            <i class="fas fa-long-arrow-alt-up"></i>
-          {{else}}
-            <i class="fas fa-long-arrow-alt-down"></i>
-          {{/if}}
-        {{else}}
-          <i class="fas fa-arrows-alt-v"></i>
-        {{/if}}
-      </span>
-    {{/button}}
-  {{else}}
+  {{#if table-th--no-wrapper}}
     {{> @partial-block}}
+  {{else if table-th--sortable}}
+    {{#> button button--modifier="pf-m-plain"}}
+      {{#> table-flexible-wrapper}}
+        {{#> table-text}}
+          {{> @partial-block}}
+        {{/table-text}}
+        {{#> table-sort-indicator}}
+          {{#if table-th--selected}}
+            {{#if table-th--asc}}
+              <i class="fas fa-long-arrow-alt-up"></i>
+            {{else}}
+              <i class="fas fa-long-arrow-alt-down"></i>
+            {{/if}}
+          {{else}}
+            <i class="fas fa-arrows-alt-v"></i>
+          {{/if}}
+        {{/table-sort-indicator}}
+      {{/table-flexible-wrapper}}
+    {{/button}}
+  {{else if table-th--check}}
+    {{> @partial-block}}
+  {{else if table-th--action}}
+    {{> @partial-block}}
+  {{else if table-th--icon}}
+    {{> @partial-block}}
+  {{else}}
+    {{#> table-flexible-wrapper}}
+      {{#> table-text}}
+        {{> @partial-block}}
+      {{/table-text}}
+    {{/table-flexible-wrapper}}
   {{/if}}
 </th>

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -150,15 +150,14 @@
 
   // Base
   width: 100%;
+
+  // Table requires a height to calculate
+  height: 100%;
   background-color: var(--pf-c-table--BackgroundColor);
 
   // Standard table row (non-expandable)
   // exclude expandable rows
   tr:not(.pf-c-table__expandable-row) {
-    // hack: buttons inside table cells will not occupy full height of parent when adjacent cells'
-    // content wraps. for those special cases, there must be an explicit height set on tr and table cell
-    // for button height: 100% to work
-    height: 1px;
     border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
 
     // stylelint-disable-next-line
@@ -387,6 +386,8 @@
 .pf-c-table__sort {
   // override pf-m-plain color
   .pf-c-button {
+    height: 100%;
+
     // stylelint-disable
     &.pf-m-plain {
       color: var(--pf-c-table__sort--c-button--Color);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1,5 +1,48 @@
-.pf-c-table {
+@mixin pf-c-table__text--m-wrap {
+  --pf-c-table__text--Overflow: var(--pf-c-table__text--m-wrap--Overflow);
+  --pf-c-table__text--TextOverflow: var(--pf-c-table__text--m-wrap--TextOverflow);
+  --pf-c-table__text--WhiteSpace: var(--pf-c-table__text--m-wrap--WhiteSpace);
+  --pf-c-table__text--WordBreak: var(--pf-c-table__text--m-wrap--WordBreak);
+}
 
+%pf-c-table__text--m-wrap {
+  @include pf-c-table__text--m-wrap();
+}
+
+@mixin pf-c-table__text--m-truncate {
+  --pf-c-table__text--Overflow: var(--pf-c-table__text--m-truncate--Overflow);
+  --pf-c-table__text--TextOverflow: var(--pf-c-table__text--m-truncate--TextOverflow);
+  --pf-c-table__text--WhiteSpace: var(--pf-c-table__text--m-truncate--WhiteSpace);
+  --pf-c-table__text--WordBreak: var(--pf-c-table__text--m-truncate--WordBreak);
+  --pf-c-table__text--MaxWidth: var(--pf-c-table__text--m-truncate--MaxWidth);
+  --pf-c-table__text--MinWidth: var(--pf-c-table__text--m-truncate--MinWidth);
+}
+
+%pf-c-table__text--m-truncate {
+  @include pf-c-table__text--m-truncate();
+}
+
+@mixin pf-c-table__text--m-no-wrap {
+  --pf-c-table__text--Overflow: var(--pf-c-table__text--m-no-wrap--Overflow);
+  --pf-c-table__text--TextOverflow: var(--pf-c-table__text--m-no-wrap--TextOverflow);
+  --pf-c-table__text--WhiteSpace: var(--pf-c-table__text--m-no-wrap--WhiteSpace);
+  --pf-c-table__text--MaxWidth: var(--pf-c-table__text--m-no-wrap--MaxWidth);
+  --pf-c-table__text--MinWidth: var(--pf-c-table__text--m-no-wrap--MinWidth);
+}
+
+%pf-c-table__text--m-no-wrap {
+  @include pf-c-table__text--m-no-wrap();
+}
+
+@mixin pf-c-table__text--m-break-word {
+  --pf-c-table__text--WordBreak: var(--pf-c-table__text--m-break-word--WordBreak);
+}
+
+%pf-c-table__text--m-break-word {
+  @include pf-c-table__text--m-break-word();
+}
+
+.pf-c-table {
   // stylelint-disable
   // ============================================================ //
   // Start non-conformant variables
@@ -32,6 +75,7 @@
   // Thead
   --pf-c-table-thead--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-table-thead--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-table--thead__flexible-wrapper--AlignItems: end;
 
   // Thead cell
   --pf-c-table-thead-cell--PaddingTop: var(--pf-global--spacer--md);
@@ -146,13 +190,46 @@
 
   // stylelint-enable
 
+  --pf-c-table__flexible-wrapper--AlignItems: start;
+  --pf-c-table__flexible-wrapper--JustifyContent: start;
+
+  // Text
+  --pf-c-table__text--Overflow: visible;
+  --pf-c-table__text--WhiteSpace: normal;
+  --pf-c-table__text--TextOverflow: clip;
+  --pf-c-table__text--WordBreak: normal;
+  --pf-c-table__text--MaxWidth: none;
+  --pf-c-table__text--MinWidth: auto;
+
+  // Text wrap
+  --pf-c-table__text--m-wrap--Overflow: visible;
+  --pf-c-table__text--m-wrap--WhiteSpace: normal;
+  --pf-c-table__text--m-wrap--TextOverflow: clip;
+  --pf-c-table__text--m-wrap--WordBreak: normal;
+
+  // Text truncate
+  --pf-c-table__text--m-truncate--Overflow: hidden;
+  --pf-c-table__text--m-truncate--WhiteSpace: nowrap;
+  --pf-c-table__text--m-truncate--TextOverflow: ellipsis;
+  --pf-c-table__text--m-truncate--WordBreak: break-word;
+  --pf-c-table__text--m-truncate--MinWidth: 6ch;
+  --pf-c-table__text--m-truncate--MaxWidth: 100%;
+
+  // Text no wrap
+  --pf-c-table__text--m-no-wrap--Overflow: visible;
+  --pf-c-table__text--m-no-wrap--WhiteSpace: nowrap;
+  --pf-c-table__text--m-no-wrap--TextOverflow: clip;
+  --pf-c-table__text--m-no-wrap--WordBreak: normal;
+  --pf-c-table__text--m-no-wrap--MinWidth: auto;
+  --pf-c-table__text--m-no-wrap--MaxWidth: none;
+
+  // Text break word
+  --pf-c-table__text--m-break-word--WordBreak: break-word;
+
   @include pf-t-light; // This component always needs to be light
 
   // Base
   width: 100%;
-
-  // Table requires a height to calculate
-  height: 100%;
   background-color: var(--pf-c-table--BackgroundColor);
 
   // Standard table row (non-expandable)
@@ -215,9 +292,14 @@
     --pf-c-table-cell--PaddingBottom: var(--pf-c-table-thead-cell--PaddingBottom);
     --pf-c-table-cell--FontSize: var(--pf-c-table-thead--FontSize);
     --pf-c-table-cell--FontWeight: var(--pf-c-table-thead--FontWeight);
+    --pf-c-table__flexible-wrapper--AlignItems: var(--pf-c-table--thead__flexible-wrapper--AlignItems);
 
-    white-space: nowrap;
-    vertical-align: top;
+    // @extend %pf-c-table__text--m-no-wrap;
+    @extend %pf-c-table__text--m-no-wrap;
+
+    > tr > * {
+      vertical-align: bottom;
+    }
   }
 
   // Table body cell
@@ -225,6 +307,10 @@
   tbody {
     --pf-c-table-cell--PaddingTop: var(--pf-c-table-tbody-cell--PaddingTop);
     --pf-c-table-cell--PaddingBottom: var(--pf-c-table-tbody-cell--PaddingBottom);
+
+    > tr > * {
+      vertical-align: baseline;
+    }
 
     // Border treatment
     // using first child as row does not calculate height appropriately
@@ -268,17 +354,103 @@
       font-size: inherit;
       font-weight: inherit;
       text-align: left;
+      white-space: normal;
     }
   }
 }
 
-// Toggle, check, action - minimize width and padding.
+// .pf-c-table__button {
+//   position: static;
+//   width: 100%;
+//   max-width: 100%;
+//   padding: var(--pf-c-table-cell--PaddingTop) var(--pf-c-table-cell--PaddingRight) var(--pf-c-table-cell--PaddingBottom) var(--pf-c-table-cell--PaddingLeft);
+//   overflow: hidden;
+//   border: 0;
+//   outline: 0;
+// }
+
+.pf-c-table__sort,
+.pf-c-table__compound-expansion-toggle {
+  &:active,
+  &:focus-within {
+    // background-color: red;
+    outline: -webkit-focus-ring-color auto 5px;
+    outline-offset: -5px;
+  }
+
+  .pf-c-button {
+    outline: 0;
+  }
+}
+
+.pf-c-table__sort .pf-c-button,
+.pf-c-table__sort .pf-c-table__button {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-content: flex-end;
+  height: 100%;
+}
+
+.pf-c-table__flexible-wrapper {
+  display: grid;
+  align-items: var(--pf-c-table__flexible-wrapper--AlignItems);
+  align-self: stretch;
+  justify-content: var(--pf-c-table__flexible-wrapper--JustifyContent);
+  min-width: var(--pf-c-table__flexible-wrapper--MinWidth);
+  grid-template-columns: auto;
+  grid-auto-columns: max-content;
+
+  // max-width: 100%;
+  // width: 100%;
+  // overflow: hidden;
+}
+
+// stylelint-disable selector-no-qualifying-type
+.pf-c-table th,
+.pf-c-table td,
+.pf-c-table__text,
+.pf-c-table__flexible-wrapper {
+  &.pf-m-wrap {
+    @extend %pf-c-table__text--m-wrap;
+  }
+
+  &.pf-m-truncate {
+    @extend %pf-c-table__text--m-truncate;
+  }
+
+  &.pf-m-no-wrap {
+    @extend %pf-c-table__text--m-no-wrap;
+  }
+
+  &.pf-m-break-word {
+    @extend %pf-c-table__text--m-break-word;
+  }
+}
+// stylelint-enable
+
+// Table text
+.pf-c-table__text {
+  min-width: var(--pf-c-table__text--MinWidth);
+  max-width: var(--pf-c-table__text--MaxWidth);
+  overflow: var(--pf-c-table__text--Overflow);
+  text-overflow: var(--pf-c-table__text--TextOverflow);
+  word-break: var(--pf-c-table__text--WordBreak);
+  white-space: var(--pf-c-table__text--WhiteSpace);
+}
+
+// Toggle, check, action - minimize padding.
+.pf-c-table .pf-c-table__toggle,
+.pf-c-table .pf-c-table__action,
+.pf-c-table .pf-c-table__inline-edit-action {
+  --pf-c-table-cell--PaddingBottom: 0;
+}
+
+// Toggle, check, action - minimize width.
 .pf-c-table .pf-c-table__toggle,
 .pf-c-table .pf-c-table__check,
 .pf-c-table .pf-c-table__action,
 .pf-c-table .pf-c-table__inline-edit-action {
-  --pf-c-table-cell--PaddingBottom: 0;
-
   width: 1%;
 }
 
@@ -388,6 +560,8 @@
   .pf-c-button {
     height: 100%;
 
+    // justify-content: flex-end;
+
     // stylelint-disable
     &.pf-m-plain {
       color: var(--pf-c-table__sort--c-button--Color);
@@ -395,12 +569,12 @@
   }
   // stylelint-enable
 
-  &.pf-m-wrap {
-    .pf-c-button {
-      display: flex;
-      white-space: normal;
-    }
-  }
+  // &.pf-m-wrap {
+  //   .pf-c-button {
+  //     display: flex;
+  //     white-space: normal;
+  //   }
+  // }
 
   &.pf-m-selected {
     // set button and indicator color
@@ -421,7 +595,7 @@
 
 // Sort indicator
 .pf-c-table__sort-indicator {
-  align-self: flex-start;
+  grid-column: 2;
   margin-left: var(--pf-c-table__sort-indicator--MarginLeft);
   line-height: var(--pf-c-table__sort-indicator--LineHeight);
   color: var(--pf-c-table__sort-indicator--Color);
@@ -581,11 +755,11 @@
   white-space: nowrap;
 }
 
-// Modifier - Wrap
-.pf-c-table .pf-m-wrap {
-  white-space: normal;
-  vertical-align: top;
-}
+// // Modifier - Wrap
+// .pf-c-table .pf-m-wrap {
+//   white-space: normal;
+//   vertical-align: top;
+// }
 
 // Modifier - Width
 // stylelint-disable

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -153,6 +153,9 @@
   --pf-c-table--nested--first-last-child--PaddingRight: var(--pf-global--spacer--3xl);
   --pf-c-table--nested--first-last-child--PaddingLeft: var(--pf-global--spacer--3xl);
 
+  // Outline offset
+  --pf-c-table--button--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
+
   // ============================================================ //
   // Modifiers
   // ============================================================ //
@@ -373,9 +376,14 @@
 .pf-c-table__compound-expansion-toggle {
   &:active,
   &:focus-within {
-    // background-color: red;
-    outline: -webkit-focus-ring-color auto 5px;
-    outline-offset: -5px;
+    outline-offset: var(--pf-c-table--button--OutlineOffset);
+
+    // stylelint-disable media-feature-name-no-vendor-prefix
+    @media (-webkit-min-device-pixel-ratio: 0) {
+      outline-style: auto;
+      outline-color: -webkit-focus-ring-color;
+    }
+    // stylelint-enable
   }
 
   .pf-c-button {

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -19,8 +19,8 @@
       {{#> table-th table-th--attribute='scope="col"'}}
         Last commit
       {{/table-th}}
-      {{#> table-td}}{{/table-td}}
-      {{#> table-td}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -29,20 +29,17 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow1" aria-labelledby="{{table--id}}-node1">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node1">Node 1</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 1" table-flexible-wrapper--example--id="node1" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 10</span>
+        <i class="fas fa-code-branch"></i> 10
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 25</span>
+        <i class="fas fa-code"></i> 25
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 5</span>
+        <i class="fas fa-cube"></i> 5
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
@@ -60,20 +57,17 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow2" aria-labelledby="{{table--id}}-node2">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node2">Node 2</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 2" table-flexible-wrapper--example--id="node2" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 8</span>
+        <i class="fas fa-code-branch"></i> 8
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 30</span>
+        <i class="fas fa-code"></i> 30
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 2</span>
+        <i class="fas fa-cube"></i> 2
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
@@ -91,20 +85,17 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow3" aria-labelledby="{{table--id}}-node3">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node3">Node 3</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 3" table-flexible-wrapper--example--id="node3" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 12</span>
+        <i class="fas fa-code-branch"></i> 12
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 48</span>
+        <i class="fas fa-code"></i> 48
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 13</span>
+        <i class="fas fa-cube"></i> 13
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         30 days ago
@@ -122,20 +113,17 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow4" aria-labelledby="{{table--id}}-node4">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node4">Node 4</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 4" table-flexible-wrapper--example--id="node4" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 3</span>
+        <i class="fas fa-code-branch"></i> 3
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 8</span>
+        <i class="fas fa-code"></i> 8
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 20</span>
+        <i class="fas fa-cube"></i> 20
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         8 days ago
@@ -153,20 +141,17 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow5" aria-labelledby="{{table--id}}-node5">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <div>
-          <div id="{{table--id}}-node5">Node 5</div>
-          <a href="#">siemur/test-space</a>
-        </div>
+      {{#> table-th table-th--data-label="Repository name" table-th--no-wrapper="true"}}
+        {{> table-flexible-wrapper table-flexible-wrapper--example="true" table-flexible-wrapper--example--text="Node 5" table-flexible-wrapper--example--id="node5" table-flexible-wrapper--example--HasLink="true"}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 34</span>
+        <i class="fas fa-code-branch"></i> 34
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 21</span>
+        <i class="fas fa-code"></i> 21
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 26</span>
+        <i class="fas fa-cube"></i> 26
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago


### PR DESCRIPTION
closes #2261
closes #2205
closes #2325

## Breaking changes
1. Sets `<td>` elements to wrap by default
2. Adds `.pf-m-truncate`, `.pf-m-wrap`, `.pf-m-no-wrap` to override default wrapping
3. Adds `.pf-c-table__flexible-wrapper`
