### PR TITLE
feat(page doc): removes "required" for issue 2651

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -137,8 +137,8 @@ This component provides the basic chrome for a page, including sidebar, header, 
 ### Accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `role="banner"` | `.pf-c-page__header` | Identifies the element that serves as the banner region. **Required** |
-| `role="main"` | `.pf-c-page__main` | Identifies the element that serves as the main region. **Required** |
+| `role="banner"` | `.pf-c-page__header` | Identifies the element that serves as the banner region. |
+| `role="main"` | `.pf-c-page__main` | Identifies the element that serves as the main region. |
 | `tabindex="-1"` | `.pf-c-page__main` | Allows the main region to receive programmatic focus. **Required** |
 | `id="[id]"` | `.pf-c-page__main` | Provides a hook for sending focus to new content. **Required** |
 | `aria-expanded="true/false"` | `.pf-c-page__header-brand-toggle > .pf-c-button` | Indicates that the expandable content is visible and the current state of the contents. **Required** |

--- a/src/patternfly/components/Page/page-header.hbs
+++ b/src/patternfly/components/Page/page-header.hbs
@@ -1,4 +1,4 @@
-<header role="banner" class="pf-c-page__header{{#if page-header--modifier}} {{page-header--modifier}}{{/if}}"
+<header class="pf-c-page__header{{#if page-header--modifier}} {{page-header--modifier}}{{/if}}"
   {{#if page-header--attribute}}
     {{{page-header--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Page/page-main.hbs
+++ b/src/patternfly/components/Page/page-main.hbs
@@ -1,4 +1,4 @@
-<main role="main" class="pf-c-page__main{{#if page-main--modifier}} {{page-main--modifier}}{{/if}}" tabindex="-1"
+<main class="pf-c-page__main{{#if page-main--modifier}} {{page-main--modifier}}{{/if}}" tabindex="-1"
   {{#if page-main--attribute}}
     {{{page-main--attribute}}}
   {{/if}}>


### PR DESCRIPTION
Removes "required" from accessibility attributes `role="banner"` and `role="main"` for Page component documentation.