### PR TITLE
fix(content): margin should not be on first-child or last-child

### DIFF
--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -58,7 +58,6 @@
   --pf-c-content--small--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-content--small--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-content--small--Color: var(--pf-global--Color--200);
-  --pf-c-content--small--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // Links
   --pf-c-content--a--Color: var(--pf-global--link--Color);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -138,6 +138,14 @@
   h6 {
     margin: 0;
     font-family: var(--pf-c-content--heading--FontFamily);
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   ol,
@@ -146,87 +154,51 @@
   }
 
   h1 {
+    margin-top: var(--pf-c-content--h1--MarginTop);
+    margin-bottom: var(--pf-c-content--h1--MarginBottom);
     font-size: var(--pf-c-content--h1--FontSize);
     font-weight: var(--pf-c-content--h1--FontWeight);
     line-height: var(--pf-c-content--h1--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h1--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h1--MarginBottom);
-    }
   }
 
   h2 {
+    margin-top: var(--pf-c-content--h2--MarginTop);
+    margin-bottom: var(--pf-c-content--h2--MarginBottom);
     font-size: var(--pf-c-content--h2--FontSize);
     font-weight: var(--pf-c-content--h2--FontWeight);
     line-height: var(--pf-c-content--h2--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h2--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h2--MarginBottom);
-    }
   }
 
   h3 {
+    margin-top: var(--pf-c-content--h3--MarginTop);
+    margin-bottom: var(--pf-c-content--h3--MarginBottom);
     font-size: var(--pf-c-content--h3--FontSize);
     font-weight: var(--pf-c-content--h3--FontWeight);
     line-height: var(--pf-c-content--h3--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h3--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h3--MarginBottom);
-    }
   }
 
   h4 {
+    margin-top: var(--pf-c-content--h4--MarginTop);
+    margin-bottom: var(--pf-c-content--h4--MarginBottom);
     font-size: var(--pf-c-content--h4--FontSize);
     font-weight: var(--pf-c-content--h4--FontWeight);
     line-height: var(--pf-c-content--h4--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h4--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h4--MarginBottom);
-    }
   }
 
   h5 {
+    margin-top: var(--pf-c-content--h5--MarginTop);
+    margin-bottom: var(--pf-c-content--h5--MarginBottom);
     font-size: var(--pf-c-content--h5--FontSize);
     font-weight: var(--pf-c-content--h5--FontWeight);
     line-height: var(--pf-c-content--h5--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h5--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h5--MarginBottom);
-    }
   }
 
   h6 {
+    margin-top: var(--pf-c-content--h6--MarginTop);
+    margin-bottom: var(--pf-c-content--h6--MarginBottom);
     font-size: var(--pf-c-content--h6--FontSize);
     font-weight: var(--pf-c-content--h6--FontWeight);
     line-height: var(--pf-c-content--h6--LineHeight);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--h6--MarginTop);
-    }
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--h6--MarginBottom);
-    }
   }
 
   small {

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -148,7 +148,6 @@
   }
 
   h1 {
-    margin-bottom: var(--pf-c-content--h1--MarginBottom);
     font-size: var(--pf-c-content--h1--FontSize);
     font-weight: var(--pf-c-content--h1--FontWeight);
     line-height: var(--pf-c-content--h1--LineHeight);
@@ -156,10 +155,13 @@
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h1--MarginTop);
     }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h1--MarginBottom);
+    }
   }
 
   h2 {
-    margin-bottom: var(--pf-c-content--h2--MarginBottom);
     font-size: var(--pf-c-content--h2--FontSize);
     font-weight: var(--pf-c-content--h2--FontWeight);
     line-height: var(--pf-c-content--h2--LineHeight);
@@ -167,10 +169,13 @@
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h2--MarginTop);
     }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h2--MarginBottom);
+    }
   }
 
   h3 {
-    margin-bottom: var(--pf-c-content--h3--MarginBottom);
     font-size: var(--pf-c-content--h3--FontSize);
     font-weight: var(--pf-c-content--h3--FontWeight);
     line-height: var(--pf-c-content--h3--LineHeight);
@@ -178,10 +183,13 @@
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h3--MarginTop);
     }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h3--MarginBottom);
+    }
   }
 
   h4 {
-    margin-bottom: var(--pf-c-content--h4--MarginBottom);
     font-size: var(--pf-c-content--h4--FontSize);
     font-weight: var(--pf-c-content--h4--FontWeight);
     line-height: var(--pf-c-content--h4--LineHeight);
@@ -189,10 +197,13 @@
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h4--MarginTop);
     }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h4--MarginBottom);
+    }
   }
 
   h5 {
-    margin-bottom: var(--pf-c-content--h5--MarginBottom);
     font-size: var(--pf-c-content--h5--FontSize);
     font-weight: var(--pf-c-content--h5--FontWeight);
     line-height: var(--pf-c-content--h5--LineHeight);
@@ -200,16 +211,23 @@
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h5--MarginTop);
     }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h5--MarginBottom);
+    }
   }
 
   h6 {
-    margin-bottom: var(--pf-c-content--h6--MarginBottom);
     font-size: var(--pf-c-content--h6--FontSize);
     font-weight: var(--pf-c-content--h6--FontWeight);
     line-height: var(--pf-c-content--h6--LineHeight);
 
     &:not(:first-child) {
       margin-top: var(--pf-c-content--h6--MarginTop);
+    }
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--h6--MarginBottom);
     }
   }
 
@@ -239,8 +257,11 @@
 
   ol {
     padding-left: var(--pf-c-content--ol--PaddingLeft);
-    margin-top: var(--pf-c-content--ol--MarginTop);
     margin-left: var(--pf-c-content--ol--MarginLeft);
+
+    &:not(:first-child) {
+      margin-top: var(--pf-c-content--ol--MarginTop);
+    }
 
     ul {
       --pf-c-content--ul--MarginTop: var(--pf-c-content--ul--nested--MarginTop);
@@ -255,9 +276,12 @@
 
   ul {
     padding-left: var(--pf-c-content--ul--PaddingLeft);
-    margin-top: var(--pf-c-content--ul--MarginTop);
     margin-left: var(--pf-c-content--ul--MarginLeft);
     list-style: var(--pf-c-content--ul--ListStyle);
+
+    &:not(:first-child) {
+      margin-top: var(--pf-c-content--ul--MarginTop);
+    }
 
     ul {
       --pf-c-content--ul--MarginTop: var(--pf-c-content--ul--nested--MarginTop);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -264,12 +264,14 @@
     }
 
     ul {
-      --pf-c-content--ul--MarginTop: var(--pf-c-content--ul--nested--MarginTop);
+      margin-top: var(--pf-c-content--ul--nested--MarginTop);
+
       --pf-c-content--ul--MarginLeft: var(--pf-c-content--ul--nested--MarginLeft);
     }
 
     ol {
-      --pf-c-content--ol--MarginTop: var(--pf-c-content--ol--nested--MarginTop);
+      margin-top: var(--pf-c-content--ol--nested--MarginTop);
+
       --pf-c-content--ol--MarginLeft: var(--pf-c-content--ol--nested--MarginLeft);
     }
   }
@@ -284,12 +286,14 @@
     }
 
     ul {
-      --pf-c-content--ul--MarginTop: var(--pf-c-content--ul--nested--MarginTop);
+      margin-top: var(--pf-c-content--ul--nested--MarginTop);
+
       --pf-c-content--ul--MarginLeft: var(--pf-c-content--ul--nested--MarginLeft);
     }
 
     ol {
-      --pf-c-content--ol--MarginTop: var(--pf-c-content--ol--nested--MarginTop);
+      margin-top: var(--pf-c-content--ol--nested--MarginTop);
+
       --pf-c-content--ol--MarginLeft: var(--pf-c-content--ol--nested--MarginLeft);
     }
   }

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -78,12 +78,10 @@
 
   // Lists
   --pf-c-content--ol--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-content--ol--MarginTop: var(--pf-global--spacer--md);
   --pf-c-content--ol--MarginLeft: var(--pf-global--spacer--lg);
   --pf-c-content--ol--nested--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-content--ol--nested--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-content--ul--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-content--ul--MarginTop: var(--pf-global--spacer--md);
   --pf-c-content--ul--MarginLeft: var(--pf-global--spacer--lg);
   --pf-c-content--ul--nested--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-content--ul--nested--MarginLeft: var(--pf-global--spacer--sm);
@@ -259,10 +257,6 @@
     padding-left: var(--pf-c-content--ol--PaddingLeft);
     margin-left: var(--pf-c-content--ol--MarginLeft);
 
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--ol--MarginTop);
-    }
-
     ul {
       margin-top: var(--pf-c-content--ul--nested--MarginTop);
 
@@ -280,10 +274,6 @@
     padding-left: var(--pf-c-content--ul--PaddingLeft);
     margin-left: var(--pf-c-content--ul--MarginLeft);
     list-style: var(--pf-c-content--ul--ListStyle);
-
-    &:not(:first-child) {
-      margin-top: var(--pf-c-content--ul--MarginTop);
-    }
 
     ul {
       margin-top: var(--pf-c-content--ul--nested--MarginTop);


### PR DESCRIPTION
closes #1844 #2096 #1842

## Breaking Changes
* If you are using `pf-c-content` in your application you may need to check to see if this change impacts the UI. The margin-bottom may now be removed if using h1-h6, and the margin-bottom may now be removed if using `<ol>` and `<ul>`.

* Removes the margin-bottom from `h1-h6` if its the last child. 
* Removes the margin-top from `<ol>` and `<ul>` if its the first-child. 