### PR TITLE
fix(optionsmenu): added color declaration to menu items

### DIFF
--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -50,6 +50,7 @@
 
   // Menu item
   --pf-c-options-menu__menu-item--Background: transparent;
+  --pf-c-options-menu__menu-item--Color: var(--pf-global--Color--100);
   --pf-c-options-menu__menu-item--FontSize: var(--pf-global--FontSize--md);
   --pf-c-options-menu__menu-item--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-options-menu__menu-item--PaddingRight: var(--pf-global--spacer--md);
@@ -253,6 +254,7 @@
   width: 100%;
   padding: var(--pf-c-options-menu__menu-item--PaddingTop) var(--pf-c-options-menu__menu-item--PaddingRight) var(--pf-c-options-menu__menu-item--PaddingBottom) var(--pf-c-options-menu__menu-item--PaddingLeft);
   font-size: var(--pf-c-options-menu__menu-item--FontSize);
+  color: var(--pf-c-options-menu__menu-item--Color);
   white-space: nowrap;
   background: var(--pf-c-options-menu__menu-item--Background);
   border: none;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2905

## Breaking changes
Adds a `color` declaration for `.pf-c-options-menu__menu-item` items so that the color will always match the default text color (`--pf-global--Color--100)`. Since this wasn't defined previously, if applications were using `<a>` elements as menu items, the item color would have been the default blue link color. This is a visual change only, no further updates are needed to consume this change.