### PR TITLE
fix(wizard): move modifier to body

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -576,6 +576,6 @@ import './Wizard.css'
 | `.pf-m-in-page` | `.pf-c-wizard` | Modifies wizard for use outside of a modal. |
 | `.pf-m-current` | `.pf-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |
 | `.pf-m-disabled` | `.pf-c-wizard__nav-link` | Modifies a step link for the disabled state. |
-| `.pf-m-no-padding` | `.pf-c-wizard__main` | Modifies the main container body to remove the padding. |
+| `.pf-m-no-padding` | `.pf-c-wizard__main-body` | Modifies the main container body to remove the padding. |
 | `.pf-m-hover` | `.pf-c-wizard__nav-link` | Modifies a step link for the hovered state. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:hover` pseudo-class. |
 | `.pf-m-focus` | `.pf-c-wizard__nav-link` | Modifies a step link for the focus state. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:focus` pseudo-class.|

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -511,16 +511,14 @@
   overflow-x: hidden;
   overflow-y: auto;
   word-break: break-word;
-
-  &.pf-m-no-padding {
-    .pf-c-wizard__main-body {
-      padding: 0;
-    }
-  }
 }
 
 .pf-c-wizard__main-body {
   padding: var(--pf-c-wizard__main-body--PaddingTop) var(--pf-c-wizard__main-body--PaddingRight) var(--pf-c-wizard__main-body--PaddingBottom) var(--pf-c-wizard__main-body--PaddingLeft);
+
+  &.pf-m-no-padding {
+    padding: 0;
+  }
 }
 
 .pf-c-wizard__footer {


### PR DESCRIPTION
closes #1715 

## Breaking Changes
* Moves `pf-m-no-padding` from `.pf-c-wizard__main` to `.pf-c-wizard__main-body` . The same styling will occur to the wizard main body. If you want to remove padding in the wizard main body you should add `pf-m-no-padding` to `.pf-c-wizard__main-body` now.