### PR TITLE
fix(app launcher): applied external link icon class to icon wrapper

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
@@ -1,8 +1,13 @@
-<span class="pf-c-app-launcher__menu-item-external-icon">
-  <i class="fas fa-external-link-alt{{#if app-launcher-menu-item-external-icon--modifier}} {{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
-    aria-hidden="true"
-    {{#if app-launcher-menu-item-external-icon--attribute}}
+<span class="pf-c-app-launcher__menu-item-external-icon
+  {{#if app-launcher-menu-item-external-icon--modifier}} 
+    {{app-launcher-menu-item-external-icon--modifier}}
+  {{/if}}
+  {{#if app-launcher-menu-item-external-icon--attribute}}
 	    {{{app-launcher-menu-item-external-icon--attribute}}}
-    {{/if}}></i>
+  {{/if}}"
+>
+  <i class="fas fa-external-link-alt"
+    aria-hidden="true"
+    ></i>
 </span>
 <span class="pf-screen-reader">(opens new window)</span>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
@@ -1,9 +1,7 @@
-<span class="pf-c-app-launcher__menu-item-external-icon{{#if app-launcher-menu-item-external-icon--modifier}}{{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
+<span class="pf-c-app-launcher__menu-item-external-icon{{#if app-launcher-menu-item-external-icon--modifier}} {{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
   {{#if app-launcher-menu-item-external-icon--attribute}}
-	    {{{app-launcher-menu-item-external-icon--attribute}}}
+	  {{{app-launcher-menu-item-external-icon--attribute}}}
   {{/if}}>
-  <i class="fas fa-external-link-alt"
-    aria-hidden="true"
-    ></i>
+  <i class="fas fa-external-link-alt" aria-hidden="true"></i>
 </span>
 <span class="pf-screen-reader">(opens new window)</span>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
@@ -1,6 +1,8 @@
-<i class="pf-c-app-launcher__menu-item-external-icon fas fa-external-link-alt{{#if app-launcher-menu-item-external-icon--modifier}} {{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
-  aria-hidden="true"
-  {{#if app-launcher-menu-item-external-icon--attribute}}
-	  {{{app-launcher-menu-item-external-icon--attribute}}}
-  {{/if}}></i>
+<span class="pf-c-app-launcher__menu-item-external-icon">
+  <i class="fas fa-external-link-alt{{#if app-launcher-menu-item-external-icon--modifier}} {{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
+    aria-hidden="true"
+    {{#if app-launcher-menu-item-external-icon--attribute}}
+	    {{{app-launcher-menu-item-external-icon--attribute}}}
+    {{/if}}></i>
+</span>
 <span class="pf-screen-reader">(opens new window)</span>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
@@ -1,6 +1,6 @@
 <span class="pf-c-app-launcher__menu-item-external-icon{{#if app-launcher-menu-item-external-icon--modifier}} {{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
   {{#if app-launcher-menu-item-external-icon--attribute}}
-	  {{{app-launcher-menu-item-external-icon--attribute}}}
+    {{{app-launcher-menu-item-external-icon--attribute}}}
   {{/if}}>
   <i class="fas fa-external-link-alt" aria-hidden="true"></i>
 </span>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-external-icon.hbs
@@ -1,11 +1,7 @@
-<span class="pf-c-app-launcher__menu-item-external-icon
-  {{#if app-launcher-menu-item-external-icon--modifier}} 
-    {{app-launcher-menu-item-external-icon--modifier}}
-  {{/if}}
+<span class="pf-c-app-launcher__menu-item-external-icon{{#if app-launcher-menu-item-external-icon--modifier}}{{app-launcher-menu-item-external-icon--modifier}}{{/if}}"
   {{#if app-launcher-menu-item-external-icon--attribute}}
 	    {{{app-launcher-menu-item-external-icon--attribute}}}
-  {{/if}}"
->
+  {{/if}}>
   <i class="fas fa-external-link-alt"
     aria-hidden="true"
     ></i>

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -316,7 +316,7 @@ import './AppLauncher.css'
 | `disabled` | `button.pf-c-app-launcher__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus. |
 | `aria-disabled="true"` | `a.pf-c-app-launcher__menu-item` | When the menu item uses a link element, indicates that it is unavailable. |
 | `tabindex="-1"` | `a.pf-c-app-launcher__menu-item` | When the menu item uses a link element, removes it from keyboard focus. |
-| `aria-hidden="true"` | `.pf-c-app-launcher__menu-item-external-icon` | Hides the icon from assistive technologies. |
+| `aria-hidden="true"` | `.pf-c-app-launcher__menu-item-external-icon > *` | Hides the icon from assistive technologies. |
 
 ### Usage
 | Class | Applied | Outcome |
@@ -328,7 +328,7 @@ import './AppLauncher.css'
 | `.pf-c-app-launcher__group-title` | `<h1>` | Defines a title for a group of items. |
 | `.pf-c-app-launcher__menu-item` | `<a>`, `<button>` | Defines a menu item. |
 | `.pf-c-app-launcher__menu-item-icon` | `<span>` | Defines the wrapper for the menu item icon. |
-| `.pf-c-app-launcher__menu-item-external-icon` | `<span>` | Defines the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
+| `.pf-c-app-launcher__menu-item-external-icon` | `<span>` | Defines the wrapper for the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
 | `.pf-c-app-launcher__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). There are no visual differences between the types of elements used as a separator. The different elements allowed are only to support valid markup depending on where you place the separator. |
 | `.pf-m-expanded` | `.pf-c-app-launcher` | Modifies for the expanded state. |
 | `.pf-m-top` | `.pf-c-app-launcher` | Modifies to display the menu above the toggle. |

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -328,7 +328,7 @@ import './AppLauncher.css'
 | `.pf-c-app-launcher__group-title` | `<h1>` | Defines a title for a group of items. |
 | `.pf-c-app-launcher__menu-item` | `<a>`, `<button>` | Defines a menu item. |
 | `.pf-c-app-launcher__menu-item-icon` | `<span>` | Defines the wrapper for the menu item icon. |
-| `.pf-c-app-launcher__menu-item-external-icon` | `<i>` | Defines the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
+| `.pf-c-app-launcher__menu-item-external-icon` | `<span>` | Defines the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
 | `.pf-c-app-launcher__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). There are no visual differences between the types of elements used as a separator. The different elements allowed are only to support valid markup depending on where you place the separator. |
 | `.pf-m-expanded` | `.pf-c-app-launcher` | Modifies for the expanded state. |
 | `.pf-m-top` | `.pf-c-app-launcher` | Modifies to display the menu above the toggle. |


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/2523
Updated `.pf-c-app-launcher__menu-item-external-icon` so that it is a <span> that wraps the icon used inside instead of applying it directly to the icon.

## Breaking changes
Moves the class `.pf-c-app-launcher__menu-item-external-icon` from the external link icon itself to a `<span>` that wraps the external link icon. Any instances of the external link icon should be wrapped in a `<span>` and the `.pf-c-app-launcher__menu-item-external-icon` class should be moved from the icon to the `<span>`.