### PR TITLE
fix(modal): left aligned footer actions, removed pf-m-align-left

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -16,7 +16,7 @@ cssPrefix: pf-c-modal-box
   {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+  {{#> modal-box-footer}}
     Modal footer
   {{/modal-box-footer}}
 {{/modal-box}}
@@ -36,7 +36,7 @@ cssPrefix: pf-c-modal-box
     quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
     consequat.
   {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+  {{#> modal-box-footer}}
     Modal footer
   {{/modal-box-footer}}
 {{/modal-box}}
@@ -56,7 +56,7 @@ cssPrefix: pf-c-modal-box
     quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
     consequat.
   {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+  {{#> modal-box-footer}}
     Modal footer
   {{/modal-box-footer}}
 {{/modal-box}}
@@ -70,7 +70,7 @@ cssPrefix: pf-c-modal-box
   {{#> modal-box-body}}
     <span id="modal-no-header-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+  {{#> modal-box-footer}}
     Modal footer
   {{/modal-box-footer}}
 {{/modal-box}}
@@ -90,7 +90,7 @@ cssPrefix: pf-c-modal-box
   {{#> modal-box-body}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
-  {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+  {{#> modal-box-footer}}
     Modal footer
   {{/modal-box-footer}}
 {{/modal-box}}
@@ -123,4 +123,3 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |
 | `.pf-m-lg` | `.pf-c-modal-box` | Modifies for a large modal box width. |
-| `.pf-m-align-left` | `.pf-c-modal-box__foter` | Modifies for buttons in footer to be left aligned. **Required** |

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -113,12 +113,6 @@
   align-items: center;
   margin-top: var(--pf-c-modal-box__footer--MarginTop);
 
-  // Using margin-left instead of justify: flex-end; as there may be other elements in the footer that align left
-  // Limit scope to direct child buttons, allows use of layouts if needed
-  > .pf-c-button:first-of-type {
-    margin-left: var(--pf-c-modal-box__footer__c-button--first-of-type--MarginLeft);
-  }
-
   // Base margin left and right equal for buttons when wrapped
   > .pf-c-button:not(:last-child) {
     margin-right: var(--pf-c-modal-box__footer--c-button--MarginRight);
@@ -126,10 +120,6 @@
     @media screen and (min-width: $pf-global--breakpoint--sm) {
       --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-c-modal-box__footer--c-button--sm--MarginRight);
     }
-  }
-
-  &.pf-m-align-left {
-    --pf-c-modal-box__footer__c-button--first-of-type--MarginLeft: 0;
   }
 }
 

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -19,7 +19,7 @@ section: demos
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
         {{/modal-box-body}}
-        {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+        {{#> modal-box-footer}}
           {{#> button button--modifier="pf-m-primary"}}
             Overwrite
           {{/button}}
@@ -58,7 +58,7 @@ section: demos
           <p>Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
           </p>
         {{/modal-box-body}}
-        {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+        {{#> modal-box-footer}}
           {{#> button button--modifier="pf-m-primary"}}
             Overwrite
           {{/button}}
@@ -87,41 +87,12 @@ section: demos
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
           <p>Form here</p>
         {{/modal-box-body}}
-        {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
-          {{#> button button--modifier="pf-m-primary"}}
-            Save
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Cancel
-          {{/button}}
-        {{/modal-box-footer}}
-      {{/modal-box}}
-    {{/bullseye}}
-  {{/backdrop}}
-{{/modal}}
-```
-
-```hbs title=Right-aligned-footer-button-(legacy) isFullscreen
-{{#> modal}}
-  {{#> backdrop}}
-    {{#> bullseye}}
-      {{#> modal-box modal-box--attribute='aria-labelledby="modal-right-aligned-footer-title" aria-describedby="modal-right-aligned-footer-description"'}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-          <i class="fas fa-times" aria-hidden="true"></i>
-        {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-right-aligned-footer-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/title}}
-        {{#> modal-box-body}}
-          <p id="modal-right-aligned-footer-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
-          <p>Form here</p>
-        {{/modal-box-body}}
         {{#> modal-box-footer}}
-          {{#> button button--modifier="pf-m-link"}}
-            Cancel
-          {{/button}}
           {{#> button button--modifier="pf-m-primary"}}
             Save
+          {{/button}}
+          {{#> button button--modifier="pf-m-link"}}
+            Cancel
           {{/button}}
         {{/modal-box-footer}}
       {{/modal-box}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -401,7 +401,7 @@ section: demos
           {{/data-list-item}}
         {{/data-list}}
       {{/modal-box-body}}
-      {{#> modal-box-footer modal-box-footer--modifier="pf-m-align-left"}}
+      {{#> modal-box-footer}}
         {{#> button button--modifier="pf-m-primary"}}
           Save
         {{/button}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2620

## Breaking changes
* Buttons in the modal footer are now left-aligned by default. No further updates are needed to consume this change.
* `.pf-m-align-left` has been removed as it is no longer needed. It can be removed from any modal footer elements it is currently applied to.
* Removed `--pf-c-modal-box__footer__c-button--first-of-type--MarginLeft`. Please remove any instances of it in your application.