### PR TITLE
feat(card): added flat variation

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -16,6 +16,8 @@
   --pf-c-card--m-compact--child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-card--m-compact__header--not--last-child--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-card--m-flat--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-card--m-flat--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-card--first-child--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingBottom: var(--pf-global--spacer--lg);
@@ -76,6 +78,12 @@
     --pf-c-card--child--PaddingBottom: var(--pf-c-card--m-compact--child--PaddingBottom);
     --pf-c-card--child--PaddingLeft: var(--pf-c-card--m-compact--child--PaddingLeft);
     --pf-c-card__header--not--last-child--PaddingBottom: var(--pf-c-card--m-compact__header--not--last-child--PaddingBottom);
+  }
+
+  &.pf-m-flat {
+    --pf-c-card--BoxShadow: none;
+
+    border: var(--pf-c-card--m-flat--BorderWidth) solid var(--pf-c-card--m-flat--BorderColor);
   }
 }
 

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -223,6 +223,20 @@ cssPrefix: pf-c-card
 {{/card}}
 ```
 
+```hbs title=Flat
+{{#> card card--modifier="pf-m-flat"}}
+  {{#> card-header}}
+    Header
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+```
+
 ## Documentation
 ### Overview
 A card is a generic rectangular container that can be used to build other components. Use a default card for regular page content and the compact variation for dashboard or small cards.
@@ -247,3 +261,4 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |
 | `.pf-m-selectable` | `.pf-c-card` | Modifies a selectable card so that it is selectable. |
 | `.pf-m-selected` | `.pf-c-card.pf-m-selectable` | Modifies a selectable card for the selected state. |
+| `.pf-m-flat` | `.pf-c-card` | Modifies the card to have a border instead of a shadow. `.pf-m-flat` is for use in layouts where cards are against a white background.


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2852

@mcarrano @lboehling I named this `.pf-m-border`. Is that OK or is there a more meaningful description for the variation name in case, for example, in the future we decide to style this variation differently in a way that doesn't involve a border?