### PR TITLE
fix(inputgroup): remove legacy button styles

### DIFF
--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -1,7 +1,6 @@
 .pf-c-input-group {
   // Input group
   --pf-c-input-group--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-input-group--BorderRadius: var(--pf-global--BorderRadius--sm);
 
   // Input group text
   --pf-c-input-group__text--FontSize: var(--pf-global--FontSize--md);
@@ -16,9 +15,6 @@
   --pf-c-input-group__text--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-input-group__textarea--MinHeight: var(--pf-global--spacer--xl);
 
-  // Button
-  --pf-c-input-group--c-button--BorderRadius: var(--pf-global--BorderRadius--sm);
-
   // Form control
   --pf-c-input-group--c-form-control--invalid--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-input-group--c-form-control--MarginRight: 1px;
@@ -29,7 +25,6 @@
   display: flex;
   width: 100%;
   background-color: var(--pf-c-input-group--BackgroundColor);
-  border-radius: var(--pf-c-input-group--BorderRadius); // This adds a default border radius to make sure the input group wont display if a button with a border radius is used.
 
   // stylelint-disable
   > * + * {
@@ -44,35 +39,6 @@
         margin-right: var(--pf-c-input-group--c-form-control--MarginRight);
       }
     }
-  }
-
-  .pf-c-button:not(.pf-m-control) {
-    position: relative;
-
-    &,
-    &::after {
-      border-radius: 0;
-    }
-
-    // Applies top/left and bottom/left border-radius to a button if it's the first item in the input group
-    &:first-child {
-      &,
-      &::after {
-        border-radius: var(--pf-c-input-group--c-button--BorderRadius) 0 0 var(--pf-c-input-group--c-button--BorderRadius);
-      }
-    }
-
-    // Applies top/right and bottom/right border-radius to a button if it's the last item in the input group
-    &:last-child {
-      &,
-      &::after {
-        border-radius: 0 var(--pf-c-input-group--c-button--BorderRadius) var(--pf-c-input-group--c-button--BorderRadius) 0;
-      }
-    }
-  }
-
-  .pf-c-dropdown__toggle {
-    height: 100%;
   }
 
   input:not([type="checkbox"]):not([type="radio"]),


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2298

## Breaking changes
This PR removes button component styles from the input group. Patternfly now recommends using the `.pf-m-control` variation of the button component in the input group.

The following variables have been removed and any reference to them should be removed as they are no longer used in patternfly.
* `--pf-c-input-group--BorderRadius`
* `--pf-c-input-group--c-button--BorderRadius`