### PR TITLE
fix(wizard): made desktop nav 250px, remove compact modifier

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -369,92 +369,6 @@ import './Wizard.css'
 {{/wizard}}
 ```
 
-```hbs title=Compact-nav isFullscreen
-{{#> wizard wizard--modifier="pf-m-compact-nav"}}
-  {{#> wizard-header}}
-    {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-    {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
-    {{#> wizard-description}}
-      Here is where the description goes
-    {{/wizard-description}}
-  {{/wizard-header}}
-  {{#> wizard-toggle}}
-    {{#> wizard-toggle-list}}
-        {{#> wizard-toggle-list-item}}
-          {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
-          Configuration
-          {{> wizard-toggle-separator}}
-        {{/wizard-toggle-list-item}}
-        {{#> wizard-toggle-list-item}}
-          Substep B
-        {{/wizard-toggle-list-item}}
-      {{/wizard-toggle-list}}
-      {{> wizard-toggle-icon}}
-    {{/wizard-toggle}}
-    {{#> wizard-outer-wrap}}
-      {{#> wizard-inner-wrap}}
-        {{#> wizard-nav}}
-          {{#> wizard-nav-list}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Information
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
-                Configuration
-              {{/wizard-nav-link}}
-              {{#> wizard-nav-list}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep A
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrent="true"}}
-                    Substep B
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep C
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-              {{/wizard-nav-list}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Additional
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-disabled" wizard-nav-link--attribute='aria-disabled="true" tabindex="-1"'}}
-                Review
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-          {{/wizard-nav-list}}
-        {{/wizard-nav}}
-      {{#> wizard-main}}
-        <p>Wizard content goes here</p>
-      {{/wizard-main}}
-    {{/wizard-inner-wrap}}
-    {{#> wizard-footer}}
-      {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-        Next
-      {{/button}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Back
-      {{/button}}
-      {{#> button button--modifier="pf-m-link"}}
-        Cancel
-      {{/button}}
-    {{/wizard-footer}}
-  {{/wizard-outer-wrap}}
-{{/wizard}}
-```
-
 ```hbs title=In-page
 {{#> wizard wizard--modifier="pf-m-in-page"}}
   {{#> wizard-toggle}}
@@ -572,7 +486,6 @@ import './Wizard.css'
 | `.pf-m-finished` | `.pf-c-wizard` | Modifies the wizard for the finished state. |
 | `.pf-m-full-width` | `.pf-c-wizard` | Modifies the wizard to expand the full width of the viewport. |
 | `.pf-m-full-height` | `.pf-c-wizard` | Modifies the wizard to expand the full height of the viewport. |
-| `.pf-m-compact-nav` | `.pf-c-wizard` | Modifies wizard nav for a compact width. |
 | `.pf-m-in-page` | `.pf-c-wizard` | Modifies wizard for use outside of a modal. |
 | `.pf-m-current` | `.pf-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |
 | `.pf-m-disabled` | `.pf-c-wizard__nav-link` | Modifies a step link for the disabled state. |

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -112,11 +112,9 @@
   --pf-c-wizard__nav--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-wizard__nav--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
   --pf-c-wizard__nav--Width: 100%;
-  --pf-c-wizard__nav--lg--Width: #{pf-size-prem(300px)};
+  --pf-c-wizard__nav--lg--Width: #{pf-size-prem(250px)};
   --pf-c-wizard__nav--lg--BorderRightWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-wizard__nav--lg--BorderRightColor: var(--pf-global--BorderColor--100);
-  --pf-c-wizard--m-compact-nav__nav--lg--Width: #{pf-size-prem(250px)};
-  --pf-c-wizard--m-in-page__nav--lg--Width: #{pf-size-prem(250px)};
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-wizard__nav--Width: var(--pf-c-wizard__nav--lg--Width);
@@ -211,10 +209,6 @@
     &.pf-m-full-height {
       --pf-c-wizard--lg--Height: var(--pf-c-wizard--m-full-height--lg--Height);
     }
-
-    &.pf-m-compact-nav {
-      --pf-c-wizard__nav--lg--Width: var(--pf-c-wizard--m-compact-nav__nav--lg--Width);
-    }
   }
 
   > *:not(.pf-c-wizard__outer-wrap) {
@@ -253,7 +247,6 @@
     @media screen and (min-width: $pf-global--breakpoint--lg) {
       --pf-c-wizard--lg--MaxWidth: var(--pf-c-wizard--m-in-page--lg--MaxWidth);
       --pf-c-wizard--lg--MaxHeight: var(--pf-c-wizard--m-in-page--lg--MaxHeight);
-      --pf-c-wizard__nav--Width: var(--pf-c-wizard--m-in-page__nav--lg--Width);
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/1737

## Breaking changes

This PR changes the wizard nav width (`--pf-c-wizard__nav--lg--Width`) from 300px to 250px on desktop. A 250px width was previously achieved using the `.pf-m-compact-nav` modifier, however since the nav width is now 250px by default, the `.pf-m-compact-nav` modifier has been removed and any reference to that class should be removed as it is no longer in patternfly.

The following variables have also been removed and any reference to them should be removed as they are no longer used in patternfly.
* `--pf-c-wizard--m-compact-nav__nav--lg--Width`
* `--pf-c-wizard--m-in-page__nav--lg--Width`
