### PR TITLE
fix(breadcrumb): add word-break, display link and icon inline, move divider

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -29,11 +29,10 @@
 
 // Breadcrumb list item
 .pf-c-breadcrumb__item {
-  display: flex;
-  align-items: center;
   font-size: var(--pf-c-breadcrumb__item--FontSize);
   font-weight: var(--pf-c-breadcrumb__item--FontWeight);
   line-height: var(--pf-c-breadcrumb__item--LineHeight);
+  list-style: none;
   cursor: default;
 
   &:not(:last-child) {
@@ -54,6 +53,7 @@
   font-size: inherit;
   font-weight: var(--pf-c-breadcrumb__link--FontWeight);
   line-height: inherit;
+  word-break: break-word;
 
   // current item
   &.pf-m-current {

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -7,7 +7,7 @@
 
   // Breadcrumb divider
   --pf-c-breadcrumb__item-divider--Color: var(--pf-global--BorderColor--200);
-  --pf-c-breadcrumb__item-divider--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-breadcrumb__item-divider--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-breadcrumb__item-divider--FontSize: var(--pf-global--FontSize--sm);
 
   // Breadcrumb link
@@ -32,8 +32,8 @@
   font-size: var(--pf-c-breadcrumb__item--FontSize);
   font-weight: var(--pf-c-breadcrumb__item--FontWeight);
   line-height: var(--pf-c-breadcrumb__item--LineHeight);
+  white-space: nowrap; // Keeps the item-divider and __link text on the same line
   list-style: none;
-  cursor: default;
 
   &:not(:last-child) {
     margin-right: var(--pf-c-breadcrumb__item--MarginRight);
@@ -42,7 +42,7 @@
 
 // Breadcrumb divider
 .pf-c-breadcrumb__item-divider {
-  margin-left: var(--pf-c-breadcrumb__item-divider--MarginLeft);
+  margin-right: var(--pf-c-breadcrumb__item-divider--MarginRight);
   font-size: var(--pf-c-breadcrumb__item-divider--FontSize);
   line-height: 1;
   color: var(--pf-c-breadcrumb__item-divider--Color);
@@ -69,7 +69,13 @@
 }
 
 .pf-c-breadcrumb__heading {
+  display: inline;
   font-size: var(--pf-c-breadcrumb__heading--FontSize);
+}
+
+.pf-c-breadcrumb__link,
+.pf-c-breadcrumb__heading {
+  white-space: normal;
 }
 
 // RedHat Font overrides

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -29,6 +29,8 @@
 
 // Breadcrumb list item
 .pf-c-breadcrumb__item {
+  display: flex;
+  align-items: baseline;
   font-size: var(--pf-c-breadcrumb__item--FontSize);
   font-weight: var(--pf-c-breadcrumb__item--FontWeight);
   line-height: var(--pf-c-breadcrumb__item--LineHeight);

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -12,21 +12,21 @@ cssPrefix: pf-c-breadcrumb
       {{#> breadcrumb-link}}
         Section home
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link breadcrumb-link--current="true"}}
         Section landing
       {{/breadcrumb-link}}
@@ -40,33 +40,33 @@ cssPrefix: pf-c-breadcrumb
   {{#> breadcrumb-list}}
     {{#> breadcrumb-item}}
         Section home
-        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link breadcrumb-link--current="true"}}
         Section landing
       {{/breadcrumb-link}}
@@ -82,27 +82,27 @@ cssPrefix: pf-c-breadcrumb
       {{#> breadcrumb-link}}
         Section home
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
+      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{#> breadcrumb-heading}}
         {{#> breadcrumb-link breadcrumb-link--current="true"}}
           Section title

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -14,19 +14,19 @@ cssPrefix: pf-c-breadcrumb
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link breadcrumb-link--current="true"}}
         Section landing
       {{/breadcrumb-link}}
@@ -42,31 +42,31 @@ cssPrefix: pf-c-breadcrumb
         Section home
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link breadcrumb-link--current="true"}}
         Section landing
       {{/breadcrumb-link}}
@@ -84,25 +84,25 @@ cssPrefix: pf-c-breadcrumb
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section title
       {{/breadcrumb-link}}
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
-      {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-heading}}
         {{#> breadcrumb-link breadcrumb-link--current="true"}}
           Section title

--- a/src/patternfly/demos/Page/page-template-breadcrumb.hbs
+++ b/src/patternfly/demos/Page/page-template-breadcrumb.hbs
@@ -5,21 +5,21 @@
         {{#> breadcrumb-link}}
           Section home
         {{/breadcrumb-link}}
-        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{/breadcrumb-item}}
       {{#> breadcrumb-item}}
+        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
         {{#> breadcrumb-link}}
           Section title
         {{/breadcrumb-link}}
-        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{/breadcrumb-item}}
       {{#> breadcrumb-item}}
+        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
         {{#> breadcrumb-link}}
           Section title
         {{/breadcrumb-link}}
-        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
       {{/breadcrumb-item}}
       {{#> breadcrumb-item}}
+        {{#> breadcrumb-item-divider}}{{/breadcrumb-item-divider}}
         {{#> breadcrumb-link breadcrumb-link--current="true"}}
           Section landing
         {{/breadcrumb-link}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2915

@mcarrano curious what you think of this. Here is the previous behavior:

A breadcrumb item that breaks to multiple lines has it's arrow vertically centered to the right of the item link.

<img width="274" alt="Screen Shot 2020-04-01 at 3 15 14 PM" src="https://user-images.githubusercontent.com/35148959/78183004-d2aa9880-742c-11ea-8e87-91d5dd234735.png">

An item that is a very long string won't break and just overflows whatever it is inside of.

<img width="351" alt="Screen Shot 2020-04-01 at 3 15 38 PM" src="https://user-images.githubusercontent.com/35148959/78183008-d3432f00-742c-11ea-97c3-da9a7237b38e.png">

----

And here is the updated behavior. Is this preferred?

<img width="267" alt="Screen Shot 2020-04-01 at 3 16 19 PM" src="https://user-images.githubusercontent.com/35148959/78183140-0980ae80-742d-11ea-9b34-7b3196074cf8.png">

<img width="262" alt="Screen Shot 2020-04-01 at 3 15 58 PM" src="https://user-images.githubusercontent.com/35148959/78183143-0a194500-742d-11ea-8471-0b42bee6d1be.png">

A side effect of that is that when the container is wide enough to fit the item, but not the arrow, the arrow will break to the next line separately like this

<img width="389" alt="Screen Shot 2020-04-01 at 3 26 44 PM" src="https://user-images.githubusercontent.com/35148959/78183389-709e6300-742d-11ea-9b54-26ad8b17fe70.png">

## Breaking changes
This PR changes the visual appearance of breadcrumbs when they break to multiple lines.
* The text will now break if there is a long string in an item link that is wider than the viewport
* The divider is displayed before the link text, instead of after it
* The divider will also always appear inline with the item text instead of wrapping to a new line in some cases.

Because the divider comes before the link text now, the variable `--pf-c-breadcrumb__item-divider--MarginLeft` has been replaced with `--pf-c-breadcrumb__item-divider--MarginRight`. Any instance of the old variable should be replaced with the new one.

Any reference to the divider element (`.pf-c-breadcrumb__item-divider`) will need to be moved in the markup to come before the breadcrumb link element (`.pf-c-breadcrumb__link`) instead of after it.