### PR TITLE
style(vertical-nav): refactored css structure

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -212,6 +212,7 @@
   --pf-global--BorderWidth--sm: #{$pf-global--BorderWidth--sm};
   --pf-global--BorderWidth--md: #{$pf-global--BorderWidth--md};
   --pf-global--BorderWidth--lg: #{$pf-global--BorderWidth--lg};
+  --pf-global--BorderWidth--xl: #{$pf-global--BorderWidth--xl};
   --pf-global--BorderColor--100: #{$pf-global--BorderColor--100};
   --pf-global--BorderColor--200: #{$pf-global--BorderColor--200};
   --pf-global--BorderColor--300: #{$pf-global--BorderColor--300};

--- a/src/patternfly/components/Nav/examples/Nav.css
+++ b/src/patternfly/components/Nav/examples/Nav.css
@@ -1,19 +1,19 @@
-#ws-core-c-nav-basic,
-#ws-core-c-nav-grouped,
-#ws-core-c-nav-default,
-#ws-core-c-nav-expanded,
-#ws-core-c-nav-expanded-with-subnav-titles,
-#ws-core-c-nav-mixed {
+#ws-core-c-navigation-basic,
+#ws-core-c-navigation-grouped,
+#ws-core-c-navigation-default,
+#ws-core-c-navigation-expanded,
+#ws-core-c-navigation-expanded-with-subnav-titles,
+#ws-core-c-navigation-mixed {
   background-color: var(--pf-global--BackgroundColor--dark-300);
 }
 
-#ws-core-c-nav-horizontal-in-masthead,
-#ws-core-c-nav-horizontal-overflow-in-masthead {
+#ws-core-c-navigation-horizontal-in-masthead,
+#ws-core-c-navigation-horizontal-overflow-in-masthead {
   background-color: var(--pf-global--BackgroundColor--dark-100);
 }
 
-#ws-core-c-nav-horizontal-in-masthead .pf-c-page__header-nav,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-page__header-nav {
+#ws-core-c-navigation-horizontal-in-masthead .pf-c-page__header-navigation,
+#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-page__header-navigation {
   grid-row: 1 / 2;
   background-color: rgba(0,0,0,0);
   margin-left: 32px;
@@ -22,19 +22,19 @@
   align-self: flex-end;
 }
 
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__link,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__link {
+#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__link,
+#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__link {
   padding-top: 16px;
   padding-bottom: 24px;
 }
 
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button {
+#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__scroll-button,
+#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__scroll-button {
   background-color: var(--pf-global--BackgroundColor--100);
   top: 8px;
 }
 
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button:nth-of-type(1),
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button:nth-of-type(1) {
+#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__scroll-button:nth-of-type(1),
+#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__scroll-button:nth-of-type(1) {
   left: 0;
 }

--- a/src/patternfly/components/Nav/examples/Nav.css
+++ b/src/patternfly/components/Nav/examples/Nav.css
@@ -1,19 +1,19 @@
-#ws-core-c-navigation-basic,
-#ws-core-c-navigation-grouped,
-#ws-core-c-navigation-default,
-#ws-core-c-navigation-expanded,
-#ws-core-c-navigation-expanded-with-subnav-titles,
-#ws-core-c-navigation-mixed {
+#ws-core-c-nav-basic,
+#ws-core-c-nav-grouped,
+#ws-core-c-nav-default,
+#ws-core-c-nav-expanded,
+#ws-core-c-nav-expanded-with-subnav-titles,
+#ws-core-c-nav-mixed {
   background-color: var(--pf-global--BackgroundColor--dark-300);
 }
 
-#ws-core-c-navigation-horizontal-in-masthead,
-#ws-core-c-navigation-horizontal-overflow-in-masthead {
+#ws-core-c-nav-horizontal-in-masthead,
+#ws-core-c-nav-horizontal-overflow-in-masthead {
   background-color: var(--pf-global--BackgroundColor--dark-100);
 }
 
-#ws-core-c-navigation-horizontal-in-masthead .pf-c-page__header-navigation,
-#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-page__header-navigation {
+#ws-core-c-nav-horizontal-in-masthead .pf-c-page__header-nav,
+#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-page__header-nav {
   grid-row: 1 / 2;
   background-color: rgba(0,0,0,0);
   margin-left: 32px;
@@ -22,19 +22,19 @@
   align-self: flex-end;
 }
 
-#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__link,
-#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__link {
+#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__link,
+#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__link {
   padding-top: 16px;
   padding-bottom: 24px;
 }
 
-#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__scroll-button,
-#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__scroll-button {
+#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button,
+#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button {
   background-color: var(--pf-global--BackgroundColor--100);
   top: 8px;
 }
 
-#ws-core-c-navigation-horizontal-in-masthead .pf-c-navigation__scroll-button:nth-of-type(1),
-#ws-core-c-navigation-horizontal-overflow-in-masthead .pf-c-navigation__scroll-button:nth-of-type(1) {
+#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button:nth-of-type(1),
+#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button:nth-of-type(1) {
   left: 0;
 }

--- a/src/patternfly/components/Nav/examples/Nav.css
+++ b/src/patternfly/components/Nav/examples/Nav.css
@@ -11,30 +11,3 @@
 #ws-core-c-nav-horizontal-overflow-in-masthead {
   background-color: var(--pf-global--BackgroundColor--dark-100);
 }
-
-#ws-core-c-nav-horizontal-in-masthead .pf-c-page__header-nav,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-page__header-nav {
-  grid-row: 1 / 2;
-  background-color: rgba(0,0,0,0);
-  margin-left: 32px;
-  margin-right: 32px;
-  padding-left: 0;
-  align-self: flex-end;
-}
-
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__link,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__link {
-  padding-top: 16px;
-  padding-bottom: 24px;
-}
-
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button,
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button {
-  background-color: var(--pf-global--BackgroundColor--100);
-  top: 8px;
-}
-
-#ws-core-c-nav-horizontal-in-masthead .pf-c-nav__scroll-button:nth-of-type(1),
-#ws-core-c-nav-horizontal-overflow-in-masthead .pf-c-nav__scroll-button:nth-of-type(1) {
-  left: 0;
-}

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -396,6 +396,102 @@ import './Nav.css'
 {{/nav}}
 ```
 
+```hbs title=Default-light-mode
+{{#> nav nav--attribute='aria-label="Global"'}}
+  {{#> nav-list}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Current link
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Link 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Link 3
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--modifier="pf-m-disabled" nav-link--href="#"}}
+        Disabled
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
+```
+
+```hbs title=Expanded-in-light-mode
+{{#> nav nav--attribute='aria-label="Global"'}}
+  {{#> nav-list}}
+    {{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
+      {{#> nav-link nav-link--href="#" nav-link--attribute='id="expandable-example1"'}}
+        Link 1 (current and expanded example)
+      {{/nav-link}}
+      {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example1"'}}
+        {{#> nav-list nav-list--type="simple"}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+              Current link
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 2
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 3
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav-subnav}}
+    {{/nav-item}}
+    {{#> nav-item nav-item--expandable="true" nav-item--expanded="true"}}
+      {{#> nav-link nav-link--href="#" nav-link--attribute='id="expandable-example2"'}}
+        Link 2 (expanded, but not current example)
+      {{/nav-link}}
+      {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example2"'}}
+        {{#> nav-list nav-list--type="simple"}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 1
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 2
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav-subnav}}
+    {{/nav-item}}
+    {{#> nav-item nav-item--expandable="true"}}
+      {{#> nav-link nav-link--href="#" nav-link--attribute='id="expandable-example3"'}}
+        Link 3
+      {{/nav-link}}
+      {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example3"'}}
+        {{#> nav-list nav-list--type="simple"}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 1
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Subnav link 2
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav-subnav}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
+```
+
 ## Documentation
 ### Overview
 The navigation system relies on several different sub-components:

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -27,8 +27,8 @@ import './Nav.css'
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
-      {{#> nav-link nav-link--href="#"}}
-        Link 4
+      {{#> nav-link nav-link--modifier="pf-m-disabled" nav-link--href="#"}}
+        Disabled
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -98,6 +98,7 @@ import './Nav.css'
               Current link
             {{/nav-link}}
           {{/nav-item}}
+          {{> divider divider--type="li"}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Subnav link 2
@@ -437,6 +438,7 @@ import './Nav.css'
               Current link
             {{/nav-link}}
           {{/nav-item}}
+          {{> divider divider--type="li"}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Subnav link 2
@@ -510,7 +512,6 @@ The navigation system relies on several different sub-components:
 | `aria-expanded="true"` | `.pf-c-nav__link` |  Indicates that subnav section is visible. |
 | `hidden` | `.pf-c-nav__subnav` |  Indicates that the subnav section is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
 | `aria-current="page"` | `.pf-c-nav__link` |  Indicates the current page link. Can only occur once on page. |
-| `role="separator"` | `.pf-c-nav__separator` |  Indicates that the divider separates and distinguishes sections of links in the nav. |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -520,7 +521,6 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__list` | `<ul>` | Initiates default nav list. |
 | `.pf-c-nav__simple-list` | `<ul>` | Initiates simple nav list. |
 | `.pf-c-nav__item` | `<li>` | Initiates default nav list item. |
-| `.pf-c-nav__separator` | `<li>` | Initiates list separator. |
 | `.pf-c-nav__scroll-button` | `<button>` | Intitiates a nav scroll button. **Required for horizontal navs** |
 | `.pf-c-nav__link` | `<a>` | Initiates default nav list link. |
 | `.pf-c-nav__section` | `<section>` | Initiates a nav section element. |

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -21,7 +21,6 @@ import './Nav.css'
         Link 2
       {{/nav-link}}
     {{/nav-item}}
-    {{#> divider divider--type="li"}}{{/divider}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#"}}
         Link 3
@@ -42,7 +41,7 @@ import './Nav.css'
     {{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
       Section title 1
     {{/nav-section-title}}
-    {{#> nav-list}}
+    {{#> nav-list nav-list--type="simple"}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
           Link 1
@@ -64,7 +63,7 @@ import './Nav.css'
     {{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
       Section title 2
     {{/nav-section-title}}
-    {{#> nav-list}}
+    {{#> nav-list nav-list--type="simple"}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#" nav-link--current="true"}}
           Current link
@@ -93,18 +92,12 @@ import './Nav.css'
         Link 1 (current and expanded example)
       {{/nav-link}}
       {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example1"'}}
-        {{!--
-        {{#> nav-subnav-title}}
-          Current and expanded example sub-navigation
-        {{/nav-subnav-title}}
-        --}}
         {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#" nav-link--current="true"}}
               Current link
             {{/nav-link}}
           {{/nav-item}}
-          {{#> divider divider--type="li"}}{{/divider}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Subnav link 2
@@ -129,7 +122,6 @@ import './Nav.css'
               Subnav link 1
             {{/nav-link}}
           {{/nav-item}}
-          {{#> divider divider--type="li"}}{{/divider}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Subnav link 2

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -12,18 +12,23 @@ import './Nav.css'
 {{#> nav nav--attribute='aria-label="Global"' nav--modifier="pf-m-dark"}}
   {{#> nav-list}}
     {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Link 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
         Current link
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#"}}
-        Link 2
+        Link 3
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#"}}
-        Link 3
+        Link 4
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
@@ -49,7 +54,7 @@ import './Nav.css'
       {{/nav-item}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
-          Disabled link
+          Link 2
         {{/nav-link}}
       {{/nav-item}}
       {{#> nav-item}}
@@ -65,13 +70,13 @@ import './Nav.css'
     {{/nav-section-title}}
     {{#> nav-list nav-list--type="simple"}}
       {{#> nav-item}}
-        {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-          Current link
+        {{#> nav-link nav-link--href="#"}}
+          Link 1
         {{/nav-link}}
       {{/nav-item}}
       {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Link 2
+        {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+          Current link
         {{/nav-link}}
       {{/nav-item}}
       {{#> nav-item}}
@@ -94,7 +99,7 @@ import './Nav.css'
       {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example1"'}}
         {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+            {{#> nav-link nav-link--href="#"}}
               Current link
             {{/nav-link}}
           {{/nav-item}}
@@ -105,7 +110,7 @@ import './Nav.css'
             {{/nav-link}}
           {{/nav-item}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
               Subnav link 3
             {{/nav-link}}
           {{/nav-item}}
@@ -167,12 +172,12 @@ import './Nav.css'
         {{/nav-subnav-title}}
         {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+            {{#> nav-link nav-link--href="#"}}
               Current link
             {{/nav-link}}
           {{/nav-item}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
               Subnav link 2
             {{/nav-link}}
           {{/nav-item}}
@@ -239,7 +244,7 @@ import './Nav.css'
     {{/nav-item}}
     {{#> nav-item nav-item--expandable="true" nav-item--current="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute='id="nav-mixed-link4"'}}
-        Link 4 (current, but not expanded example)
+        Link 3 (current, but not expanded example)
       {{/nav-link}}
       {{#> nav-subnav nav-subnav--attribute='aria-labelledby="nav-mixed-link4"'}}
         {{#> nav-list nav-list--type="simple"}}

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -526,7 +526,7 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__section` | `<section>` | Initiates a nav section element. |
 | `.pf-c-nav__section-title` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>` | Initiates a nav section title. |
 | `.pf-c-nav__toggle` | `<span>` | Initiates a chevron indicating expandability of a `pf-c-nav__list-link`. |
-| `.pf-c-nav__toggle-icon` | `<i>` | Initiates a nav toggle icon. |
+| `.pf-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon. |
 | `.pf-m-dark` | `.pf-c-nav` | Modifies the nav for the dark variation. **Note: only for use with vertical navs, and requires `.pf-m-dark` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |
 | `.pf-m-expandable` | `.pf-c-nav__item` | Modifies for the expandable state. |
 | `.pf-m-expanded` | `.pf-c-nav__item` | Modifies for the expanded state. |

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -31,11 +31,6 @@ import './Nav.css'
         Link 4
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item}}
-      {{#> nav-link nav-link--modifier="pf-m-disabled" nav-link--href="#"}}
-        Disabled
-      {{/nav-link}}
-    {{/nav-item}}
   {{/nav-list}}
 {{/nav}}
 ```
@@ -406,12 +401,12 @@ import './Nav.css'
 {{#> nav nav--attribute='aria-label="Global"'}}
   {{#> nav-list}}
     {{#> nav-item}}
-      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+      {{#> nav-link nav-link--href="#"}}
         Current link
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
-      {{#> nav-link nav-link--href="#"}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
         Link 2
       {{/nav-link}}
     {{/nav-item}}
@@ -421,8 +416,8 @@ import './Nav.css'
       {{/nav-link}}
     {{/nav-item}}
     {{#> nav-item}}
-      {{#> nav-link nav-link--modifier="pf-m-disabled" nav-link--href="#"}}
-        Disabled
+      {{#> nav-link nav-link--href="#"}}
+        Link 4
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
@@ -439,7 +434,7 @@ import './Nav.css'
       {{#> nav-subnav nav-subnav--attribute='aria-labelledby="expandable-example1"'}}
         {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+            {{#> nav-link nav-link--href="#"}}
               Current link
             {{/nav-link}}
           {{/nav-item}}
@@ -450,7 +445,7 @@ import './Nav.css'
             {{/nav-link}}
           {{/nav-item}}
           {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
               Subnav link 3
             {{/nav-link}}
           {{/nav-item}}

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -534,6 +534,5 @@ The navigation system relies on several different sub-components:
 | `.pf-m-focus` | `.pf-c-nav__link` | Modifies to display the link as focussed. |
 | `.pf-m-current` | `.pf-c-nav__link` | Modifies for the current state. |
 | `.pf-m-active` | `.pf-c-nav__link` | Modifies to display the link as active. |
-| `.pf-m-disabled` | `.pf-c-nav__link` | Modifies to display the link as disabled. |
 | `.pf-m-start` | `.pf-c-nav` | Modifiers the nav to show the overflow at the start. |
 | `.pf-m-end` | `.pf-c-nav` | Modifiers the nav to show the overflow at the end. |

--- a/src/patternfly/components/Nav/nav-link.hbs
+++ b/src/patternfly/components/Nav/nav-link.hbs
@@ -1,4 +1,4 @@
-<a href="{{nav-link--href}}" class="pf-c-nav__link{{#if nav-link--current}} pf-m-current{{/if}}{{#if nav-link--disabled}} pf-m-disabled{{/if}}{{#if nav-link--modifier}} {{nav-link--modifier}}{{/if}}"
+<a href="{{nav-link--href}}" class="pf-c-nav__link{{#if nav-link--current}} pf-m-current{{/if}}{{#if nav-link--modifier}} {{nav-link--modifier}}{{/if}}"
   {{#if nav-link--attribute}}
     {{{nav-link--attribute}}}
   {{/if}}

--- a/src/patternfly/components/Nav/nav-toggle-icon.hbs
+++ b/src/patternfly/components/Nav/nav-toggle-icon.hbs
@@ -1,1 +1,3 @@
-<i class="fas fa-angle-right" aria-hidden="true"></i>
+<span class="pf-c-nav__toggle-icon">
+  <i class="fas fa-angle-right" aria-hidden="true"></i>
+</span>

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -257,6 +257,7 @@
   font-size: var(--pf-c-nav__link--FontSize);
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
+  user-select: text;
   background-color: var(--pf-c-nav__link--BackgroundColor);
 
   &::before,

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -9,17 +9,17 @@
   --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
   --pf-c-nav--m-dark__link--after--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-c-nav__link--before--BorderColor);
-  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
+  --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__item--before--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
 
   // Link
   --pf-c-nav__link--FontSize: var(--pf-global--FontSize--md);
@@ -44,20 +44,11 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
-  // Link ::before borders
-  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__link--hover--BackgroundColor);
-  --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__link--before--BorderTopWidth: 0;
-  --pf-c-nav__link--before--BorderBottomWidth: 0;
-
   // Link ::after borders
   --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-nav__link--after--BorderBottomWidth: 0;
   --pf-c-nav__link--after--BorderLeftWidth: 0;
-
-  // Nav list
-  --pf-c-nav__list__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Simple list
   --pf-c-nav__simple-list__link--MarginTop: var(--pf-global--spacer--sm);
@@ -73,8 +64,6 @@
   --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
 
   // Horizontal list
-  // --pf-c-nav__horizontal-list__item--MarginRight: var(--pf-global--spacer--xl);
-
   --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-nav__horizontal-list__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-global--spacer--sm);
@@ -108,7 +97,7 @@
   --pf-c-nav__tertiary-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--after--BorderColor: var(--pf-global--active-color--100);
 
-  // Horizonta/tertiary list offsets
+  // Horizontal/tertiary list offsets
   --pf-c-nav__link--offset: calc(var(--pf-global--spacer--xs) * -1);
 
   // Sub nav
@@ -116,8 +105,6 @@
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-nav__subnav__link--before--BorderTopWidth: 0;
-  --pf-c-nav__subnav__link--before--BorderBottomWidth: 0;
   --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
   --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
 
@@ -136,6 +123,10 @@
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
   --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
+
+  // Nav item
+  --pf-c-nav__item--before--Height: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__item--before--BackgroundColor: var(--pf-global--BorderColor--300);
 
   // Scroll button
   --pf-c-nav__scroll-button--Display: none;
@@ -165,6 +156,7 @@
   --pf-c-nav__c-divider--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-nav--c-divider--PaddingRight: 0;
   --pf-c-nav--c-divider--PaddingLeft: 0;
+  --pf-c-nav__c-divider--BackgroundColor: var(--pf-global--BorderColor--300);
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-nav__link--PaddingRight: var(--pf-c-nav__link--md--PaddingRight);
@@ -200,6 +192,7 @@
     --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor);
     --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
     --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
+    --pf-c-nav__item--before--BackgroundColor: var(--pf-c-nav--m-dark__item--before--BackgroundColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
@@ -214,7 +207,7 @@
 
   // Divider
   .pf-c-divider {
-    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
+    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__c-divider--BackgroundColor);
 
     padding-right: var(--pf-c-nav--c-divider--PaddingRight);
     padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
@@ -248,6 +241,20 @@
   transform: var(--pf-c-nav__item--m-expanded__toggle--i--Transform);
 }
 
+.pf-c-nav__item {
+  position: relative;
+
+  &::before {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: var(--pf-c-nav__item--before--Height);
+    content: "";
+    background-color: var(--pf-c-nav__item--before--BackgroundColor);
+  }
+}
+
 // Nav link
 .pf-c-nav__link {
   position: relative;
@@ -260,32 +267,15 @@
   user-select: text;
   background-color: var(--pf-c-nav__link--BackgroundColor);
 
-  &::before,
   &::after {
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
-
-    // set pointer events so text is selectable
-    pointer-events: none;
     content: "";
-    border-width: 0;
-  }
-
-  &::before {
-    right: 0;
-    border-color: var(--pf-c-nav__link--before--BorderColor);
-    border-style: solid;
-    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);
-    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
-  }
-
-  &::after {
     border-color: var(--pf-c-nav__link--after--BorderColor);
     border-style: solid;
-    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth);
-    border-left-width: var(--pf-c-nav__link--after--BorderLeftWidth);
+    border-width: 0 0 var(--pf-c-nav__link--after--BorderBottomWidth) var(--pf-c-nav__link--after--BorderLeftWidth);
   }
 
   // States
@@ -324,17 +314,6 @@
   }
 }
 
-// List default
-.pf-c-nav__list {
-  --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__link--before--BorderWidth);
-
-  border-bottom: var(--pf-c-nav__link--before--BorderWidth) solid var(--pf-c-nav__link--before--BorderColor);
-
-  .pf-c-nav__item:first-child {
-    --pf-c-nav__link--before--BorderTopWidth: 0;
-  }
-}
-
 // Active border treatment
 .pf-c-nav__list,
 .pf-c-nav__simple-list {
@@ -354,6 +333,10 @@
   --pf-c-nav--c-divider--PaddingRight: var(--pf-c-nav__simple-list__link--PaddingRight);
   --pf-c-nav--c-divider--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
 
+  .pf-c-nav__item {
+    --pf-c-nav__item--before--BackgroundColor: transparent;
+  }
+
   .pf-c-nav__link {
     margin-top: var(--pf-c-nav__simple-list__link--MarginTop);
     margin-bottom: var(--pf-c-nav__simple-list__link--MarginBottom);
@@ -365,6 +348,10 @@
 .pf-c-nav__tertiary-list {
   --pf-c-nav__link--Right: var(--pf-c-nav__link--PaddingRight);
   --pf-c-nav__link--Left: var(--pf-c-nav__link--PaddingLeft);
+
+  .pf-c-nav__item {
+    --pf-c-nav__item--before--BackgroundColor: transparent;
+  }
 
   @include pf-overflow-hide-scroll;
 
@@ -441,8 +428,6 @@
 
 // Subnav
 .pf-c-nav__subnav {
-  --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__subnav__link--before--BorderTopWidth);
-  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__subnav__link--before--BorderBottomWidth);
   --pf-c-nav__link--FontSize: var(--pf-c-nav__subnav__link--FontSize);
   --pf-c-nav__simple-list__link--MarginTop: var(--pf-c-nav--subnav__simple-list__link--MarginTop);
   --pf-c-nav__simple-list__link--MarginBottom: var(--pf-c-nav--subnav__simple-list__link--MarginBottom);
@@ -452,10 +437,6 @@
   padding-bottom: var(--pf-c-nav__subnav--PaddingBottom);
   padding-left: var(--pf-c-nav__subnav--PaddingLeft);
   transition: var(--pf-c-nav--Transition);
-
-  .pf-c-nav__item:last-child {
-    --pf-c-nav__link--before--BorderBottomWidth: 0;
-  }
 
   .pf-c-nav__item.pf-m-expanded & {
     max-height: var(--pf-c-nav__subnav--MaxHeight);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -285,7 +285,6 @@
 
   &::before {
     right: 0;
-    z-index: -1;
     border-color: var(--pf-c-nav__link--before--BorderColor);
     border-style: solid;
     border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,169 +1,117 @@
 .pf-c-nav {
   --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);
-  --pf-c-nav__item--m-expanded__toggle-icon--Transform: rotate(90deg);
+  --pf-c-nav__item--m-expanded__toggle--i--Transform: rotate(90deg);
 
-  // dark modifier
-  --pf-c-nav--m-dark__list-link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav--m-dark__list-link--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav--m-dark__list-link--Color: var(--pf-global--Color--light-300);
-  --pf-c-nav--m-dark__list-link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__list-link--hover--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__list-link--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__list-link--after--Bottom: var(--pf-global--spacer--sm);
-  --pf-c-nav--m-dark__list-link--active--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__simple-list-link--Color: var(--pf-global--Color--light-300);
-  --pf-c-nav--m-dark__simple-list-link--hover--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__simple-list-link--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__simple-list-link--active--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__simple-list-link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__simple-list-link--focus--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__simple-list-link--active--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__simple-list-link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__simple-list-link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__item--m-expanded--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav--m-dark__item--m-expanded__list-link--after--Bottom: 0;
-  --pf-c-nav--m-dark__item--m-expanded__list-link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav--m-dark__item--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__item--m-current__simple-list-link--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__item--m-current__list-link--Color: var(--pf-global--Color--light-100);
+  // Dark theme
+  --pf-c-nav--m-dark__link--BackgroundColor: transparent;
+  --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--hover--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
+  --pf-c-nav--m-dark__link--before--BorderColor: #{$pf-global--BackgroundColor--dark-200};
+  --pf-c-nav--m-dark__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav--m-dark__link--hover--BackgroundColor: #{rgba($pf-global--BackgroundColor--dark-200, .5)};
+  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__separator--BackgroundColor: var(--pf-global--BackgroundColor--dark-400); // remove at breaking change
-  --pf-c-nav--m-dark__item--m-current__c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
-  --pf-c-nav--m-dark__item--m-current__separator--BackgroundColor: var(--pf-global--BackgroundColor--dark-300); // remove at breaking change
-  --pf-c-nav--m-dark__subnav--MarginTop: 0;
-  --pf-c-nav--m-dark__list-link--after--Width: #{pf-size-prem(40px)};
+  --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-c-nav__link--before--BorderColor);
 
-  // divider
-  --pf-c-nav__c-divider--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__c-divider--MarginBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__c-divider--MarginLeft: var(--pf-c-nav__list-link--PaddingLeft);
-  --pf-c-nav__simple-list__c-divider--MarginLeft: var(--pf-c-nav__simple-list-link--PaddingLeft);
-  --pf-c-nav__simple-list--nested__c-divider--MarginLeft: var(--pf-c-nav__simple-list-link--nested--PaddingLeft);
+  // Link
+  --pf-c-nav__link--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-nav__link--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-nav__link--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__link--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-nav__link--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-nav__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--BackgroundColor: transparent;
+  --pf-c-nav__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
+  --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
-  // List link
-  --pf-c-nav__list-link--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-nav__list-link--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-nav__list-link--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__list-link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__list-link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-nav__list-link--md--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-nav__list-link--after--Width: #{pf-size-prem(50px)};
-  --pf-c-nav__list-link--after--Height: #{pf-size-prem(3px)};
+  // Link ::before borders
+  --pf-c-nav__link--before--BorderStyle: solid;
+  --pf-c-nav__link--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__link--before--BorderTopWidth: 0;
+  --pf-c-nav__link--before--BorderBottomWidth: 0;
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-nav__list-link--PaddingRight: var(--pf-c-nav__list-link--md--PaddingRight);
-    --pf-c-nav__list-link--PaddingLeft: var(--pf-c-nav__list-link--md--PaddingLeft);
-  }
+  // Link ::before borders
+  --pf-c-nav__link--after--BorderStyle: solid;
+  --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
+  --pf-c-nav__link--after--BorderBottomWidth: 0;
+  --pf-c-nav__link--after--BorderLeftWidth: 0;
 
-  // font weight
-  --pf-c-nav__list-link--FontWeight: var(--pf-global--FontWeight--normal);
-  --pf-c-nav__list-link--active--FontWeight: var(--pf-global--FontWeight--normal);
-  --pf-c-nav__list-link--focus--FontWeight: var(--pf-global--FontWeight--normal);
+  // Nav list
+  --pf-c-nav__list__link--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__list__link--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__list__link--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-nav__list__link--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-nav__list__link--md--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__list__link--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-nav__list__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
-  // color
-  --pf-c-nav__list-link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__list-link--hover--Color: var(--pf-global--link--Color);
-  --pf-c-nav__list-link--active--Color: var(--pf-global--link--Color);
-  --pf-c-nav__list-link--focus--Color: var(--pf-global--link--Color);
+  // Simple list
+  --pf-c-nav__simple-list__link--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-nav__simple-list__link--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav__simple-list__link--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-nav__simple-list__link--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__simple-list__link--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav__simple-list__link--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
 
-  // after
-  --pf-c-nav__list-link--after--Bottom: 0;
-  --pf-c-nav__list-link--after--Left: var(--pf-c-nav__list-link--PaddingLeft);
-  --pf-c-nav__list-link--after--md--Left: var(--pf-c-nav__list-link--md--PaddingLeft);
-  --pf-c-nav__list-link--hover--after--BackgroundColor: var(--pf-global--link--Color);
-  --pf-c-nav__list-link--active--after--BackgroundColor: var(--pf-global--link--Color);
-  --pf-c-nav__list-link--focus--after--BackgroundColor: var(--pf-global--link--Color);
+  // Horizontal list
+  --pf-c-nav__horizontal-list__item--MarginRight: var(--pf-global--spacer--xl);
+  --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-nav__horizontal-list__link--PaddingRight: 0;
+  --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav__horizontal-list__link--PaddingLeft: 0;
+  --pf-c-nav__horizontal-list__link--md--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__horizontal-list__link--lg--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list__link--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
+  --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-nav__list-link--after--Left: var(--pf-c-nav__list-link--after--md--Left);
-  }
+  // Tertiary list
+  --pf-c-nav__tertiary-list__item--MarginRight: var(--pf-global--spacer--xl);
+  --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__tertiary-list__link--PaddingRight: 0;
+  --pf-c-nav__tertiary-list__link--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav__tertiary-list__link--PaddingLeft: 0;
+  --pf-c-nav__tertiary-list__link--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
+  --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
 
-  // List simple link
-  --pf-c-nav__simple-list-link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__simple-list-link--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__simple-list-link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__simple-list-link--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-nav__simple-list-link--nested--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-nav__simple-list-link--nested--md--PaddingLeft: calc(var(--pf-global--spacer--lg) + var(--pf-global--spacer--md));
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-nav__simple-list-link--nested--PaddingLeft: var(--pf-c-nav__simple-list-link--nested--md--PaddingLeft);
-  }
-
-  // font
-  --pf-c-nav__simple-list-link--FontWeight: var(--pf-global--FontWeight--normal);
-  --pf-c-nav__simple-list-link--active--FontWeight: var(--pf-global--FontWeight--semi-bold);
-  --pf-c-nav__simple-list-link--focus--FontWeight: var(--pf-global--FontWeight--semi-bold);
-
-  // color
-  --pf-c-nav__simple-list-link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__simple-list-link--hover--Color: var(--pf-global--link--Color);
-  --pf-c-nav__simple-list-link--active--Color: var(--pf-global--link--Color);
-  --pf-c-nav__simple-list-link--focus--Color: var(--pf-global--link--Color);
-
-  // background
-  --pf-c-nav__simple-list-link--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
-  --pf-c-nav__simple-list-link--active--BackgroundColor: var(--pf-global--BackgroundColor--200);
-  --pf-c-nav__simple-list-link--focus--BackgroundColor: var(--pf-global--BackgroundColor--200);
-
-  // List horizontal link
-  --pf-c-nav__horizontal-list-item--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list-link--md--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list-link--lg--PaddingBottom: var(--pf-global--spacer--lg);
-
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-c-nav__horizontal-list-link--lg--PaddingBottom);
-    --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-c-nav__horizontal-list-link--md--PaddingTop);
-  }
-
-  // font
-  --pf-c-nav__horizontal-list-link--FontWeight: var(--pf-global--FontWeight--normal);
-
-  // color
-  --pf-c-nav__horizontal-list-link--Color: var(--pf-global--Color--light-300);
-  --pf-c-nav__horizontal-list-link--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list-link--active--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list-link--focus--Color: var(--pf-global--active-color--400);
-
-  // after
-  --pf-c-nav__horizontal-list-link--after--Height: #{pf-size-prem(3px)};
-  --pf-c-nav__horizontal-list-link--hover--after--BackgroundColor: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list-link--active--after--BackgroundColor: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list-link--focus--after--BackgroundColor: var(--pf-global--active-color--400);
-
-  // List tertiary item
-  --pf-c-nav__tertiary-list-item--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-nav__tertiary-list-link--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-nav__tertiary-list-link--PaddingBottom: var(--pf-global--spacer--sm);
-
-  // font
-  --pf-c-nav__tertiary-list-link--FontWeight: var(--pf-global--FontWeight--normal);
-
-  // color
-  --pf-c-nav__tertiary-list-link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__tertiary-list-link--hover--Color: var(--pf-global--link--Color);
-  --pf-c-nav__tertiary-list-link--active--Color: var(--pf-global--link--Color);
-  --pf-c-nav__tertiary-list-link--focus--Color: var(--pf-global--link--Color);
-
-  // after
-  --pf-c-nav__tertiary-list-link--after--Height: #{pf-size-prem(3px)};
-  --pf-c-nav__tertiary-list-link--hover--after--BackgroundColor: var(--pf-global--link--Color);
-  --pf-c-nav__tertiary-list-link--active--after--BackgroundColor: var(--pf-global--link--Color);
-  --pf-c-nav__tertiary-list-link--focus--after--BackgroundColor: var(--pf-global--link--Color);
-
-  // Subnav links
-  --pf-c-nav__subnav--MarginTop: var(--pf-global--spacer--sm);
+  // Sub nav
   --pf-c-nav__subnav--MaxHeight: 100%;
-
-  // List toggle
-  --pf-c-nav__list-toggle--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-nav__list-toggle--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-nav__list-toggle--FontSize: #{pf-font-prem(16px)}; // set unique font size for dropdown caret based on design spec
-  --pf-c-nav__list-toggle--Transition: .2s ease-in 0s;
+  --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__list__link--PaddingLeft);
+  --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-nav__subnav__link--before--BorderTopWidth: 0;
+  --pf-c-nav__subnav__link--before--BorderBottomWidth: 0;
+  --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
+  --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
 
   // Nav section
   --pf-c-nav__section--MarginTop: var(--pf-global--spacer--sm);
@@ -172,55 +120,22 @@
   // Nav section title
   --pf-c-nav__section-title--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-nav__section-title--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-nav__section-title--md--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__section-title--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav__section-title--md--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
-  --pf-c-nav__section-title--FontWeight: var(--pf-global--FontWeight--semi-bold);
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-nav__section-title--PaddingRight: var(--pf-c-nav__section-title--md--PaddingRight);
-    --pf-c-nav__section-title--PaddingLeft: var(--pf-c-nav__section-title--md--PaddingLeft);
-  }
-
-  // ============================================================ //
-  // Modifiers
-  // ============================================================ //
-
-  // Modifier - current item
-  --pf-c-nav__list-link--m-current--Color: var(--pf-global--link--Color);
-  --pf-c-nav__list-link--m-current--FontWeight: var(--pf-global--FontWeight--semi-bold);
-  --pf-c-nav__list-link--m-current--after--BackgroundColor: var(--pf-global--link--Color);
-
-  // Modifier - simple list current
-  --pf-c-nav__simple-list-link--m-current--Color: var(--pf-global--link--Color);
-  --pf-c-nav__simple-list-link--m-current--FontWeight: var(--pf-global--FontWeight--semi-bold);
-  --pf-c-nav__simple-list-link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--200);
-
-  // List item seperator
-  --pf-c-nav__separator--Height: var(--pf-global--BorderWidth--sm); // remove at breaking change
-  --pf-c-nav__separator--BackgroundColor: var(--pf-global--BorderColor--100); // remove at breaking change
-  --pf-c-nav__separator--MarginTop: var(--pf-global--spacer--sm); // remove at breaking change
-  --pf-c-nav__separator--MarginBottom: var(--pf-global--spacer--sm); // remove at breaking change
-  --pf-c-nav__separator--MarginLeft: var(--pf-c-nav__list-link--PaddingLeft); // remove at breaking change
-  --pf-c-nav__simple-list__separator--MarginLeft: var(--pf-c-nav__simple-list-link--PaddingLeft); // remove at breaking change
-  --pf-c-nav__simple-list--nested__separator--MarginLeft: var(--pf-c-nav__simple-list-link--nested--PaddingLeft); // remove at breaking change
-
-  // Modifier - current item
-  --pf-c-nav__horizontal-list-link--m-current--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list-link--m-current--after--BackgroundColor: var(--pf-global--active-color--400);
-
-  // Modifier - current item
-  --pf-c-nav__tertiary-list-link--m-current--Color: var(--pf-global--link--Color);
-  --pf-c-nav__tertiary-list-link--m-current--after--BackgroundColor: var(--pf-global--link--Color);
+  --pf-c-nav__section-title--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__section-title--BorderBottomStyle: solid;
 
   // Scroll button
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
-  --pf-c-nav__scroll-button--Height: #{pf-size-prem(40px)};
+  --pf-c-nav__scroll-button--Height: var(--pf-global--target-size--MinHeight);
   --pf-c-nav__scroll-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
@@ -230,12 +145,51 @@
   --pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
 
-  // Base styling
+
+  // List toggle
+  --pf-c-nav__toggle--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-nav__toggle--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-nav__toggle--FontSize: var(--pf-global--icon--FontSize--md);
+  --pf-c-nav__toggle--Transition: var(--pf-global--TransitionDuration);
+
+  // Divider
+  --pf-c-nav__c-divider--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-nav__c-divider--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav--c-divider--PaddingRight: 0;
+  --pf-c-nav--c-divider--PaddingLeft: 0;
+
+  @media screen and (min-width: $pf-global--breakpoint--md) {
+    --pf-c-nav__list__link--PaddingRight: var(--pf-c-nav__list__link--md--PaddingRight);
+    --pf-c-nav__list__link--PaddingLeft: var(--pf-c-nav__list__link--md--PaddingLeft);
+    --pf-c-nav__section-title--PaddingRight: var(--pf-c-nav__section-title--md--PaddingRight);
+    --pf-c-nav__section-title--PaddingLeft: var(--pf-c-nav__section-title--md--PaddingLeft);
+    --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--md--PaddingTop);
+    --pf-c-nav__subnav--PaddingLeft: var(--pf-c-nav__subnav--md--PaddingLeft);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-c-nav__horizontal-list__link--lg--PaddingBottom);
+  }
+
   position: relative;
 
-  .pf-c-nav__scroll-button {
-    display: none;
-    visibility: hidden;
+  &.pf-m-dark {
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-dark__link--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav--m-dark__link--Color);
+    --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-dark__link--hover--Color);
+    --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-dark__link--focus--Color);
+    --pf-c-nav__link--active--Color: var(--pf-c-nav--m-dark__link--active--Color);
+    --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-dark__link--m-current--Color);
+    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav--m-dark__link--after--BorderColor);
+    --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
+    --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
+    --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
+
+    .pf-c-divider {
+      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
+    }
   }
 
   // Disable underline
@@ -246,6 +200,12 @@
     &:active {
       text-decoration: none;
     }
+  }
+
+  // Scroll button
+  .pf-c-nav__scroll-button {
+    display: none;
+    visibility: hidden;
   }
 
   &.pf-m-start .pf-c-nav__scroll-button:nth-of-type(1) {
@@ -260,76 +220,10 @@
 
   // Divider
   .pf-c-divider {
-    // Update during breaking change
-    padding-left: var(--pf-c-nav__c-divider--MarginLeft);
-
-    // end - Update during breaking change
+    padding-right: var(--pf-c-nav--c-divider--PaddingRight);
+    padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
     margin-top: var(--pf-c-nav__c-divider--MarginTop);
     margin-bottom: var(--pf-c-nav__c-divider--MarginBottom);
-    margin-left: 0;
-  }
-
-  &.pf-m-dark {
-    --pf-c-nav__list-link--PaddingTop: var(--pf-c-nav--m-dark__list-link--PaddingTop);
-    --pf-c-nav__list-link--PaddingBottom: var(--pf-c-nav--m-dark__list-link--PaddingBottom);
-    --pf-c-nav__list-link--Color: var(--pf-c-nav--m-dark__list-link--Color);
-    --pf-c-nav__list-link--hover--Color: var(--pf-c-nav--m-dark__list-link--hover--Color);
-    --pf-c-nav__list-link--focus--Color: var(--pf-c-nav--m-dark__list-link--focus--Color);
-    --pf-c-nav__list-link--active--Color: var(--pf-c-nav--m-dark__list-link--active--Color);
-    --pf-c-nav__list-link--m-current--Color: var(--pf-c-nav--m-dark__list-link--m-current--Color);
-    --pf-c-nav__list-link--hover--after--BackgroundColor: var(--pf-global--active-color--400);
-    --pf-c-nav__list-link--active--after--BackgroundColor: var(--pf-global--active-color--400);
-    --pf-c-nav__list-link--focus--after--BackgroundColor: var(--pf-global--active-color--400);
-    --pf-c-nav__list-link--after--Bottom: var(--pf-c-nav--m-dark__list-link--after--Bottom);
-    --pf-c-nav__list-link--m-current--after--BackgroundColor: var(--pf-global--active-color--400);
-    --pf-c-nav__simple-list-link--Color: var(--pf-c-nav--m-dark__simple-list-link--Color);
-    --pf-c-nav__simple-list-link--hover--Color: var(--pf-c-nav--m-dark__simple-list-link--hover--Color);
-    --pf-c-nav__simple-list-link--focus--Color: var(--pf-c-nav--m-dark__simple-list-link--focus--Color);
-    --pf-c-nav__simple-list-link--active--Color: var(--pf-c-nav--m-dark__simple-list-link--active--Color);
-    --pf-c-nav__simple-list-link--hover--BackgroundColor: var(--pf-c-nav--m-dark__simple-list-link--hover--BackgroundColor);
-    --pf-c-nav__simple-list-link--focus--BackgroundColor: var(--pf-c-nav--m-dark__simple-list-link--focus--BackgroundColor);
-    --pf-c-nav__simple-list-link--active--BackgroundColor: var(--pf-c-nav--m-dark__simple-list-link--active--BackgroundColor);
-    --pf-c-nav__simple-list-link--m-current--Color: var(--pf-c-nav--m-dark__simple-list-link--m-current--Color);
-    --pf-c-nav__simple-list-link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__simple-list-link--m-current--BackgroundColor);
-    --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
-    --pf-c-nav__separator--BackgroundColor: var(--pf-c-nav--m-dark__separator--BackgroundColor);
-    --pf-c-nav__subnav--MarginTop: var(--pf-c-nav--m-dark__subnav--MarginTop);
-    --pf-c-nav__list-link--after--Width: var(--pf-c-nav--m-dark__list-link--after--Width);
-
-    .pf-c-divider {
-      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
-    }
-
-    .pf-c-nav__item {
-      &.pf-m-current {
-        --pf-c-nav__simple-list-link--Color: var(--pf-c-nav--m-dark__item--m-current__simple-list-link--Color);
-        --pf-c-nav__list-link--Color: var(--pf-c-nav--m-dark__item--m-current__list-link--Color);
-        --pf-c-nav__separator--BackgroundColor: var(--pf-c-nav--m-dark__item--m-current__separator--BackgroundColor); // remove at breaking change
-
-        // stylelint-disable-next-line
-        .pf-c-divider {
-          --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__item--m-current__c-divider--BackgroundColor);
-        }
-      }
-
-      &.pf-m-expanded {
-        padding-bottom: var(--pf-c-nav--m-dark__item--m-expanded--PaddingBottom);
-
-        // stylelint-disable-next-line
-        > .pf-c-nav__link {
-          --pf-c-nav__list-link--after--Bottom: var(--pf-c-nav--m-dark__item--m-expanded__list-link--after--Bottom);
-          --pf-c-nav__list-link--PaddingBottom: var(--pf-c-nav--m-dark__item--m-expanded__list-link--PaddingBottom);
-        }
-      }
-    }
-
-    .pf-c-nav__list > .pf-c-nav__item {
-      // stylelint-disable-next-line
-      &.pf-m-current,
-      > .pf-c-nav__link.pf-m-current {
-        background-color: var(--pf-c-nav--m-dark__item--m-current--BackgroundColor);
-      }
-    }
   }
 }
 
@@ -354,180 +248,103 @@
   }
 }
 
+.pf-c-nav__item.pf-m-expanded .pf-c-nav__toggle > * {
+  transform: var(--pf-c-nav__item--m-expanded__toggle--i--Transform);
+}
 
-// List default
-.pf-c-nav__list {
-  // Item
-  > .pf-c-nav__item {
-    position: relative;
+// Nav link
+.pf-c-nav__link {
+  position: relative;
+  display: flex;
+  align-items: baseline;
+  padding: var(--pf-c-nav__link--PaddingTop) var(--pf-c-nav__link--PaddingRight) var(--pf-c-nav__link--PaddingBottom) var(--pf-c-nav__link--PaddingLeft);
+  font-size: var(--pf-c-nav__link--FontSize);
+  font-weight: var(--pf-c-nav__link--FontWeight);
+  color: var(--pf-c-nav__link--Color);
+  background-color: var(--pf-c-nav__link--BackgroundColor);
 
-    .pf-c-divider {
-      --pf-c-nav__c-divider--MarginLeft: var(--pf-c-nav__simple-list--nested__c-divider--MarginLeft);
-    }
+  &::before,
+  &::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+    border-width: 0;
   }
 
-  > .pf-c-nav__item > .pf-c-nav__link {
-    // After - border bottom treatment for top level links
-    &::after {
-      position: absolute;
-      bottom: var(--pf-c-nav__list-link--after--Bottom);
-      left: var(--pf-c-nav__list-link--after--Left);
-      width: var(--pf-c-nav__list-link--after--Width);
-      height: var(--pf-c-nav__list-link--after--Height);
-      content: "";
-    }
+  &::before {
+    border-color: var(--pf-c-nav__link--before--BorderColor);
+    border-style: var(--pf-c-nav__link--before--BorderStyle);
+    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);
+    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
   }
 
-  // Link
-  .pf-c-nav__link {
-    position: relative;
-    display: flex;
-    align-items: baseline;
-    padding:
-      var(--pf-c-nav__list-link--PaddingTop)
-      var(--pf-c-nav__list-link--PaddingRight)
-      var(--pf-c-nav__list-link--PaddingBottom)
-      var(--pf-c-nav__list-link--PaddingLeft);
-    font-weight: var(--pf-c-nav__list-link--FontWeight);
-    color: var(--pf-c-nav__list-link--Color);
-
-
-    // States
-    &.pf-m-hover,
-    &:hover {
-      --pf-c-nav__list-link--Color: var(--pf-c-nav__list-link--hover--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__list-link--hover--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-active,
-    &:active {
-      --pf-c-nav__list-link--FontWeight: var(--pf-c-nav__list-link--active--FontWeight);
-      --pf-c-nav__list-link--Color: var(--pf-c-nav__list-link--active--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__list-link--active--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-focus,
-    &:focus {
-      --pf-c-nav__list-link--FontWeight: var(--pf-c-nav__list-link--focus--FontWeight);
-      --pf-c-nav__list-link--Color: var(--pf-c-nav__list-link--focus--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__list-link--focus--after--BackgroundColor);
-      }
-    }
+  &::after {
+    border-color: var(--pf-c-nav__link--after--BorderColor);
+    border-style: var(--pf-c-nav__link--after--BorderStyle);
+    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth);
+    border-left-width: var(--pf-c-nav__link--after--BorderLeftWidth);
   }
 
   // States
-  .pf-m-current.pf-c-nav__link,
-  .pf-m-current > .pf-c-nav__link {
-    --pf-c-nav__list-link--FontWeight: var(--pf-c-nav__list-link--m-current--FontWeight);
-    --pf-c-nav__list-link--Color: var(--pf-c-nav__list-link--m-current--Color);
+  &:hover {
+    color: var(--pf-c-nav__link--hover--Color);
+    background-color: var(--pf-c-nav__link--hover--BackgroundColor);
+  }
 
-    &::after {
-      background-color: var(--pf-c-nav__list-link--m-current--after--BackgroundColor);
-    }
+  &:active {
+    color: var(--pf-c-nav__link--active--Color);
+    background-color: var(--pf-c-nav__link--active--BackgroundColor);
+  }
+
+  &:focus {
+    color: var(--pf-c-nav__link--focus--Color);
+    background-color: var(--pf-c-nav__link--focus--BackgroundColor);
+  }
+
+  &.pf-m-current {
+    color: var(--pf-c-nav__link--m-current--Color);
+    background-color: var(--pf-c-nav__link--m-current--BackgroundColor);
   }
 }
 
+// List default
+.pf-c-nav__list {
+  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__list__link--PaddingTop);
+  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__list__link--PaddingRight);
+  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__list__link--PaddingBottom);
+  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__list__link--PaddingLeft);
+  --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__link--before--BorderWidth);
 
-// Separator --- remove this block at breaking change
-.pf-c-nav__separator {
-  height: var(--pf-c-nav__separator--Height);
-  margin-top: var(--pf-c-nav__separator--MarginTop);
-  margin-bottom: var(--pf-c-nav__separator--MarginBottom);
-  margin-left: var(--pf-c-nav__separator--MarginLeft);
-  background-color: var(--pf-c-nav__separator--BackgroundColor);
-
-  .pf-c-nav__simple-list & {
-    --pf-c-nav__separator--MarginLeft: var(--pf-c-nav__simple-list__separator--MarginLeft);
-  }
-
-  .pf-c-nav__item & {
-    --pf-c-nav__separator--MarginLeft: var(--pf-c-nav__simple-list--nested__separator--MarginLeft);
+  .pf-c-nav__item:last-child {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__link--before--BorderWidth);
   }
 }
 
-// Toggle caret
-.pf-c-nav__toggle {
-  flex: none;
-  padding-right: var(--pf-c-nav__list-toggle--PaddingRight);
-  padding-left: var(--pf-c-nav__list-toggle--PaddingLeft);
-  margin-left: auto;
-  font-size: var(--pf-c-nav__list-toggle--FontSize);
-  line-height: 1;
-  pointer-events: none;
-  border: 0;
-
-  // Add transition to base
-  & > * {
-    transition: var(--pf-c-nav__list-toggle--Transition);
+// Active border treatment
+.pf-c-nav__list,
+.pf-c-nav__simple-list {
+  .pf-c-nav__link.pf-m-current {
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__link--after--BorderWidth);
   }
 }
 
-// Rotate the icon
-.pf-c-nav__item.pf-m-expanded .pf-c-nav__toggle > * {
-  transform: var(--pf-c-nav__item--m-expanded__toggle-icon--Transform);
-}
-
-// List simple
+// Simple list
 // no bottom border, no children. Used independently or as a subnav item of .pf-c-nav__list (default list component).
 .pf-c-nav__simple-list {
-  .pf-c-divider {
-    --pf-c-nav__c-divider--MarginLeft: var(--pf-c-nav__simple-list__c-divider--MarginLeft);
-  }
+  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__simple-list__link--PaddingTop);
+  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__simple-list__link--PaddingRight);
+  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__simple-list__link--PaddingBottom);
+  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
+  --pf-c-nav__link--FontSize: var(--pf-c-nav__simple-list__link--FontSize);
+  --pf-c-nav--c-divider--PaddingRight: var(--pf-c-nav__simple-list__link--PaddingRight);
+  --pf-c-nav--c-divider--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
 
-  // List simple link
   .pf-c-nav__link {
-    display: block;
-    padding:
-      var(--pf-c-nav__simple-list-link--PaddingTop)
-      var(--pf-c-nav__simple-list-link--PaddingRight)
-      var(--pf-c-nav__simple-list-link--PaddingBottom)
-      var(--pf-c-nav__simple-list-link--PaddingLeft);
-    font-weight: var(--pf-c-nav__simple-list-link--FontWeight);
-    color: var(--pf-c-nav__simple-list-link--Color);
-
-    // States
-    &.pf-m-hover,
-    &:hover {
-      --pf-c-nav__simple-list-link--Color: var(--pf-c-nav__simple-list-link--hover--Color);
-
-      background-color: var(--pf-c-nav__simple-list-link--hover--BackgroundColor);
-    }
-
-    &.pf-m-focus,
-    &:focus {
-      --pf-c-nav__simple-list-link--FontWeight: var(--pf-c-nav__simple-list-link--focus--FontWeight);
-      --pf-c-nav__simple-list-link--Color: var(--pf-c-nav__simple-list-link--focus--Color);
-
-      background-color: var(--pf-c-nav__simple-list-link--focus--BackgroundColor);
-    }
-
-    &.pf-m-active,
-    &:active {
-      --pf-c-nav__simple-list-link--FontWeight: var(--pf-c-nav__simple-list-link--active--FontWeight);
-      --pf-c-nav__simple-list-link--Color: var(--pf-c-nav__simple-list-link--active--Color);
-
-      background-color: var(--pf-c-nav__simple-list-link--active--BackgroundColor);
-    }
-
-    &.pf-m-current {
-      --pf-c-nav__simple-list-link--FontWeight: var(--pf-c-nav__simple-list-link--m-current--FontWeight);
-      --pf-c-nav__simple-list-link--Color: var(--pf-c-nav__simple-list-link--m-current--Color);
-
-      background-color: var(--pf-c-nav__simple-list-link--m-current--BackgroundColor);
-    }
-
-    // Adjust padding of descendant links
-    .pf-c-nav__item & {
-      --pf-c-nav__simple-list-link--PaddingLeft: var(--pf-c-nav__simple-list-link--nested--PaddingLeft);
-    }
+    margin-top: var(--pf-c-nav__simple-list__link--MarginTop);
+    margin-bottom: var(--pf-c-nav__simple-list__link--MarginBottom);
   }
 }
 
@@ -539,6 +356,7 @@
   display: inline-flex;
   max-width: 100%;
   overflow-x: auto;
+  white-space: nowrap;
 
   .pf-c-nav__link {
     position: relative;
@@ -548,157 +366,85 @@
 
 // List horizontal, masthead
 .pf-c-nav__horizontal-list {
+  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--PaddingTop);
+  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__horizontal-list__link--PaddingRight);
+  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__horizontal-list__link--PaddingBottom);
+  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__horizontal-list__link--PaddingLeft);
+  --pf-c-nav__link--Color: var(--pf-c-nav__horizontal-list__link--Color);
+  --pf-c-nav__link--hover--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
+  --pf-c-nav__link--active--Color: var(--pf-c-nav__horizontal-list__link--active--Color);
+  --pf-c-nav__link--focus--Color: var(--pf-c-nav__horizontal-list__link--focus--Color);
+  --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__horizontal-list__link--BackgroundColor);
+  --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
+  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
+
   vertical-align: bottom;
 
   .pf-c-nav__item {
-    margin-right: var(--pf-c-nav__horizontal-list-item--MarginRight);
+    margin-right: var(--pf-c-nav__horizontal-list__item--MarginRight);
   }
 
-  .pf-c-nav__link {
-    padding-top: var(--pf-c-nav__horizontal-list-link--PaddingTop);
-    padding-bottom: var(--pf-c-nav__horizontal-list-link--PaddingBottom);
-    font-weight: var(--pf-c-nav__horizontal-list-link--FontWeight);
-    color: var(--pf-c-nav__horizontal-list-link--Color);
-    white-space: nowrap;
-
-    // States
-    &.pf-m-hover,
-    &:hover {
-      --pf-c-nav__horizontal-list-link--Color: var(--pf-c-nav__horizontal-list-link--hover--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__horizontal-list-link--hover--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-focus,
-    &:focus {
-      --pf-c-nav__horizontal-list-link--Color: var(--pf-c-nav__horizontal-list-link--focus--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__horizontal-list-link--focus--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-active,
-    &:active {
-      --pf-c-nav__horizontal-list-link--Color: var(--pf-c-nav__horizontal-list-link--active--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__horizontal-list-link--active--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-current {
-      --pf-c-nav__horizontal-list-link--Color: var(--pf-c-nav__horizontal-list-link--m-current--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__horizontal-list-link--m-current--after--BackgroundColor);
-      }
-    }
-
-    // After - border bottom treatment
-    &::after {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      display: block;
-      width: 100%;
-      height: var(--pf-c-nav__horizontal-list-link--after--Height);
-      content: "";
-    }
+  .pf-c-nav__link:hover,
+  .pf-c-nav__link.pf-m-current {
+    --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--after--BorderWidth);
   }
 }
 
 // List tertiary
 .pf-c-nav__tertiary-list {
+  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__tertiary-list__link--PaddingTop);
+  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__tertiary-list__link--PaddingRight);
+  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__tertiary-list__link--PaddingBottom);
+  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__tertiary-list__link--PaddingLeft);
+  --pf-c-nav__link--FontWeight: var(--pf-c-nav__tertiary-list__link--FontWeight);
+  --pf-c-nav__link--Color: var(--pf-c-nav__tertiary-list__link--Color);
+  --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__tertiary-list__link--BackgroundColor);
+  --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
+  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
+
   .pf-c-nav__item {
-    margin-right: var(--pf-c-nav__tertiary-list-item--MarginRight);
+    margin-right: var(--pf-c-nav__tertiary-list__item--MarginRight);
   }
 
-  // List tertiary link
-  .pf-c-nav__link {
-    padding-top: var(--pf-c-nav__tertiary-list-link--PaddingTop);
-    padding-bottom: var(--pf-c-nav__tertiary-list-link--PaddingBottom);
-    font-weight: var(--pf-c-nav__tertiary-list-link--FontWeight);
-    color: var(--pf-c-nav__tertiary-list-link--Color);
-    white-space: nowrap;
-
-    // Hover
-    &.pf-m-hover,
-    &:hover {
-      --pf-c-nav__tertiary-list-link--Color: var(--pf-c-nav__tertiary-list-link--hover--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__tertiary-list-link--hover--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-focus,
-    &:focus {
-      --pf-c-nav__tertiary-list-link--Color: var(--pf-c-nav__tertiary-list-link--focus--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__tertiary-list-link--focus--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-active,
-    &:active {
-      --pf-c-nav__tertiary-list-link--Color: var(--pf-c-nav__tertiary-list-link--active--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__tertiary-list-link--active--after--BackgroundColor);
-      }
-    }
-
-    &.pf-m-current {
-      --pf-c-nav__tertiary-list-link--Color: var(--pf-c-nav__tertiary-list-link--m-current--Color);
-
-      &::after {
-        background-color: var(--pf-c-nav__tertiary-list-link--m-current--after--BackgroundColor);
-      }
-    }
-
-    // After - border bottom treatment
-    &::after {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      display: block;
-      width: 100%;
-      height: var(--pf-c-nav__tertiary-list-link--after--Height);
-      content: "";
-    }
+  .pf-c-nav__link:hover,
+  .pf-c-nav__link.pf-m-current {
+    --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--after--BorderWidth);
   }
 }
 
 // Subnav
 .pf-c-nav__subnav {
-  flex: 1 0 100%;
+  --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__subnav__link--before--BorderTopWidth);
+  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__subnav__link--before--BorderBottomWidth);
+  --pf-c-nav__link--FontSize: var(--pf-c-nav__subnav__link--FontSize);
+  --pf-c-nav__simple-list__link--MarginTop: var(--pf-c-nav--subnav__simple-list__link--MarginTop);
+  --pf-c-nav__simple-list__link--MarginBottom: var(--pf-c-nav--subnav__simple-list__link--MarginBottom);
+  --pf-c-nav__simple-list__link--FontSize: var(--pf-c-nav__subnav__link--FontSize);
 
-  // Set default states
   max-height: 0;
-  margin-top: 0;
-  overflow: hidden;
-  opacity: 0;
+  padding-bottom: var(--pf-c-nav__subnav--PaddingBottom);
+  padding-left: var(--pf-c-nav__subnav--PaddingLeft);
   transition: var(--pf-c-nav--Transition);
 
-  // Hide scrollbars
+  .pf-c-nav__item:last-child {
+    --pf-c-nav__link--before--BorderBottomWidth: 0;
+  }
+
+  .pf-c-nav__item.pf-m-expanded & {
+    max-height: var(--pf-c-nav__subnav--MaxHeight);
+    overflow-y: auto;
+    opacity: 1;
+  }
+
   &::-webkit-scrollbar {
     display: none;
     visibility: hidden;
   }
-
-  // Expanded list item
-  .pf-c-nav__item.pf-m-expanded & {
-    max-height: var(--pf-c-nav__subnav--MaxHeight);
-    margin-top: var(--pf-c-nav__subnav--MarginTop);
-    overflow-y: auto;
-    opacity: 1;
-  }
 }
 
+// Section
 .pf-c-nav__section {
   margin-top: var(--pf-c-nav__section--MarginTop);
 
@@ -707,7 +453,7 @@
   }
 }
 
-// Section
+// Section title
 .pf-c-nav__section-title {
   padding:
     var(--pf-c-nav__section-title--PaddingTop)
@@ -717,8 +463,26 @@
   font-size: var(--pf-c-nav__section-title--FontSize);
   font-weight: var(--pf-c-nav__section-title--FontWeight);
   color: var(--pf-c-nav__section-title--Color);
+  border-bottom: var(--pf-c-nav__section-title--BorderBottomWidth) var(--pf-c-nav__section-title--BorderBottomStyle) var(--pf-c-nav__section-title--BorderBottomColor);
 }
 
+// Toggle caret
+.pf-c-nav__toggle {
+  flex: none;
+  padding-right: var(--pf-c-nav__toggle--PaddingRight);
+  padding-left: var(--pf-c-nav__toggle--PaddingLeft);
+  margin-left: auto;
+  font-size: var(--pf-c-nav__toggle--FontSize);
+  line-height: 1;
+  pointer-events: none;
+  border: 0;
+
+  & > * {
+    transition: var(--pf-c-nav__toggle--Transition);
+  }
+}
+
+// Scroll button
 .pf-c-nav__scroll-button {
   position: absolute;
   top: var(--pf-c-nav__scroll-button--Top);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -73,16 +73,17 @@
   --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
 
   // Horizontal list
-  --pf-c-nav__horizontal-list__item--MarginRight: var(--pf-global--spacer--xl);
+  // --pf-c-nav__horizontal-list__item--MarginRight: var(--pf-global--spacer--xl);
+
   --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list__link--PaddingRight: 0;
+  --pf-c-nav__horizontal-list__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list__link--PaddingLeft: 0;
+  --pf-c-nav__horizontal-list__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav__horizontal-list__link--lg--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-nav__horizontal-list__link--lg--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-nav__horizontal-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
   --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--lg--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
@@ -92,12 +93,10 @@
   --pf-c-nav__horizontal-list__link--after--BorderColor: var(--pf-global--active-color--400);
 
   // Tertiary list
-  --pf-c-nav__tertiary-list__item--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-nav__tertiary-list__link--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__tertiary-list__link--PaddingRight: 0;
+  --pf-c-nav__tertiary-list__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__tertiary-list__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__tertiary-list__link--PaddingLeft: 0;
+  --pf-c-nav__tertiary-list__link--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-nav__tertiary-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--active-color--100);
@@ -109,10 +108,13 @@
   --pf-c-nav__tertiary-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--after--BorderColor: var(--pf-global--active-color--100);
 
+  // Horizonta/tertiary list offsets
+  --pf-c-nav__link--offset: calc(var(--pf-global--spacer--xs) * -1);
+
   // Sub nav
   --pf-c-nav__subnav--MaxHeight: 100%;
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__list__link--PaddingLeft);
+  --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__subnav__link--before--BorderTopWidth: 0;
   --pf-c-nav__subnav__link--before--BorderBottomWidth: 0;
@@ -270,7 +272,6 @@
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
   background-color: var(--pf-c-nav__link--BackgroundColor);
-  outline-offset: calc(var(--pf-global--spacer--sm) * -1);
 
   &::before,
   &::after {
@@ -365,6 +366,9 @@
 // Horizontal and tertiary nav
 .pf-c-nav__horizontal-list,
 .pf-c-nav__tertiary-list {
+  --pf-c-nav__link--Right: var(--pf-c-nav__link--PaddingRight);
+  --pf-c-nav__link--Left: var(--pf-c-nav__link--PaddingLeft);
+
   @include pf-overflow-hide-scroll;
 
   display: inline-flex;
@@ -375,11 +379,13 @@
   .pf-c-nav__link {
     position: relative;
     display: inline-block;
+    outline-offset: var(--pf-c-nav__link--offset);
   }
 
   .pf-c-nav__link::after {
     top: auto;
-    right: 0;
+    right: var(--pf-c-nav__link--Right);
+    left: var(--pf-c-nav__link--Left);
   }
 }
 
@@ -400,12 +406,6 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
   --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__horizontal-list__link--after--BorderColor);
-
-  vertical-align: bottom;
-
-  .pf-c-nav__item {
-    margin-right: var(--pf-c-nav__horizontal-list__item--MarginRight);
-  }
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,
@@ -433,10 +433,6 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
   --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__tertiary-list__link--after--BorderColor);
-
-  .pf-c-nav__item {
-    margin-right: var(--pf-c-nav__tertiary-list__item--MarginRight);
-  }
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -9,10 +9,10 @@
   --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--before--BorderColor: #{$pf-global--BackgroundColor--dark-200};
+  --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
   --pf-c-nav--m-dark__link--after--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
-  --pf-c-nav--m-dark__link--hover--BackgroundColor: #{rgba($pf-global--BackgroundColor--dark-200, .5)};
+  --pf-c-nav--m-dark__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-c-nav__link--before--BorderColor);
@@ -36,7 +36,7 @@
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav__link--BackgroundColor: transparent;
-  --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
@@ -45,12 +45,12 @@
   --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Link ::before borders
-  --pf-c-nav__link--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__link--before--BorderTopWidth: 0;
   --pf-c-nav__link--before--BorderBottomWidth: 0;
 
-  // Link ::before borders
+  // Link ::after borders
   --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-nav__link--after--BorderBottomWidth: 0;
@@ -258,7 +258,7 @@
   }
 }
 
-.pf-c-nav__item.pf-m-expanded .pf-c-nav__toggle > * {
+.pf-c-nav__item.pf-m-expanded .pf-c-nav__toggle > i {
   transform: var(--pf-c-nav__item--m-expanded__toggle--i--Transform);
 }
 
@@ -285,16 +285,17 @@
 
   &::before {
     right: 0;
+    z-index: -1;
     border-color: var(--pf-c-nav__link--before--BorderColor);
     border-style: solid;
-    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth); // --pf-c-nav__link--before--BorderTopWidth: 0
-    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth); // --pf-c-nav__link--before--BorderBottomWidth: 0
+    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);
+    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
   }
 
   &::after {
     border-color: var(--pf-c-nav__link--after--BorderColor);
     border-style: solid;
-    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth); // --pf-c-nav__link--after--BorderTopWidth: 0
+    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth);
     border-left-width: var(--pf-c-nav__link--after--BorderLeftWidth);
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -17,6 +17,9 @@
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-c-nav__link--before--BorderColor);
   --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
+  --pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
 
   // Link
   --pf-c-nav__link--FontSize: var(--pf-global--FontSize--md);
@@ -25,14 +28,18 @@
   --pf-c-nav__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__link--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav__link--md--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__link--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav__link--BackgroundColor: transparent;
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
   --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
+  --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
@@ -50,12 +57,6 @@
   --pf-c-nav__link--after--BorderLeftWidth: 0;
 
   // Nav list
-  --pf-c-nav__list__link--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-nav__list__link--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__list__link--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav__list__link--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-nav__list__link--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__list__link--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__list__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Simple list
@@ -67,39 +68,46 @@
   --pf-c-nav__simple-list__link--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
 
+  // Subnav
+  --pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
+
   // Horizontal list
   --pf-c-nav__horizontal-list__item--MarginRight: var(--pf-global--spacer--xl);
   --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-nav__horizontal-list__link--PaddingRight: 0;
   --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__horizontal-list__link--PaddingLeft: 0;
-  --pf-c-nav__horizontal-list__link--md--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list__link--lg--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-nav__horizontal-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
   --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--lg--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__horizontal-list__link--after--BorderColor: var(--pf-global--active-color--400);
 
   // Tertiary list
   --pf-c-nav__tertiary-list__item--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__tertiary-list__link--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-nav__tertiary-list__link--PaddingRight: 0;
   --pf-c-nav__tertiary-list__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__tertiary-list__link--PaddingLeft: 0;
   --pf-c-nav__tertiary-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--after--BorderColor: var(--pf-global--active-color--100);
 
   // Sub nav
   --pf-c-nav__subnav--MaxHeight: 100%;
@@ -124,16 +132,15 @@
   --pf-c-nav__section-title--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
-  --pf-c-nav__section-title--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
-  --pf-c-nav__section-title--BorderBottomStyle: solid;
 
   // Scroll button
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
-  --pf-c-nav__scroll-button--Height: var(--pf-global--target-size--MinHeight);
+  --pf-c-nav__scroll-button--Height: 100%;
+  --pf-c-nav__scroll-button--lg--Height: pf-size-prem(40px);
   --pf-c-nav__scroll-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
@@ -142,7 +149,6 @@
   --pf-c-nav__scroll-button--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(255, 255, 255, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
-
 
   // List toggle
   --pf-c-nav__toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -157,16 +163,19 @@
   --pf-c-nav--c-divider--PaddingLeft: 0;
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
+    --pf-c-nav__link--PaddingRight: var(--pf-c-nav__link--md--PaddingRight);
+    --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__link--md--PaddingLeft);
     --pf-c-nav__list__link--PaddingRight: var(--pf-c-nav__list__link--md--PaddingRight);
     --pf-c-nav__list__link--PaddingLeft: var(--pf-c-nav__list__link--md--PaddingLeft);
     --pf-c-nav__section-title--PaddingRight: var(--pf-c-nav__section-title--md--PaddingRight);
     --pf-c-nav__section-title--PaddingLeft: var(--pf-c-nav__section-title--md--PaddingLeft);
-    --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--md--PaddingTop);
     --pf-c-nav__subnav--PaddingLeft: var(--pf-c-nav__subnav--md--PaddingLeft);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
+    --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--lg--PaddingTop);
     --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-c-nav__horizontal-list__link--lg--PaddingBottom);
+    --pf-c-nav__scroll-button--Height: var(--pf-c-nav__scroll-button--lg--Height);
   }
 
   position: relative;
@@ -184,6 +193,9 @@
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
+    --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
+    --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
@@ -206,24 +218,20 @@
     visibility: hidden;
   }
 
-  &.pf-m-start .pf-c-nav__scroll-button:nth-of-type(1) {
-    display: block;
-    visibility: visible;
-  }
-
+  &.pf-m-start .pf-c-nav__scroll-button:nth-of-type(1),
   &.pf-m-end .pf-c-nav__scroll-button:nth-of-type(2) {
-    display: block;
+    display: flex;
     visibility: visible;
   }
 
   // Divider
   .pf-c-divider {
+    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
+
     padding-right: var(--pf-c-nav--c-divider--PaddingRight);
     padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
     margin-top: var(--pf-c-nav__c-divider--MarginTop);
     margin-bottom: var(--pf-c-nav__c-divider--MarginBottom);
-
-    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
   }
 }
 
@@ -262,12 +270,12 @@
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
   background-color: var(--pf-c-nav__link--BackgroundColor);
+  outline-offset: calc(var(--pf-global--spacer--sm) * -1);
 
   &::before,
   &::after {
     position: absolute;
     top: 0;
-    right: 0;
     bottom: 0;
     left: 0;
     content: "";
@@ -275,16 +283,17 @@
   }
 
   &::before {
+    right: 0;
     border-color: var(--pf-c-nav__link--before--BorderColor);
     border-style: solid;
-    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);
-    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
+    border-top-width: var(--pf-c-nav__link--before--BorderTopWidth); // --pf-c-nav__link--before--BorderTopWidth: 0
+    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth); // --pf-c-nav__link--before--BorderBottomWidth: 0
   }
 
   &::after {
     border-color: var(--pf-c-nav__link--after--BorderColor);
     border-style: solid;
-    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth);
+    border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth); // --pf-c-nav__link--after--BorderTopWidth: 0
     border-left-width: var(--pf-c-nav__link--after--BorderLeftWidth);
   }
 
@@ -294,35 +303,38 @@
     background-color: var(--pf-c-nav__link--hover--BackgroundColor);
   }
 
-  &:active {
-    color: var(--pf-c-nav__link--active--Color);
-    background-color: var(--pf-c-nav__link--active--BackgroundColor);
-  }
-
   &:focus {
     color: var(--pf-c-nav__link--focus--Color);
     background-color: var(--pf-c-nav__link--focus--BackgroundColor);
+  }
+
+  &:active {
+    color: var(--pf-c-nav__link--active--Color);
+    background-color: var(--pf-c-nav__link--active--BackgroundColor);
   }
 
   &.pf-m-current {
     color: var(--pf-c-nav__link--m-current--Color);
     background-color: var(--pf-c-nav__link--m-current--BackgroundColor);
   }
+
+  &:disabled,
+  &.pf-m-disabled {
+    color: var(--pf-c-nav__link--disabled--Color);
+    pointer-events: none;
+    background-color: var(--pf-c-nav__link--disabled--BackgroundColor);
+  }
 }
 
 // List default
 .pf-c-nav__list {
-  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__list__link--PaddingTop);
-  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__list__link--PaddingRight);
-  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__list__link--PaddingBottom);
-  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__list__link--PaddingLeft);
   --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__link--before--BorderWidth);
+
+  border-bottom: var(--pf-c-nav__link--before--BorderWidth) solid var(--pf-c-nav__link--before--BorderColor);
 
   .pf-c-nav__item:first-child {
     --pf-c-nav__link--before--BorderTopWidth: 0;
   }
-
-  border-bottom: var(--pf-c-nav__link--before--BorderWidth) solid var(--pf-c-nav__link--before--BorderColor);
 }
 
 // Active border treatment
@@ -364,6 +376,11 @@
     position: relative;
     display: inline-block;
   }
+
+  .pf-c-nav__link::after {
+    top: auto;
+    right: 0;
+  }
 }
 
 // List horizontal, masthead
@@ -378,8 +395,11 @@
   --pf-c-nav__link--focus--Color: var(--pf-c-nav__horizontal-list__link--focus--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__horizontal-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
+  --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__horizontal-list__link--after--BorderColor);
 
   vertical-align: bottom;
 
@@ -388,6 +408,8 @@
   }
 
   .pf-c-nav__link:hover,
+  .pf-c-nav__link:focus,
+  .pf-c-nav__link:active,
   .pf-c-nav__link.pf-m-current {
     --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--after--BorderWidth);
   }
@@ -401,16 +423,24 @@
   --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__tertiary-list__link--PaddingLeft);
   --pf-c-nav__link--FontWeight: var(--pf-c-nav__tertiary-list__link--FontWeight);
   --pf-c-nav__link--Color: var(--pf-c-nav__tertiary-list__link--Color);
+  --pf-c-nav__link--hover--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__link--active--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__link--focus--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__tertiary-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
+  --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__tertiary-list__link--after--BorderColor);
 
   .pf-c-nav__item {
     margin-right: var(--pf-c-nav__tertiary-list__item--MarginRight);
   }
 
   .pf-c-nav__link:hover,
+  .pf-c-nav__link:focus,
+  .pf-c-nav__link:active,
   .pf-c-nav__link.pf-m-current {
     --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--after--BorderWidth);
   }
@@ -440,6 +470,12 @@
     opacity: 1;
   }
 
+  .pf-c-nav__link:not(.pf-m-current):hover {
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__link--after--BorderTopWidth: 0;
+  }
+
   &::-webkit-scrollbar {
     display: none;
     visibility: hidden;
@@ -450,22 +486,17 @@
 .pf-c-nav__section {
   margin-top: var(--pf-c-nav__section--MarginTop);
 
-  + .pf-c-nav__section {
+  + & {
     --pf-c-nav__section--MarginTop: var(--pf-c-nav__section__section--MarginTop);
   }
 }
 
 // Section title
 .pf-c-nav__section-title {
-  padding:
-    var(--pf-c-nav__section-title--PaddingTop)
-    var(--pf-c-nav__section-title--PaddingRight)
-    var(--pf-c-nav__section-title--PaddingBottom)
-    var(--pf-c-nav__section-title--PaddingLeft);
+  padding: var(--pf-c-nav__section-title--PaddingTop) var(--pf-c-nav__section-title--PaddingRight) var(--pf-c-nav__section-title--PaddingBottom) var(--pf-c-nav__section-title--PaddingLeft);
   font-size: var(--pf-c-nav__section-title--FontSize);
-  font-weight: var(--pf-c-nav__section-title--FontWeight);
   color: var(--pf-c-nav__section-title--Color);
-  border-bottom: var(--pf-c-nav__section-title--BorderBottomWidth) var(--pf-c-nav__section-title--BorderBottomStyle) var(--pf-c-nav__section-title--BorderBottomColor);
+  border-bottom: var(--pf-c-nav__section-title--BorderBottomWidth) solid var(--pf-c-nav__section-title--BorderBottomColor);
 }
 
 // Toggle caret
@@ -476,8 +507,6 @@
   margin-left: auto;
   font-size: var(--pf-c-nav__toggle--FontSize);
   line-height: 1;
-  pointer-events: none;
-  border: 0;
 
   & > * {
     transition: var(--pf-c-nav__toggle--Transition);
@@ -487,22 +516,20 @@
 // Scroll button
 .pf-c-nav__scroll-button {
   position: absolute;
-  top: var(--pf-c-nav__scroll-button--Top);
+  top: 0;
   bottom: 0;
   z-index: var(--pf-c-nav__scroll-button--ZIndex);
+  justify-content: center;
   width: var(--pf-c-nav__scroll-button--Width);
-  height: var(--pf-c-nav__scroll-button--Height); // this fixes the positioning on FF
+  height: 100%;
   padding-right: var(--pf-c-nav__scroll-button--PaddingRight);
   padding-left: var(--pf-c-nav__scroll-button--PaddingLeft);
   background-color: var(--pf-c-nav__scroll-button--BackgroundColor);
   border: 0;
 
-  &.pf-m-hover,
   &:hover,
-  &.pf-m-active,
-  &:active,
-  &.pf-m-focus,
-  &:focus {
+  &:focus,
+  &:active {
     color: var(--pf-c-nav__scroll-button--hover--Color);
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -138,6 +138,8 @@
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
 
   // Scroll button
+  --pf-c-nav__scroll-button--Display: none;
+  --pf-c-nav__scroll-button--Visibility: hidden;
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
@@ -204,26 +206,10 @@
     }
   }
 
-  // Disable underline
-  [class*="list"] [class*="link"] {
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-      text-decoration: none;
-    }
-  }
-
-  // Scroll button
-  .pf-c-nav__scroll-button {
-    display: none;
-    visibility: hidden;
-  }
-
   &.pf-m-start .pf-c-nav__scroll-button:nth-of-type(1),
   &.pf-m-end .pf-c-nav__scroll-button:nth-of-type(2) {
-    display: flex;
-    visibility: visible;
+    --pf-c-nav__scroll-button--Display: flex;
+    --pf-c-nav__scroll-button--Visibility: visible;
   }
 
   // Divider
@@ -279,6 +265,9 @@
     top: 0;
     bottom: 0;
     left: 0;
+
+    // set pointer events so text is selectable
+    pointer-events: none;
     content: "";
     border-width: 0;
   }
@@ -324,6 +313,13 @@
     color: var(--pf-c-nav__link--disabled--Color);
     pointer-events: none;
     background-color: var(--pf-c-nav__link--disabled--BackgroundColor);
+  }
+
+  &,
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: none;
   }
 }
 
@@ -515,11 +511,14 @@
   top: 0;
   bottom: 0;
   z-index: var(--pf-c-nav__scroll-button--ZIndex);
+  display: var(--pf-c-nav__scroll-button--Display);
+  align-items: center;
   justify-content: center;
   width: var(--pf-c-nav__scroll-button--Width);
   height: 100%;
   padding-right: var(--pf-c-nav__scroll-button--PaddingRight);
   padding-left: var(--pf-c-nav__scroll-button--PaddingLeft);
+  visibility: var(--pf-c-nav__scroll-button--Visibility);
   background-color: var(--pf-c-nav__scroll-button--BackgroundColor);
   border: 0;
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -4,19 +4,19 @@
   --pf-c-nav__item--m-expanded__toggle--i--Transform: rotate(90deg);
 
   // Dark theme
-  --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__link--before--BorderColor: #{$pf-global--BackgroundColor--dark-200};
   --pf-c-nav--m-dark__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--hover--BackgroundColor: #{rgba($pf-global--BackgroundColor--dark-200, .5)};
-  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
+  --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-c-nav__link--before--BorderColor);
+  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
 
   // Link
   --pf-c-nav__link--FontSize: var(--pf-global--FontSize--md);
@@ -30,7 +30,7 @@
   --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
-  --pf-c-nav__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
   --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
@@ -38,14 +38,12 @@
   --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Link ::before borders
-  --pf-c-nav__link--before--BorderStyle: solid;
   --pf-c-nav__link--before--BorderColor: var(--pf-global--BorderColor--300);
   --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__link--before--BorderTopWidth: 0;
   --pf-c-nav__link--before--BorderBottomWidth: 0;
 
   // Link ::before borders
-  --pf-c-nav__link--after--BorderStyle: solid;
   --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-nav__link--after--BorderBottomWidth: 0;
@@ -224,6 +222,8 @@
     padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
     margin-top: var(--pf-c-nav__c-divider--MarginTop);
     margin-bottom: var(--pf-c-nav__c-divider--MarginBottom);
+
+    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__link--before--BorderColor);
   }
 }
 
@@ -276,14 +276,14 @@
 
   &::before {
     border-color: var(--pf-c-nav__link--before--BorderColor);
-    border-style: var(--pf-c-nav__link--before--BorderStyle);
+    border-style: solid;
     border-top-width: var(--pf-c-nav__link--before--BorderTopWidth);
     border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
   }
 
   &::after {
     border-color: var(--pf-c-nav__link--after--BorderColor);
-    border-style: var(--pf-c-nav__link--after--BorderStyle);
+    border-style: solid;
     border-bottom-width: var(--pf-c-nav__link--after--BorderBottomWidth);
     border-left-width: var(--pf-c-nav__link--after--BorderLeftWidth);
   }
@@ -318,9 +318,11 @@
   --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__list__link--PaddingLeft);
   --pf-c-nav__link--before--BorderTopWidth: var(--pf-c-nav__link--before--BorderWidth);
 
-  .pf-c-nav__item:last-child {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__link--before--BorderWidth);
+  .pf-c-nav__item:first-child {
+    --pf-c-nav__link--before--BorderTopWidth: 0;
   }
+
+  border-bottom: var(--pf-c-nav__link--before--BorderWidth) solid var(--pf-c-nav__link--before--BorderColor);
 }
 
 // Active border treatment

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -17,7 +17,7 @@
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-nav--m-dark__subnav__link--hover--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
@@ -111,18 +111,18 @@
   --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Sub nav
-  --pf-c-nav__subnav--MaxHeight: 100%;
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
   --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
-  --pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__item--m-expanded__subnav--MaxHeight: 100%;
 
   // Nav section
   --pf-c-nav__section--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__section__section--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-nav__section--section--MarginTop: var(--pf-global--spacer--xl);
 
   // Nav section title
   --pf-c-nav__section-title--PaddingTop: var(--pf-global--spacer--sm);
@@ -202,7 +202,7 @@
     --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
-    --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__subnav__link--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--BorderColor);
     --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
     --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
     --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
@@ -462,20 +462,21 @@
   --pf-c-nav__simple-list__link--MarginBottom: var(--pf-c-nav--subnav__simple-list__link--MarginBottom);
   --pf-c-nav__simple-list__link--FontSize: var(--pf-c-nav__subnav__link--FontSize);
 
-  max-height: 0;
+  max-height: var(--pf-c-nav__subnav--MaxHeight);
   padding-bottom: var(--pf-c-nav__subnav--PaddingBottom);
   padding-left: var(--pf-c-nav__subnav--PaddingLeft);
   transition: var(--pf-c-nav--Transition);
 
   .pf-c-nav__item.pf-m-expanded & {
-    max-height: var(--pf-c-nav__subnav--MaxHeight);
+    --pf-c-nav__subnav--MaxHeight: var(--pf-c-nav__item--m-expanded__subnav--MaxHeight);
+
     overflow-y: auto;
     opacity: 1;
   }
 
   .pf-c-nav__link:not(.pf-m-current):hover {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--hover--BorderLeftWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--hover--BorderColor);
   }
 
   &::-webkit-scrollbar {
@@ -489,7 +490,7 @@
   margin-top: var(--pf-c-nav__section--MarginTop);
 
   + & {
-    --pf-c-nav__section--MarginTop: var(--pf-c-nav__section__section--MarginTop);
+    --pf-c-nav__section--MarginTop: var(--pf-c-nav__section--section--MarginTop);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -18,8 +18,6 @@
   --pf-c-nav--m-dark__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--active--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
-  --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
-  --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
@@ -41,13 +39,11 @@
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--disabled--BackgroundColor: transparent;
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
@@ -216,13 +212,11 @@
     --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-dark__link--focus--Color);
     --pf-c-nav__link--active--Color: var(--pf-c-nav--m-dark__link--active--Color);
     --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-dark__link--m-current--Color);
-    --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
     --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-dark__link--BackgroundColor);
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
     --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-dark__link--focus--BackgroundColor);
     --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
     --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
-    --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
     --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
@@ -365,13 +359,6 @@
     --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--m-current--BackgroundColor);
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__link--m-current--before--BorderWidth);
     --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__link--m-current--after--BorderWidth);
-  }
-
-  &.pf-m-disabled {
-    --pf-c-nav__link--Color: var(--pf-c-nav__link--disabled--Color);
-    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--disabled--BackgroundColor);
-
-    pointer-events: none;
   }
 
   &,

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -45,6 +45,7 @@
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
+  --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
 
   // Link ::before borders
@@ -108,9 +109,6 @@
   --pf-c-nav__tertiary-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-
-  // Horizontal/tertiary list offsets
-  --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
   // Sub nav
   --pf-c-nav__subnav--MaxHeight: 100%;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -6,8 +6,8 @@
   // Dark theme
   --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--hover--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--focus--Color: var(--pf-c-nav--m-dark__link--hover--Color);
-  --pf-c-nav--m-dark__link--active--Color: var(--pf-c-nav--m-dark__link--hover--Color);
+  --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
@@ -18,7 +18,7 @@
   --pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__item--before--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
 
   // Link
@@ -32,8 +32,8 @@
   --pf-c-nav__link--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__link--active--Color: var(--pf-c-nav__link--hover--Color);
-  --pf-c-nav__link--focus--Color: var(--pf-c-nav__link--hover--Color);
+  --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
@@ -130,12 +130,10 @@
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
 
   // Nav item
-  --pf-c-nav__item--before--Height: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__item--before--BackgroundColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__item--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__item--before--BorderColor: var(--pf-global--BorderColor--300);
 
   // Scroll button
-  --pf-c-nav__scroll-button--Display: none;
-  --pf-c-nav__scroll-button--Visibility: hidden;
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
@@ -143,8 +141,8 @@
   --pf-c-nav__scroll-button--lg--Height: pf-size-prem(40px);
   --pf-c-nav__scroll-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-nav__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-nav__scroll-button--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(255, 255, 255, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(255, 255, 255, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
@@ -196,7 +194,7 @@
     --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor);
     --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
     --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
-    --pf-c-nav__item--before--BackgroundColor: var(--pf-c-nav--m-dark__item--before--BackgroundColor);
+    --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
@@ -227,6 +225,7 @@
   }
 }
 
+// Header nav
 .pf-c-page__header-nav {
   .pf-c-nav__scroll-button {
     background-color: var(--pf-global--BackgroundColor--100);
@@ -245,7 +244,9 @@
   transform: var(--pf-c-nav__item--m-expanded__toggle--i--Transform);
 }
 
-.pf-c-nav__item {
+// Borders
+.pf-c-nav__item,
+.pf-c-nav__link {
   position: relative;
 
   &::before {
@@ -253,13 +254,19 @@
     right: 0;
     bottom: 0;
     left: 0;
-    height: var(--pf-c-nav__item--before--Height);
     content: "";
-    background-color: var(--pf-c-nav__item--before--BackgroundColor);
+    border: 0;
+    border-style: solid;
   }
 }
 
-// Nav link
+// Item
+.pf-c-nav__item::before {
+  border-color: var(--pf-c-nav__item--before--BorderColor);
+  border-bottom-width: var(--pf-c-nav__item--before--BorderWidth);
+}
+
+// Link
 .pf-c-nav__link {
   position: relative;
   display: flex;
@@ -271,13 +278,6 @@
   background-color: var(--pf-c-nav__link--BackgroundColor);
 
   &::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    content: "";
-    border-color: var(--pf-c-nav__link--before--BorderColor);
-    border-style: solid;
     border-width: 0 0 var(--pf-c-nav__link--before--BorderBottomWidth) var(--pf-c-nav__link--before--BorderLeftWidth);
   }
 
@@ -332,7 +332,7 @@
   --pf-c-nav--c-divider--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
 
   .pf-c-nav__item {
-    --pf-c-nav__item--before--BackgroundColor: transparent;
+    --pf-c-nav__item--before--BorderColor: transparent;
   }
 
   .pf-c-nav__link {
@@ -341,14 +341,14 @@
   }
 }
 
-// Horizontal and tertiary nav
+// Horizontal and tertiary list
 .pf-c-nav__horizontal-list,
 .pf-c-nav__tertiary-list {
   --pf-c-nav__link--Right: var(--pf-c-nav__link--PaddingRight);
   --pf-c-nav__link--Left: var(--pf-c-nav__link--PaddingLeft);
 
   .pf-c-nav__item {
-    --pf-c-nav__item--before--BackgroundColor: transparent;
+    --pf-c-nav__item--before--BorderColor: transparent;
   }
 
   @include pf-overflow-hide-scroll;
@@ -371,7 +371,7 @@
   }
 }
 
-// List horizontal, masthead
+// Horizontal list, masthead
 .pf-c-nav__horizontal-list {
   --pf-c-nav__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--PaddingTop);
   --pf-c-nav__link--PaddingRight: var(--pf-c-nav__horizontal-list__link--PaddingRight);
@@ -400,7 +400,7 @@
   }
 }
 
-// List tertiary
+// Tertiary list
 .pf-c-nav__tertiary-list {
   --pf-c-nav__link--PaddingTop: var(--pf-c-nav__tertiary-list__link--PaddingTop);
   --pf-c-nav__link--PaddingRight: var(--pf-c-nav__tertiary-list__link--PaddingRight);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -2,27 +2,30 @@
   --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);
   --pf-c-nav__item--m-expanded__toggle-icon--Transform: rotate(90deg);
+  --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-nav__link--m-current--not--m-expanded__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Dark theme
+  --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__item--m-current--not--m-expandable__link--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--active--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
+  --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__subnav__link--hover--before--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__subnav__link--focus--before--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--200);
-  --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
-  --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark--c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
 
   // Link
@@ -46,15 +49,23 @@
   --pf-c-nav__link--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
-
   // Link ::before borders
-  --pf-c-nav__link--before--BorderColor: var(--pf-global--active-color--400);
-  --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--xl);
-  --pf-c-nav__link--before--BorderBottomWidth: 0;
-  --pf-c-nav__link--before--BorderLeftWidth: 0;
+  --pf-c-nav__link--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__link--m-current--before--BorderWidth: 0;
+
+  // Link ::after borders
+  --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
+  --pf-c-nav__link--after--BorderBottomWidth: 0;
+  --pf-c-nav__link--after--BorderLeftWidth: 0;
+  --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
+
+  // Item ::before borders
+  --pf-c-nav__item--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__item--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Simple list
   --pf-c-nav__simple-list__link--MarginTop: var(--pf-global--spacer--sm);
@@ -64,7 +75,7 @@
   --pf-c-nav__simple-list__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__simple-list__link--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__simple-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
+  --pf-c-nav__simple-list__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Horizontal list
   --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
@@ -85,6 +96,7 @@
   --pf-c-nav__horizontal-list__link--active--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--before--BorderWidth: 0;
   --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
@@ -107,6 +119,7 @@
   --pf-c-nav__tertiary-list__link--active--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--before--BorderWidth: 0;
   --pf-c-nav__tertiary-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
@@ -116,14 +129,14 @@
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-global--BorderColor--dark-100);
-  --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-global--BorderColor--dark-100);
-  --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--dark-100);
-  --pf-c-nav__subnav__link--m-current--before--BorderColor: var(--pf-global--active-color--100);
-  --pf-c-nav__subnav__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--active--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__subnav__link--hover--after--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--focus--after--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--active--after--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--m-current--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__subnav__link--hover--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--focus--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--active--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-nav__subnav--MaxHeight: 0;
   --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
   --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
@@ -144,10 +157,6 @@
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
   --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-
-  // Nav item
-  --pf-c-nav__item--before--BorderColor: var(--pf-global--BorderColor--300);
-  --pf-c-nav__item--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Scroll button
   --pf-c-nav__scroll-button--Display: none;
@@ -201,6 +210,7 @@
 
   &.pf-m-dark {
     --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
+    --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-c-nav--m-dark__item--m-current--not--m-expandable__link--BackgroundColor);
     --pf-c-nav__link--Color: var(--pf-c-nav--m-dark__link--Color);
     --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-dark__link--hover--Color);
     --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-dark__link--focus--Color);
@@ -212,13 +222,13 @@
     --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-dark__link--focus--BackgroundColor);
     --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
     --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
-    --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--before--BorderColor);
-    --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--active--before--BorderColor);
-    --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--focus--before--BorderColor);
+    --pf-c-nav__subnav__link--hover--after--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--before--BorderColor);
+    --pf-c-nav__subnav__link--focus--after--BorderColor: var(--pf-c-nav--m-dark__subnav__link--active--before--BorderColor);
+    --pf-c-nav__subnav__link--active--after--BorderColor: var(--pf-c-nav--m-dark__subnav__link--focus--before--BorderColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark--c-divider--BackgroundColor);
@@ -275,30 +285,30 @@
 }
 
 // Borders
-.pf-c-nav__item,
-.pf-c-nav__link {
+.pf-c-nav__item {
   position: relative;
 
-  &::before {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    content: "";
-    border: 0;
-    border-style: solid;
-  }
-}
+  &.pf-m-expandable {
+    --pf-c-nav__link--before--BorderBottomWidth: 0;
 
-// Item
-.pf-c-nav__item::before {
-  right: 0;
-  border-color: var(--pf-c-nav__item--before--BorderColor);
-  border-bottom-width: var(--pf-c-nav__item--before--BorderWidth);
+    &::before {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      content: "";
+      border-bottom: var(--pf-c-nav__item--before--BorderWidth) solid var(--pf-c-nav__item--before--BorderColor);
+    }
+  }
+
+  &.pf-m-current:not(.pf-m-expanded) {
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__link--m-current--not--m-expanded__link--after--BorderWidth);
+  }
 }
 
 // Link
 .pf-c-nav__link {
-  position: relative;
   display: flex;
   align-items: baseline;
   padding: var(--pf-c-nav__link--PaddingTop) var(--pf-c-nav__link--PaddingRight) var(--pf-c-nav__link--PaddingBottom) var(--pf-c-nav__link--PaddingLeft);
@@ -308,10 +318,30 @@
   background-color: var(--pf-c-nav__link--BackgroundColor);
   outline-offset: var(--pf-c-nav__link--OutlineOffset);
 
+  &::after,
   &::before {
-    top: 0;
+    position: absolute;
+    content: "";
+    border: 0;
+    border-style: solid;
+  }
+
+  &::before {
+    right: 0;
+
+    // offset to hide sibling borders for hover state
+    bottom: calc(var(--pf-c-nav__link--before--BorderBottomWidth) * -1);
+    left: 0;
     border-color: var(--pf-c-nav__link--before--BorderColor);
-    border-width: 0 0 var(--pf-c-nav__link--before--BorderBottomWidth) var(--pf-c-nav__link--before--BorderLeftWidth);
+    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
+  }
+
+  &::after {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    border-color: var(--pf-c-nav__link--after--BorderColor);
+    border-width: 0 0 var(--pf-c-nav__link--after--BorderBottomWidth) var(--pf-c-nav__link--after--BorderLeftWidth);
   }
 
   // States
@@ -333,10 +363,10 @@
   &.pf-m-current {
     --pf-c-nav__link--Color: var(--pf-c-nav__link--m-current--Color);
     --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--m-current--BackgroundColor);
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__link--m-current--before--BorderWidth);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__link--m-current--before--BorderWidth);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__link--m-current--after--BorderWidth);
   }
 
-  &:disabled,
   &.pf-m-disabled {
     --pf-c-nav__link--Color: var(--pf-c-nav__link--disabled--Color);
     --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--disabled--BackgroundColor);
@@ -360,13 +390,10 @@
   --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__simple-list__link--PaddingBottom);
   --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
   --pf-c-nav__link--FontSize: var(--pf-c-nav__simple-list__link--FontSize);
-  --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-c-nav__simple-list__link--m-current--before--BorderWidth);
+  --pf-c-nav__link--before--BorderColor: transparent;
+  --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-c-nav__simple-list__link--m-current--after--BorderWidth);
   --pf-c-nav--c-divider--PaddingRight: var(--pf-c-nav__simple-list__link--PaddingRight);
   --pf-c-nav--c-divider--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
-
-  .pf-c-nav__item {
-    --pf-c-nav__item--before--BorderColor: transparent;
-  }
 
   .pf-c-nav__link {
     margin-top: var(--pf-c-nav__simple-list__link--MarginTop);
@@ -399,7 +426,13 @@
   .pf-c-nav__link::before {
     top: auto;
     right: var(--pf-c-nav__link--Right);
+    bottom: 0;
     left: var(--pf-c-nav__link--Left);
+    border-bottom-width: var(--pf-c-nav__link--before--BorderBottomWidth);
+  }
+
+  .pf-c-nav__link::after {
+    content: none;
   }
 }
 
@@ -420,6 +453,7 @@
   --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--active--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
+  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--before--BorderWidth);
 
   .pf-c-nav__link:hover {
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--hover--before--BorderWidth);
@@ -456,6 +490,7 @@
   --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--active--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
+  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--before--BorderWidth);
 
   .pf-c-nav__link:hover {
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--hover--before--BorderWidth);
@@ -494,23 +529,23 @@
   }
 
   .pf-c-nav__link:hover {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--hover--before--BorderWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--hover--before--BorderColor);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--hover--after--BorderWidth);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--hover--after--BorderColor);
   }
 
   .pf-c-nav__link:focus {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--focus--before--BorderWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--focus--before--BorderColor);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--focus--after--BorderWidth);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--focus--after--BorderColor);
   }
 
   .pf-c-nav__link:active {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--active--before--BorderWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--active--before--BorderColor);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--active--after--BorderWidth);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--active--after--BorderColor);
   }
 
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--m-current--before--BorderWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--m-current--before--BorderColor);
+    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--m-current--after--BorderWidth);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--m-current--after--BorderColor);
   }
 
   &::-webkit-scrollbar {
@@ -523,7 +558,7 @@
 .pf-c-nav__section {
   margin-top: var(--pf-c-nav__section--MarginTop);
 
-  + & {
+  & + & {
     --pf-c-nav__section--MarginTop: var(--pf-c-nav__section--section--MarginTop);
   }
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -6,8 +6,8 @@
   // Dark theme
   --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--hover--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
+  --pf-c-nav--m-dark__link--focus--Color: var(--pf-c-nav--m-dark__link--hover--Color);
+  --pf-c-nav--m-dark__link--active--Color: var(--pf-c-nav--m-dark__link--hover--Color);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
@@ -32,16 +32,18 @@
   --pf-c-nav__link--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--active--Color: var(--pf-c-nav__link--hover--Color);
+  --pf-c-nav__link--focus--Color: var(--pf-c-nav__link--hover--Color);
   --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
-  --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
+
 
   // Link ::before borders
   --pf-c-nav__link--before--BorderColor: var(--pf-global--active-color--400);
@@ -57,6 +59,7 @@
   --pf-c-nav__simple-list__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__simple-list__link--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__simple-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Subnav
   --pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
@@ -72,13 +75,14 @@
   --pf-c-nav__horizontal-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
   --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
+  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
+  --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__horizontal-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Tertiary list
   --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--sm);
@@ -88,13 +92,15 @@
   --pf-c-nav__tertiary-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Horizontal/tertiary list offsets
   --pf-c-nav__link--offset: calc(var(--pf-global--spacer--xs) * -1);
@@ -277,30 +283,32 @@
 
   // States
   &:hover {
-    color: var(--pf-c-nav__link--hover--Color);
-    background-color: var(--pf-c-nav__link--hover--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav__link--hover--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
   }
 
   &:focus {
-    color: var(--pf-c-nav__link--focus--Color);
-    background-color: var(--pf-c-nav__link--focus--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav__link--focus--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--focus--BackgroundColor);
   }
 
   &:active {
-    color: var(--pf-c-nav__link--active--Color);
-    background-color: var(--pf-c-nav__link--active--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav__link--active--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--active--BackgroundColor);
   }
 
   &.pf-m-current {
-    color: var(--pf-c-nav__link--m-current--Color);
-    background-color: var(--pf-c-nav__link--m-current--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav__link--m-current--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__link--m-current--before--BorderWidth);
   }
 
   &:disabled,
   &.pf-m-disabled {
-    color: var(--pf-c-nav__link--disabled--Color);
+    --pf-c-nav__link--Color: var(--pf-c-nav__link--disabled--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__link--disabled--BackgroundColor);
+
     pointer-events: none;
-    background-color: var(--pf-c-nav__link--disabled--BackgroundColor);
   }
 
   &,
@@ -308,14 +316,6 @@
   &:focus,
   &:active {
     text-decoration: none;
-  }
-}
-
-// Active border treatment
-.pf-c-nav__list,
-.pf-c-nav__simple-list {
-  .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__link--before--BorderWidth);
   }
 }
 
@@ -327,6 +327,7 @@
   --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__simple-list__link--PaddingBottom);
   --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
   --pf-c-nav__link--FontSize: var(--pf-c-nav__simple-list__link--FontSize);
+  --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-c-nav__simple-list__link--m-current--before--BorderWidth);
   --pf-c-nav--c-divider--PaddingRight: var(--pf-c-nav__simple-list__link--PaddingRight);
   --pf-c-nav--c-divider--PaddingLeft: var(--pf-c-nav__simple-list__link--PaddingLeft);
 
@@ -380,19 +381,22 @@
   --pf-c-nav__link--hover--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
   --pf-c-nav__link--active--Color: var(--pf-c-nav__horizontal-list__link--active--Color);
   --pf-c-nav__link--focus--Color: var(--pf-c-nav__horizontal-list__link--focus--Color);
+  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__horizontal-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
-  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,
-  .pf-c-nav__link:active,
+  .pf-c-nav__link:active {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--hover--before--BorderWidth);
+  }
+
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--before--BorderWidth);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--m-current--before--BorderWidth);
   }
 }
 
@@ -405,21 +409,24 @@
   --pf-c-nav__link--FontWeight: var(--pf-c-nav__tertiary-list__link--FontWeight);
   --pf-c-nav__link--Color: var(--pf-c-nav__tertiary-list__link--Color);
   --pf-c-nav__link--hover--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
-  --pf-c-nav__link--active--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
-  --pf-c-nav__link--focus--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__link--active--Color: var(--pf-c-nav__tertiary-list__link--active--Color);
+  --pf-c-nav__link--focus--Color: var(--pf-c-nav__tertiary-list__link--focus--Color);
+  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__tertiary-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
-  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,
-  .pf-c-nav__link:active,
+  .pf-c-nav__link:active {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--hover--before--BorderWidth);
+  }
+
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--before--BorderWidth);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--m-current--before--BorderWidth);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -110,7 +110,7 @@
   --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Horizontal/tertiary list offsets
-  --pf-c-nav__link--offset: calc(var(--pf-global--spacer--xs) * -1);
+  --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
   // Sub nav
   --pf-c-nav__subnav--MaxHeight: 100%;
@@ -289,7 +289,7 @@
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
   background-color: var(--pf-c-nav__link--BackgroundColor);
-  outline-offset: var(--pf-c-nav__link--offset);
+  outline-offset: var(--pf-c-nav__link--OutlineOffset);
 
   &::before {
     top: 0;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -21,7 +21,7 @@
   --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark--c-divider--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
 
   // Link
   --pf-c-nav__link--FontSize: var(--pf-global--FontSize--md);
@@ -208,7 +208,7 @@
     --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
 
     .pf-c-divider {
-      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark__c-divider--BackgroundColor);
+      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark--c-divider--BackgroundColor);
     }
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,7 +1,7 @@
 .pf-c-nav {
   --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);
-  --pf-c-nav__item--m-expanded__toggle--i--Transform: rotate(90deg);
+  --pf-c-nav__item--m-expanded__toggle-icon--Transform: rotate(90deg);
 
   // Dark theme
   --pf-c-nav--m-dark__link--Color: var(--pf-global--Color--light-100);
@@ -165,11 +165,14 @@
   --pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
   --pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
 
-  // List toggle
+  // Toggle
   --pf-c-nav__toggle--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-nav__toggle--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-nav__toggle--FontSize: var(--pf-global--icon--FontSize--md);
   --pf-c-nav__toggle--Transition: var(--pf-global--TransitionDuration);
+
+  // Toggle icon
+  --pf-c-nav__toggle-icon--Transform: none;
 
   // Divider
   --pf-c-nav--c-divider--MarginTop: var(--pf-global--spacer--sm);
@@ -261,8 +264,14 @@
   }
 }
 
-.pf-c-nav__item.pf-m-expanded .pf-c-nav__toggle > i {
-  transform: var(--pf-c-nav__item--m-expanded__toggle--i--Transform);
+// Toggle icon
+.pf-c-nav__toggle-icon {
+  display: inline-block;
+  transform: var(--pf-c-nav__toggle-icon--Transform);
+
+  .pf-c-nav__item.pf-m-expanded & {
+    --pf-c-nav__toggle-icon--Transform: var(--pf-c-nav__item--m-expanded__toggle-icon--Transform);
+  }
 }
 
 // Borders

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -42,7 +42,6 @@
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
   // Link ::before borders
   --pf-c-nav__link--before--BorderColor: var(--pf-global--active-color--400);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -17,7 +17,9 @@
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-nav--m-dark__subnav__link--hover--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-nav--m-dark__subnav__link--hover--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-nav--m-dark__subnav__link--focus--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-nav--m-dark__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--200);
   --pf-c-nav--m-dark__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav--m-dark__link--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__item--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
@@ -116,8 +118,15 @@
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
   --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
-  --pf-c-nav__subnav__link--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--m-current--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav__subnav__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--active--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__subnav--MaxHeight: 0;
   --pf-c-nav__item--m-expanded__subnav--MaxHeight: 100%;
 
   // Nav section
@@ -202,10 +211,12 @@
     --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
-    --pf-c-nav__subnav__link--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--BorderColor);
     --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
     --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
     --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
+    --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--before--BorderColor);
+    --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--focus--before--BorderColor);
+    --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--active--before--BorderColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark--c-divider--BackgroundColor);
@@ -474,9 +485,24 @@
     opacity: 1;
   }
 
-  .pf-c-nav__link:not(.pf-m-current):hover {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--hover--BorderLeftWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--hover--BorderColor);
+  .pf-c-nav__link:hover {
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--hover--before--BorderWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--hover--before--BorderColor);
+  }
+
+  .pf-c-nav__link:focus {
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--focus--before--BorderWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--focus--before--BorderColor);
+  }
+
+  .pf-c-nav__link:active {
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--active--before--BorderWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--active--before--BorderColor);
+  }
+
+  .pf-c-nav__link.pf-m-current {
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--m-current--before--BorderWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--m-current--before--BorderColor);
   }
 
   &::-webkit-scrollbar {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -278,6 +278,9 @@
   background-color: var(--pf-c-nav__link--BackgroundColor);
 
   &::before {
+    top: 0;
+    right: auto;
+    border-color: var(--pf-c-nav__link--before--BorderColor);
     border-width: 0 0 var(--pf-c-nav__link--before--BorderBottomWidth) var(--pf-c-nav__link--before--BorderLeftWidth);
   }
 
@@ -446,12 +449,6 @@
     max-height: var(--pf-c-nav__subnav--MaxHeight);
     overflow-y: auto;
     opacity: 1;
-  }
-
-  .pf-c-nav__link:not(.pf-m-current):hover {
-    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
-    --pf-c-nav__link--before--BorderTopWidth: 0;
   }
 
   &::-webkit-scrollbar {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -83,6 +83,8 @@
   --pf-c-nav__horizontal-list__link--m-active--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__horizontal-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__horizontal-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Tertiary list
@@ -103,6 +105,8 @@
   --pf-c-nav__tertiary-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Horizontal/tertiary list offsets
@@ -285,6 +289,7 @@
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
   background-color: var(--pf-c-nav__link--BackgroundColor);
+  outline-offset: var(--pf-c-nav__link--offset);
 
   &::before {
     top: 0;
@@ -372,7 +377,6 @@
   .pf-c-nav__link {
     position: relative;
     display: inline-block;
-    outline-offset: var(--pf-c-nav__link--offset);
   }
 
   .pf-c-nav__link::before {
@@ -400,10 +404,16 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
 
-  .pf-c-nav__link:hover,
-  .pf-c-nav__link:focus,
-  .pf-c-nav__link:active {
+  .pf-c-nav__link:hover {
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--hover--before--BorderWidth);
+  }
+
+  .pf-c-nav__link:focus {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--focus--before--BorderWidth);
+  }
+
+  .pf-c-nav__link:active {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--active--before--BorderWidth);
   }
 
   .pf-c-nav__link.pf-m-current {
@@ -430,10 +440,16 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
 
-  .pf-c-nav__link:hover,
-  .pf-c-nav__link:focus,
-  .pf-c-nav__link:active {
+  .pf-c-nav__link:hover {
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--hover--before--BorderWidth);
+  }
+
+  .pf-c-nav__link:focus {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--focus--before--BorderWidth);
+  }
+
+  .pf-c-nav__link:active {
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--active--before--BorderWidth);
   }
 
   .pf-c-nav__link.pf-m-current {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -47,7 +47,7 @@
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
+  --pf-c-nav__link--disabled--BackgroundColor: transparent;
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--OutlineOffset: calc(var(--pf-global--spacer--xs) * -1);
 
@@ -294,7 +294,7 @@
     &::before {
       position: absolute;
       right: 0;
-      bottom: 0;
+      bottom: calc(var(--pf-c-nav__item--before--BorderWidth) * -1);
       left: 0;
       content: "";
       border-bottom: var(--pf-c-nav__item--before--BorderWidth) solid var(--pf-c-nav__item--before--BorderColor);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -9,7 +9,7 @@
   --pf-c-nav--m-dark__link--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--active--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__link--m-current--Color: var(--pf-global--Color--light-100);
-  --pf-c-nav--m-dark__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
@@ -44,11 +44,11 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
 
-  // Link ::after borders
-  --pf-c-nav__link--after--BorderColor: var(--pf-global--active-color--400);
-  --pf-c-nav__link--after--BorderWidth: var(--pf-global--BorderWidth--xl);
-  --pf-c-nav__link--after--BorderBottomWidth: 0;
-  --pf-c-nav__link--after--BorderLeftWidth: 0;
+  // Link ::before borders
+  --pf-c-nav__link--before--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__link--before--BorderWidth: var(--pf-global--BorderWidth--xl);
+  --pf-c-nav__link--before--BorderBottomWidth: 0;
+  --pf-c-nav__link--before--BorderLeftWidth: 0;
 
   // Simple list
   --pf-c-nav__simple-list__link--MarginTop: var(--pf-global--spacer--sm);
@@ -78,8 +78,8 @@
   --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__horizontal-list__link--after--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
 
   // Tertiary list
   --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--sm);
@@ -94,8 +94,8 @@
   --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__tertiary-list__link--after--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
 
   // Horizontal/tertiary list offsets
   --pf-c-nav__link--offset: calc(var(--pf-global--spacer--xs) * -1);
@@ -185,7 +185,7 @@
     --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-dark__link--m-current--Color);
     --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
     --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
-    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav--m-dark__link--after--BorderColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
@@ -264,18 +264,17 @@
   font-size: var(--pf-c-nav__link--FontSize);
   font-weight: var(--pf-c-nav__link--FontWeight);
   color: var(--pf-c-nav__link--Color);
-  user-select: text;
   background-color: var(--pf-c-nav__link--BackgroundColor);
 
-  &::after {
+  &::before {
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
     content: "";
-    border-color: var(--pf-c-nav__link--after--BorderColor);
+    border-color: var(--pf-c-nav__link--before--BorderColor);
     border-style: solid;
-    border-width: 0 0 var(--pf-c-nav__link--after--BorderBottomWidth) var(--pf-c-nav__link--after--BorderLeftWidth);
+    border-width: 0 0 var(--pf-c-nav__link--before--BorderBottomWidth) var(--pf-c-nav__link--before--BorderLeftWidth);
   }
 
   // States
@@ -318,7 +317,7 @@
 .pf-c-nav__list,
 .pf-c-nav__simple-list {
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__link--after--BorderWidth);
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__link--before--BorderWidth);
   }
 }
 
@@ -366,7 +365,7 @@
     outline-offset: var(--pf-c-nav__link--offset);
   }
 
-  .pf-c-nav__link::after {
+  .pf-c-nav__link::before {
     top: auto;
     right: var(--pf-c-nav__link--Right);
     left: var(--pf-c-nav__link--Left);
@@ -389,13 +388,13 @@
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
-  --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__horizontal-list__link--after--BorderColor);
+  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,
   .pf-c-nav__link:active,
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--after--BorderWidth);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--before--BorderWidth);
   }
 }
 
@@ -416,13 +415,13 @@
   --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
-  --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__tertiary-list__link--after--BorderColor);
+  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
 
   .pf-c-nav__link:hover,
   .pf-c-nav__link:focus,
   .pf-c-nav__link:active,
   .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--after--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--after--BorderWidth);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--before--BorderWidth);
   }
 }
 
@@ -445,9 +444,9 @@
   }
 
   .pf-c-nav__link:not(.pf-m-current):hover {
-    --pf-c-nav__link--after--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
-    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
-    --pf-c-nav__link--after--BorderTopWidth: 0;
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__link--before--BorderTopWidth: 0;
   }
 
   &::-webkit-scrollbar {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -36,8 +36,8 @@
   --pf-c-nav__link--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav__link--active--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
@@ -83,7 +83,7 @@
   --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--focus--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--active--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--m-active--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
@@ -116,17 +116,17 @@
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
-  --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
   --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-global--BorderColor--dark-100);
-  --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--dark-100);
   --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-global--BorderColor--dark-100);
+  --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-global--BorderColor--dark-100);
   --pf-c-nav__subnav__link--m-current--before--BorderColor: var(--pf-global--active-color--100);
   --pf-c-nav__subnav__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__subnav__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__subnav__link--active--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__subnav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__subnav--MaxHeight: 0;
+  --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
+  --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
   --pf-c-nav__item--m-expanded__subnav--MaxHeight: 100%;
 
   // Nav section
@@ -142,17 +142,16 @@
   --pf-c-nav__section-title--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
-  --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
 
   // Nav item
-  --pf-c-nav__item--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-nav__item--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__item--before--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Scroll button
   --pf-c-nav__scroll-button--Display: none;
   --pf-c-nav__scroll-button--Visibility: hidden;
-  --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
   --pf-c-nav__scroll-button--Height: 100%;
@@ -198,25 +197,25 @@
   position: relative;
 
   &.pf-m-dark {
-    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-dark__link--BackgroundColor);
+    --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
     --pf-c-nav__link--Color: var(--pf-c-nav--m-dark__link--Color);
     --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-dark__link--hover--Color);
     --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-dark__link--focus--Color);
     --pf-c-nav__link--active--Color: var(--pf-c-nav--m-dark__link--active--Color);
     --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-dark__link--m-current--Color);
-    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
+    --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-dark__link--BackgroundColor);
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
     --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-dark__link--focus--BackgroundColor);
     --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
+    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
+    --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
-    --pf-c-nav__link--disabled--Color: var(--pf-c-nav--m-dark__link--disabled--Color);
-    --pf-c-nav__link--disabled--BackgroundColor: var(--pf-c-nav--m-dark__link--disabled--BackgroundColor);
-    --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
     --pf-c-nav__subnav__link--hover--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--hover--before--BorderColor);
-    --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--focus--before--BorderColor);
     --pf-c-nav__subnav__link--focus--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--active--before--BorderColor);
+    --pf-c-nav__subnav__link--active--before--BorderColor: var(--pf-c-nav--m-dark__subnav__link--focus--before--BorderColor);
 
     .pf-c-divider {
       --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-dark--c-divider--BackgroundColor);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -139,6 +139,8 @@
   --pf-c-nav__item--before--BorderColor: var(--pf-global--BorderColor--300);
 
   // Scroll button
+  --pf-c-nav__scroll-button--Display: none;
+  --pf-c-nav__scroll-button--Visibility: hidden;
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
   --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
@@ -460,7 +462,6 @@
   .pf-c-nav__link:not(.pf-m-current):hover {
     --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
     --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
-    --pf-c-nav__link--before--BorderTopWidth: 0;
   }
 
   &::-webkit-scrollbar {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -164,11 +164,11 @@
   --pf-c-nav__toggle--Transition: var(--pf-global--TransitionDuration);
 
   // Divider
-  --pf-c-nav__c-divider--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__c-divider--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav--c-divider--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-nav--c-divider--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-nav--c-divider--PaddingRight: 0;
   --pf-c-nav--c-divider--PaddingLeft: 0;
-  --pf-c-nav__c-divider--BackgroundColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav--c-divider--BackgroundColor: var(--pf-global--BorderColor--300);
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-nav__link--PaddingRight: var(--pf-c-nav__link--md--PaddingRight);
@@ -220,12 +220,12 @@
 
   // Divider
   .pf-c-divider {
-    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav__c-divider--BackgroundColor);
+    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--c-divider--BackgroundColor);
 
     padding-right: var(--pf-c-nav--c-divider--PaddingRight);
     padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
-    margin-top: var(--pf-c-nav__c-divider--MarginTop);
-    margin-bottom: var(--pf-c-nav__c-divider--MarginBottom);
+    margin-top: var(--pf-c-nav--c-divider--MarginTop);
+    margin-bottom: var(--pf-c-nav--c-divider--MarginBottom);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -115,6 +115,8 @@
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav--subnav__simple-list__link--MarginTop: 0;
   --pf-c-nav--subnav__simple-list__link--MarginBottom: 0;
+  --pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
 
   // Nav section
   --pf-c-nav__section--MarginTop: var(--pf-global--spacer--sm);
@@ -453,6 +455,12 @@
     max-height: var(--pf-c-nav__subnav--MaxHeight);
     overflow-y: auto;
     opacity: 1;
+  }
+
+  .pf-c-nav__link:not(.pf-m-current):hover {
+    --pf-c-nav__link--before--BorderLeftWidth: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__subnav__link--not--m-current--hover--BorderColor);
+    --pf-c-nav__link--before--BorderTopWidth: 0;
   }
 
   &::-webkit-scrollbar {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -12,6 +12,8 @@
   --pf-c-nav--m-dark__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav--m-dark__link--BackgroundColor: transparent;
   --pf-c-nav--m-dark__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-nav--m-dark__link--active--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-nav--m-dark__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
   --pf-c-nav--m-dark__section-title--Color: var(--pf-global--Color--light-100);
   --pf-c-nav--m-dark__section-title--BorderBottomColor: var(--pf-global--BackgroundColor--dark-200);
@@ -38,8 +40,8 @@
   --pf-c-nav__link--m-current--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--BackgroundColor: transparent;
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
@@ -61,10 +63,6 @@
   --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__simple-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--xl);
 
-  // Subnav
-  --pf-c-nav__subnav__link--not--m-current--hover--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-global--BorderColor--dark-100);
-
   // Horizontal list
   --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-nav__horizontal-list__link--PaddingRight: var(--pf-global--spacer--md);
@@ -75,11 +73,14 @@
   --pf-c-nav__horizontal-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
   --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
-  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
+  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--focus--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--active--BackgroundColor: transparent;
+  --pf-c-nav__horizontal-list__link--m-active--BackgroundColor: transparent;
   --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
   --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__horizontal-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
@@ -92,11 +93,13 @@
   --pf-c-nav__tertiary-list__link--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
-  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
+  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
+  --pf-c-nav__tertiary-list__link--focus--BackgroundColor: transparent;
+  --pf-c-nav__tertiary-list__link--active--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--m-current--BackgroundColor: transparent;
   --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
   --pf-c-nav__tertiary-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
@@ -189,6 +192,8 @@
     --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
     --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
+    --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-dark__link--focus--BackgroundColor);
+    --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-dark__link--active--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);
     --pf-c-nav__subnav__link--not--m-current--hover--BorderColor: var(--pf-c-nav--m-dark__subnav__link--not--m-current--hover--BorderColor);
@@ -386,8 +391,8 @@
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__horizontal-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--focus--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--active--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
 
@@ -416,8 +421,8 @@
   --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
   --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__tertiary-list__link--BackgroundColor);
   --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
+  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--focus--BackgroundColor);
+  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--active--BackgroundColor);
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -184,7 +184,6 @@
     --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-dark__link--m-current--Color);
     --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-dark__link--m-current--BackgroundColor);
     --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-dark__link--before--BorderColor);
     --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-dark__link--hover--BackgroundColor);
     --pf-c-nav__section-title--Color: var(--pf-c-nav--m-dark__section-title--Color);
     --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-dark__section-title--BorderBottomColor);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -251,7 +251,6 @@
 
   &::before {
     position: absolute;
-    right: 0;
     bottom: 0;
     left: 0;
     content: "";
@@ -262,6 +261,7 @@
 
 // Item
 .pf-c-nav__item::before {
+  right: 0;
   border-color: var(--pf-c-nav__item--before--BorderColor);
   border-bottom-width: var(--pf-c-nav__item--before--BorderWidth);
 }
@@ -279,7 +279,6 @@
 
   &::before {
     top: 0;
-    right: auto;
     border-color: var(--pf-c-nav__link--before--BorderColor);
     border-width: 0 0 var(--pf-c-nav__link--before--BorderBottomWidth) var(--pf-c-nav__link--before--BorderLeftWidth);
   }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -36,15 +36,14 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-brand-link--c-brand--MaxHeight: #{pf-size-prem(60px)};
 
   // Header nav
-  --pf-c-page__header-nav--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-nav--md--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-page__header-nav--lg--PaddingLeft: 0;
-  --pf-c-page__header-nav--lg--MarginLeft: var(--pf-global--spacer--xl);
   --pf-c-page__header-nav--lg--MarginRight: var(--pf-global--spacer--xl);
+  --pf-c-page__header-nav--lg--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-nav--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
   --pf-c-page__header-nav--lg--BackgroundColor: transparent;
   --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs))); // This sets the the button to the edge of its container with 4px clearance on the left
-  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--md--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
+  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--md--Left: var(--pf-global--spacer--xl);
   --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left: 0;
   --pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor: var(--pf-c-page__header-nav--BackgroundColor);
   --pf-c-page__header-nav--c-nav__scroll-button--lg--Top: 0;
@@ -121,12 +120,12 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-page__main-nav--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-page__main-nav--md--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left: calc(-1 * (var(--pf-global--spacer--lg) - var(--pf-global--spacer--xs))); // This sets the the button to the edge of its container with 4px clearance on the left
+  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the left
   --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right: calc(-1 * (var(--pf-global--spacer--lg) - var(--pf-global--spacer--xs))); // This sets the the button to the edge of its container with 4px clearance on the right
+  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the right
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left);
@@ -240,7 +239,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   grid-column: 1 / -1;
   grid-row: 2 / 3;
   min-width: 0;
-  padding-left: var(--pf-c-page__header-nav--PaddingLeft);
   background-color: var(--pf-c-page__header-nav--BackgroundColor);
 
   > .pf-c-nav {
@@ -422,6 +420,18 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   background-color: var(--pf-c-page__main-nav--BackgroundColor);
 
   .pf-c-nav {
+    // stylelint-disable max-nesting-depth
+    .pf-c-nav__item:first-child {
+      .pf-c-nav__link {
+        padding-left: 0;
+
+        @media screen and (min-width: $pf-global--breakpoint--md) {
+          padding-left: var(--pf-c-nav__link--PaddingLeft);
+        }
+      }
+    }
+    // stylelint-enable
+
     .pf-c-nav__scroll-button {
       &:nth-of-type(1) {
         left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -118,7 +118,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
   // Main section horizontal nav
   --pf-c-page__main-nav--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--lg);

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -247,7 +247,7 @@ section: demos
         {{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
           System panel
         {{/nav-section-title}}
-        {{#> nav-list}}
+        {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Overview
@@ -284,7 +284,7 @@ section: demos
         {{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
           Policy
         {{/nav-section-title}}
-        {{#> nav-list}}
+        {{#> nav-list nav-list--type="simple"}}
           {{#> nav-item newcontent}}
             {{#> nav-link nav-link--href="#"}}
               Hosts

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -317,16 +317,8 @@ section: demos
 {{/page}}
 ```
 
-```hbs title=Legacy-nav-separators isFullscreen
-{{#> page-demo-expandable-nav page-demo-expandable--id="page-legacy-nav-separators-example" page--IsLegacySeparators="true" page-sidebar--modifier="pf-m-dark" nav--modifier="pf-m-dark"}}{{/page-demo-expandable-nav}}
-```
-
 ```hbs title=Light-theme-sidebar-and-nav isFullscreen
 {{#> page-demo-expandable-nav page-demo-expandable--id="page-light-sidebar-nav-example"}}{{/page-demo-expandable-nav}}
-```
-
-```hbs title=Light-theme-sidebar-and-nav-and-legacy-nav-separators isFullscreen
-{{#> page-demo-expandable-nav page-demo-expandable--id="page-light-sidebar-nav-legacy-nav-example" page--IsLegacySeparators="true"}}{{/page-demo-expandable-nav}}
 ```
 
 ## Documentation

--- a/src/patternfly/demos/Page/page-demo-default.hbs
+++ b/src/patternfly/demos/Page/page-demo-default.hbs
@@ -23,12 +23,12 @@
     {{#> nav nav--attribute=(concat 'id="' page--id '-primary-nav" aria-label="Global"')}}
       {{#> nav-list}}
         {{#> nav-item}}
-          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+          {{#> nav-link nav-link--href="#"}}
             System panel
           {{/nav-link}}
         {{/nav-item}}
         {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
+          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
             Policy
           {{/nav-link}}
         {{/nav-item}}

--- a/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
+++ b/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
@@ -84,11 +84,6 @@
             {{/nav-list}}
           {{/nav-subnav}}
         {{/nav-item}}
-        {{#if page--IsLegacySeparators}}
-          {{#> nav-separator}}{{/nav-separator}}
-        {{else}}
-          {{#> divider divider--type="li"}}{{/divider}}
-        {{/if}}
         {{#> nav-item nav-item--expandable="true"}}
           {{#> nav-link nav-link--href="#" nav-link--attribute=(concat 'id="' page--id '-expandable-nav-link3"')}}
             Authentication

--- a/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
+++ b/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
@@ -42,11 +42,7 @@
                   Hypervisors
                 {{/nav-link}}
               {{/nav-item}}
-              {{#if page--IsLegacySeparators}}
-                {{#> nav-separator}}{{/nav-separator}}
-              {{else}}
-                {{#> divider divider--type="li"}}{{/divider}}
-              {{/if}}
+              {{#> divider divider--type="li"}}{{/divider}}
               {{#> nav-item newcontent}}
                 {{#> nav-link nav-link--href="#"}}
                   Instances

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -171,6 +171,7 @@ $pf-global--breakpoint--2xl: 1450px !default;
 $pf-global--BorderWidth--sm:     1px !default;
 $pf-global--BorderWidth--md:     2px !default;
 $pf-global--BorderWidth--lg:     3px !default;
+$pf-global--BorderWidth--xl:     4px !default;
 $pf-global--BorderColor--100:    $pf-color-black-300 !default;
 $pf-global--BorderColor--200:    $pf-color-black-500 !default;
 $pf-global--BorderColor--300:    $pf-color-black-200 !default;


### PR DESCRIPTION
closes #1849 
closes #2196
closes #2650 

**Nav component preview**
https://patternfly-pr-2884.surge.sh/documentation/core/demos/page

## Breaking changes
The nav component's css was refactored, see the file list for details on what changed 
https://github.com/patternfly/patternfly/pull/2884/files

This PR:
1. Applies stylistic updates to css variables rather than redefining component elements.
2. Updates `--pf-c-nav__c-nested-component--Property` to `--pf-c-nav--c-nested-component--Property`. Any instances of the old variable should be updated to the new variable.
3. Updates visual style of navigation only, no HTML updates are necessary. 