### PR TITLE
style(nav-scroll): updated nav buttons to inline

### DIFF
--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -495,6 +495,7 @@ The navigation system relies on several different sub-components:
 | `aria-expanded="false"` | `.pf-c-nav__link` |  Indicates that subnav section is hidden. |
 | `aria-expanded="true"` | `.pf-c-nav__link` |  Indicates that subnav section is visible. |
 | `hidden` | `.pf-c-nav__subnav` |  Indicates that the subnav section is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
+| `disabled` | `.pf-c-nav__scroll-button` | Indicates that a scroll button is disabled, when at the first or last item of a list. **Required when disabled** |
 | `aria-current="page"` | `.pf-c-nav__link` |  Indicates the current page link. Can only occur once on page. |
 
 ### Usage

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -511,7 +511,8 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__section-title` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>` | Initiates a nav section title. |
 | `.pf-c-nav__toggle` | `<span>` | Initiates a chevron indicating expandability of a `pf-c-nav__list-link`. |
 | `.pf-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon. |
-| `.pf-m-dark` | `.pf-c-nav` | Modifies the nav for the dark variation. **Note: only for use with vertical navs, and requires `.pf-m-dark` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |
+| `.pf-m-scrollable` | `.pf-c-nav` | Modifies nav for the scrollable state. |
+| `.pf-m-dark` | `.pf-c-nav` | Modifies nav for the dark variation. **Note: only for use with vertical navs, and requires `.pf-m-dark` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |
 | `.pf-m-expandable` | `.pf-c-nav__item` | Modifies for the expandable state. |
 | `.pf-m-expanded` | `.pf-c-nav__item` | Modifies for the expanded state. |
 | `.pf-m-hover` | `.pf-c-nav__link` | Modifies to display the link as hovered. |

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -268,9 +268,7 @@ import './Nav.css'
 ```hbs title=Horizontal-in-masthead
 <div class="pf-c-page__header">
   <div class="pf-c-page__header-nav">
-    {{#> nav nav--attribute='aria-label="Global"'}}
-      {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-      {{/nav-scroll-button}}
+    {{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Global"'}}
       {{#> nav-list nav-list--type="horizontal"}}
         {{#> nav-item}}
           {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -288,8 +286,6 @@ import './Nav.css'
           {{/nav-link}}
         {{/nav-item}}
       {{/nav-list}}
-      {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-      {{/nav-scroll-button}}
     {{/nav}}
   </div>
 </div>
@@ -298,9 +294,7 @@ import './Nav.css'
 ```hbs title=Horizontal-overflow-in-masthead
 <div class="pf-c-page__header">
   <div class="pf-c-page__header-nav">
-    {{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Global"'}}
-      {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-      {{/nav-scroll-button}}
+    {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Global"'}}
       {{#> nav-list nav-list--type="horizontal"}}
         {{#> nav-item}}
           {{#> nav-link nav-link--href="#"}}
@@ -328,17 +322,13 @@ import './Nav.css'
           {{/nav-link}}
         {{/nav-item}}
       {{/nav-list}}
-      {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-      {{/nav-scroll-button}}
     {{/nav}}
   </div>
 </div>
 ```
 
 ```hbs title=Tertiary
-{{#> nav nav--attribute='aria-label="Local"'}}
-  {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-  {{/nav-scroll-button}}
+{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"'}}
   {{#> nav-list nav-list--type="tertiary"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -356,15 +346,11 @@ import './Nav.css'
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
-  {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-  {{/nav-scroll-button}}
 {{/nav}}
 ```
 
 ```hbs title=Tertiary-overflow
-{{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Local"'}}
-  {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-  {{/nav-scroll-button}}
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
   {{#> nav-list nav-list--type="tertiary"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -392,8 +378,6 @@ import './Nav.css'
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
-  {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-  {{/nav-scroll-button}}
 {{/nav}}
 ```
 

--- a/src/patternfly/components/Nav/nav.hbs
+++ b/src/patternfly/components/Nav/nav.hbs
@@ -1,9 +1,19 @@
-<nav class="pf-c-nav{{#if nav--modifier}} {{nav--modifier}}{{/if}}"
+<nav class="pf-c-nav{{#if nav--modifier}} {{nav--modifier}}{{/if}}{{#if nav--IsScrollable}} pf-m-scrollable{{/if}}"
   {{#if aria-label}}
     aria-label="{{aria-label}}"
   {{/if}}
   {{#if nav--attribute}}
     {{{nav--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if nav--IsHorizontal}}
+    {{> nav-scroll-button nav-scroll-button--attribute="disabled" nav-scroll-button--IsLeft="true"}}
+    {{> @partial-block}}
+    {{#if nav--IsScrollable}}
+      {{> nav-scroll-button nav-scroll-button--IsRight="true"}}
+    {{else}}
+      {{> nav-scroll-button nav-scroll-button--attribute="disabled" nav-scroll-button--IsRight="true"}}
+    {{/if}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
 </nav>

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -157,10 +157,10 @@
 
   // Scroll buttons
   --pf-c-nav__scroll-button--Color: var(--pf-global--Color--100);
-  --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__scroll-button--focus--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__scroll-button--active--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-global--disabled-color--200);
+  --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__scroll-button--focus--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__scroll-button--active--Color: var(--pf-global--active-color--400);
+  --pf-c-nav__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-nav__scroll-button--BackgroundColor: transparent;
   --pf-c-nav__scroll-button--Width: var(--pf-global--target-size--MinWidth);
   --pf-c-nav__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
@@ -627,7 +627,7 @@
   }
 
   &:disabled {
-    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--m-disabled--Color);
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--disabled--Color);
     --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav__scroll-button--disabled--before--BorderColor);
 
     pointer-events: none;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -119,6 +119,8 @@
   --pf-c-nav__tertiary-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav__tertiary-list__scroll-button--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav__tertiary-list__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
 
   // Sub nav
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
@@ -153,21 +155,24 @@
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
   --pf-c-nav__section-title--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
 
-  // Scroll button
-  --pf-c-nav__scroll-button--Display: none;
-  --pf-c-nav__scroll-button--Visibility: hidden;
-  --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
-  --pf-c-nav__scroll-button--Height: 100%;
-  --pf-c-nav__scroll-button--lg--Height: pf-size-prem(40px);
-  --pf-c-nav__scroll-button--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-nav__scroll-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-nav__scroll-button--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(255, 255, 255, .7); // This is a special one-off shadow for nav
-  --pf-c-nav__scroll-button--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(255, 255, 255, .7); // This is a special one-off shadow for nav
-  --pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow: 20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
-  --pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow: -20px 0 10px -4px rgba(21, 21, 21, .7); // This is a special one-off shadow for nav
+  // Scroll buttons
+  --pf-c-nav__scroll-button--Color: var(--pf-global--Color--100);
+  --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__scroll-button--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__scroll-button--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
+  --pf-c-nav__scroll-button--BackgroundColor: transparent;
+  --pf-c-nav__scroll-button--Width: var(--pf-global--target-size--MinWidth);
+  --pf-c-nav__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
+  --pf-c-nav__scroll-button--Transition: margin .125s, transform .125s, opacity .125s;
+
+  // Scroll buttons before
+  --pf-c-nav__scroll-button--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-nav__scroll-button--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-nav__scroll-button--before--BorderRightWidth: 0;
+  --pf-c-nav__scroll-button--before--BorderLeftWidth: 0;
+  --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
+
 
   // Toggle
   --pf-c-nav__toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -202,6 +207,34 @@
   }
 
   position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  overflow: hidden;
+
+  &.pf-m-scrollable {
+    .pf-c-nav__scroll-button {
+      opacity: 1;
+    }
+
+    // Scroll buttons
+    .pf-c-nav__scroll-button:nth-of-type(1) {
+      margin-right: 0;
+      transform: translateX(0);
+
+      &::before {
+        right: 0;
+      }
+    }
+
+    .pf-c-nav__scroll-button:nth-of-type(2) {
+      margin-left: 0;
+      transform: translateX(0);
+
+      &::before {
+        left: 0;
+      }
+    }
+  }
 
   &.pf-m-dark {
     --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-dark__item--before--BorderColor);
@@ -228,12 +261,6 @@
     }
   }
 
-  &.pf-m-start .pf-c-nav__scroll-button:nth-of-type(1),
-  &.pf-m-end .pf-c-nav__scroll-button:nth-of-type(2) {
-    --pf-c-nav__scroll-button--Display: flex;
-    --pf-c-nav__scroll-button--Visibility: visible;
-  }
-
   // Divider
   .pf-c-divider {
     --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--c-divider--BackgroundColor);
@@ -245,18 +272,10 @@
   }
 }
 
-// Header nav
-.pf-c-page__header-nav {
-  .pf-c-nav__scroll-button {
-    background-color: var(--pf-global--BackgroundColor--100);
-
-    &:nth-of-type(1) {
-      box-shadow: var(--pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow);
-    }
-
-    &:nth-of-type(2) {
-      box-shadow: var(--pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow);
-    }
+// Set width when nav is child of sidebar to prevent collapsing
+.pf-c-page__sidebar .pf-c-nav {
+  @media screen and (min-width: $pf-global--breakpoint--md) {
+    width: var(--pf-c-nav--Width);
   }
 }
 
@@ -386,20 +405,23 @@
   --pf-c-nav__link--Right: var(--pf-c-nav__link--PaddingRight);
   --pf-c-nav__link--Left: var(--pf-c-nav__link--PaddingLeft);
 
-  .pf-c-nav__item {
-    --pf-c-nav__item--before--BorderColor: transparent;
-  }
-
   @include pf-overflow-hide-scroll;
 
-  display: inline-flex;
+  position: relative;
+  display: flex;
+  flex: 1;
   max-width: 100%;
   overflow-x: auto;
   white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+
+  .pf-c-nav__item {
+    display: flex;
+  }
 
   .pf-c-nav__link {
-    position: relative;
-    display: inline-block;
+    align-items: center;
+    align-self: stretch;
   }
 
   .pf-c-nav__link::before {
@@ -470,6 +492,8 @@
   --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
   --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
   --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--before--BorderWidth);
+  --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav__tertiary-list__scroll-button--before--BorderColor);
+  --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-nav__tertiary-list__scroll-button--disabled--before--BorderColor);
 
   .pf-c-nav__link:hover {
     --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--hover--before--BorderWidth);
@@ -564,36 +588,63 @@
   }
 }
 
-// Scroll button
+.pf-c-nav__list,
+.pf-c-nav__simple-list,
+.pf-c-nav__section {
+  flex: 1 0 100%;
+}
+
+// Scroll buttons
 .pf-c-nav__scroll-button {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: var(--pf-c-nav__scroll-button--ZIndex);
-  display: var(--pf-c-nav__scroll-button--Display);
-  align-items: center;
-  justify-content: center;
+  flex: none;
   width: var(--pf-c-nav__scroll-button--Width);
-  height: 100%;
-  padding-right: var(--pf-c-nav__scroll-button--PaddingRight);
-  padding-left: var(--pf-c-nav__scroll-button--PaddingLeft);
-  visibility: var(--pf-c-nav__scroll-button--Visibility);
+  color: var(--pf-c-nav__scroll-button--Color);
   background-color: var(--pf-c-nav__scroll-button--BackgroundColor);
   border: 0;
+  outline-offset: var(--pf-c-nav__scroll-button--OutlineOffset);
+  opacity: 0;
+  transition: var(--pf-c-nav__scroll-button--Transition);
 
-  &:hover,
-  &:focus,
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    content: "";
+    border-color: var(--pf-c-nav__scroll-button--before--BorderColor);
+    border-style: solid;
+    border-width: 0 var(--pf-c-nav__scroll-button--before--BorderRightWidth) 0 var(--pf-c-nav__scroll-button--before--BorderLeftWidth);
+  }
+
+  &:hover {
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--hover--Color);
+  }
+
+  &:focus {
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--focus--Color);
+  }
+
   &:active {
-    color: var(--pf-c-nav__scroll-button--hover--Color);
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--active--Color);
+  }
+
+  &:disabled {
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav__scroll-button--disabled--before--BorderColor);
+
+    pointer-events: none;
   }
 
   &:nth-of-type(1) {
-    left: 0;
-    box-shadow: var(--pf-c-nav__scroll-button--nth-of-type-1--BoxShadow);
+    --pf-c-nav__scroll-button--before--BorderRightWidth: var(--pf-c-nav__scroll-button--before--BorderWidth);
+
+    margin-right: calc(var(--pf-c-nav__scroll-button--Width) * -1);
+    transform: translateX(-100%);
   }
 
   &:nth-of-type(2) {
-    right: 0;
-    box-shadow: var(--pf-c-nav__scroll-button--nth-of-type-2--BoxShadow);
+    --pf-c-nav__scroll-button--before--BorderLeftWidth: var(--pf-c-nav__scroll-button--before--BorderWidth);
+
+    margin-left: calc(var(--pf-c-nav__scroll-button--Width) * -1);
+    transform: translateX(100%);
   }
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -271,13 +271,6 @@
   }
 }
 
-// Set width when nav is child of sidebar to prevent collapsing
-.pf-c-page__sidebar .pf-c-nav {
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    width: var(--pf-c-nav--Width);
-  }
-}
-
 // Toggle icon
 .pf-c-nav__toggle-icon {
   display: inline-block;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -160,7 +160,7 @@
   --pf-c-nav__scroll-button--hover--Color: var(--pf-global--active-color--100);
   --pf-c-nav__scroll-button--focus--Color: var(--pf-global--active-color--100);
   --pf-c-nav__scroll-button--active--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
+  --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-nav__scroll-button--BackgroundColor: transparent;
   --pf-c-nav__scroll-button--Width: var(--pf-global--target-size--MinWidth);
   --pf-c-nav__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
@@ -172,7 +172,6 @@
   --pf-c-nav__scroll-button--before--BorderRightWidth: 0;
   --pf-c-nav__scroll-button--before--BorderLeftWidth: 0;
   --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
-
 
   // Toggle
   --pf-c-nav__toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -628,7 +627,7 @@
   }
 
   &:disabled {
-    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav__scroll-button--m-disabled--Color);
     --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav__scroll-button--disabled--before--BorderColor);
 
     pointer-events: none;

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -47,6 +47,9 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left: 0;
   --pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor: var(--pf-c-page__header-nav--BackgroundColor);
   --pf-c-page__header-nav--c-nav__scroll-button--lg--Top: 0;
+  --pf-c-page__header__nav-scroll-button--disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-page__header__nav-scroll-button--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-page__header__nav-scroll-button--disabled--before--BorderColor: transparent;
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--xl--PaddingLeft);
@@ -238,28 +241,19 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   grid-column: 1 / -1;
   grid-row: 2 / 3;
   min-width: 0;
-  background-color: var(--pf-c-page__header-nav--BackgroundColor);
 
-  > .pf-c-nav {
-    min-width: 0;
+  .pf-c-nav {
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--before--BorderColor);
+    --pf-c-nav__scroll-button--disabled--Color: var(--pf-c-page__header__nav-scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--disabled--before--BorderColor);
 
-    .pf-c-nav__scroll-button {
-      @media screen and (max-width: #{$pf-global--breakpoint--lg - 1}) {
-        top: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--Top);
-        background-color: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor);
-      }
-
-      &:nth-of-type(1) {
-        left: var(--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left);
-      }
-    }
+    align-self: stretch;
   }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
     flex: 1;
-    align-self: flex-end;
     order: initial;
     width: auto;
     margin-right: var(--pf-c-page__header-nav--lg--MarginRight);
@@ -416,30 +410,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   padding-right: var(--pf-c-page__main-nav--PaddingRight);
   padding-left: var(--pf-c-page__main-nav--PaddingLeft);
   background-color: var(--pf-c-page__main-nav--BackgroundColor);
-
-  .pf-c-nav {
-    // stylelint-disable max-nesting-depth
-    .pf-c-nav__item:first-child {
-      .pf-c-nav__link {
-        padding-left: 0;
-
-        @media screen and (min-width: $pf-global--breakpoint--xl) {
-          padding-left: var(--pf-c-nav__link--PaddingLeft);
-        }
-      }
-    }
-    // stylelint-enable
-
-    .pf-c-nav__scroll-button {
-      &:nth-of-type(1) {
-        left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left);
-      }
-
-      &:nth-of-type(2) {
-        right: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right);
-      }
-    }
-  }
 }
 
 .pf-c-page__main-breadcrumb {

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -36,19 +36,20 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-brand-link--c-brand--MaxHeight: #{pf-size-prem(60px)};
 
   // Header nav
-  --pf-c-page__header-nav--xl--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-page__header-nav--lg--PaddingLeft: 0;
-  --pf-c-page__header-nav--lg--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-page__header-nav--lg--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-nav--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
   --pf-c-page__header-nav--lg--BackgroundColor: transparent;
-  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs))); // This sets the the button to the edge of its container with 4px clearance on the left
-  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--xl--Left: var(--pf-global--spacer--xl);
-  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left: 0;
-  --pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor: var(--pf-c-page__header-nav--BackgroundColor);
-  --pf-c-page__header-nav--c-nav__scroll-button--lg--Top: 0;
+  --pf-c-page__header-nav--BorderTop: 1px solid var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-page__header-nav--lg--BorderTop: 0;
+  --pf-c-page__header-nav--PaddingRight: 0;
+  --pf-c-page__header-nav--PaddingLeft: 0;
+  --pf-c-page__header-nav--md--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-page__header-nav--md--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-page__header-nav--xl--PaddingRight: 0;
+  --pf-c-page__header-nav--xl--PaddingLeft: 0;
   --pf-c-page__header__nav-scroll-button--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-page__header__nav-scroll-button--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
+
+  // --pf-c-page__header__nav-scroll-button--disabled--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
   --pf-c-page__header__nav-scroll-button--disabled--before--BorderColor: transparent;
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
@@ -57,9 +58,15 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--lg--PaddingLeft);
     --pf-c-page__header-nav--BackgroundColor: var(--pf-c-page__header-nav--lg--BackgroundColor);
-    --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left);
+    --pf-c-page__header-nav--BorderTop: var(--pf-c-page__header-nav--lg--BorderTop);
+    --pf-c-page__header-nav--PaddingRight: var(--pf-c-page__header-nav--lg--PaddingRight);
+    --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--lg--PaddingLeft);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__header-nav--PaddingRight: var(--pf-c-page__header-nav--xl--PaddingRight);
+    --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--xl--PaddingLeft);
   }
 
   // Header tools
@@ -120,19 +127,10 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   // Main section horizontal nav
   --pf-c-page__main-nav--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--xl--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-page__main-nav--xl--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--xl--Left: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the left
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--xl--Right: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the right
-
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--xl--Left);
-    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--xl--Right);
-  }
+  --pf-c-page__main-nav--PaddingRight: 0;
+  --pf-c-page__main-nav--PaddingLeft: 0;
+  --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-page__main-nav--md--PaddingLeft: var(--pf-global--spacer--sm);
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__main-nav--PaddingRight: var(--pf-c-page__main-nav--xl--PaddingRight);
@@ -238,26 +236,29 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
 // Header navigation
 .pf-c-page__header-nav {
+  align-self: stretch;
+  min-width: 0;
+  padding-right: var(--pf-c-page__header-nav--PaddingRight);
+  padding-left: var(--pf-c-page__header-nav--PaddingLeft);
+  background-color: var(--pf-c-page__header-nav--BackgroundColor);
+  border-top: var(--pf-c-page__header-nav--BorderTop);
   grid-column: 1 / -1;
   grid-row: 2 / 3;
-  min-width: 0;
-
-  .pf-c-nav {
-    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--before--BorderColor);
-    --pf-c-nav__scroll-button--disabled--Color: var(--pf-c-page__header__nav-scroll-button--disabled--Color);
-    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--disabled--before--BorderColor);
-
-    align-self: stretch;
-  }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
-    grid-column: 2 / 3;
-    grid-row: 1 / 2;
     flex: 1;
     order: initial;
     width: auto;
-    margin-right: var(--pf-c-page__header-nav--lg--MarginRight);
-    margin-left: var(--pf-c-page__header-nav--lg--MarginLeft);
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+  }
+
+  .pf-c-nav {
+    --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-c-page__header__nav-scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--before--BorderColor);
+    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--disabled--before--BorderColor);
+
+    align-self: stretch;
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -38,8 +38,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   // Header nav
   --pf-c-page__header-nav--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
   --pf-c-page__header-nav--lg--BackgroundColor: transparent;
-  --pf-c-page__header-nav--BorderTop: 1px solid var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-page__header-nav--lg--BorderTop: 0;
   --pf-c-page__header-nav--PaddingRight: 0;
   --pf-c-page__header-nav--PaddingLeft: 0;
   --pf-c-page__header-nav--md--PaddingRight: var(--pf-global--spacer--sm);
@@ -59,7 +57,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-page__header-nav--BackgroundColor: var(--pf-c-page__header-nav--lg--BackgroundColor);
-    --pf-c-page__header-nav--BorderTop: var(--pf-c-page__header-nav--lg--BorderTop);
     --pf-c-page__header-nav--PaddingRight: var(--pf-c-page__header-nav--lg--PaddingRight);
     --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--lg--PaddingLeft);
   }
@@ -241,20 +238,16 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   padding-right: var(--pf-c-page__header-nav--PaddingRight);
   padding-left: var(--pf-c-page__header-nav--PaddingLeft);
   background-color: var(--pf-c-page__header-nav--BackgroundColor);
-  border-top: var(--pf-c-page__header-nav--BorderTop);
   grid-column: 1 / -1;
   grid-row: 2 / 3;
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
-    flex: 1;
-    order: initial;
-    width: auto;
     grid-column: 2 / 3;
     grid-row: 1 / 2;
   }
 
   .pf-c-nav {
-    --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-c-page__header--c-nav__scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--disabled--Color: var(--pf-c-page__header--c-nav__scroll-button--disabled--Color);
     --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header--c-nav__scroll-button--before--BorderColor);
     --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header--c-nav__scroll-button--disabled--before--BorderColor);
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -46,11 +46,11 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-nav--md--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-page__header-nav--xl--PaddingRight: 0;
   --pf-c-page__header-nav--xl--PaddingLeft: 0;
-  --pf-c-page__header__nav-scroll-button--disabled--Color: var(--pf-global--disabled-color--100);
-  --pf-c-page__header__nav-scroll-button--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-page__header--c-nav__scroll-button--disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-page__header--c-nav__scroll-button--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
 
-  // --pf-c-page__header__nav-scroll-button--disabled--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
-  --pf-c-page__header__nav-scroll-button--disabled--before--BorderColor: transparent;
+  // --pf-c-page__header--c-nav__scroll-button--disabled--before--BorderColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-page__header--c-nav__scroll-button--disabled--before--BorderColor: transparent;
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--xl--PaddingLeft);
@@ -254,9 +254,9 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   }
 
   .pf-c-nav {
-    --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-c-page__header__nav-scroll-button--disabled--Color);
-    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--before--BorderColor);
-    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header__nav-scroll-button--disabled--before--BorderColor);
+    --pf-c-nav__scroll-button--m-disabled--Color: var(--pf-c-page__header--c-nav__scroll-button--disabled--Color);
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-page__header--c-nav__scroll-button--before--BorderColor);
+    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-page__header--c-nav__scroll-button--disabled--before--BorderColor);
 
     align-self: stretch;
   }

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -24,7 +24,7 @@ import './Tabs.css'
 
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `disabled` | `.pf-c-tabs__scroll-button` | Indicates that a scroll button is disable, typically when at the first or last item of a list. **Required when disabled** |
+| `disabled` | `.pf-c-tabs__scroll-button` | Indicates that a scroll button is disabled, when at the first or last item of a list. **Required when disabled** |
 | `aria-hidden="true"` | `.pf-c-tabs__scroll-button` | Hides the icon from assistive technologies.**Required when not scrollable** |
 
 ### Usage

--- a/src/patternfly/demos/DataList/data-list-main-section-nav.hbs
+++ b/src/patternfly/demos/DataList/data-list-main-section-nav.hbs
@@ -1,6 +1,4 @@
-{{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Local"'}}
-  {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-  {{/nav-scroll-button}}
+{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"'}}
   {{#> nav-list nav-list--type="tertiary"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -28,6 +26,4 @@
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
-  {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-  {{/nav-scroll-button}}
 {{/nav}}

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -24,9 +24,7 @@ section: demos
       {{/page-header-brand-link}}
     {{/page-header-brand}}
     {{#> page-header-nav}}
-    {{#> nav nav--modifier="pf-m-end" nav--attribute=(concat 'id="' page--id '-horizontal-nav" aria-label="Global"')}}
-      {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-      {{/nav-scroll-button}}
+    {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute=(concat 'id="' page--id '-horizontal-nav" aria-label="Global"')}}
       {{#> nav-list nav-list--type="horizontal"}}
         {{#> nav-item}}
           {{#> nav-link nav-link--href="#"}}
@@ -54,8 +52,6 @@ section: demos
           {{/nav-link}}
         {{/nav-item}}
       {{/nav-list}}
-      {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-      {{/nav-scroll-button}}
     {{/nav}}
     {{/page-header-nav}}
     {{#> page-template-header-tools-elements}}
@@ -94,7 +90,7 @@ section: demos
   {{/page-header}}
 
   {{#> page-sidebar page-sidebar--modifier="pf-m-dark"}}
-    {{#> nav nav--expandable="true" nav--attribute=(concat 'id="' page--id '-tertiary-nav" aria-label="Global"')  nav--modifier="pf-m-dark"}}
+    {{#> nav nav--attribute=(concat 'id="' page--id '-tertiary-nav" aria-label="Global"')  nav--modifier="pf-m-dark"}}
       {{#> nav-list}}
         {{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
           {{#> nav-link nav-link--href="#" nav-link--attribute='id="tertiary-nav-link1"'}}
@@ -178,9 +174,7 @@ section: demos
   {{/page-sidebar}}
   {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav}}
-      {{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Local"'}}
-        {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-        {{/nav-scroll-button}}
+      {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
         {{#> nav-list nav-list--type="tertiary"}}
           {{#> nav-item}}
             {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -208,8 +202,6 @@ section: demos
             {{/nav-link}}
           {{/nav-item}}
         {{/nav-list}}
-        {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-        {{/nav-scroll-button}}
       {{/nav}}
     {{/page-main-nav}}
     {{#> page-template-breadcrumb}}

--- a/src/patternfly/demos/Table/table-main-section-nav.hbs
+++ b/src/patternfly/demos/Table/table-main-section-nav.hbs
@@ -1,6 +1,4 @@
-{{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Local"'}}
-  {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
-  {{/nav-scroll-button}}
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
   {{#> nav-list nav-list--type="tertiary"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
@@ -28,6 +26,4 @@
       {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
-  {{#> nav-scroll-button nav-scroll-button--IsRight="true"}}
-  {{/nav-scroll-button}}
 {{/nav}}


### PR DESCRIPTION
Closes #1839
Closes #1848
Closes #2435

## Breaking changes
This PR modifies the nav behavior to display inline with navigational elements rather than being absolutely positioned above them.  

The following classes have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `.pf-m-start`
* `.pf-m-end`

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--pf-c-nav__scroll-button--Display`
* `--pf-c-nav__scroll-button--Visibility`
* `--pf-c-nav__scroll-button--ZIndex`
* `--pf-c-nav__scroll-button--Height`
* `--pf-c-nav__scroll-button--lg--Height`
* `--pf-c-nav__scroll-button--PaddingRight`
* `--pf-c-nav__scroll-button--PaddingLeft`
* `--pf-c-nav__scroll-button--nth-of-type-1--BoxShadow`
* `--pf-c-nav__scroll-button--nth-of-type-2--BoxShadow`
* `--pf-c-nav__scroll-button--m-dark--nth-of-type-1--BoxShadow`
* `--pf-c-nav__scroll-button--m-dark--nth-of-type-2--BoxShadow`
* `--pf-c-page__header-nav--lg--MarginRight`
* `--pf-c-page__header-nav--lg--MarginLeft`
* `--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left`
* `--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--md--Left`
* `--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left`
* `--pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor`
* `--pf-c-page__header-nav--c-nav__scroll-button--lg--Top`
* `--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left`
* `--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left`
* `--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right`
* `--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right`

Some of the general CSS structure has also changed, so please reference the [file changeset](https://github.com/patternfly/patternfly/pull/2942/files).