### PR TITLE
fix(drawer): removed m-border, enabled m-no-border on inline/static

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -287,15 +287,9 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // stylelint-enable
 
   // Border
-  .pf-c-drawer .pf-c-drawer__panel.pf-m-border,
-  .pf-c-drawer.pf-m-panel-left .pf-c-drawer__panel.pf-m-border,
   .pf-c-drawer .pf-c-drawer__panel.pf-m-no-border,
   .pf-c-drawer.pf-m-panel-left .pf-c-drawer__panel.pf-m-no-border {
     --pf-c-drawer__panel--BoxShadow: transparent;
-  }
-
-  .pf-c-drawer.pf-m-expanded .pf-c-drawer__panel.pf-m-border::after {
-    --pf-c-drawer__panel--after--BackgroundColor: var(--pf-c-drawer--m-inline--m-expanded__panel--after--BackgroundColor);
   }
 }
 
@@ -335,7 +329,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       .pf-c-drawer__panel {
         --pf-c-drawer__panel--BoxShadow: transparent;
 
-        &::after {
+        &:not(.pf-m-no-border)::after {
           --pf-c-drawer__panel--after--BackgroundColor: var(--pf-c-drawer--m-inline--m-expanded__panel--after--BackgroundColor);
         }
       }

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -143,17 +143,6 @@ cssPrefix: pf-c-drawer
 {{/drawer}}
 ```
 
-```hbs title=Modified-panel-border
-{{#> drawer drawer--id="panel-border-example" drawer-panel--IsOpen="true"}}
-  {{#> drawer-main}}
-    {{#> drawer-content}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-    {{/drawer-content}}
-    {{> drawer-example-panel drawer-panel--modifier="pf-m-border"}}
-  {{/drawer-main}}
-{{/drawer}}
-```
-
 ```hbs title=Additional-section-above-main
 {{#> drawer drawer--id="additional-section-above-main" drawer-panel--IsOpen="true"}}
   {{#> drawer-section}}
@@ -163,7 +152,7 @@ cssPrefix: pf-c-drawer
     {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
     {{/drawer-content}}
-    {{> drawer-example-panel drawer-panel--modifier="pf-m-border"}}
+    {{> drawer-example-panel}}
   {{/drawer-main}}
 {{/drawer}}
 ```
@@ -205,7 +194,6 @@ cssPrefix: pf-c-drawer
 | `.pf-m-expanded` | `.pf-c-drawer` | Modifies the drawer panel for the expanded state. |
 | `.pf-m-static{-on-[lg, xl, 2xl]}` | `.pf-c-drawer` | Modifies the drawer panel state to always show both content and panel. |
 | `.pf-m-inline{-on-[lg, xl, 2xl]}` | `.pf-c-drawer` | Modifies the drawer so the content element and panel element are displayed side by side. `.pf-m-inline` used without a breakpoint will default to the `md` breakpoint. |
-| `.pf-m-border` | `.pf-c-drawer__panel` | Modifies the drawer panel border treatment to disable box-shadow and enable solid border. |
 | `.pf-m-no-border` | `.pf-c-drawer__panel` | Modifies the drawer panel border treatment to disable all border treatment. |
 | `.pf-m-padding` | `.pf-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-c-drawer__body` | Modifies the element to remove padding. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2853

@lboehling from the issue

> add variation that replaces shadow with grey border for use on white backgrounds when drawer expands inline with page content.

The non-inline drawers have a shadow by default and can have a border instead with use of a `pf-m-border` variation. You can see that here https://www.patternfly.org/v4/documentation/core/components/drawer

Is that already done, or did you want a different update?

> small left shadow to be used on drawer that expand inline with content that is placed on a grey background

When the panel displays inline with the content, the drawer changed the shadow to a border. In this PR, I disabled that behavior, so that the panel has a shadow by default, and you can set a border instead by using the `.pf-m-border` variation mentioned above. I also updated that shadow size when used on an inline drawer to be `sm`

> medium left shadow will remain and only be used when drawers expand over content.

I'm showing a `lg` shadow. Do you want to update it to be `md`?

----

Also currently you can apply `.pf-m-border` to a panel that expands on top of content - is that OK or do we want to not support that - or maybe not show examples of that? And any other changes to the examples? For example, none of our examples show content with a grey background because the grey background would come from the page component. I created a demo showing the inline drawer's shadow in https://patternfly-pr-2887.surge.sh/documentation/core/demos/drawer

## Breaking changes
* This PR removes the `.pf-m-border` variation as when the panel overlays content, a shadow should always be used instead of a border. And when the panel is inline with content (`pf-m-inline`, `pf-m-static`), a border should always be used instead of a shadow.
* Enables `.pf-m-no-border` on inline and static variations, to remove the border if necessary.