### PR TITLE
fix(chip): refactor styles

### DIFF
--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -9,9 +9,9 @@
   --pf-c-chip--BorderRadius: var(--pf-global--BorderRadius--sm);
 
   // overflow chip button
-  --pf-c-chip--m-overflow--c-button--hover--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--c-button--active--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--c-button--focus--BorderColor: var(--pf-global--secondary-color--100);
+  --pf-c-chip--m-overflow--hover--before--BorderColor: var(--pf-global--secondary-color--100);
+  --pf-c-chip--m-overflow--active--before--BorderColor: var(--pf-global--secondary-color--100);
+  --pf-c-chip--m-overflow--focus--before--BorderColor: var(--pf-global--secondary-color--100);
 
   // chip text
   --pf-c-chip__text--FontSize: var(--pf-global--FontSize--xs);
@@ -57,21 +57,21 @@
     &.pf-m-hover,
     &:hover {
       &::before {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--hover--BorderColor);
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--hover--before--BorderColor);
       }
     }
 
     &.pf-m-focus,
     &:focus {
       &::before {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--focus--BorderColor);
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--focus--before--BorderColor);
       }
     }
 
     &.pf-m-active,
     &:active {
       &::after {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--active--BorderColor);
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--active--before--BorderColor);
       }
     }
   }

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -1,31 +1,17 @@
 .pf-c-chip {
+  --pf-c-chip--PaddingTop: var(--pf-global--spacer--form-element);
+  --pf-c-chip--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-chip--PaddingBottom: var(--pf-global--spacer--form-element);
   --pf-c-chip--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-chip--BackgroundColor: var(--pf-global--Color--light-100);
-  --pf-c-chip--BorderColor: var(--pf-global--secondary-color--100);
+  --pf-c-chip--BorderColor: var(--pf-global--BackgroundColor--200);
   --pf-c-chip--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-chip--BorderRadius: var(--pf-global--BorderRadius--sm);
 
-  // overflow chip
-  --pf-c-chip--m-overflow--BackgroundColor: var(--pf-global--BackgroundColor--200);
-  --pf-c-chip--m-overflow--PaddingLeft: 0;
-  --pf-c-chip--m-overflow--BorderWidth: 0;
-
   // overflow chip button
-  --pf-c-chip--m-overflow--c-button--BorderRadius: var(--pf-global--BorderRadius--sm);
-  --pf-c-chip--m-overflow--c-button--BorderWidth: 0;
-  --pf-c-chip--m-overflow--c-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-chip--m-overflow--c-button--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-chip--m-overflow--c-button--hover--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-chip--m-overflow--c-button--hover--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--c-button--active--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-chip--m-overflow--c-button--active--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--c-button--focus--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-chip--m-overflow--c-button--focus--BorderColor: var(--pf-global--secondary-color--100);
-
-  // read-only chip
-  --pf-c-chip--m-read-only--PaddingTop: var(--pf-global--spacer--form-element);
-  --pf-c-chip--m-read-only--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-chip--m-read-only--PaddingBottom: var(--pf-global--spacer--form-element);
 
   // chip text
   --pf-c-chip__text--FontSize: var(--pf-global--FontSize--xs);
@@ -35,6 +21,9 @@
   // chip button
   --pf-c-chip--c-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-chip--c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-chip--c-button--MarginTop: calc(var(--pf-c-chip--PaddingTop) * -1);
+  --pf-c-chip--c-button--MarginRight: calc(var(--pf-c-chip--PaddingRight) / 2 * -1);
+  --pf-c-chip--c-button--MarginBottom: calc(var(--pf-c-chip--PaddingBottom) * -1);
   --pf-c-chip--c-button--FontSize: var(--pf-global--FontSize--xs);
 
   // chip badge
@@ -45,7 +34,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  padding-left: var(--pf-c-chip--PaddingLeft);
+  padding: var(--pf-c-chip--PaddingTop) var(--pf-c-chip--PaddingRight) var(--pf-c-chip--PaddingBottom) var(--pf-c-chip--PaddingLeft);
   list-style: none;
   background-color: var(--pf-c-chip--BackgroundColor);
   border-radius: var(--pf-c-chip--BorderRadius);
@@ -63,63 +52,39 @@
 
   // Chip overflow modifier
   &.pf-m-overflow {
-    --pf-c-chip--PaddingLeft: var(--pf-c-chip--m-overflow--PaddingLeft);
-    --pf-c-chip--BackgroundColor: var(--pf-c-chip--m-overflow--BackgroundColor);
+    border: 0;
 
-    // Remove chip border
-    &::before {
-      --pf-c-chip--BorderWidth: var(--pf-c-chip--m-overflow--BorderWidth);
+    &.pf-m-hover,
+    &:hover {
+      &::before {
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--hover--BorderColor);
+      }
     }
 
-    .pf-c-button {
-      padding-right: var(--pf-c-chip--m-overflow--c-button--PaddingRight);
-      padding-left: var(--pf-c-chip--m-overflow--c-button--PaddingLeft);
+    &.pf-m-focus,
+    &:focus {
+      &::before {
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--focus--BorderColor);
+      }
+    }
 
+    &.pf-m-active,
+    &:active {
       &::after {
-        border: var(--pf-c-chip--m-overflow--c-button--BorderWidth) solid var(--pf-c-chip--m-overflow--c-button--active--BorderColor);
-        border-radius: var(--pf-c-chip--m-overflow--c-button--BorderRadius);
-      }
-
-      &.pf-m-hover,
-      &:hover {
-        // stylelint-disable-next-line
-        &::after {
-          --pf-c-chip--m-overflow--c-button--BorderWidth: var(--pf-c-chip--m-overflow--c-button--hover--BorderWidth);
-          --pf-c-chip--m-overflow--c-button--BorderColor: var(--pf-c-chip--m-overflow--c-button--hover--BorderColor);
-        }
-      }
-
-      &.pf-m-active,
-      &:active {
-        // stylelint-disable-next-line
-        &::after {
-          --pf-c-chip--m-overflow--c-button--BorderWidth: var(--pf-c-chip--m-overflow--c-button--active--BorderWidth);
-          --pf-c-chip--m-overflow--c-button--BorderColor: var(--pf-c-chip--m-overflow--c-button--active--BorderColor);
-        }
-      }
-
-      &.pf-m-focus,
-      &:focus {
-        // stylelint-disable-next-line
-        &::after {
-          --pf-c-chip--m-overflow--c-button--BorderWidth: var(--pf-c-chip--m-overflow--c-button--focus--BorderWidth);
-          --pf-c-chip--m-overflow--c-button--BorderColor: var(--pf-c-chip--m-overflow--c-button--focus--BorderColor);
-        }
+        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--c-button--active--BorderColor);
       }
     }
-  }
-
-  &.pf-m-read-only {
-    padding-top: var(--pf-c-chip--m-read-only--PaddingTop);
-    padding-right: var(--pf-c-chip--m-read-only--PaddingRight);
-    padding-bottom: var(--pf-c-chip--m-read-only--PaddingBottom);
   }
 
   // Button
   .pf-c-button {
-    padding-right: var(--pf-c-chip--c-button--PaddingRight);
-    padding-left: var(--pf-c-chip--c-button--PaddingLeft);
+    margin-top: var(--pf-c-chip--c-button--MarginTop);
+    margin-right: var(--pf-c-chip--c-button--MarginRight);
+    margin-bottom: var(--pf-c-chip--c-button--MarginBottom);
     font-size: var(--pf-c-chip--c-button--FontSize);
+
+    --pf-c-button--PaddingRight: var(--pf-c-chip--c-button--PaddingRight);
+    --pf-c-button--PaddingLeft: var(--pf-c-chip--c-button--PaddingLeft);
   }
 
   // badge

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -9,9 +9,9 @@
   --pf-c-chip--before--BorderRadius: var(--pf-global--BorderRadius--sm);
 
   // overflow chip button
-  --pf-c-chip--m-overflow--hover--before--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--active--before--BorderColor: var(--pf-global--secondary-color--100);
-  --pf-c-chip--m-overflow--focus--before--BorderColor: var(--pf-global--secondary-color--100);
+  --pf-c-chip--m-overflow--hover--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-chip--m-overflow--active--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-chip--m-overflow--focus--before--BorderColor: var(--pf-global--BorderColor--200);
 
   // chip text
   --pf-c-chip__text--FontSize: var(--pf-global--FontSize--xs);
@@ -37,7 +37,6 @@
   padding: var(--pf-c-chip--PaddingTop) var(--pf-c-chip--PaddingRight) var(--pf-c-chip--PaddingBottom) var(--pf-c-chip--PaddingLeft);
   list-style: none;
   background-color: var(--pf-c-chip--BackgroundColor);
-  border-radius: var(--pf-c-chip--BorderRadius);
 
   &::before {
     position: absolute;
@@ -57,21 +56,21 @@
     &.pf-m-hover,
     &:hover {
       &::before {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--hover--before--BorderColor);
+        --pf-c-chip--before--BorderColor: var(--pf-c-chip--m-overflow--hover--before--BorderColor);
       }
     }
 
     &.pf-m-focus,
     &:focus {
       &::before {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--focus--before--BorderColor);
+        --pf-c-chip--before--BorderColor: var(--pf-c-chip--m-overflow--focus--before--BorderColor);
       }
     }
 
     &.pf-m-active,
     &:active {
       &::after {
-        --pf-c-chip--BorderColor: var(--pf-c-chip--m-overflow--active--before--BorderColor);
+        --pf-c-chip--before--BorderColor: var(--pf-c-chip--m-overflow--active--before--BorderColor);
       }
     }
   }

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -4,9 +4,9 @@
   --pf-c-chip--PaddingBottom: var(--pf-global--spacer--form-element);
   --pf-c-chip--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-chip--BackgroundColor: var(--pf-global--Color--light-100);
-  --pf-c-chip--BorderColor: var(--pf-global--BackgroundColor--200);
-  --pf-c-chip--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-chip--BorderRadius: var(--pf-global--BorderRadius--sm);
+  --pf-c-chip--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-chip--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-chip--before--BorderRadius: var(--pf-global--BorderRadius--sm);
 
   // overflow chip button
   --pf-c-chip--m-overflow--hover--before--BorderColor: var(--pf-global--secondary-color--100);
@@ -19,15 +19,15 @@
   --pf-c-chip__text--MaxWidth: #{pf-size-prem(120px)};
 
   // chip button
-  --pf-c-chip--c-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-chip--c-button--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-chip--c-button--MarginTop: calc(var(--pf-c-chip--PaddingTop) * -1);
-  --pf-c-chip--c-button--MarginRight: calc(var(--pf-c-chip--PaddingRight) / 2 * -1);
-  --pf-c-chip--c-button--MarginBottom: calc(var(--pf-c-chip--PaddingBottom) * -1);
-  --pf-c-chip--c-button--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-chip__c-button--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-chip__c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-chip__c-button--MarginTop: calc(var(--pf-c-chip--PaddingTop) * -1);
+  --pf-c-chip__c-button--MarginRight: calc(var(--pf-c-chip--PaddingRight) / 2 * -1);
+  --pf-c-chip__c-button--MarginBottom: calc(var(--pf-c-chip--PaddingBottom) * -1);
+  --pf-c-chip__c-button--FontSize: var(--pf-global--FontSize--xs);
 
   // chip badge
-  --pf-c-chip--c-badge--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-chip__c-badge--MarginLeft: var(--pf-global--spacer--xs);
 
   @include pf-t-light;  // This component always needs to be light
 
@@ -46,8 +46,8 @@
     bottom: 0;
     left: 0;
     content: "";
-    border: var(--pf-c-chip--BorderWidth) solid var(--pf-c-chip--BorderColor);
-    border-radius: var(--pf-c-chip--BorderRadius);
+    border: var(--pf-c-chip--before--BorderWidth) solid var(--pf-c-chip--before--BorderColor);
+    border-radius: var(--pf-c-chip--before--BorderRadius);
   }
 
   // Chip overflow modifier
@@ -78,18 +78,18 @@
 
   // Button
   .pf-c-button {
-    margin-top: var(--pf-c-chip--c-button--MarginTop);
-    margin-right: var(--pf-c-chip--c-button--MarginRight);
-    margin-bottom: var(--pf-c-chip--c-button--MarginBottom);
-    font-size: var(--pf-c-chip--c-button--FontSize);
+    --pf-c-button--PaddingRight: var(--pf-c-chip__c-button--PaddingRight);
+    --pf-c-button--PaddingLeft: var(--pf-c-chip__c-button--PaddingLeft);
+    --pf-c-button--FontSize: var(--pf-c-chip__c-button--FontSize);
 
-    --pf-c-button--PaddingRight: var(--pf-c-chip--c-button--PaddingRight);
-    --pf-c-button--PaddingLeft: var(--pf-c-chip--c-button--PaddingLeft);
+    margin-top: var(--pf-c-chip__c-button--MarginTop);
+    margin-right: var(--pf-c-chip__c-button--MarginRight);
+    margin-bottom: var(--pf-c-chip__c-button--MarginBottom);
   }
 
   // badge
   .pf-c-badge {
-    margin-left: var(--pf-c-chip--c-badge--MarginLeft);
+    margin-left: var(--pf-c-chip__c-badge--MarginLeft);
   }
 }
 
@@ -97,6 +97,7 @@
 .pf-c-chip__text {
   @include pf-text-overflow;
 
+  position: relative;
   max-width: var(--pf-c-chip__text--MaxWidth);
   font-size: var(--pf-c-chip__text--FontSize);
   color: var(--pf-c-chip__text--Color);

--- a/src/patternfly/components/Chip/examples/Chip.css
+++ b/src/patternfly/components/Chip/examples/Chip.css
@@ -1,4 +1,0 @@
-#ws-core-c-chip-basic .pf-c-chip {
-  margin-top: 8px;
-  margin-right: 8px;
-}

--- a/src/patternfly/components/Chip/examples/Chip.css
+++ b/src/patternfly/components/Chip/examples/Chip.css
@@ -1,0 +1,4 @@
+#ws-core-c-chip-basic .pf-c-chip {
+  margin-top: 8px;
+  margin-right: 8px;
+}

--- a/src/patternfly/components/Chip/examples/Chip.md
+++ b/src/patternfly/components/Chip/examples/Chip.md
@@ -4,8 +4,6 @@ section: components
 cssPrefix: pf-c-chip
 ---
 
-import './Chip.css'
-
 ## Examples
 ```hbs title=Basic
 
@@ -17,7 +15,8 @@ import './Chip.css'
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-
+<br>
+<br>
 {{#> chip chip--type="div"}}
   {{#> chip-text chip-text--attribute='id="chip_two"'}}
     Really long chip that goes on and on
@@ -26,7 +25,8 @@ import './Chip.css'
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-
+<br>
+<br>
 {{#> chip chip--type="div"}}
   {{#> chip-text chip-text--attribute='id="chip_three"'}}
     Chip
@@ -38,13 +38,15 @@ import './Chip.css'
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-
+<br>
+<br>
 {{#> chip chip--type="div" chip--modifier="pf-m-read-only"}}
   {{#> chip-text}}
     Read-only chip
   {{/chip-text}}
 {{/chip}}
-
+<br>
+<br>
 {{#> chip chip--type="button" chip--modifier="pf-m-overflow"}}
   {{#> chip-text}}
     Overflow chip
@@ -67,10 +69,9 @@ A Chip is used to display items that have been filtered or selected from a large
 ## Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-chip` | `<div>, <li>` | Initiates the body of a chip. If used inside a `.pf-c-chip-group` use `<li>`. |
+| `.pf-c-chip` | `<div>`, `<button>`, `<li>` | Initiates the body of a chip. If used inside a `.pf-c-chip-group` use `<li>`. |
 | `.pf-c-chip__text` | `*` | Initiates the text inside of the chip. **Required.** |
 | `.pf-c-button` | `.pf-c-chip <button>` | Initiates the button used to remove the chip. **Required.** |
 | `.pf-c-badge` | `<span>` | Initiates the badge inside the chip. |
-| `.pf-m-overflow` | `.pf-c-chip` | Applies styling of the overflow chip. |
+| `.pf-m-overflow` | `button.pf-c-chip` | Applies styling of the overflow chip. |
 | `.pf-c-button` | `.pf-c-chip.pf-m-overflow <button>` | Initiates the button used to show the overflow toggle. |
-| `.pf-m-read-only` | `.pf-c-chip` | Modifies chip for read-only state. |

--- a/src/patternfly/components/Chip/examples/Chip.md
+++ b/src/patternfly/components/Chip/examples/Chip.md
@@ -4,6 +4,8 @@ section: components
 cssPrefix: pf-c-chip
 ---
 
+import './Chip.css'
+
 ## Examples
 ```hbs title=Basic
 
@@ -12,47 +14,41 @@ cssPrefix: pf-c-chip
     Chip
   {{/chip-text}}
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-labelledby="remove_chip_one chip_one" aria-label="Remove" id="remove_chip_one"'}}
-    <i class="fas fa-times-circle" aria-hidden="true"></i>
+    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-<br>
-<br>
+
 {{#> chip chip--type="div"}}
   {{#> chip-text chip-text--attribute='id="chip_two"'}}
     Really long chip that goes on and on
   {{/chip-text}}
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-labelledby="remove_chip_two chip_two" aria-label="Remove" id="remove_chip_two"'}}
-    <i class="fas fa-times-circle" aria-hidden="true"></i>
+    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-<br>
-<br>
+
 {{#> chip chip--type="div"}}
   {{#> chip-text chip-text--attribute='id="chip_three"'}}
     Chip
   {{/chip-text}}
   {{#> badge badge--modifier="pf-m-read"}}
-    7
+    00
   {{/badge}}
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-labelledby="remove_chip_three chip_three" aria-label="Remove" id="remove_chip_three"'}}
-    <i class="fas fa-times-circle" aria-hidden="true"></i>
+    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
 {{/chip}}
-<br>
-<br>
+
 {{#> chip chip--type="div" chip--modifier="pf-m-read-only"}}
   {{#> chip-text}}
     Read-only chip
   {{/chip-text}}
 {{/chip}}
-<br>
-<br>
-{{#> chip chip--type="div" chip--modifier="pf-m-overflow"}}
-  {{#> button button--modifier="pf-m-plain"}}
-    {{#> chip-text}}
-      4 more
-    {{/chip-text}}
-  {{/button}}
+
+{{#> chip chip--type="button" chip--modifier="pf-m-overflow"}}
+  {{#> chip-text}}
+    Overflow chip
+  {{/chip-text}}
 {{/chip}}
 ```
 

--- a/src/patternfly/components/ChipGroup/examples/ChipGroup.md
+++ b/src/patternfly/components/ChipGroup/examples/ChipGroup.md
@@ -17,7 +17,7 @@ cssPrefix: pf-c-chip-group
           Chip one
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_one_toolbar_collapsed ' chip-group--id 'chip_one_toolbar_collapsed" aria-label="Remove" id="' chip-group--id 'remove_chip_one_toolbar_collapsed"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -25,7 +25,7 @@ cssPrefix: pf-c-chip-group
           Chip two
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_two_toolbar_collapsed ' chip-group--id 'chip_two_toolbar_collapsed" aria-label="Remove" id="' chip-group--id 'remove_chip_two_toolbar_collapsed"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -33,7 +33,7 @@ cssPrefix: pf-c-chip-group
           Chip three
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_three_toolbar_collapsed ' chip-group--id 'chip_three_toolbar_collapsed" aria-label="Remove" id="' chip-group--id 'remove_chip_three_toolbar_collapsed"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -41,17 +41,15 @@ cssPrefix: pf-c-chip-group
           Chip four
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_four_toolbar_collapsed ' chip-group--id 'chip_four_toolbar_collapsed" aria-label="Remove" id="' chip-group--id 'remove_chip_four_toolbar_collapsed"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
     {{/chip-group}}
   {{/chip-group-list-item}}
-  {{#> chip chip--modifier="pf-m-overflow"}}
-    {{#> button button--modifier="pf-m-plain"}}
+  {{#> chip chip--type="button" chip--modifier="pf-m-overflow"}}
       {{#> chip-text}}
         3 more
       {{/chip-text}}
-    {{/button}}
   {{/chip}}
 {{/chip-group}}
 ```
@@ -68,7 +66,7 @@ cssPrefix: pf-c-chip-group
         Chip one
       {{/chip-text}}
       {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_one_toolbar ' chip-group--id 'chip_one_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_one_toolbar"')}}
-        <i class="fas fa-times-circle" aria-hidden="true"></i>
+        <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -76,7 +74,7 @@ cssPrefix: pf-c-chip-group
           Chip two
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_two_toolbar ' chip-group--id 'chip_two_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_two_toolbar"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -84,7 +82,7 @@ cssPrefix: pf-c-chip-group
           Chip three
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_three_toolbar ' chip-group--id 'chip_three_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_three_toolbar"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -92,7 +90,7 @@ cssPrefix: pf-c-chip-group
           Chip four
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_four_toolbar ' chip-group--id 'chip_four_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_four_toolbar"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
     {{/chip-group}}
@@ -107,7 +105,7 @@ cssPrefix: pf-c-chip-group
       Chip one
     {{/chip-text}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_five_toolbar ' chip-group--id 'chip_five_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_five_toolbar"')}}
-      <i class="fas fa-times-circle" aria-hidden="true"></i>
+      <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/chip}}
   {{#> chip}}
@@ -115,7 +113,7 @@ cssPrefix: pf-c-chip-group
       Chip two
     {{/chip-text}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_six_toolbar ' chip-group--id 'chip_six_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_six_toolbar"')}}
-      <i class="fas fa-times-circle" aria-hidden="true"></i>
+      <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/chip}}
   {{#> chip}}
@@ -123,7 +121,7 @@ cssPrefix: pf-c-chip-group
       Chip three
     {{/chip-text}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_seven_toolbar ' chip-group--id 'chip_seven_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_seven_toolbar"')}}
-      <i class="fas fa-times-circle" aria-hidden="true"></i>
+      <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/chip}}
 {{/chip-group}}
@@ -143,7 +141,7 @@ cssPrefix: pf-c-chip-group
           Chip one
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_one_toolbar ' chip-group--id 'chip_one_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_one_toolbar"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
       {{#> chip}}
@@ -151,7 +149,7 @@ cssPrefix: pf-c-chip-group
           Chip two
         {{/chip-text}}
         {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove_chip_two_toolbar ' chip-group--id 'chip_two_toolbar" aria-label="Remove" id="' chip-group--id 'remove_chip_two_toolbar"')}}
-          <i class="fas fa-times-circle" aria-hidden="true"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
       {{/chip}}
     {{/chip-group}}


### PR DESCRIPTION
closes #2657 

## Breaking Changes
* The read-only modifier: `.pf-m-read-only` was removed as you can achieve the same result with the plain chip. With this the following variables were removed, all instances of them should be removed from your application:
  * `--pf-c-chip--m-read-only--PaddingTop`
  * `--pf-c-chip--m-read-only--PaddingRight`
  *  `--pf-c-chip--m-read-only--PaddingBottom`

* The following variables were removed from the overflow chip component, all instances of them should be removed from your application:
  * `--pf-c-chip--m-overflow--BackgroundColor`
  * `--pf-c-chip--m-overflow--PaddingLeft`
  * ` --pf-c-chip--m-overflow--BorderWidth`
  * `--pf-c-chip--m-overflow--c-button--BorderRadius`
  * `--pf-c-chip--m-overflow--c-button--BorderWidth`
  * ` --pf-c-chip--m-overflow--c-button--PaddingLeft`
  * `--pf-c-chip--m-overflow--c-button--PaddingRight`
  *  `--pf-c-chip--m-overflow--c-button--hover--BorderWidth`
  * `--pf-c-chip--m-overflow--c-button--active--BorderWidth`
  * `--pf-c-chip--m-overflow--c-button--focus--BorderWidth`

* The following variables were renamed from the overflow chip component:
  * `--pf-c-chip--m-overflow--c-button--hover--BorderColor` to `--pf-c-chip--m-overflow--hover--before--BorderColor`
  * `--pf-c-chip--m-overflow--c-button--active--BorderColor` to `--pf-c-chip--m-overflow--active--before--BorderColor`
  * `--pf-c-chip--m-overflow--c-button--focus--BorderColor` to `--pf-c-chip--m-overflow--focus--before--BorderColor`


* `--pf-c-chip--BorderColor` replaced `var(--pf-global--secondary-color--100)` with `var(--pf-global--BackgroundColor--200)`. This is just a visual change, no updates are needed.