### PR TITLE
fix(page): updated page and page header background colors

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -1,8 +1,9 @@
 // URL.com/guidelines#layout
 .pf-c-page {
-  --pf-c-page--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
+  --pf-c-page--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
 
   // Header
+  --pf-c-page__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
   --pf-c-page__header--ZIndex: var(--pf-global--ZIndex--md);
   --pf-c-page__header--MinHeight: #{pf-size-prem(76px)}; // fixed height for header to ensure consistency across screen sizes.
 
@@ -192,6 +193,7 @@
   align-items: center;
   min-width: 0;
   min-height: var(--pf-c-page__header--MinHeight);
+  background-color: var(--pf-c-page__header--BackgroundColor);
 
   > * {
     display: flex;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2240

## Breaking changes
* Changes `--pf-c-page--BackgroundColor` from `--pf-global--BackgroundColor--dark-100` to `--pf-global--BackgroundColor--light-300`. This is just a visual change, no code updates are needed to consume it.
* Adds a background-color of `--pf-global--BackgroundColor--dark-100` to `.pf-c-page__header`. This is just a visual change, no code updates are needed to consume it.