### PR TITLE
feat(label): refactored label component

### DIFF
--- a/src/patternfly/components/Label/examples/Label.css
+++ b/src/patternfly/components/Label/examples/Label.css
@@ -1,3 +1,7 @@
-.ws-core-c-label .pf-c-label {
-  margin-right: 6px;
+.ws-core-c-label .ws-preview-html {
+  margin: -4px;
+}
+
+.pf-c-label {
+  margin: 4px;
 }

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -38,30 +38,99 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-compact" label--modifier="pf-m-compact" label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
+<br><br>
+
+{{#> label label--id="default-grey-compact" label--modifier="pf-m-compact"}}
   {{#> label-text}}
     Grey compact
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-link" label--type="a"}}
+{{#> label label--id="default-grey-compact-icon" label--modifier="pf-m-compact"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey compact icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-compact-removable" label--modifier="pf-m-compact" label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey compact removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-compact-icon-removable" label--modifier="pf-m-compact" label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey compact icon removable
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-grey-link" label-content--type="a" label-content--attribute='href="#"'}}
   {{#> label-text}}
     Grey link
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-button" label--type="button"}}
+{{#> label label--id="default-grey-link-icon" label-content--type="a" label-content--attribute='href="#"'}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey link icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-link-close" label-content--type="a" label-content--attribute='href="#"'  label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey link removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-link-icon-close" label-content--type="a" label-content--attribute='href="#"' label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey link icon and removable
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-grey-button" label-content--type="button"}}
   {{#> label-text}}
     Grey button
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-clickable-removable" label--modifier="pf-m-clickable" label--attribute='tabindex="0"' label--isRemovable="true"}}
+{{#> label label--id="default-grey-button-icon" label-content--type="button"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
   {{#> label-text}}
-    Grey clickable removable
+    Grey button icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-button-removable" label-content--type="button" label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey button removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-button-icon-removable" label-content--type="button" label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey button icon and removable
   {{/label-text}}
 {{/label}}
 
@@ -97,12 +166,6 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-blue" label--modifier="pf-m-blue pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Blue clickable label
-  {{/label-text}}
-{{/label}}
-
 <br><br>
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
@@ -132,12 +195,6 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Green label
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-green" label--modifier="pf-m-green pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Green clickable label
   {{/label-text}}
 {{/label}}
 
@@ -173,12 +230,6 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-orange" label--modifier="pf-m-orange pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Orange clickable label
-  {{/label-text}}
-{{/label}}
-
 <br><br>
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
@@ -208,12 +259,6 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Red label
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-red" label--modifier="pf-m-red pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Red clickable label
   {{/label-text}}
 {{/label}}
 
@@ -249,12 +294,6 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-purple" label--modifier="pf-m-purple pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Purple clickable label
-  {{/label-text}}
-{{/label}}
-
 <br><br>
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
@@ -286,19 +325,13 @@ import './Label.css'
     Cyan label
   {{/label-text}}
 {{/label}}
-
-{{#> label label--id="default-cyan-clickable" label--modifier="pf-m-cyan pf-m-clickable" label--attribute='tabindex="0"'}}
-  {{#> label-text}}
-    Cyan clickable label
-  {{/label-text}}
-{{/label}}
 ```
 
 
 ```hbs title=Outline
 {{#> label label--id="outline-grey" label--modifier="pf-m-outline"}}
   {{#> label-text}}
-    Grey label
+    Grey
   {{/label-text}}
 {{/label}}
 
@@ -307,13 +340,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Grey label
+    Grey icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-text}}
-    Grey label
+    Grey removable
   {{/label-text}}
 {{/label}}
 
@@ -322,34 +355,103 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Grey label
+    Grey icon and removable
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-compact" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
+<br><br>
+
+{{#> label label--id="outline-grey-compact" label--modifier="pf-m-outline pf-m-compact"}}
   {{#> label-text}}
     Grey compact
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-link" label--type="a" label--modifier="pf-m-outline"}}
+{{#> label label--id="outline-grey-compact-icon" label--modifier="pf-m-outline pf-m-compact"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey compact icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-compact-removable" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey compact removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-compact-icon-removable" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey compact icon removable
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-grey-link" label-content--type="a" label-content--attribute='href="#"' label--modifier="pf-m-outline"}}
   {{#> label-text}}
     Grey link
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-button" label--type="button" label--modifier="pf-m-outline"}}
+{{#> label label--id="outline-grey-link-icon" label-content--type="a" label-content--attribute='href="#"' label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey link icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-link-close" label-content--type="a" label-content--attribute='href="#"'  label--isRemovable="true" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    Grey link removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-link-icon-close" label-content--type="a" label-content--attribute='href="#"' label--isRemovable="true" label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey link icon and removable
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-grey-button" label-content--type="button" label--modifier="pf-m-outline"}}
   {{#> label-text}}
     Grey button
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-clickable-removable" label--modifier="pf-m-outline pf-m-clickable" label--attribute='tabindex="0"' label--isRemovable="true"}}
+{{#> label label--id="outline-grey-button-icon" label-content--type="button" label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
   {{#> label-text}}
-    Grey clickable removable
+    Grey button icon
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-button-removable" label-content--type="button" label--isRemovable="true" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    Grey button removable
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-button-icon-removable" label-content--type="button" label--isRemovable="true" label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    Grey button icon and removable
   {{/label-text}}
 {{/label}}
 
@@ -592,7 +694,6 @@ Labels can be used in a variety of components and can adjust in font size to mat
 | `.pf-c-label` | `<span>`, `<a>`, `<button>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
 | `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
-| `.pf-m-clickable` | `span.pf-c-label` | Modifies the label to have clickable styles. This is used with removable labels that also serve as a link or button. |
 | `.pf-m-blue` | `.pf-c-label` | Modifies the label to have blue colored styling. |
 | `.pf-m-green` | `.pf-c-label` | Modifies the label to have green colored styling. |
 | `.pf-m-orange` | `.pf-c-label` | Modifies the label to have orange colored styling. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -691,7 +691,10 @@ Labels can be used in a variety of components and can adjust in font size to mat
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-label` | `<span>`, `<a>`, `<button>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
+| `.pf-c-label` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
+| `.pf-c-label__content` | `<span>`, `<a>`, `<button>` | Iniates a label content. Use an `<a>` or `<button>` instead of a `<span>` for interactive label content. **Required** |
+| `.pf-c-label__icon` | `<span>` | Iniates a label icon. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
+| `.pf-c-label__text` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
 | `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
 | `.pf-m-blue` | `.pf-c-label` | Modifies the label to have blue colored styling. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -44,6 +44,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-grey-link-close" label-content--IsLink="true" label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
@@ -79,6 +85,12 @@ import './Label.css'
 {{#> label label--id="default-blue-link" label-content--IsLink="true" label--modifier="pf-m-blue"}}
   {{#> label-text}}
     Blue link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-blue-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-blue"}}
+  {{#> label-text}}
+    Blue removable link
   {{/label-text}}
 {{/label}}
 
@@ -120,6 +132,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-green-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-gren"}}
+  {{#> label-text}}
+    Green removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
@@ -155,6 +173,12 @@ import './Label.css'
 {{#> label label--id="default-orange-link" label-content--IsLink="true" label--modifier="pf-m-orange"}}
   {{#> label-text}}
     Orange link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-orange-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-orange"}}
+  {{#> label-text}}
+    Orange removable link
   {{/label-text}}
 {{/label}}
 
@@ -196,6 +220,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-red-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-red"}}
+  {{#> label-text}}
+    Red removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
@@ -234,6 +264,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-purple-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-purple"}}
+  {{#> label-text}}
+    Purple removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
@@ -269,6 +305,12 @@ import './Label.css'
 {{#> label label--id="default-cyan-link" label-content--IsLink="true" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
     Cyan link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-cyan"}}
+  {{#> label-text}}
+    Cyan removable link
   {{/label-text}}
 {{/label}}
 ```
@@ -311,6 +353,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="outline-grey-link-close" label-content--IsLink="true" label--modifier="pf-m-outline" label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
@@ -346,6 +394,12 @@ import './Label.css'
 {{#> label label--id="outline-blue-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue"}}
   {{#> label-text}}
     Blue link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-blue-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue" label--isRemovable="true"}}
+  {{#> label-text}}
+    Blue removable link
   {{/label-text}}
 {{/label}}
 
@@ -387,6 +441,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="outline-green-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green" label--isRemovable="true"}}
+  {{#> label-text}}
+    Green removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
@@ -422,6 +482,12 @@ import './Label.css'
 {{#> label label--id="outline-orange-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange"}}
   {{#> label-text}}
     Orange link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-orange-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange" label--isRemovable="true"}}
+  {{#> label-text}}
+    Orange removable link
   {{/label-text}}
 {{/label}}
 
@@ -463,6 +529,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="outline-red-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red" label--isRemovable="true"}}
+  {{#> label-text}}
+    Red removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
@@ -500,6 +572,13 @@ import './Label.css'
     Purple link
   {{/label-text}}
 {{/label}}
+
+{{#> label label--id="outline-purple-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple" label--isRemovable="true"}}
+  {{#> label-text}}
+    Purple removable link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
@@ -535,6 +614,12 @@ import './Label.css'
 {{#> label label--id="outline-cyan-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan"}}
   {{#> label-text}}
     Cyan link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-cyan-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan" label--isRemovable="true"}}
+  {{#> label-text}}
+    Cyan removable link
   {{/label-text}}
 {{/label}}
 ```

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -14,7 +14,7 @@ import './Label.css'
 
 {{#> label label--id="default-grey-icon"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Grey icon
 {{/label}}
@@ -25,7 +25,7 @@ import './Label.css'
 
 {{#> label label--id="default-grey-icon-close" label--isRemovable="true"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Grey icon removable
 {{/label}}
@@ -46,7 +46,7 @@ import './Label.css'
 
 {{#> label label--id="default-blue-icon" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Blue icon
 {{/label}}
@@ -57,7 +57,7 @@ import './Label.css'
 
 {{#> label label--id="default-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Blue icon removable
 {{/label}}
@@ -78,7 +78,7 @@ import './Label.css'
 
 {{#> label label--id="default-green-icon" label--modifier="pf-m-green"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Green icon
 {{/label}}
@@ -89,7 +89,7 @@ import './Label.css'
 
 {{#> label label--id="default-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Green icon removable
 {{/label}}
@@ -110,7 +110,7 @@ import './Label.css'
 
 {{#> label label--id="default-orange-icon" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Orange icon
 {{/label}}
@@ -121,7 +121,7 @@ import './Label.css'
 
 {{#> label label--id="default-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Orange icon removable
 {{/label}}
@@ -142,7 +142,7 @@ import './Label.css'
 
 {{#> label label--id="default-red-icon" label--modifier="pf-m-red"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Red icon
 {{/label}}
@@ -153,7 +153,7 @@ import './Label.css'
 
 {{#> label label--id="default-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Red icon removable
 {{/label}}
@@ -174,7 +174,7 @@ import './Label.css'
 
 {{#> label label--id="default-purple-icon" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Purple icon
 {{/label}}
@@ -185,7 +185,7 @@ import './Label.css'
 
 {{#> label label--id="default-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Purple icon removable
 {{/label}}
@@ -206,7 +206,7 @@ import './Label.css'
 
 {{#> label label--id="default-cyan-icon" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Cyan icon
 {{/label}}
@@ -217,7 +217,7 @@ import './Label.css'
 
 {{#> label label--id="default-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Cyan icon removable
 {{/label}}
@@ -239,7 +239,7 @@ import './Label.css'
 
 {{#> label label--id="outline-grey-icon" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Grey icon
 {{/label}}
@@ -250,7 +250,7 @@ import './Label.css'
 
 {{#> label label--id="outline-grey-icon-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Grey icon removable
 {{/label}}
@@ -271,7 +271,7 @@ import './Label.css'
 
 {{#> label label--id="outline-blue-icon" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Blue icon
 {{/label}}
@@ -282,7 +282,7 @@ import './Label.css'
 
 {{#> label label--id="outline-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Blue icon removable
 {{/label}}
@@ -303,7 +303,7 @@ import './Label.css'
 
 {{#> label label--id="outline-green-icon" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Green icon
 {{/label}}
@@ -314,7 +314,7 @@ import './Label.css'
 
 {{#> label label--id="outline-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Green icon removable
 {{/label}}
@@ -335,7 +335,7 @@ import './Label.css'
 
 {{#> label label--id="outline-orange-icon" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Orange icon
 {{/label}}
@@ -346,7 +346,7 @@ import './Label.css'
 
 {{#> label label--id="outline-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Orange icon removable
 {{/label}}
@@ -367,7 +367,7 @@ import './Label.css'
 
 {{#> label label--id="outline-red-icon" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Red icon
 {{/label}}
@@ -378,7 +378,7 @@ import './Label.css'
 
 {{#> label label--id="outline-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Red icon removable
 {{/label}}
@@ -399,7 +399,7 @@ import './Label.css'
 
 {{#> label label--id="outline-purple-icon" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Purple icon
 {{/label}}
@@ -410,7 +410,7 @@ import './Label.css'
 
 {{#> label label--id="outline-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Purple icon removable
 {{/label}}
@@ -431,7 +431,7 @@ import './Label.css'
 
 {{#> label label--id="outline-cyan-icon" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Cyan icon
 {{/label}}
@@ -442,7 +442,7 @@ import './Label.css'
 
 {{#> label label--id="outline-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   Cyan icon removable
 {{/label}}

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -40,38 +40,6 @@ import './Label.css'
 
 <br><br>
 
-{{#> label label--id="default-grey-compact" label--modifier="pf-m-compact"}}
-  {{#> label-text}}
-    Grey compact
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-compact-icon" label--modifier="pf-m-compact"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey compact icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-compact-removable" label--modifier="pf-m-compact" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey compact removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-compact-icon-removable" label--modifier="pf-m-compact" label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey compact icon removable
-  {{/label-text}}
-{{/label}}
-
-<br><br>
-
 {{#> label label--id="default-grey-link" label-content--type="a" label-content--attribute='href="#"'}}
   {{#> label-text}}
     Grey link
@@ -356,38 +324,6 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Grey icon and removable
-  {{/label-text}}
-{{/label}}
-
-<br><br>
-
-{{#> label label--id="outline-grey-compact" label--modifier="pf-m-outline pf-m-compact"}}
-  {{#> label-text}}
-    Grey compact
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-compact-icon" label--modifier="pf-m-outline pf-m-compact"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey compact icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-compact-removable" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey compact removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-compact-icon-removable" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey compact icon removable
   {{/label-text}}
 {{/label}}
 
@@ -685,8 +621,6 @@ import './Label.css'
 ```
 
 ## Documentation
-### Overview
-Labels can be used in a variety of components and can adjust in font size to match that of the component it lives in. For example, labels can be used in tables. Specifically, the compact table has a modifier that adjusts its font size, so when using a label in this table, it's important to also add its respective `.pf-c-compact` modifier.
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -695,7 +629,6 @@ Labels can be used in a variety of components and can adjust in font size to mat
 | `.pf-c-label__content` | `<span>`, `<a>`, `<button>` | Iniates a label content. Use an `<a>` or `<button>` instead of a `<span>` for interactive label content. **Required** |
 | `.pf-c-label__icon` | `<span>` | Iniates a label icon. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
 | `.pf-c-label__text` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
-| `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
 | `.pf-m-blue` | `.pf-c-label` | Modifies the label to have blue colored styling. |
 | `.pf-m-green` | `.pf-c-label` | Modifies the label to have green colored styling. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -38,67 +38,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-<br><br>
-
-{{#> label label--id="default-grey-link" label-content--type="a" label-content--attribute='href="#"'}}
+{{#> label label--id="default-grey-link" label-content--IsLink="true"}}
   {{#> label-text}}
     Grey link
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-link-icon" label-content--type="a" label-content--attribute='href="#"'}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey link icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-link-close" label-content--type="a" label-content--attribute='href="#"'  label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey link removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-link-icon-close" label-content--type="a" label-content--attribute='href="#"' label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey link icon and removable
-  {{/label-text}}
-{{/label}}
-
-<br><br>
-
-{{#> label label--id="default-grey-button" label-content--type="button"}}
-  {{#> label-text}}
-    Grey button
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-button-icon" label-content--type="button"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey button icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-button-removable" label-content--type="button" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey button removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="default-grey-button-icon-removable" label-content--type="button" label--isRemovable="true"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey button icon and removable
   {{/label-text}}
 {{/label}}
 
@@ -134,6 +76,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-blue-link" label-content--IsLink="true" label--modifier="pf-m-blue"}}
+  {{#> label-text}}
+    Blue link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
@@ -163,6 +111,12 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-green-link" label-content--IsLink="true" label--modifier="pf-m-green"}}
+  {{#> label-text}}
+    Green link
   {{/label-text}}
 {{/label}}
 
@@ -198,6 +152,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-orange-link" label-content--IsLink="true" label--modifier="pf-m-orange"}}
+  {{#> label-text}}
+    Orange link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
@@ -227,6 +187,12 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-red-link" label-content--IsLink="true" label--modifier="pf-m-red"}}
+  {{#> label-text}}
+    Red link
   {{/label-text}}
 {{/label}}
 
@@ -262,6 +228,12 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
+{{#> label label--id="default-purple-link" label-content--IsLink="true" label--modifier="pf-m-purple"}}
+  {{#> label-text}}
+    Purple link
+  {{/label-text}}
+{{/label}}
+
 <br><br>
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
@@ -291,6 +263,12 @@ import './Label.css'
   {{/label-icon}}
   {{#> label-text}}
     Cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-link" label-content--IsLink="true" label--modifier="pf-m-cyan"}}
+  {{#> label-text}}
+    Cyan link
   {{/label-text}}
 {{/label}}
 ```
@@ -327,67 +305,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-<br><br>
-
-{{#> label label--id="outline-grey-link" label-content--type="a" label-content--attribute='href="#"' label--modifier="pf-m-outline"}}
+{{#> label label--id="outline-grey-link" label-content--IsLink="true" label--modifier="pf-m-outline"}}
   {{#> label-text}}
     Grey link
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-link-icon" label-content--type="a" label-content--attribute='href="#"' label--modifier="pf-m-outline"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey link icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-link-close" label-content--type="a" label-content--attribute='href="#"'  label--isRemovable="true" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey link removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-link-icon-close" label-content--type="a" label-content--attribute='href="#"' label--isRemovable="true" label--modifier="pf-m-outline"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey link icon and removable
-  {{/label-text}}
-{{/label}}
-
-<br><br>
-
-{{#> label label--id="outline-grey-button" label-content--type="button" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey button
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-button-icon" label-content--type="button" label--modifier="pf-m-outline"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey button icon
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-button-removable" label-content--type="button" label--isRemovable="true" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey button removable
-  {{/label-text}}
-{{/label}}
-
-{{#> label label--id="outline-grey-button-icon-removable" label-content--type="button" label--isRemovable="true" label--modifier="pf-m-outline"}}
-  {{#> label-icon}}
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  {{/label-icon}}
-  {{#> label-text}}
-    Grey button icon and removable
   {{/label-text}}
 {{/label}}
 
@@ -423,9 +343,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-blue-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue"}}
   {{#> label-text}}
-    Blue clickable label
+    Blue link
   {{/label-text}}
 {{/label}}
 
@@ -461,9 +381,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-green-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green"}}
   {{#> label-text}}
-    Green clickable label
+    Green link
   {{/label-text}}
 {{/label}}
 
@@ -499,9 +419,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-orange-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange"}}
   {{#> label-text}}
-    Orange clickable label
+    Orange link
   {{/label-text}}
 {{/label}}
 
@@ -537,9 +457,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-red-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red"}}
   {{#> label-text}}
-    Red clickable label
+    Red link
   {{/label-text}}
 {{/label}}
 
@@ -575,12 +495,11 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-purple-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple"}}
   {{#> label-text}}
-    Purple clickable label
+    Purple link
   {{/label-text}}
 {{/label}}
-
 <br><br>
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
@@ -613,9 +532,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-cyan-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan"}}
   {{#> label-text}}
-    Cyan clickable label
+    Cyan link
   {{/label-text}}
 {{/label}}
 ```
@@ -626,7 +545,7 @@ import './Label.css'
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-label` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
-| `.pf-c-label__content` | `<span>`, `<a>`, `<button>` | Iniates a label content. Use an `<a>` or `<button>` instead of a `<span>` for interactive label content. **Required** |
+| `.pf-c-label__content` | `<span>`, `<a>` | Iniates a label content. Use as an `<a>` if the label serves as a link. **Required** |
 | `.pf-c-label__icon` | `<span>` | Iniates a label icon. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
 | `.pf-c-label__text` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -7,22 +7,553 @@ cssPrefix: pf-c-label
 import './Label.css'
 
 ## Examples
-```hbs title=Basic
-{{#> label}}
-  Default label
+```hbs title=Filled
+{{#> label label--id="default-grey"}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--modifier="pf-m-compact"}}
-  Compact label
+{{#> label label--id="default-grey-icon"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-close" label--IsClosable="true"}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-icon-close" label--IsClosable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey" label--modifier="pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    grey hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-blue-icon" label--modifier="pf-m-blue"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-blue-close" label--IsClosable="true" label--modifier="pf-m-blue"}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-blue-icon-close" label--IsClosable="true" label--modifier="pf-m-blue"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-blue" label--modifier="pf-m-blue pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    blue hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-green" label--modifier="pf-m-green"}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-green-icon" label--modifier="pf-m-green"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-green-close" label--IsClosable="true" label--modifier="pf-m-green"}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-green-icon-close" label--IsClosable="true" label--modifier="pf-m-green"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-green" label--modifier="pf-m-green pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    green hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-orange-icon" label--modifier="pf-m-orange"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-orange-close" label--IsClosable="true" label--modifier="pf-m-orange"}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-orange-icon-close" label--IsClosable="true" label--modifier="pf-m-orange"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-orange" label--modifier="pf-m-orange pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    orange hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-red" label--modifier="pf-m-red"}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-red-icon" label--modifier="pf-m-red"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-red-close" label--IsClosable="true" label--modifier="pf-m-red"}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-red-icon-close" label--IsClosable="true" label--modifier="pf-m-red"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-red" label--modifier="pf-m-red pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    red hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-purple-icon" label--modifier="pf-m-purple"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-purple-close" label--IsClosable="true" label--modifier="pf-m-purple"}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-purple-icon-close" label--IsClosable="true" label--modifier="pf-m-purple"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-purple" label--modifier="pf-m-purple pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    purple hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-icon" label--modifier="pf-m-cyan"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-close" label--IsClosable="true" label--modifier="pf-m-cyan"}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-icon-close" label--IsClosable="true" label--modifier="pf-m-cyan"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-cyan-hoverable" label--modifier="pf-m-cyan pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    cyan hoverable label
+  {{/label-text}}
+{{/label}}
+```
+
+
+```hbs title=Outline
+{{#> label label--id="outline-grey" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-icon" label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-close" label--IsClosable="true" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-icon-close" label--IsClosable="true" label--modifier="pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    grey label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey" label--modifier="pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    grey hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-blue-icon" label--modifier="pf-m-blue pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-blue-close" label--IsClosable="true" label--modifier="pf-m-blue pf-m-outline"}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-blue-icon-close" label--IsClosable="true" label--modifier="pf-m-blue pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    blue label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    blue hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline"}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-green-icon" label--modifier="pf-m-green pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-green-close" label--IsClosable="true" label--modifier="pf-m-green pf-m-outline"}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-green-icon-close" label--IsClosable="true" label--modifier="pf-m-green pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    green label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    green hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-orange-icon" label--modifier="pf-m-orange pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-orange-close" label--IsClosable="true" label--modifier="pf-m-orange pf-m-outline"}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-orange-icon-close" label--IsClosable="true" label--modifier="pf-m-orange pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    orange label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    orange hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline"}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-red-icon" label--modifier="pf-m-red pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-red-close" label--IsClosable="true" label--modifier="pf-m-red pf-m-outline"}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-red-icon-close" label--IsClosable="true" label--modifier="pf-m-red pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    red label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    red hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-purple-icon" label--modifier="pf-m-purple pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-purple-close" label--IsClosable="true" label--modifier="pf-m-purple pf-m-outline"}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-purple-icon-close" label--IsClosable="true" label--modifier="pf-m-purple pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    purple label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    purple hoverable label
+  {{/label-text}}
+{{/label}}
+
+<br><br>
+
+{{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-cyan-icon" label--modifier="pf-m-cyan pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-cyan-close" label--IsClosable="true" label--modifier="pf-m-cyan pf-m-outline"}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-cyan-icon-close" label--IsClosable="true" label--modifier="pf-m-cyan pf-m-outline"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
+  {{#> label-text}}
+    cyan label
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+  {{#> label-text}}
+    cyan hoverable label
+  {{/label-text}}
 {{/label}}
 ```
 
 ## Documentation
 ### Overview
-Labels can be used in a variety of components and can adjust in font size to match that of the component it lives in. For example, labels can be used in tables. Specifically, the compact table has a modifier that adjusts its font size, so when using a label in this table, it's important to also add its respective modifier.
+Labels can be used in a variety of components and can adjust in font size to match that of the component it lives in. For example, labels can be used in tables. Specifically, the compact table has a modifier that adjusts its font size, so when using a label in this table, it's important to also add its respective `.pf-c-compact` modifier.
 
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-label` | `<span>` | Iniates a label. |
-| `.pf-m-compact` | `.pf-c-label` | Modifies label for a compact table. |
+| `.pf-c-label` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
+| `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
+| `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
+| `.pf-m-hoverable` | `.pf-c-label` | Modifies label for a hoverable styles. |
+| `.pf-m-blue` | `.pf-c-label` | Modifies label for a blue styles. |
+| `.pf-m-green` | `.pf-c-label` | Modifies label for a green styles. |
+| `.pf-m-orange` | `.pf-c-label` | Modifies label for a orange styles. |
+| `.pf-m-red` | `.pf-c-label` | Modifies label for a red styles. |
+| `.pf-m-purple` | `.pf-c-label` | Modifies label for a purple styles. |
+| `.pf-m-cyan` | `.pf-c-label` | Modifies label for a cyan styles. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -9,618 +9,450 @@ import './Label.css'
 ## Examples
 ```hbs title=Filled
 {{#> label label--id="default-grey"}}
-  {{#> label-text}}
-    Grey
-  {{/label-text}}
+  Grey
 {{/label}}
 
 {{#> label label--id="default-grey-icon"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Grey icon
-  {{/label-text}}
+  Grey icon
 {{/label}}
 
 {{#> label label--id="default-grey-close" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey removable
-  {{/label-text}}
+  Grey removable
 {{/label}}
 
 {{#> label label--id="default-grey-icon-close" label--isRemovable="true"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Grey icon removable
-  {{/label-text}}
+  Grey icon removable
 {{/label}}
 
 {{#> label label--id="default-grey-link" label-content--IsLink="true"}}
-  {{#> label-text}}
-    Grey link
-  {{/label-text}}
+  Grey link
 {{/label}}
 
 {{#> label label--id="default-grey-link-close" label-content--IsLink="true" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey link removable
-  {{/label-text}}
+  Grey link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
-  {{#> label-text}}
-    Blue
-  {{/label-text}}
+  Blue
 {{/label}}
 
 {{#> label label--id="default-blue-icon" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Blue icon
-  {{/label-text}}
+  Blue icon
 {{/label}}
 
 {{#> label label--id="default-blue-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
-  {{#> label-text}}
-    Blue removable
-  {{/label-text}}
+  Blue removable
 {{/label}}
 
 {{#> label label--id="default-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Blue icon removable
-  {{/label-text}}
+  Blue icon removable
 {{/label}}
 
 {{#> label label--id="default-blue-link" label-content--IsLink="true" label--modifier="pf-m-blue"}}
-  {{#> label-text}}
-    Blue link
-  {{/label-text}}
+  Blue link
 {{/label}}
 
 {{#> label label--id="default-blue-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-blue"}}
-  {{#> label-text}}
-    Blue link removable
-  {{/label-text}}
+  Blue link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
-  {{#> label-text}}
-    Green
-  {{/label-text}}
+  Green
 {{/label}}
 
 {{#> label label--id="default-green-icon" label--modifier="pf-m-green"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Green icon
-  {{/label-text}}
+  Green icon
 {{/label}}
 
 {{#> label label--id="default-green-close" label--isRemovable="true" label--modifier="pf-m-green"}}
-  {{#> label-text}}
-    Green removable
-  {{/label-text}}
+  Green removable
 {{/label}}
 
 {{#> label label--id="default-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Green icon removable
-  {{/label-text}}
+  Green icon removable
 {{/label}}
 
 {{#> label label--id="default-green-link" label-content--IsLink="true" label--modifier="pf-m-green"}}
-  {{#> label-text}}
-    Green link
-  {{/label-text}}
+  Green link
 {{/label}}
 
 {{#> label label--id="default-green-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-green"}}
-  {{#> label-text}}
-    Green link removable
-  {{/label-text}}
+  Green link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
-  {{#> label-text}}
-    Orange
-  {{/label-text}}
+  Orange
 {{/label}}
 
 {{#> label label--id="default-orange-icon" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Orange icon
-  {{/label-text}}
+  Orange icon
 {{/label}}
 
 {{#> label label--id="default-orange-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
-  {{#> label-text}}
-    Orange removable
-  {{/label-text}}
+  Orange removable
 {{/label}}
 
 {{#> label label--id="default-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Orange icon removable
-  {{/label-text}}
+  Orange icon removable
 {{/label}}
 
 {{#> label label--id="default-orange-link" label-content--IsLink="true" label--modifier="pf-m-orange"}}
-  {{#> label-text}}
-    Orange link
-  {{/label-text}}
+  Orange link
 {{/label}}
 
 {{#> label label--id="default-orange-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-orange"}}
-  {{#> label-text}}
-    Orange link removable
-  {{/label-text}}
+  Orange link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
-  {{#> label-text}}
-    Red
-  {{/label-text}}
+  Red
 {{/label}}
 
 {{#> label label--id="default-red-icon" label--modifier="pf-m-red"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Red icon
-  {{/label-text}}
+  Red icon
 {{/label}}
 
 {{#> label label--id="default-red-close" label--isRemovable="true" label--modifier="pf-m-red"}}
-  {{#> label-text}}
-    Red removable
-  {{/label-text}}
+  Red removable
 {{/label}}
 
 {{#> label label--id="default-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Red icon removable
-  {{/label-text}}
+  Red icon removable
 {{/label}}
 
 {{#> label label--id="default-red-link" label-content--IsLink="true" label--modifier="pf-m-red"}}
-  {{#> label-text}}
-    Red link
-  {{/label-text}}
+  Red link
 {{/label}}
 
 {{#> label label--id="default-red-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-red"}}
-  {{#> label-text}}
-    Red link removable
-  {{/label-text}}
+  Red link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
-  {{#> label-text}}
-    Purple
-  {{/label-text}}
+  Purple
 {{/label}}
 
 {{#> label label--id="default-purple-icon" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Purple icon
-  {{/label-text}}
+  Purple icon
 {{/label}}
 
 {{#> label label--id="default-purple-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
-  {{#> label-text}}
-    Purple removable
-  {{/label-text}}
+  Purple removable
 {{/label}}
 
 {{#> label label--id="default-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Purple icon removable
-  {{/label-text}}
+  Purple icon removable
 {{/label}}
 
 {{#> label label--id="default-purple-link" label-content--IsLink="true" label--modifier="pf-m-purple"}}
-  {{#> label-text}}
-    Purple link
-  {{/label-text}}
+  Purple link
 {{/label}}
 
 {{#> label label--id="default-purple-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-purple"}}
-  {{#> label-text}}
-    Purple link removable
-  {{/label-text}}
+  Purple link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
-  {{#> label-text}}
-    Cyan
-  {{/label-text}}
+  Cyan
 {{/label}}
 
 {{#> label label--id="default-cyan-icon" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Cyan icon
-  {{/label-text}}
+  Cyan icon
 {{/label}}
 
 {{#> label label--id="default-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
-  {{#> label-text}}
     Cyan removable
-  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Cyan icon removable
-  {{/label-text}}
+  Cyan icon removable
 {{/label}}
 
 {{#> label label--id="default-cyan-link" label-content--IsLink="true" label--modifier="pf-m-cyan"}}
-  {{#> label-text}}
-    Cyan link
-  {{/label-text}}
+  Cyan link
 {{/label}}
 
 {{#> label label--id="default-cyan-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-cyan"}}
-  {{#> label-text}}
-    Cyan link removable
-  {{/label-text}}
+  Cyan link removable
 {{/label}}
 ```
 
 
 ```hbs title=Outline
 {{#> label label--id="outline-grey" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey
-  {{/label-text}}
+  Grey
 {{/label}}
 
 {{#> label label--id="outline-grey-icon" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Grey icon
-  {{/label-text}}
+  Grey icon
 {{/label}}
 
 {{#> label label--id="outline-grey-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey removable
-  {{/label-text}}
+  Grey removable
 {{/label}}
 
 {{#> label label--id="outline-grey-icon-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Grey icon removable
-  {{/label-text}}
+  Grey icon removable
 {{/label}}
 
 {{#> label label--id="outline-grey-link" label-content--IsLink="true" label--modifier="pf-m-outline"}}
-  {{#> label-text}}
-    Grey link
-  {{/label-text}}
+  Grey link
 {{/label}}
 
 {{#> label label--id="outline-grey-link-close" label-content--IsLink="true" label--modifier="pf-m-outline" label--isRemovable="true"}}
-  {{#> label-text}}
-    Grey link removable
-  {{/label-text}}
+  Grey link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
-  {{#> label-text}}
-    Blue
-  {{/label-text}}
+  Blue
 {{/label}}
 
 {{#> label label--id="outline-blue-icon" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Blue icon
-  {{/label-text}}
+  Blue icon
 {{/label}}
 
 {{#> label label--id="outline-blue-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
-  {{#> label-text}}
-    Blue removable
-  {{/label-text}}
+  Blue removable
 {{/label}}
 
 {{#> label label--id="outline-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Blue icon removable
-  {{/label-text}}
+  Blue icon removable
 {{/label}}
 
 {{#> label label--id="outline-blue-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue"}}
-  {{#> label-text}}
-    Blue link
-  {{/label-text}}
+  Blue link
 {{/label}}
 
 {{#> label label--id="outline-blue-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue" label--isRemovable="true"}}
-  {{#> label-text}}
-    Blue link removable
-  {{/label-text}}
+  Blue link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline"}}
-  {{#> label-text}}
-    Green
-  {{/label-text}}
+  Green
 {{/label}}
 
 {{#> label label--id="outline-green-icon" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Green icon
-  {{/label-text}}
+  Green icon
 {{/label}}
 
 {{#> label label--id="outline-green-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
-  {{#> label-text}}
-    Green removable
-  {{/label-text}}
+  Green removable
 {{/label}}
 
 {{#> label label--id="outline-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Green icon removable
-  {{/label-text}}
+  Green icon removable
 {{/label}}
 
 {{#> label label--id="outline-green-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green"}}
-  {{#> label-text}}
-    Green link
-  {{/label-text}}
+  Green link
 {{/label}}
 
 {{#> label label--id="outline-green-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green" label--isRemovable="true"}}
-  {{#> label-text}}
-    Green link removable
-  {{/label-text}}
+  Green link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
-  {{#> label-text}}
-    Orange
-  {{/label-text}}
+  Orange
 {{/label}}
 
 {{#> label label--id="outline-orange-icon" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Orange icon
-  {{/label-text}}
+  Orange icon
 {{/label}}
 
 {{#> label label--id="outline-orange-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
-  {{#> label-text}}
-    Orange removable
-  {{/label-text}}
+  Orange removable
 {{/label}}
 
 {{#> label label--id="outline-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Orange icon removable
-  {{/label-text}}
+  Orange icon removable
 {{/label}}
 
 {{#> label label--id="outline-orange-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange"}}
-  {{#> label-text}}
-    Orange link
-  {{/label-text}}
+  Orange link
 {{/label}}
 
 {{#> label label--id="outline-orange-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange" label--isRemovable="true"}}
-  {{#> label-text}}
-    Orange link removable
-  {{/label-text}}
+  Orange link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline"}}
-  {{#> label-text}}
-    Red
-  {{/label-text}}
+  Red
 {{/label}}
 
 {{#> label label--id="outline-red-icon" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Red icon
-  {{/label-text}}
+  Red icon
 {{/label}}
 
 {{#> label label--id="outline-red-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
-  {{#> label-text}}
-    Red removable
-  {{/label-text}}
+  Red removable
 {{/label}}
 
 {{#> label label--id="outline-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Red icon removable
-  {{/label-text}}
+  Red icon removable
 {{/label}}
 
 {{#> label label--id="outline-red-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red"}}
-  {{#> label-text}}
-    Red link
-  {{/label-text}}
+  Red link
 {{/label}}
 
 {{#> label label--id="outline-red-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red" label--isRemovable="true"}}
-  {{#> label-text}}
-    Red link removable
-  {{/label-text}}
+  Red link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
-  {{#> label-text}}
-    Purple
-  {{/label-text}}
+  Purple
 {{/label}}
 
 {{#> label label--id="outline-purple-icon" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Purple icon
-  {{/label-text}}
+  Purple icon
 {{/label}}
 
 {{#> label label--id="outline-purple-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
-  {{#> label-text}}
-    Purple removable
-  {{/label-text}}
+  Purple removable
 {{/label}}
 
 {{#> label label--id="outline-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Purple icon removable
-  {{/label-text}}
+  Purple icon removable
 {{/label}}
 
 {{#> label label--id="outline-purple-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple"}}
-  {{#> label-text}}
-    Purple link
-  {{/label-text}}
+  Purple link
 {{/label}}
 
 {{#> label label--id="outline-purple-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple" label--isRemovable="true"}}
-  {{#> label-text}}
-    Purple link removable
-  {{/label-text}}
+  Purple link removable
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
-  {{#> label-text}}
-    Cyan
-  {{/label-text}}
+  Cyan
 {{/label}}
 
 {{#> label label--id="outline-cyan-icon" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Cyan icon
-  {{/label-text}}
+  Cyan icon
 {{/label}}
 
 {{#> label label--id="outline-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
-  {{#> label-text}}
-    Cyan removable
-  {{/label-text}}
+  Cyan removable
 {{/label}}
 
 {{#> label label--id="outline-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  {{#> label-text}}
-    Cyan icon removable
-  {{/label-text}}
+  Cyan icon removable
 {{/label}}
 
 {{#> label label--id="outline-cyan-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan"}}
-  {{#> label-text}}
-    Cyan link
-  {{/label-text}}
+  Cyan link
 {{/label}}
 
 {{#> label label--id="outline-cyan-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan" label--isRemovable="true"}}
-  {{#> label-text}}
-    Cyan link removable
-  {{/label-text}}
+  Cyan link removable
 {{/label}}
 ```
 
@@ -630,9 +462,8 @@ import './Label.css'
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-label` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
-| `.pf-c-label__content` | `<span>`, `<a>` | Iniates a label content. Use as an `<a>` if the label serves as a link. **Required** |
-| `.pf-c-label__icon` | `<span>` | Iniates a label icon. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
-| `.pf-c-label__text` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color. **Required** |
+| `.pf-c-label__content` | `<span>`, `<a>` | Iniates a label content. Use as an `<a>` element if the label serves as a link. **Required** |
+| `.pf-c-label__icon` | `<span>` | Iniates a label icon. |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
 | `.pf-m-blue` | `.pf-c-label` | Modifies the label to have blue colored styling. |
 | `.pf-m-green` | `.pf-c-label` | Modifies the label to have green colored styling. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -10,7 +10,7 @@ import './Label.css'
 ```hbs title=Filled
 {{#> label label--id="default-grey"}}
   {{#> label-text}}
-    grey label
+    Grey
   {{/label-text}}
 {{/label}}
 
@@ -19,28 +19,49 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    grey label
+    Grey icon
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-close" label--IsClosable="true"}}
+{{#> label label--id="default-grey-close" label--isRemovable="true"}}
   {{#> label-text}}
-    grey label
+    Grey removable
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-icon-close" label--IsClosable="true"}}
+{{#> label label--id="default-grey-icon-close" label--isRemovable="true"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    grey label
+    Grey icon and removable
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey" label--modifier="pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-grey-compact" label--modifier="pf-m-compact" label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
   {{#> label-text}}
-    grey hoverable label
+    Grey compact
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-link" label--type="a"}}
+  {{#> label-text}}
+    Grey link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-button" label--type="button"}}
+  {{#> label-text}}
+    Grey button
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="default-grey-clickable-removable" label--modifier="pf-m-clickable" label--attribute='tabindex="0"' label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey clickable removable
   {{/label-text}}
 {{/label}}
 
@@ -48,7 +69,7 @@ import './Label.css'
 
 {{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
@@ -57,28 +78,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-blue-close" label--IsClosable="true" label--modifier="pf-m-blue"}}
+{{#> label label--id="default-blue-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-blue-icon-close" label--IsClosable="true" label--modifier="pf-m-blue"}}
+{{#> label label--id="default-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-blue" label--modifier="pf-m-blue pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-blue" label--modifier="pf-m-blue pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    blue hoverable label
+    Blue clickable label
   {{/label-text}}
 {{/label}}
 
@@ -86,7 +107,7 @@ import './Label.css'
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
@@ -95,28 +116,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-green-close" label--IsClosable="true" label--modifier="pf-m-green"}}
+{{#> label label--id="default-green-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-green-icon-close" label--IsClosable="true" label--modifier="pf-m-green"}}
+{{#> label label--id="default-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-green" label--modifier="pf-m-green pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-green" label--modifier="pf-m-green pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    green hoverable label
+    Green clickable label
   {{/label-text}}
 {{/label}}
 
@@ -124,7 +145,7 @@ import './Label.css'
 
 {{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
@@ -133,28 +154,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-orange-close" label--IsClosable="true" label--modifier="pf-m-orange"}}
+{{#> label label--id="default-orange-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-orange-icon-close" label--IsClosable="true" label--modifier="pf-m-orange"}}
+{{#> label label--id="default-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-orange" label--modifier="pf-m-orange pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-orange" label--modifier="pf-m-orange pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    orange hoverable label
+    Orange clickable label
   {{/label-text}}
 {{/label}}
 
@@ -162,7 +183,7 @@ import './Label.css'
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
@@ -171,28 +192,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-red-close" label--IsClosable="true" label--modifier="pf-m-red"}}
+{{#> label label--id="default-red-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-red-icon-close" label--IsClosable="true" label--modifier="pf-m-red"}}
+{{#> label label--id="default-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-red" label--modifier="pf-m-red pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-red" label--modifier="pf-m-red pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    red hoverable label
+    Red clickable label
   {{/label-text}}
 {{/label}}
 
@@ -200,7 +221,7 @@ import './Label.css'
 
 {{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
@@ -209,28 +230,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-purple-close" label--IsClosable="true" label--modifier="pf-m-purple"}}
+{{#> label label--id="default-purple-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-purple-icon-close" label--IsClosable="true" label--modifier="pf-m-purple"}}
+{{#> label label--id="default-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-purple" label--modifier="pf-m-purple pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-purple" label--modifier="pf-m-purple pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    purple hoverable label
+    Purple clickable label
   {{/label-text}}
 {{/label}}
 
@@ -238,7 +259,7 @@ import './Label.css'
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
@@ -247,28 +268,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-cyan-close" label--IsClosable="true" label--modifier="pf-m-cyan"}}
+{{#> label label--id="default-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-cyan-icon-close" label--IsClosable="true" label--modifier="pf-m-cyan"}}
+{{#> label label--id="default-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-cyan-hoverable" label--modifier="pf-m-cyan pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="default-cyan-clickable" label--modifier="pf-m-cyan pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    cyan hoverable label
+    Cyan clickable label
   {{/label-text}}
 {{/label}}
 ```
@@ -277,7 +298,7 @@ import './Label.css'
 ```hbs title=Outline
 {{#> label label--id="outline-grey" label--modifier="pf-m-outline"}}
   {{#> label-text}}
-    grey label
+    Grey label
   {{/label-text}}
 {{/label}}
 
@@ -286,28 +307,49 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    grey label
+    Grey label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-close" label--IsClosable="true" label--modifier="pf-m-outline"}}
+{{#> label label--id="outline-grey-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-text}}
-    grey label
+    Grey label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey-icon-close" label--IsClosable="true" label--modifier="pf-m-outline"}}
+{{#> label label--id="outline-grey-icon-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    grey label
+    Grey label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-grey" label--modifier="pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-grey-compact" label--modifier="pf-m-outline pf-m-compact" label--isRemovable="true"}}
+  {{#> label-icon}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{/label-icon}}
   {{#> label-text}}
-    grey hoverable label
+    Grey compact
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-link" label--type="a" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    Grey link
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-button" label--type="button" label--modifier="pf-m-outline"}}
+  {{#> label-text}}
+    Grey button
+  {{/label-text}}
+{{/label}}
+
+{{#> label label--id="outline-grey-clickable-removable" label--modifier="pf-m-outline pf-m-clickable" label--attribute='tabindex="0"' label--isRemovable="true"}}
+  {{#> label-text}}
+    Grey clickable removable
   {{/label-text}}
 {{/label}}
 
@@ -315,7 +357,7 @@ import './Label.css'
 
 {{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
@@ -324,28 +366,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-blue-close" label--IsClosable="true" label--modifier="pf-m-blue pf-m-outline"}}
+{{#> label label--id="outline-blue-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-blue-icon-close" label--IsClosable="true" label--modifier="pf-m-blue pf-m-outline"}}
+{{#> label label--id="outline-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    blue label
+    Blue label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    blue hoverable label
+    Blue clickable label
   {{/label-text}}
 {{/label}}
 
@@ -353,7 +395,7 @@ import './Label.css'
 
 {{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
@@ -362,28 +404,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-green-close" label--IsClosable="true" label--modifier="pf-m-green pf-m-outline"}}
+{{#> label label--id="outline-green-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-green-icon-close" label--IsClosable="true" label--modifier="pf-m-green pf-m-outline"}}
+{{#> label label--id="outline-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    green label
+    Green label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    green hoverable label
+    Green clickable label
   {{/label-text}}
 {{/label}}
 
@@ -391,7 +433,7 @@ import './Label.css'
 
 {{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
@@ -400,28 +442,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-orange-close" label--IsClosable="true" label--modifier="pf-m-orange pf-m-outline"}}
+{{#> label label--id="outline-orange-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-orange-icon-close" label--IsClosable="true" label--modifier="pf-m-orange pf-m-outline"}}
+{{#> label label--id="outline-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    orange label
+    Orange label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    orange hoverable label
+    Orange clickable label
   {{/label-text}}
 {{/label}}
 
@@ -429,7 +471,7 @@ import './Label.css'
 
 {{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
@@ -438,28 +480,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-red-close" label--IsClosable="true" label--modifier="pf-m-red pf-m-outline"}}
+{{#> label label--id="outline-red-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-red-icon-close" label--IsClosable="true" label--modifier="pf-m-red pf-m-outline"}}
+{{#> label label--id="outline-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    red label
+    Red label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    red hoverable label
+    Red clickable label
   {{/label-text}}
 {{/label}}
 
@@ -467,7 +509,7 @@ import './Label.css'
 
 {{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
@@ -476,28 +518,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-purple-close" label--IsClosable="true" label--modifier="pf-m-purple pf-m-outline"}}
+{{#> label label--id="outline-purple-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-purple-icon-close" label--IsClosable="true" label--modifier="pf-m-purple pf-m-outline"}}
+{{#> label label--id="outline-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    purple label
+    Purple label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    purple hoverable label
+    Purple clickable label
   {{/label-text}}
 {{/label}}
 
@@ -505,7 +547,7 @@ import './Label.css'
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
@@ -514,28 +556,28 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-cyan-close" label--IsClosable="true" label--modifier="pf-m-cyan pf-m-outline"}}
+{{#> label label--id="outline-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-cyan-icon-close" label--IsClosable="true" label--modifier="pf-m-cyan pf-m-outline"}}
+{{#> label label--id="outline-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    cyan label
+    Cyan label
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline pf-m-hoverable" label--attribute='tabindex="0"'}}
+{{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline pf-m-clickable" label--attribute='tabindex="0"'}}
   {{#> label-text}}
-    cyan hoverable label
+    Cyan clickable label
   {{/label-text}}
 {{/label}}
 ```
@@ -547,13 +589,13 @@ Labels can be used in a variety of components and can adjust in font size to mat
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-label` | `<span>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
+| `.pf-c-label` | `<span>`, `<a>`, `<button>` | Iniates a label. Without a color modifier, the label's default style is grey. Use a color modifier to change the label color.  |
 | `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
-| `.pf-m-hoverable` | `.pf-c-label` | Modifies label for a hoverable styles. |
-| `.pf-m-blue` | `.pf-c-label` | Modifies label for a blue styles. |
-| `.pf-m-green` | `.pf-c-label` | Modifies label for a green styles. |
-| `.pf-m-orange` | `.pf-c-label` | Modifies label for a orange styles. |
-| `.pf-m-red` | `.pf-c-label` | Modifies label for a red styles. |
-| `.pf-m-purple` | `.pf-c-label` | Modifies label for a purple styles. |
-| `.pf-m-cyan` | `.pf-c-label` | Modifies label for a cyan styles. |
+| `.pf-m-clickable` | `span.pf-c-label` | Modifies the label to have clickable styles. This is used with removable labels that also serve as a link or button. |
+| `.pf-m-blue` | `.pf-c-label` | Modifies the label to have blue colored styling. |
+| `.pf-m-green` | `.pf-c-label` | Modifies the label to have green colored styling. |
+| `.pf-m-orange` | `.pf-c-label` | Modifies the label to have orange colored styling. |
+| `.pf-m-red` | `.pf-c-label` | Modifies the label to have red colored styling. |
+| `.pf-m-purple` | `.pf-c-label` | Modifies the label to have purple colored styling. |
+| `.pf-m-cyan` | `.pf-c-label` | Modifies the label to have cyan colored styling. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -34,7 +34,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Grey icon and removable
+    Grey icon removable
   {{/label-text}}
 {{/label}}
 
@@ -46,7 +46,7 @@ import './Label.css'
 
 {{#> label label--id="default-grey-link-close" label-content--IsLink="true" label--isRemovable="true"}}
   {{#> label-text}}
-    Grey removable link
+    Grey link removable
   {{/label-text}}
 {{/label}}
 
@@ -54,7 +54,7 @@ import './Label.css'
 
 {{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
   {{#> label-text}}
-    Blue label
+    Blue
   {{/label-text}}
 {{/label}}
 
@@ -63,13 +63,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Blue label
+    Blue icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-text}}
-    Blue label
+    Blue removable
   {{/label-text}}
 {{/label}}
 
@@ -78,7 +78,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Blue label
+    Blue icon removable
   {{/label-text}}
 {{/label}}
 
@@ -90,7 +90,7 @@ import './Label.css'
 
 {{#> label label--id="default-blue-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-text}}
-    Blue removable link
+    Blue link removable
   {{/label-text}}
 {{/label}}
 
@@ -98,7 +98,7 @@ import './Label.css'
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
   {{#> label-text}}
-    Green label
+    Green
   {{/label-text}}
 {{/label}}
 
@@ -107,13 +107,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Green label
+    Green icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-text}}
-    Green label
+    Green removable
   {{/label-text}}
 {{/label}}
 
@@ -122,7 +122,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Green label
+    Green icon removable
   {{/label-text}}
 {{/label}}
 
@@ -132,9 +132,9 @@ import './Label.css'
   {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-green-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-gren"}}
+{{#> label label--id="default-green-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-text}}
-    Green removable link
+    Green link removable
   {{/label-text}}
 {{/label}}
 
@@ -142,7 +142,7 @@ import './Label.css'
 
 {{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
   {{#> label-text}}
-    Orange label
+    Orange
   {{/label-text}}
 {{/label}}
 
@@ -151,13 +151,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Orange label
+    Orange icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-text}}
-    Orange label
+    Orange removable
   {{/label-text}}
 {{/label}}
 
@@ -166,7 +166,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Orange label
+    Orange icon removable
   {{/label-text}}
 {{/label}}
 
@@ -178,7 +178,7 @@ import './Label.css'
 
 {{#> label label--id="default-orange-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-text}}
-    Orange removable link
+    Orange link removable
   {{/label-text}}
 {{/label}}
 
@@ -186,7 +186,7 @@ import './Label.css'
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
   {{#> label-text}}
-    Red label
+    Red
   {{/label-text}}
 {{/label}}
 
@@ -195,13 +195,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Red label
+    Red icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-text}}
-    Red label
+    Red removable
   {{/label-text}}
 {{/label}}
 
@@ -210,7 +210,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Red label
+    Red icon removable
   {{/label-text}}
 {{/label}}
 
@@ -222,7 +222,7 @@ import './Label.css'
 
 {{#> label label--id="default-red-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-text}}
-    Red removable link
+    Red link removable
   {{/label-text}}
 {{/label}}
 
@@ -230,7 +230,7 @@ import './Label.css'
 
 {{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
   {{#> label-text}}
-    Purple label
+    Purple
   {{/label-text}}
 {{/label}}
 
@@ -239,13 +239,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Purple label
+    Purple icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-text}}
-    Purple label
+    Purple removable
   {{/label-text}}
 {{/label}}
 
@@ -254,7 +254,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Purple label
+    Purple icon removable
   {{/label-text}}
 {{/label}}
 
@@ -266,7 +266,7 @@ import './Label.css'
 
 {{#> label label--id="default-purple-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-text}}
-    Purple removable link
+    Purple link removable
   {{/label-text}}
 {{/label}}
 
@@ -274,7 +274,7 @@ import './Label.css'
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
-    Cyan label
+    Cyan
   {{/label-text}}
 {{/label}}
 
@@ -283,13 +283,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Cyan label
+    Cyan icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
-    Cyan label
+    Cyan removable
   {{/label-text}}
 {{/label}}
 
@@ -298,7 +298,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Cyan label
+    Cyan icon removable
   {{/label-text}}
 {{/label}}
 
@@ -310,7 +310,7 @@ import './Label.css'
 
 {{#> label label--id="default-cyan-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-text}}
-    Cyan removable link
+    Cyan link removable
   {{/label-text}}
 {{/label}}
 ```
@@ -343,7 +343,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Grey icon and removable
+    Grey icon removable
   {{/label-text}}
 {{/label}}
 
@@ -355,7 +355,7 @@ import './Label.css'
 
 {{#> label label--id="outline-grey-link-close" label-content--IsLink="true" label--modifier="pf-m-outline" label--isRemovable="true"}}
   {{#> label-text}}
-    Grey removable link
+    Grey link removable
   {{/label-text}}
 {{/label}}
 
@@ -363,7 +363,7 @@ import './Label.css'
 
 {{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-text}}
-    Blue label
+    Blue
   {{/label-text}}
 {{/label}}
 
@@ -372,13 +372,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Blue label
+    Blue icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-text}}
-    Blue label
+    Blue removable
   {{/label-text}}
 {{/label}}
 
@@ -387,7 +387,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Blue label
+    Blue icon removable
   {{/label-text}}
 {{/label}}
 
@@ -399,7 +399,7 @@ import './Label.css'
 
 {{#> label label--id="outline-blue-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue" label--isRemovable="true"}}
   {{#> label-text}}
-    Blue removable link
+    Blue link removable
   {{/label-text}}
 {{/label}}
 
@@ -407,7 +407,7 @@ import './Label.css'
 
 {{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-text}}
-    Green label
+    Green
   {{/label-text}}
 {{/label}}
 
@@ -416,13 +416,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Green label
+    Green icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-text}}
-    Green label
+    Green removable
   {{/label-text}}
 {{/label}}
 
@@ -431,7 +431,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Green label
+    Green icon removable
   {{/label-text}}
 {{/label}}
 
@@ -443,7 +443,7 @@ import './Label.css'
 
 {{#> label label--id="outline-green-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green" label--isRemovable="true"}}
   {{#> label-text}}
-    Green removable link
+    Green link removable
   {{/label-text}}
 {{/label}}
 
@@ -451,7 +451,7 @@ import './Label.css'
 
 {{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-text}}
-    Orange label
+    Orange
   {{/label-text}}
 {{/label}}
 
@@ -460,13 +460,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Orange label
+    Orange icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-text}}
-    Orange label
+    Orange removable
   {{/label-text}}
 {{/label}}
 
@@ -475,7 +475,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Orange label
+    Orange icon removable
   {{/label-text}}
 {{/label}}
 
@@ -487,7 +487,7 @@ import './Label.css'
 
 {{#> label label--id="outline-orange-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange" label--isRemovable="true"}}
   {{#> label-text}}
-    Orange removable link
+    Orange link removable
   {{/label-text}}
 {{/label}}
 
@@ -495,7 +495,7 @@ import './Label.css'
 
 {{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-text}}
-    Red label
+    Red
   {{/label-text}}
 {{/label}}
 
@@ -504,13 +504,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Red label
+    Red icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-text}}
-    Red label
+    Red removable
   {{/label-text}}
 {{/label}}
 
@@ -519,7 +519,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Red label
+    Red icon removable
   {{/label-text}}
 {{/label}}
 
@@ -531,7 +531,7 @@ import './Label.css'
 
 {{#> label label--id="outline-red-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red" label--isRemovable="true"}}
   {{#> label-text}}
-    Red removable link
+    Red link removable
   {{/label-text}}
 {{/label}}
 
@@ -539,7 +539,7 @@ import './Label.css'
 
 {{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-text}}
-    Purple label
+    Purple
   {{/label-text}}
 {{/label}}
 
@@ -548,13 +548,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Purple label
+    Purple icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-text}}
-    Purple label
+    Purple removable
   {{/label-text}}
 {{/label}}
 
@@ -563,7 +563,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Purple label
+    Purple icon removable
   {{/label-text}}
 {{/label}}
 
@@ -575,7 +575,7 @@ import './Label.css'
 
 {{#> label label--id="outline-purple-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple" label--isRemovable="true"}}
   {{#> label-text}}
-    Purple removable link
+    Purple link removable
   {{/label-text}}
 {{/label}}
 
@@ -583,7 +583,7 @@ import './Label.css'
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-text}}
-    Cyan label
+    Cyan
   {{/label-text}}
 {{/label}}
 
@@ -592,13 +592,13 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Cyan label
+    Cyan icon
   {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-text}}
-    Cyan label
+    Cyan removable
   {{/label-text}}
 {{/label}}
 
@@ -607,7 +607,7 @@ import './Label.css'
     <i class="fas fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
   {{#> label-text}}
-    Cyan label
+    Cyan icon removable
   {{/label-text}}
 {{/label}}
 
@@ -619,7 +619,7 @@ import './Label.css'
 
 {{#> label label--id="outline-cyan-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan" label--isRemovable="true"}}
   {{#> label-text}}
-    Cyan removable link
+    Cyan link removable
   {{/label-text}}
 {{/label}}
 ```

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -1,0 +1,6 @@
+<{{# if label-content--type}}{{label-content--type}}{{else}}span{{/if}} class="pf-c-label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
+  {{#if label-content--attribute}}
+    {{{label-content--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{# if label-content--type}}{{label-content--type}}{{else}}span{{/if}}>

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -1,6 +1,9 @@
-<{{# if label-content--type}}{{label-content--type}}{{else}}span{{/if}} class="pf-c-label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
+<{{# if label-content--IsLink}}a{{else}}span{{/if}} class="pf-c-label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
+  {{# if label-content--IsLink}}
+    href="#"
+  {{/if}}
   {{#if label-content--attribute}}
     {{{label-content--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</{{# if label-content--type}}{{label-content--type}}{{else}}span{{/if}}>
+</{{# if label-content--IsLink}}a{{else}}span{{/if}}>

--- a/src/patternfly/components/Label/label-icon.hbs
+++ b/src/patternfly/components/Label/label-icon.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-label__icon{{#if label-icon--modifier}} {{label-icon--modifier}}{{/if}}"
+  {{#if label-icon--attribute}}
+    {{{label-icon--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Label/label-text.hbs
+++ b/src/patternfly/components/Label/label-text.hbs
@@ -1,0 +1,9 @@
+<span class="pf-c-label__text{{#if label-text--modifier}} {{label-text--modifier}}{{/if}}"
+  {{#if label--IsClosable}}
+    id="{{label--id}}-text"
+  {{/if}}
+  {{#if label-text--attribute}}
+    {{{label-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Label/label-text.hbs
+++ b/src/patternfly/components/Label/label-text.hbs
@@ -1,9 +1,0 @@
-<span class="pf-c-label__text{{#if label-text--modifier}} {{label-text--modifier}}{{/if}}"
-  {{#if label--IsClosable}}
-    id="{{label--id}}-text"
-  {{/if}}
-  {{#if label-text--attribute}}
-    {{{label-text--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -2,11 +2,13 @@
   {{#if label--attribute}}
     {{{label--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#> label-content}}
+    {{> @partial-block}}
+  {{/label-content}}
   {{#if label--isRemovable}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' label--id '-button"
   aria-label="Remove" aria-labelledby="' label--id '-text ' label--id '-button"')}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/if}}
-</{{# if label--type}}{{label--type}}{{else}}span{{/if}}>
+</span>

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -3,4 +3,10 @@
     {{{label--attribute}}}
   {{/if}}>
   {{> @partial-block}}
+  {{#if label--IsClosable}}
+    {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' label--id '-button"
+  aria-label="Remove" aria-labelledby="' label--id '-text ' label--id '-button"')}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+  {{/if}}
 </span>

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -7,7 +7,7 @@
   {{/label-content}}
   {{#if label--isRemovable}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' label--id '-button"
-  aria-label="Remove" aria-labelledby="' label--id '-text ' label--id '-button"')}}
+  aria-label="Remove" aria-labelledby="' label--id '-button ' label--id '-text"')}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/if}}

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -1,12 +1,12 @@
-<span class="pf-c-label{{#if label--modifier}} {{label--modifier}}{{/if}}"
+<{{# if label--type}}{{label--type}}{{else}}span{{/if}} class="pf-c-label{{#if label--modifier}} {{label--modifier}}{{/if}}"
   {{#if label--attribute}}
     {{{label--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-  {{#if label--IsClosable}}
+  {{#if label--isRemovable}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' label--id '-button"
   aria-label="Remove" aria-labelledby="' label--id '-text ' label--id '-button"')}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
   {{/if}}
-</span>
+</{{# if label--type}}{{label--type}}{{else}}span{{/if}}>

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -13,82 +13,82 @@
   --pf-c-label__content--before--BorderWidth: 0;
   --pf-c-label__content--before--BorderColor: transparent;
 
-  // Hoverable
-  --pf-c-label--m-clickable--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-label--m-clickable--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-global--BorderColor--200);
-  --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-global--BorderColor--200);
-
   // Outline
   --pf-c-label--m-outline--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-label--m-outline--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-label--m-outline--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-label--m-outline__content--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-outline__content--before--BorderColor: var(--pf-global--BorderColor--100);
 
-  // Hoverable + Outline
-  --pf-c-label--m-outline--m-clickable--hover--before--BorderWidth: var(--pf-global--BorderWidth--md);
-  --pf-c-label--m-outline--m-clickable--focus--before--BorderWidth: var(--pf-global--BorderWidth--md);
-  --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-global--BorderColor--100);
+  // Content as link
+  --pf-c-label__content--link--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label__content--link--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label__content--link--hover--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-label__content--link--focus--before--BorderColor: var(--pf-global--BorderColor--200);
+
+  // Outline + link
+  --pf-c-label--m-outline__content--link--hover--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline__content--link--focus--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-global--BorderColor--100);
 
   // Blue
   --pf-c-label--m-blue--BackgroundColor: var(--pf-global--palette--blue-50);
   --pf-c-label--m-blue__text--Color: var(--pf-global--info-color--200);
   --pf-c-label--m-blue__icon--Color: var(--pf-global--primary-color--100);
-  --pf-c-label--m-clickable--m-blue--hover--before--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-label--m-clickable--m-blue--focus--before--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-label--m-outline--m-blue--before--BorderColor: var(--pf-global--active-color--200);
-  --pf-c-label--m-outline--m-clickable--m-blue--hover--before--BorderColor: var(--pf-global--active-color--200);
-  --pf-c-label--m-outline--m-clickable--m-blue--focus--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-blue__content--link--hover--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-blue__content--link--focus--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-outline--m-blue__content--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-blue__content--link--hover--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-blue__content--link--focus--before--BorderColor: var(--pf-global--active-color--200);
 
   // Green
   --pf-c-label--m-green--BackgroundColor: var(--pf-global--palette--green-100);
   --pf-c-label--m-green__text--Color: var(--pf-global--success-color--200);
   --pf-c-label--m-green__icon--Color: var(--pf-global--success-color--100);
-  --pf-c-label--m-clickable--m-green--hover--before--BorderColor: var(--pf-global--success-color--100);
-  --pf-c-label--m-clickable--m-green--focus--before--BorderColor: var(--pf-global--success-color--100);
-  --pf-c-label--m-outline--m-green--before--BorderColor: var(--pf-global--palette--green-100);
-  --pf-c-label--m-outline--m-clickable--m-green--hover--before--BorderColor: var(--pf-global--palette--green-100);
-  --pf-c-label--m-outline--m-clickable--m-green--focus--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-green__content--link--hover--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-green__content--link--focus--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-outline--m-green__content--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-green__content--link--hover--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-green__content--link--focus--before--BorderColor: var(--pf-global--palette--green-100);
 
   // Orange
   --pf-c-label--m-orange--BackgroundColor: var(--pf-global--palette--gold-50);
   --pf-c-label--m-orange__text--Color: var(--pf-global--palette--gold-700);
   --pf-c-label--m-orange__icon--Color: var(--pf-global--palette--orange-300);
-  --pf-c-label--m-clickable--m-orange--hover--before--BorderColor: var(--pf-global--palette--orange-300);
-  --pf-c-label--m-clickable--m-orange--focus--before--BorderColor: var(--pf-global--palette--orange-300);
-  --pf-c-label--m-outline--m-orange--before--BorderColor: var(--pf-global--palette--gold-100);
-  --pf-c-label--m-outline--m-clickable--m-orange--hover--before--BorderColor: var(--pf-global--palette--gold-100);
-  --pf-c-label--m-outline--m-clickable--m-orange--focus--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-orange__content--link--hover--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-orange__content--link--focus--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-outline--m-orange__content--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-orange__content--link--hover--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-orange__content--link--focus--before--BorderColor: var(--pf-global--palette--gold-100);
 
   // Red
   --pf-c-label--m-red--BackgroundColor: var(--pf-global--palette--red-50);
   --pf-c-label--m-red__text--Color: var(--pf-global--palette--red-300);
   --pf-c-label--m-red__icon--Color: var(--pf-global--danger-color--100);
-  --pf-c-label--m-clickable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-clickable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-outline--m-red--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-outline--m-clickable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-outline--m-clickable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-red__content--link--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-red__content--link--focus--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-red__content--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-red__content--link--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-red__content--link--focus--before--BorderColor: var(--pf-global--danger-color--100);
 
   // Purple
   --pf-c-label--m-purple--BackgroundColor: var(--pf-global--palette--purple-100);
   --pf-c-label--m-purple__text--Color: var(--pf-global--palette--purple-700);
   --pf-c-label--m-purple__icon--Color: var(--pf-global--palette--purple-500);
-  --pf-c-label--m-clickable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-500);
-  --pf-c-label--m-clickable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-500);
-  --pf-c-label--m-outline--m-purple--before--BorderColor: var(--pf-global--palette--purple-100);
-  --pf-c-label--m-outline--m-clickable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-100);
-  --pf-c-label--m-outline--m-clickable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-purple__content--link--hover--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-purple__content--link--focus--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-outline--m-purple__content--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-purple__content--link--hover--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-purple__content--link--focus--before--BorderColor: var(--pf-global--palette--purple-100);
 
   // Cyan
   --pf-c-label--m-cyan--BackgroundColor: var(--pf-global--palette--cyan-50);
   --pf-c-label--m-cyan__text--Color: var(--pf-global--default-color--300);
   --pf-c-label--m-cyan__icon--Color: var(--pf-global--default-color--200);
-  --pf-c-label--m-clickable--m-cyan--hover--before--BorderColor: var(--pf-global--default-color--200);
-  --pf-c-label--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--default-color--200);
-  --pf-c-label--m-outline--m-cyan--before--BorderColor: var(--pf-global--palette--cyan-100);
-  --pf-c-label--m-outline--m-clickable--m-cyan--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
-  --pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-cyan__content--link--hover--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-cyan__content--link--focus--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-outline--m-cyan__content--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-cyan__content--link--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-cyan__content--link--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
 
   // Icon
   --pf-c-label__icon--Color: var(--pf-global--Color--100);
@@ -121,86 +121,84 @@
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-blue--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-blue__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-blue__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-blue--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-blue--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-blue--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-blue--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-blue--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-blue__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-blue__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-blue__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-blue__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-blue__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-green {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-green--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-green__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-green__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-green--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-green--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-green--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-green--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-green--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-green__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-green__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-green__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-green__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-green__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-orange {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-orange--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-orange__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-orange__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-orange--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-orange--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-orange--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-orange--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-orange--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-orange__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-orange__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-orange__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-orange__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-orange__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-red {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-red--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-red__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-red__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-red--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-red--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-red--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-red--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-red--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-red__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-red__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-red__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-red__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-red__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-purple {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-purple--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-purple__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-purple__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-purple--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-purple--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-purple--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-purple--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-purple--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-purple__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-purple__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-purple__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-purple__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-purple__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-cyan {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-cyan--BackgroundColor);
     --pf-c-label__text--Color: var(--pf-c-label--m-cyan__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-cyan__icon--Color);
-    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-cyan--before--BorderColor);
-    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-cyan--hover--before--BorderColor);
-    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-cyan--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-cyan--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-cyan__content--before--BorderColor);
+    --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-cyan__content--link--hover--before--BorderColor);
+    --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-cyan__content--link--focus--before--BorderColor);
+    --pf-c-label--m-outline__content--link--hover--before--BorderColor: var(--pf-c-label--m-outline--m-cyan__content--link--hover--before--BorderColor);
+    --pf-c-label--m-outline__content--link--focus--before--BorderColor: var(--pf-c-label--m-outline--m-cyan__content--link--focus--before--BorderColor);
   }
 
   &.pf-m-outline {
-    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--before--BorderWidth);
-    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
+    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline__content--before--BorderWidth);
+    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline__content--before--BorderColor);
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-outline--BackgroundColor);
 
     // stylelint-disable selector-no-qualifying-type
-    a.pf-c-label__content,
-    button.pf-c-label__content,
-    // stylelint-enable selector-no-qualifying-type
-    .pf-c-label__content.pf-m-clickable {
+    a.pf-c-label__content {
+      // stylelint-enable selector-no-qualifying-type
       &:hover {
-        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderWidth);
-        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderColor);
+        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline__content--link--hover--before--BorderWidth);
+        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline__content--link--hover--before--BorderColor);
       }
 
       &:focus {
-        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderWidth);
-        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderColor);
+        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline__content--link--focus--before--BorderWidth);
+        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline__content--link--focus--before--BorderColor);
       }
     }
   }
@@ -236,29 +234,28 @@
     border: var(--pf-c-label__content--before--BorderWidth) solid var(--pf-c-label__content--before--BorderColor);
     border-radius: var(--pf-c-label--BorderRadius);
   }
-}
 
-a.pf-c-label__content,
-button.pf-c-label__content,
-.pf-c-label__content.pf-m-clickable {
-  cursor: pointer;
-  background: transparent;
-  border: none;
+  // the content element can be used as a link
+  @at-root a#{&} {
+    cursor: pointer;
+    background: transparent;
+    border: none;
 
-  &,
-  &:hover,
-  &:focus {
-    text-decoration: none;
-  }
+    &,
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
 
-  &:hover {
-    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-clickable--hover--before--BorderWidth);
-    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-clickable--hover--before--BorderColor);
-  }
+    &:hover {
+      --pf-c-label__content--before--BorderWidth: var(--pf-c-label__content--link--hover--before--BorderWidth);
+      --pf-c-label__content--before--BorderColor: var(--pf-c-label__content--link--hover--before--BorderColor);
+    }
 
-  &:focus {
-    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-clickable--focus--before--BorderWidth);
-    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-clickable--focus--before--BorderColor);
+    &:focus {
+      --pf-c-label__content--before--BorderWidth: var(--pf-c-label__content--link--focus--before--BorderWidth);
+      --pf-c-label__content--before--BorderColor: var(--pf-c-label__content--link--focus--before--BorderColor);
+    }
   }
 }
 

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,9 +1,9 @@
 .pf-c-label {
   // Component
   --pf-c-label--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-label--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-label--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-label--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-label--BorderRadius: var(--pf-global--BorderRadius--lg);
   --pf-c-label--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-label--Color: var(--pf-global--Color--100);
@@ -95,8 +95,7 @@
 
   // Icon
   --pf-c-label__icon--Color: var(--pf-global--Color--100);
-  --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
+  --pf-c-label__icon--MarginRight: var(--pf-global--spacer--xs);
 
   // Close button
   --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
@@ -263,6 +262,5 @@
 
 .pf-c-label__icon {
   margin-right: var(--pf-c-label__icon--MarginRight);
-  margin-left: var(--pf-c-label__icon--MarginLeft);
   color: var(--pf-c-label__icon--Color);
 }

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,9 +1,9 @@
 .pf-c-label {
   // Component
   --pf-c-label--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-label--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-label--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-label--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-label--BorderRadius: var(--pf-global--BorderRadius--lg);
   --pf-c-label--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-label--Color: var(--pf-global--Color--100);
@@ -96,6 +96,7 @@
   // Icon
   --pf-c-label__icon--Color: var(--pf-global--Color--100);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
 
   // Close button
   --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
@@ -262,5 +263,6 @@
 
 .pf-c-label__icon {
   margin-right: var(--pf-c-label__icon--MarginRight);
+  margin-left: var(--pf-c-label__icon--MarginLeft);
   color: var(--pf-c-label__icon--Color);
 }

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -15,12 +15,13 @@
 
   // Compact
   --pf-c-label--m-compact--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-label--m-compact__c-button--FontSize: var(--pf-global--icon--FontSize--sm);
 
   // Hoverable
-  --pf-c-label--m-hoverable--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-label--m-hoverable--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-global--BorderColor--200);
-  --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-label--m-clickable--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-clickable--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-global--BorderColor--200);
 
   // Outline
   --pf-c-label--m-outline--BackgroundColor: var(--pf-global--BackgroundColor--100);
@@ -28,74 +29,72 @@
   --pf-c-label--m-outline--before--BorderColor: var(--pf-global--BorderColor--100);
 
   // Hoverable + Outline
-  --pf-c-label--m-outline--m-hoverable--hover--before--BorderWidth: var(--pf-global--BorderWidth--md);
-  --pf-c-label--m-outline--m-hoverable--focus--before--BorderWidth: var(--pf-global--BorderWidth--md);
-  --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-label--m-outline--m-clickable--hover--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline--m-clickable--focus--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-global--BorderColor--100);
 
   // Blue
   --pf-c-label--m-blue--BackgroundColor: var(--pf-global--palette--blue-50);
   --pf-c-label--m-blue__text--Color: var(--pf-global--info-color--200);
   --pf-c-label--m-blue__icon--Color: var(--pf-global--primary-color--100);
-  --pf-c-label--m-hoverable--m-blue--hover--before--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-label--m-hoverable--m-blue--focus--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-clickable--m-blue--hover--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-clickable--m-blue--focus--before--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-label--m-outline--m-blue--before--BorderColor: var(--pf-global--active-color--200);
-  --pf-c-label--m-outline--m-hoverable--m-blue--hover--before--BorderColor: var(--pf-global--active-color--200);
-  --pf-c-label--m-outline--m-hoverable--m-blue--focus--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-clickable--m-blue--hover--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-clickable--m-blue--focus--before--BorderColor: var(--pf-global--active-color--200);
 
   // Green
   --pf-c-label--m-green--BackgroundColor: var(--pf-global--palette--green-100);
   --pf-c-label--m-green__text--Color: var(--pf-global--success-color--200);
   --pf-c-label--m-green__icon--Color: var(--pf-global--success-color--100);
-  --pf-c-label--m-hoverable--m-green--hover--before--BorderColor: var(--pf-global--success-color--100);
-  --pf-c-label--m-hoverable--m-green--focus--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-clickable--m-green--hover--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-clickable--m-green--focus--before--BorderColor: var(--pf-global--success-color--100);
   --pf-c-label--m-outline--m-green--before--BorderColor: var(--pf-global--palette--green-100);
-  --pf-c-label--m-outline--m-hoverable--m-green--hover--before--BorderColor: var(--pf-global--palette--green-100);
-  --pf-c-label--m-outline--m-hoverable--m-green--focus--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-clickable--m-green--hover--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-clickable--m-green--focus--before--BorderColor: var(--pf-global--palette--green-100);
 
   // Orange
   --pf-c-label--m-orange--BackgroundColor: var(--pf-global--palette--gold-50);
   --pf-c-label--m-orange__text--Color: var(--pf-global--palette--gold-700);
   --pf-c-label--m-orange__icon--Color: var(--pf-global--palette--orange-300);
-  --pf-c-label--m-hoverable--m-orange--hover--before--BorderColor: var(--pf-global--palette--orange-300);
-  --pf-c-label--m-hoverable--m-orange--focus--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-clickable--m-orange--hover--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-clickable--m-orange--focus--before--BorderColor: var(--pf-global--palette--orange-300);
   --pf-c-label--m-outline--m-orange--before--BorderColor: var(--pf-global--palette--gold-100);
-  --pf-c-label--m-outline--m-hoverable--m-orange--hover--before--BorderColor: var(--pf-global--palette--gold-100);
-  --pf-c-label--m-outline--m-hoverable--m-orange--focus--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-clickable--m-orange--hover--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-clickable--m-orange--focus--before--BorderColor: var(--pf-global--palette--gold-100);
 
   // Red
   --pf-c-label--m-red--BackgroundColor: var(--pf-global--palette--red-50);
   --pf-c-label--m-red__text--Color: var(--pf-global--palette--red-300);
   --pf-c-label--m-red__icon--Color: var(--pf-global--danger-color--100);
-  --pf-c-label--m-hoverable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-hoverable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-clickable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-clickable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
   --pf-c-label--m-outline--m-red--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-outline--m-hoverable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
-  --pf-c-label--m-outline--m-hoverable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-clickable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-clickable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
 
   // Purple
   --pf-c-label--m-purple--BackgroundColor: var(--pf-global--palette--purple-100);
   --pf-c-label--m-purple__text--Color: var(--pf-global--palette--purple-700);
   --pf-c-label--m-purple__icon--Color: var(--pf-global--palette--purple-500);
-  --pf-c-label--m-hoverable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-500);
-  --pf-c-label--m-hoverable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-clickable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-clickable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-500);
   --pf-c-label--m-outline--m-purple--before--BorderColor: var(--pf-global--palette--purple-100);
-  --pf-c-label--m-outline--m-hoverable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-100);
-  --pf-c-label--m-outline--m-hoverable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-clickable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-clickable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-100);
 
   // Cyan
   --pf-c-label--m-cyan--BackgroundColor: var(--pf-global--palette--cyan-50);
   --pf-c-label--m-cyan__text--Color: var(--pf-global--default-color--300);
   --pf-c-label--m-cyan__icon--Color: var(--pf-global--default-color--200);
-  --pf-c-label--m-hoverable--m-cyan--hover--before--BorderColor: var(--pf-global--default-color--200);
-  --pf-c-label--m-hoverable--m-cyan--focus--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-clickable--m-cyan--hover--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--default-color--200);
   --pf-c-label--m-outline--m-cyan--before--BorderColor: var(--pf-global--palette--cyan-100);
-  --pf-c-label--m-outline--m-hoverable--m-cyan--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
-  --pf-c-label--m-outline--m-hoverable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-clickable--m-cyan--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
 
   // Icon
-  --pf-c-label__icon--FontSize: var(--pf-global--FontSize--md);
-  --pf-c-label--m-compact__icon--FontSize: var(--pf-global--icon--FontSize--sm);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
 
@@ -105,7 +104,9 @@
   --pf-c-label__c-button--MarginRight: calc(var(--pf-global--spacer--form-element) * -1);
   --pf-c-label__c-button--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
   --pf-c-label__c-button--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-label__c-button--PaddingTop: var(--pf-global--spacer--xs);
   --pf-c-label__c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-label__c-button--PaddingBottom: var(--pf-global--spacer--xs);
   --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
 
   position: relative;
@@ -130,8 +131,8 @@
   }
 
   &.pf-m-compact {
+    --pf-c-button--FontSize: var(--pf-c-label--m-compact__c-button--FontSize);
     --pf-c-label--FontSize: var(--pf-c-label--m-compact--FontSize);
-    --pf-c-label__icon--FontSize: var(--pf-c-label--m-compact__icon--FontSize);
   }
 
   &.pf-m-blue {
@@ -139,10 +140,10 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-blue__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-blue__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-blue--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-blue--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-blue--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-blue--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-blue--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-blue--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-blue--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-blue--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-blue--focus--before--BorderColor);
   }
 
   &.pf-m-green {
@@ -150,10 +151,10 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-green__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-green__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-green--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-green--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-green--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-green--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-green--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-green--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-green--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-green--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-green--focus--before--BorderColor);
   }
 
   &.pf-m-orange {
@@ -161,10 +162,10 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-orange__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-orange__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-orange--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-orange--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-orange--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-orange--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-orange--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-orange--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-orange--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-orange--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-orange--focus--before--BorderColor);
   }
 
   &.pf-m-red {
@@ -172,10 +173,10 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-red__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-red__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-red--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-red--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-red--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-red--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-red--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-red--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-red--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-red--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-red--focus--before--BorderColor);
   }
 
   &.pf-m-purple {
@@ -183,10 +184,10 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-purple__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-purple__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-purple--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-purple--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-purple--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-purple--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-purple--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-purple--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-purple--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-purple--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-purple--focus--before--BorderColor);
   }
 
   &.pf-m-cyan {
@@ -194,47 +195,23 @@
     --pf-c-label__text--Color: var(--pf-c-label--m-cyan__text--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-cyan__icon--Color);
     --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-cyan--before--BorderColor);
-    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-cyan--hover--before--BorderColor);
-    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-cyan--focus--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-cyan--hover--before--BorderColor);
-    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-cyan--focus--before--BorderColor);
+    --pf-c-label--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-clickable--m-cyan--hover--before--BorderColor);
+    --pf-c-label--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-clickable--m-cyan--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-cyan--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-clickable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor);
   }
 
   &.pf-m-outline {
     --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--before--BorderWidth);
     --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-outline--BackgroundColor);
-
-    &.pf-m-hoverable {
-      &:hover {
-        --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-hoverable--hover--before--BorderWidth);
-        --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--hover--before--BorderColor);
-      }
-
-      &:focus {
-        --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-hoverable--focus--before--BorderWidth);
-        --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--focus--before--BorderColor);
-      }
-    }
-  }
-
-  &.pf-m-hoverable {
-    cursor: pointer;
-
-    &:hover {
-      --pf-c-label--before--BorderWidth: var(--pf-c-label--m-hoverable--hover--before--BorderWidth);
-      --pf-c-label--before--BorderColor: var(--pf-c-label--m-hoverable--hover--before--BorderColor);
-    }
-
-    &:focus {
-      --pf-c-label--before--BorderWidth: var(--pf-c-label--m-hoverable--focus--before--BorderWidth);
-      --pf-c-label--before--BorderColor: var(--pf-c-label--m-hoverable--focus--before--BorderColor);
-    }
   }
 
   .pf-c-button {
     --pf-c-button--FontSize: var(--pf-c-label__c-button--FontSize);
+    --pf-c-button--PaddingTop: var(--pf-c-label__c-button--PaddingTop);
     --pf-c-button--PaddingRight: var(--pf-c-label__c-button--PaddingRight);
+    --pf-c-button--PaddingBottom: var(--pf-c-label__c-button--PaddingBottom);
     --pf-c-button--PaddingLeft: var(--pf-c-label__c-button--PaddingLeft);
 
     margin-top: var(--pf-c-label__c-button--MarginTop);
@@ -244,11 +221,48 @@
   }
 }
 
+/* stylelint-disable */
+a.pf-c-label,
+button.pf-c-label,
+/* stylelint-enable */
+.pf-c-label.pf-m-clickable {
+  cursor: pointer;
+  border: none;
+
+  &,
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  &:hover {
+    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-clickable--hover--before--BorderWidth);
+    --pf-c-label--before--BorderColor: var(--pf-c-label--m-clickable--hover--before--BorderColor);
+  }
+
+  &:focus {
+    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-clickable--focus--before--BorderWidth);
+    --pf-c-label--before--BorderColor: var(--pf-c-label--m-clickable--focus--before--BorderColor);
+  }
+}
+
+a.pf-c-label.pf-m-outline,
+button.pf-c-label.pf-m-outline,
+.pf-c-label.pf-m-outline.pf-m-clickable {
+  &:hover {
+    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderWidth);
+    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderColor);
+  }
+
+  &:focus {
+    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderWidth);
+    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderColor);
+  }
+}
+
 .pf-c-label__icon {
   margin-right: var(--pf-c-label__icon--MarginRight);
   margin-left: var(--pf-c-label__icon--MarginLeft);
-  font-size: var(--pf-c-label__icon--FontSize);
-  line-height: 1;
   color: var(--pf-c-label__icon--Color);
 }
 

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -32,7 +32,7 @@
 
   // Blue
   --pf-c-label--m-blue--BackgroundColor: var(--pf-global--palette--blue-50);
-  --pf-c-label--m-blue__text--Color: var(--pf-global--info-color--200);
+  --pf-c-label--m-blue__content--Color: var(--pf-global--info-color--200);
   --pf-c-label--m-blue__icon--Color: var(--pf-global--primary-color--100);
   --pf-c-label--m-blue__content--link--hover--before--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-label--m-blue__content--link--focus--before--BorderColor: var(--pf-global--primary-color--100);
@@ -42,7 +42,7 @@
 
   // Green
   --pf-c-label--m-green--BackgroundColor: var(--pf-global--palette--green-100);
-  --pf-c-label--m-green__text--Color: var(--pf-global--success-color--200);
+  --pf-c-label--m-green__content--Color: var(--pf-global--success-color--200);
   --pf-c-label--m-green__icon--Color: var(--pf-global--success-color--100);
   --pf-c-label--m-green__content--link--hover--before--BorderColor: var(--pf-global--success-color--100);
   --pf-c-label--m-green__content--link--focus--before--BorderColor: var(--pf-global--success-color--100);
@@ -52,7 +52,7 @@
 
   // Orange
   --pf-c-label--m-orange--BackgroundColor: var(--pf-global--palette--gold-50);
-  --pf-c-label--m-orange__text--Color: var(--pf-global--palette--gold-700);
+  --pf-c-label--m-orange__content--Color: var(--pf-global--palette--gold-700);
   --pf-c-label--m-orange__icon--Color: var(--pf-global--palette--orange-300);
   --pf-c-label--m-orange__content--link--hover--before--BorderColor: var(--pf-global--palette--orange-300);
   --pf-c-label--m-orange__content--link--focus--before--BorderColor: var(--pf-global--palette--orange-300);
@@ -62,7 +62,7 @@
 
   // Red
   --pf-c-label--m-red--BackgroundColor: var(--pf-global--palette--red-50);
-  --pf-c-label--m-red__text--Color: var(--pf-global--palette--red-300);
+  --pf-c-label--m-red__content--Color: var(--pf-global--palette--red-300);
   --pf-c-label--m-red__icon--Color: var(--pf-global--danger-color--100);
   --pf-c-label--m-red__content--link--hover--before--BorderColor: var(--pf-global--danger-color--100);
   --pf-c-label--m-red__content--link--focus--before--BorderColor: var(--pf-global--danger-color--100);
@@ -72,7 +72,7 @@
 
   // Purple
   --pf-c-label--m-purple--BackgroundColor: var(--pf-global--palette--purple-100);
-  --pf-c-label--m-purple__text--Color: var(--pf-global--palette--purple-700);
+  --pf-c-label--m-purple__content--Color: var(--pf-global--palette--purple-700);
   --pf-c-label--m-purple__icon--Color: var(--pf-global--palette--purple-500);
   --pf-c-label--m-purple__content--link--hover--before--BorderColor: var(--pf-global--palette--purple-500);
   --pf-c-label--m-purple__content--link--focus--before--BorderColor: var(--pf-global--palette--purple-500);
@@ -82,7 +82,7 @@
 
   // Cyan
   --pf-c-label--m-cyan--BackgroundColor: var(--pf-global--palette--cyan-50);
-  --pf-c-label--m-cyan__text--Color: var(--pf-global--default-color--300);
+  --pf-c-label--m-cyan__content--Color: var(--pf-global--default-color--300);
   --pf-c-label--m-cyan__icon--Color: var(--pf-global--default-color--200);
   --pf-c-label--m-cyan__content--link--hover--before--BorderColor: var(--pf-global--default-color--200);
   --pf-c-label--m-cyan__content--link--focus--before--BorderColor: var(--pf-global--default-color--200);
@@ -90,13 +90,13 @@
   --pf-c-label--m-outline--m-cyan__content--link--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
   --pf-c-label--m-outline--m-cyan__content--link--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
 
+  // Content
+  --pf-c-label__content--Color: var(--pf-global--Color--100);
+
   // Icon
   --pf-c-label__icon--Color: var(--pf-global--Color--100);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
-
-  // Text
-  --pf-c-label__text--Color: var(--pf-global--Color--100);
 
   // Close button
   --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
@@ -119,7 +119,7 @@
 
   &.pf-m-blue {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-blue--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-blue__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-blue__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-blue__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-blue__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-blue__content--link--hover--before--BorderColor);
@@ -130,7 +130,7 @@
 
   &.pf-m-green {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-green--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-green__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-green__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-green__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-green__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-green__content--link--hover--before--BorderColor);
@@ -141,7 +141,7 @@
 
   &.pf-m-orange {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-orange--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-orange__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-orange__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-orange__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-orange__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-orange__content--link--hover--before--BorderColor);
@@ -152,7 +152,7 @@
 
   &.pf-m-red {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-red--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-red__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-red__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-red__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-red__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-red__content--link--hover--before--BorderColor);
@@ -163,7 +163,7 @@
 
   &.pf-m-purple {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-purple--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-purple__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-purple__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-purple__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-purple__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-purple__content--link--hover--before--BorderColor);
@@ -174,7 +174,7 @@
 
   &.pf-m-cyan {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-cyan--BackgroundColor);
-    --pf-c-label__text--Color: var(--pf-c-label--m-cyan__text--Color);
+    --pf-c-label__content--Color: var(--pf-c-label--m-cyan__content--Color);
     --pf-c-label__icon--Color: var(--pf-c-label--m-cyan__icon--Color);
     --pf-c-label--m-outline__content--before--BorderColor: var(--pf-c-label--m-outline--m-cyan__content--before--BorderColor);
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-cyan__content--link--hover--before--BorderColor);
@@ -224,6 +224,8 @@
 }
 
 .pf-c-label__content {
+  color: var(--pf-c-label__content--Color);
+
   &::before {
     position: absolute;
     top: 0;
@@ -263,9 +265,4 @@
   margin-right: var(--pf-c-label__icon--MarginRight);
   margin-left: var(--pf-c-label__icon--MarginLeft);
   color: var(--pf-c-label__icon--Color);
-}
-
-.pf-c-label__text {
-  position: relative;
-  color: var(--pf-c-label__text--Color);
 }

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -13,10 +13,6 @@
   --pf-c-label__content--before--BorderWidth: 0;
   --pf-c-label__content--before--BorderColor: transparent;
 
-  // Compact
-  --pf-c-label--m-compact--FontSize: var(--pf-global--FontSize--xs);
-  --pf-c-label--m-compact__c-button--FontSize: var(--pf-global--icon--FontSize--sm);
-
   // Hoverable
   --pf-c-label--m-clickable--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-label--m-clickable--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
@@ -95,9 +91,8 @@
   --pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
 
   // Icon
-  --pf-c-label__icon--Color: var(--pf-global--primary-color--100);
+  --pf-c-label__icon--Color: var(--pf-global--Color--100);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-label--m-compact__icon--MarginRight: var(--pf-global--spacer--xs);
   --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
 
   // Text
@@ -121,13 +116,6 @@
   white-space: nowrap;
   background-color: var(--pf-c-label--BackgroundColor);
   border-radius: var(--pf-c-label--BorderRadius);
-
-  &.pf-m-compact {
-    --pf-c-button--FontSize: var(--pf-c-label--m-compact__c-button--FontSize);
-    --pf-c-label--FontSize: var(--pf-c-label--m-compact--FontSize);
-    --pf-c-label__icon--MarginRight: var(--pf-c-label--m-compact__icon--MarginRight);
-    --pf-c-label__c-button--MarginLeft: 0;
-  }
 
   &.pf-m-blue {
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-blue--BackgroundColor);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -10,8 +10,8 @@
   --pf-c-label--FontSize: var(--pf-global--FontSize--sm);
 
   // Border base styles
-  --pf-c-label--before--BorderWidth: 0;
-  --pf-c-label--before--BorderColor: transparent;
+  --pf-c-label__content--before--BorderWidth: 0;
+  --pf-c-label__content--before--BorderColor: transparent;
 
   // Compact
   --pf-c-label--m-compact--FontSize: var(--pf-global--FontSize--xs);
@@ -95,8 +95,13 @@
   --pf-c-label--m-outline--m-clickable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
 
   // Icon
+  --pf-c-label__icon--Color: var(--pf-global--primary-color--100);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-label--m-compact__icon--MarginRight: var(--pf-global--spacer--xs);
   --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
+
+  // Text
+  --pf-c-label__text--Color: var(--pf-global--Color--100);
 
   // Close button
   --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
@@ -110,8 +115,6 @@
   --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
 
   position: relative;
-  display: inline-flex;
-  align-items: center;
   padding: var(--pf-c-label--PaddingTop) var(--pf-c-label--PaddingRight) var(--pf-c-label--PaddingBottom) var(--pf-c-label--PaddingLeft);
   font-size: var(--pf-c-label--FontSize);
   color: var(--pf-c-label--Color);
@@ -119,20 +122,11 @@
   background-color: var(--pf-c-label--BackgroundColor);
   border-radius: var(--pf-c-label--BorderRadius);
 
-  &::before {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    content: "";
-    border: var(--pf-c-label--before--BorderWidth) solid var(--pf-c-label--before--BorderColor);
-    border-radius: var(--pf-c-label--BorderRadius);
-  }
-
   &.pf-m-compact {
     --pf-c-button--FontSize: var(--pf-c-label--m-compact__c-button--FontSize);
     --pf-c-label--FontSize: var(--pf-c-label--m-compact--FontSize);
+    --pf-c-label__icon--MarginRight: var(--pf-c-label--m-compact__icon--MarginRight);
+    --pf-c-label__c-button--MarginLeft: 0;
   }
 
   &.pf-m-blue {
@@ -202,9 +196,25 @@
   }
 
   &.pf-m-outline {
-    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--before--BorderWidth);
-    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
+    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--before--BorderWidth);
+    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-outline--BackgroundColor);
+
+    /* stylelint-disable selector-no-qualifying-type */
+    a.pf-c-label__content,
+    button.pf-c-label__content,
+    /* stylelint-enable selector-no-qualifying-type */
+    .pf-c-label__content.pf-m-clickable {
+      &:hover {
+        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderWidth);
+        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderColor);
+      }
+
+      &:focus {
+        --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderWidth);
+        --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderColor);
+      }
+    }
   }
 
   .pf-c-button {
@@ -221,12 +231,30 @@
   }
 }
 
-/* stylelint-disable */
-a.pf-c-label,
-button.pf-c-label,
-/* stylelint-enable */
-.pf-c-label.pf-m-clickable {
+.pf-c-label,
+.pf-c-label__content {
+  display: inline-flex;
+  align-items: center;
+}
+
+.pf-c-label__content {
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+    border: var(--pf-c-label__content--before--BorderWidth) solid var(--pf-c-label__content--before--BorderColor);
+    border-radius: var(--pf-c-label--BorderRadius);
+  }
+}
+
+a.pf-c-label__content,
+button.pf-c-label__content,
+.pf-c-label__content.pf-m-clickable {
   cursor: pointer;
+  background: transparent;
   border: none;
 
   &,
@@ -236,27 +264,13 @@ button.pf-c-label,
   }
 
   &:hover {
-    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-clickable--hover--before--BorderWidth);
-    --pf-c-label--before--BorderColor: var(--pf-c-label--m-clickable--hover--before--BorderColor);
+    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-clickable--hover--before--BorderWidth);
+    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-clickable--hover--before--BorderColor);
   }
 
   &:focus {
-    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-clickable--focus--before--BorderWidth);
-    --pf-c-label--before--BorderColor: var(--pf-c-label--m-clickable--focus--before--BorderColor);
-  }
-}
-
-a.pf-c-label.pf-m-outline,
-button.pf-c-label.pf-m-outline,
-.pf-c-label.pf-m-outline.pf-m-clickable {
-  &:hover {
-    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderWidth);
-    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderColor);
-  }
-
-  &:focus {
-    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderWidth);
-    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-clickable--focus--before--BorderColor);
+    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-clickable--focus--before--BorderWidth);
+    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-clickable--focus--before--BorderColor);
   }
 }
 

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -200,10 +200,10 @@
     --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-outline--BackgroundColor);
 
-    /* stylelint-disable selector-no-qualifying-type */
+    // stylelint-disable selector-no-qualifying-type
     a.pf-c-label__content,
     button.pf-c-label__content,
-    /* stylelint-enable selector-no-qualifying-type */
+    // stylelint-enable selector-no-qualifying-type
     .pf-c-label__content.pf-m-clickable {
       &:hover {
         --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-outline--m-clickable--hover--before--BorderWidth);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,31 +1,258 @@
 .pf-c-label {
   // Component
   --pf-c-label--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-label--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-label--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-label--BorderRadius: var(--pf-global--BorderRadius--sm);
-
-  // Color
-  --pf-c-label--BackgroundColor: var(--pf-global--primary-color--100);
-  --pf-c-label--Color: var(--pf-global--Color--light-100);
-
-  // Font
+  --pf-c-label--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-label--BorderRadius: var(--pf-global--BorderRadius--lg);
+  --pf-c-label--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-label--Color: var(--pf-global--Color--100);
   --pf-c-label--FontSize: var(--pf-global--FontSize--sm);
 
-  // Modifiers
+  // Border base styles
+  --pf-c-label--before--BorderWidth: 0;
+  --pf-c-label--before--BorderColor: transparent;
+
+  // Compact
   --pf-c-label--m-compact--FontSize: var(--pf-global--FontSize--xs);
 
-  display: inline-block;
+  // Hoverable
+  --pf-c-label--m-hoverable--hover--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-hoverable--focus--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-global--BorderColor--200);
+
+  // Outline
+  --pf-c-label--m-outline--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-label--m-outline--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-outline--before--BorderColor: var(--pf-global--BorderColor--100);
+
+  // Hoverable + Outline
+  --pf-c-label--m-outline--m-hoverable--hover--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline--m-hoverable--focus--before--BorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-global--BorderColor--100);
+
+  // Blue
+  --pf-c-label--m-blue--BackgroundColor: var(--pf-global--palette--blue-50);
+  --pf-c-label--m-blue__text--Color: var(--pf-global--info-color--200);
+  --pf-c-label--m-blue__icon--Color: var(--pf-global--primary-color--100);
+  --pf-c-label--m-hoverable--m-blue--hover--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-hoverable--m-blue--focus--before--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-label--m-outline--m-blue--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-hoverable--m-blue--hover--before--BorderColor: var(--pf-global--active-color--200);
+  --pf-c-label--m-outline--m-hoverable--m-blue--focus--before--BorderColor: var(--pf-global--active-color--200);
+
+  // Green
+  --pf-c-label--m-green--BackgroundColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-green__text--Color: var(--pf-global--success-color--200);
+  --pf-c-label--m-green__icon--Color: var(--pf-global--success-color--100);
+  --pf-c-label--m-hoverable--m-green--hover--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-hoverable--m-green--focus--before--BorderColor: var(--pf-global--success-color--100);
+  --pf-c-label--m-outline--m-green--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-hoverable--m-green--hover--before--BorderColor: var(--pf-global--palette--green-100);
+  --pf-c-label--m-outline--m-hoverable--m-green--focus--before--BorderColor: var(--pf-global--palette--green-100);
+
+  // Orange
+  --pf-c-label--m-orange--BackgroundColor: var(--pf-global--palette--gold-50);
+  --pf-c-label--m-orange__text--Color: var(--pf-global--palette--gold-700);
+  --pf-c-label--m-orange__icon--Color: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-hoverable--m-orange--hover--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-hoverable--m-orange--focus--before--BorderColor: var(--pf-global--palette--orange-300);
+  --pf-c-label--m-outline--m-orange--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-hoverable--m-orange--hover--before--BorderColor: var(--pf-global--palette--gold-100);
+  --pf-c-label--m-outline--m-hoverable--m-orange--focus--before--BorderColor: var(--pf-global--palette--gold-100);
+
+  // Red
+  --pf-c-label--m-red--BackgroundColor: var(--pf-global--palette--red-50);
+  --pf-c-label--m-red__text--Color: var(--pf-global--palette--red-300);
+  --pf-c-label--m-red__icon--Color: var(--pf-global--danger-color--100);
+  --pf-c-label--m-hoverable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-hoverable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-red--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-hoverable--m-red--hover--before--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-label--m-outline--m-hoverable--m-red--focus--before--BorderColor: var(--pf-global--danger-color--100);
+
+  // Purple
+  --pf-c-label--m-purple--BackgroundColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-purple__text--Color: var(--pf-global--palette--purple-700);
+  --pf-c-label--m-purple__icon--Color: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-hoverable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-hoverable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-500);
+  --pf-c-label--m-outline--m-purple--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-hoverable--m-purple--hover--before--BorderColor: var(--pf-global--palette--purple-100);
+  --pf-c-label--m-outline--m-hoverable--m-purple--focus--before--BorderColor: var(--pf-global--palette--purple-100);
+
+  // Cyan
+  --pf-c-label--m-cyan--BackgroundColor: var(--pf-global--palette--cyan-50);
+  --pf-c-label--m-cyan__text--Color: var(--pf-global--default-color--300);
+  --pf-c-label--m-cyan__icon--Color: var(--pf-global--default-color--200);
+  --pf-c-label--m-hoverable--m-cyan--hover--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-hoverable--m-cyan--focus--before--BorderColor: var(--pf-global--default-color--200);
+  --pf-c-label--m-outline--m-cyan--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-hoverable--m-cyan--hover--before--BorderColor: var(--pf-global--palette--cyan-100);
+  --pf-c-label--m-outline--m-hoverable--m-cyan--focus--before--BorderColor: var(--pf-global--palette--cyan-100);
+
+  // Icon
+  --pf-c-label__icon--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-label--m-compact__icon--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
+
+  // Close button
+  --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-label__c-button--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
+  --pf-c-label__c-button--MarginRight: calc(var(--pf-global--spacer--form-element) * -1);
+  --pf-c-label__c-button--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
+  --pf-c-label__c-button--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-label__c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   padding: var(--pf-c-label--PaddingTop) var(--pf-c-label--PaddingRight) var(--pf-c-label--PaddingBottom) var(--pf-c-label--PaddingLeft);
   font-size: var(--pf-c-label--FontSize);
   color: var(--pf-c-label--Color);
-  text-align: center;
   white-space: nowrap;
   background-color: var(--pf-c-label--BackgroundColor);
   border-radius: var(--pf-c-label--BorderRadius);
 
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+    border: var(--pf-c-label--before--BorderWidth) solid var(--pf-c-label--before--BorderColor);
+    border-radius: var(--pf-c-label--BorderRadius);
+  }
+
   &.pf-m-compact {
     --pf-c-label--FontSize: var(--pf-c-label--m-compact--FontSize);
+    --pf-c-label__icon--FontSize: var(--pf-c-label--m-compact__icon--FontSize);
   }
+
+  &.pf-m-blue {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-blue--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-blue__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-blue__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-blue--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-blue--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-blue--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-blue--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-blue--focus--before--BorderColor);
+  }
+
+  &.pf-m-green {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-green--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-green__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-green__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-green--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-green--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-green--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-green--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-green--focus--before--BorderColor);
+  }
+
+  &.pf-m-orange {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-orange--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-orange__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-orange__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-orange--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-orange--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-orange--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-orange--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-orange--focus--before--BorderColor);
+  }
+
+  &.pf-m-red {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-red--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-red__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-red__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-red--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-red--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-red--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-red--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-red--focus--before--BorderColor);
+  }
+
+  &.pf-m-purple {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-purple--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-purple__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-purple__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-purple--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-purple--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-purple--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-purple--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-purple--focus--before--BorderColor);
+  }
+
+  &.pf-m-cyan {
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-cyan--BackgroundColor);
+    --pf-c-label__text--Color: var(--pf-c-label--m-cyan__text--Color);
+    --pf-c-label__icon--Color: var(--pf-c-label--m-cyan__icon--Color);
+    --pf-c-label--m-outline--before--BorderColor: var(--pf-c-label--m-outline--m-cyan--before--BorderColor);
+    --pf-c-label--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-hoverable--m-cyan--hover--before--BorderColor);
+    --pf-c-label--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-hoverable--m-cyan--focus--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--hover--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-cyan--hover--before--BorderColor);
+    --pf-c-label--m-outline--m-hoverable--focus--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--m-cyan--focus--before--BorderColor);
+  }
+
+  &.pf-m-outline {
+    --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--before--BorderWidth);
+    --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--before--BorderColor);
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-outline--BackgroundColor);
+
+    &.pf-m-hoverable {
+      &:hover {
+        --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-hoverable--hover--before--BorderWidth);
+        --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--hover--before--BorderColor);
+      }
+
+      &:focus {
+        --pf-c-label--before--BorderWidth: var(--pf-c-label--m-outline--m-hoverable--focus--before--BorderWidth);
+        --pf-c-label--before--BorderColor: var(--pf-c-label--m-outline--m-hoverable--focus--before--BorderColor);
+      }
+    }
+  }
+
+  &.pf-m-hoverable {
+    cursor: pointer;
+
+    &:hover {
+      --pf-c-label--before--BorderWidth: var(--pf-c-label--m-hoverable--hover--before--BorderWidth);
+      --pf-c-label--before--BorderColor: var(--pf-c-label--m-hoverable--hover--before--BorderColor);
+    }
+
+    &:focus {
+      --pf-c-label--before--BorderWidth: var(--pf-c-label--m-hoverable--focus--before--BorderWidth);
+      --pf-c-label--before--BorderColor: var(--pf-c-label--m-hoverable--focus--before--BorderColor);
+    }
+  }
+
+  .pf-c-button {
+    --pf-c-button--FontSize: var(--pf-c-label__c-button--FontSize);
+    --pf-c-button--PaddingRight: var(--pf-c-label__c-button--PaddingRight);
+    --pf-c-button--PaddingLeft: var(--pf-c-label__c-button--PaddingLeft);
+
+    margin-top: var(--pf-c-label__c-button--MarginTop);
+    margin-right: var(--pf-c-label__c-button--MarginRight);
+    margin-bottom: var(--pf-c-label__c-button--MarginBottom);
+    margin-left: var(--pf-c-label__c-button--MarginLeft);
+  }
+}
+
+.pf-c-label__icon {
+  margin-right: var(--pf-c-label__icon--MarginRight);
+  margin-left: var(--pf-c-label__icon--MarginLeft);
+  font-size: var(--pf-c-label__icon--FontSize);
+  line-height: 1;
+  color: var(--pf-c-label__icon--Color);
+}
+
+.pf-c-label__text {
+  position: relative;
+  color: var(--pf-c-label__text--Color);
 }

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,9 +1,9 @@
 .pf-c-label {
   // Component
   --pf-c-label--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-label--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-label--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-label--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-label--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-label--BorderRadius: var(--pf-global--BorderRadius--lg);
   --pf-c-label--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-label--Color: var(--pf-global--Color--100);
@@ -96,7 +96,6 @@
   // Icon
   --pf-c-label__icon--Color: var(--pf-global--Color--100);
   --pf-c-label__icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-label__icon--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
 
   // Close button
   --pf-c-label__c-button--FontSize: var(--pf-global--FontSize--xs);
@@ -263,6 +262,5 @@
 
 .pf-c-label__icon {
   margin-right: var(--pf-c-label__icon--MarginRight);
-  margin-left: var(--pf-c-label__icon--MarginLeft);
   color: var(--pf-c-label__icon--Color);
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2656

## Breaking changes
The label component has been redesigned and refactored. This PR introduces breaking visual and code changes. At a minimum to update to the new label component, the `.pf-c-label` component now requires `.pf-c-label__text` element to wrap the label text. And the label will be grey by default now, so to achieve the previous blue styling, the closest match visually would be using the new `.pf-m-blue` modifier. However, reference the new component documentation and the PR changeset for more info regarding the changes https://github.com/patternfly/patternfly/pull/2943/files