### PR TITLE
fix(form): moved helper text icon from login to form component

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -91,10 +91,23 @@ cssPrefix: pf-c-form
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-simple-form-comment"')}}
       Comment
     {{/form-label}}
-    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form--id '-simple-form-comment" name="' form--id '-simple-form-comment" aria-describedby="' form--id '-simple-form-comment-help"')}}
+    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment" type="text" id="' form--id '-simple-form-comment" name="' form--id '-simple-form-comment" aria-describedby="' form--id '-simple-form-comment-help"')}}
     {{/form-control}}
     {{#> form-helper-text form-helper-text--modifier="pf-m-success" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-comment-help" aria-live="polite"')}}
       This is helper text for success input
+    {{/form-helper-text}}
+  {{/form-group}}
+  {{#> form-group}}
+    {{#> form-label form-label--attribute=(concat 'for="' form--id '-simple-form-info"')}}
+      Information
+    {{/form-label}}
+    {{#> form-control controlType="textarea" form-control--attribute=(concat 'id="' form--id '-simple-form-info" name="' form--id '-simple-form-info" aria-invalid="true" aria-describedby="' form--id '-simple-form-info-helper"')}}
+    {{/form-control}}
+    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-info-helper" aria-live="polite"')}}
+      {{#> form-helper-text-icon}}
+        <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+      {{/form-helper-text-icon}}
+      This is helper text with an icon.
     {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
@@ -134,7 +147,8 @@ cssPrefix: pf-c-form
 | `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
 | `.pf-c-form__label-text` | `<span>` |  Initiates a form label text. **Required** |
 | `.pf-c-form__label-required` | `<span>` |  Initiates a form label required indicator. |
-| `.pf-c-form__helper-text` | `<span>` |  Initiates a form helper text block. |
+| `.pf-c-form__helper-text` | `<p>` |  Initiates a form helper text block. |
+| `.pf-c-form__helper-text-icon` | `<span>` |  Initiates a form helper text icon. |
 | `.pf-c-form__group` | `<div>` |  Wraps form fields `<label>` + `<field>` + `.form-helper-text`. |
 | `.pf-c-form__horizontal-group` | `<div>`| Wraps `.pf-c-form-control` when using `.pf-m-horizontal` on `.pf-c-form` to provide proper spacing for longer labels. |
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |

--- a/src/patternfly/components/Form/form-helper-text-icon.hbs
+++ b/src/patternfly/components/Form/form-helper-text-icon.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-form__helper-text-icon{{#if form-helper-text-icon--modifier}} {{form-helper-text-icon--modifier}}{{/if}}"
+  {{#if form-helper-text-icon--attribute}}
+    {{{form-helper-text-icon--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -33,10 +33,14 @@
   --pf-c-form__actions--MarginBottom: calc(var(--pf-c-form__actions--child--MarginBottom) * -1);
   --pf-c-form__actions--MarginLeft: calc(var(--pf-c-form__actions--child--MarginLeft) * -1);
 
-  // Helpers
+  // Helper text
   --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--xs);
   --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
+
+  // Helper text icon
+  --pf-c-form__helper-text-icon--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-form__helper-text-icon--MarginRight: var(--pf-global--spacer--xs);
 
   // Inline
   --pf-c-form--m-inline--MarginRight: var(--pf-global--spacer--lg);
@@ -175,6 +179,11 @@
     visibility: hidden;
     opacity: 0;
   }
+}
+
+.pf-c-form__helper-text-icon {
+  margin-right: var(--pf-c-form__helper-text-icon--MarginRight);
+  font-size: var(--pf-c-form__helper-text-icon--FontSize);
 }
 
 // Fieldset

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -29,7 +29,9 @@ cssPrefix: pf-c-login
       {{#> login-main-body}}
         {{#> form}}
           {{#> form-helper-text form-helper-text--modifier="pf-m-error pf-m-hidden"}}
-            <i class="fas fa-exclamation-circle pf-c-form__helper-text-icon" aria-hidden="true"></i>
+            {{#> form-helper-text-icon}}
+              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            {{/form-helper-text-icon}}
             Invalid login credentials.
           {{/form-helper-text}}
           {{#> form-group}}
@@ -139,7 +141,9 @@ cssPrefix: pf-c-login
       {{#> login-main-body}}
         {{#> form}}
           {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute='aria-live="polite"'}}
-            <i class="fas fa-exclamation-circle pf-c-form__helper-text-icon" aria-hidden="true"></i>
+            {{#> form-helper-text-icon}}
+              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            {{/form-helper-text-icon}}
             Invalid login credentials.
           {{/form-helper-text}}
           {{#> form-group}}

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -71,8 +71,6 @@
   --pf-c-login__main-body--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-login__main-body--md--PaddingRight: var(--pf-global--spacer--2xl);
   --pf-c-login__main-body--md--PaddingLeft: var(--pf-global--spacer--2xl);
-  --pf-c-login__main-body--c-form__helper-text-icon--FontSize: var(--pf-global--icon--FontSize--md);
-  --pf-c-login__main-body--c-form__helper-text-icon--MarginRight: var(--pf-global--spacer--sm);
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-login__main-body--PaddingRight: var(--pf-c-login__main-body--md--PaddingRight);
@@ -213,17 +211,6 @@
   padding-right: var(--pf-c-login__main-body--PaddingRight);
   padding-bottom: var(--pf-c-login__main-body--PaddingBottom);
   padding-left: var(--pf-c-login__main-body--PaddingLeft);
-
-  // the form helper text is always present but visually hidden to provide proper spacing if the error is shown.
-  .pf-c-form__helper-text {
-    display: flex;
-    align-items: center;
-
-    .pf-c-form__helper-text-icon {
-      margin-right: var(--pf-c-login__main-body--c-form__helper-text-icon--MarginRight);
-      font-size: var(--pf-c-login__main-body--c-form__helper-text-icon--FontSize);
-    }
-  }
 }
 
 .pf-c-login__main-footer {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/1959

## Breaking changes
This PR moves the form helper text icon feature from the login component back into the form component.

* The `.pf-c-form__helper-text-icon` styles have moved from the login component stylesheet to the form component stylesheet
* Removes the following variables from the login component and replaces the variables in the form component. If you're overriding any of these using the `.pf-c-login` component selector, you will need to update the selector to `.pf-c-form`.
  * `--pf-c-login__main-body--c-form__helper-text-icon--FontSize` has been renamed to `--pf-c-form__helper-text-icon--FontSize`
  * `--pf-c-login__main-body--c-form__helper-text-icon--MarginRight` has been renamed to `--pf-c-form__helper-text-icon--MarginRight`