### PR TITLE
Don't merge - fix(tab-focus): updated tab focus

### DIFF
--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -130,17 +130,17 @@ cssPrefix: pf-c-tabs
 | `.pf-m-fill`  | `.pf-c-tabs` | Modifies the tabs to fill the available space. **Required** |
 
 ```hbs title=Using-the-nav-element
-{{#> tabs tabs--id="default-scroll-nav-example" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Local"' tabs-link--type="a"}}
+{{#> tabs tabs--id="default-scroll-nav-example" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Local"' tabs-link--isLink="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 ```
 
 ```hbs title=Sub-nav-using-the-nav-element
-{{#> tabs tabs--id="primary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local"' tabs-link--type="a"}}
+{{#> tabs tabs--id="primary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local"' tabs-link--isLink="true"}}
   {{> __tabs-list}}
 {{/tabs}}
 
-{{#> tabs tabs--id="secondary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local secondary"' tabs-link--type="a" tabs--modifier="pf-m-secondary"}}
+{{#> tabs tabs--id="secondary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local secondary"' tabs-link--isLink="true" tabs--modifier="pf-m-secondary"}}
   {{> __tabs-list-secondary}}
 {{/tabs}}
 ```

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -1,6 +1,9 @@
-<{{#if tabs-link--type}}{{tabs-link--type}}{{else}}button{{/if}} class="pf-c-tabs__link{{#if tabs-link--modifier}} {{tabs-link--modifier}}{{/if}}"
+<{{#if tabs-link--isLink}}a{{else}}button{{/if}} class="pf-c-tabs__link{{#if tabs-link--modifier}} {{tabs-link--modifier}}{{/if}}"
+  {{#if tabs-link--isLink}}
+    href="#"
+  {{/if}}
   {{#if tabs-link--attribute}}
     {{{tabs-link--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</{{#if tabs-link--type}}{{tabs-link--type}}{{else}}button{{/if}}>
+</{{#if tabs-link--isLink}}a{{else}}button{{/if}}>

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -1,258 +1,105 @@
-$pf-c-tabs--breakpoint-map: build-breakpoint-map("base", "md", "lg", "xl", "2xl");
-$pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
-
 .pf-c-tabs {
-  --pf-c-tabs--Inset: 0;
-  --pf-c-tabs--before--BorderStyle: solid;
-  --pf-c-tabs--before--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-tabs--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-tabs--before--BorderTopWidth: 0;
-  --pf-c-tabs--before--BorderRightWidth: 0;
-  --pf-c-tabs--before--BorderBottomWidth: var(--pf-c-tabs--before--BorderWidth);
-  --pf-c-tabs--before--BorderLeftWidth: 0;
-  --pf-c-tabs--m-vertical--Inset: var(--pf-global--spacer--lg);
-  --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
-  --pf-c-tabs--m-vertical--m-box--Inset: var(--pf-global--spacer--xl);
+  // Primary tab items
+  --pf-c-tabs__item--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-tabs__item--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-tabs__item--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-tabs__item--m-current--ZIndex: var(--pf-global--ZIndex--sm);
+  --pf-c-tabs__item--m-current--Color: var(--pf-global--active-color--100);
+  --pf-c-tabs__item--m-current--BorderTopWidth: var(--pf-global--BorderWidth--md);
 
-  // Tab link
-  --pf-c-tabs__link--Color: var(--pf-global--Color--200);
-  --pf-c-tabs__link--BackgroundColor: transparent;
-  --pf-c-tabs__link--OutlineOffset: calc(-1 * #{pf-size-prem(6px)});
-  --pf-c-tabs__link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
-  --pf-c-tabs__item--m-current__link--Background: var(--pf-global--BackgroundColor--100);
-  --pf-c-tabs--m-vertical__link--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-tabs--m-vertical__link--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-tabs--m-box__link--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  // Secondary tab items
+  --pf-c-tabs__item--hover--Color: var(--pf-global--Color--dark-200);
 
-  // Link before
-  --pf-c-tabs__link--before--BorderStyle: solid;
-  --pf-c-tabs__link--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
-  --pf-c-tabs__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-tabs__link--before--BorderTopWidth: 0;
-  --pf-c-tabs__link--before--BorderRightWidth: 0;
-  --pf-c-tabs__link--before--BorderBottomWidth: 0;
-  --pf-c-tabs__link--before--BorderLeftWidth: 0;
-  --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--BorderColor);
-  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--BorderColor);
-  --pf-c-tabs__link--before--Left: calc(var(--pf-c-tabs__link--before--BorderWidth) * -1);
-  --pf-c-tabs__item--m-current__link--after--BorderColor: var(--pf-global--active-color--100);
-
-  // Link after
-  --pf-c-tabs__link--after--BorderStyle: solid;
-  --pf-c-tabs__link--after--BorderColor: var(--pf-global--BorderColor--light-100);
-  --pf-c-tabs__link--after--BorderWidth: 0;
-  --pf-c-tabs__link--after--BorderTopWidth: 0;
-  --pf-c-tabs__link--after--BorderRightWidth: 0;
-  --pf-c-tabs__link--after--BorderLeftWidth: 0;
-  --pf-c-tabs__link--hover--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-tabs__link--child--MarginRight: var(--pf-global--spacer--md);
-  --pf-c-tabs__item--m-current__link--after--BorderColor: var(--pf-global--active-color--100);
-  --pf-c-tabs__item--m-current__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-tabs--m-vertical--m-box__link--after--Top: 0;
+  // Tab buttons
+  --pf-c-tabs__button--Color: var(--pf-global--Color--100);
+  --pf-c-tabs__button--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-tabs__button--Background: transparent;
+  --pf-c-tabs__button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
+  --pf-c-tabs__button--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tabs__button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tabs__button--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-tabs__button--PaddingLeft: var(--pf-global--spacer--sm);
 
   // Scroll buttons
-  --pf-c-tabs__scroll-button--BorderStyle: solid;
-  --pf-c-tabs__scroll-button--Color: var(--pf-global--Color--100);
-  --pf-c-tabs__scroll-button--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-tabs__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
-  --pf-c-tabs__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-tabs__scroll-button--Width: var(--pf-global--spacer--2xl);
-  --pf-c-tabs__scroll-button--xl--Width: var(--pf-global--spacer--3xl);
-  --pf-c-tabs__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-tabs__scroll-button--Transition: margin .125s, transform .125s, opacity .125s;
-
-  // Scroll buttons before
-  --pf-c-tabs__scroll-button--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
-  --pf-c-tabs__scroll-button--before--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-tabs__scroll-button--before--BorderRightWidth: 0;
-  --pf-c-tabs__scroll-button--before--BorderBottomWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
-  --pf-c-tabs__scroll-button--before--BorderLeftWidth: 0;
-
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-tabs__scroll-button--Width: var(--pf-c-tabs__scroll-button--xl--Width);
-  }
+  --pf-c-tabs__scroll-button--Width: var(--pf-global--spacer--xl);
+  --pf-c-tabs__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-tabs__scroll-button--m-secondary--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-tabs__scroll-button--m-secondary--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-tabs__scroll-button--m-secondary-right--m-start-current--Color: var(--pf-global--active-color--100);
+  --pf-c-tabs__scroll-button--m-secondary--nth-of-type-1--BoxShadow: var(--pf-global--BoxShadow--lg-right);
+  --pf-c-tabs__scroll-button--m-secondary--nth-of-type-2--BoxShadow: var(--pf-global--BoxShadow--lg-left);
 
   position: relative;
   display: flex;
-  padding-right: var(--pf-c-tabs--Inset);
-  padding-left: var(--pf-c-tabs--Inset);
-  overflow: hidden;
+  flex-direction: column;
+  align-items: flex-start;
 
-  &::before {
-    border-color: var(--pf-c-tabs--before--BorderColor);
-    border-style: var(--pf-c-tabs--before--BorderStyle);
-    border-width: var(--pf-c-tabs--before--BorderTopWidth) var(--pf-c-tabs--before--BorderRightWidth) var(--pf-c-tabs--before--BorderBottomWidth) var(--pf-c-tabs--before--BorderLeftWidth);
+  // Scroll buttons hidden by default
+  .pf-c-tabs__scroll-button {
+    display: none;
+    visibility: hidden;
+  }
+
+  // Scroll buttons shown with modifiers
+  &.pf-m-start .pf-c-tabs__scroll-button:nth-of-type(1),
+  &.pf-m-end .pf-c-tabs__scroll-button:nth-of-type(2) {
+    display: block;
+    visibility: visible;
+  }
+
+  // Scroll button current state
+  &.pf-m-start-current:not(.pf-m-tabs-secondary) .pf-c-tabs__scroll-button:nth-of-type(1),
+  &.pf-m-end-current:not(.pf-m-tabs-secondary) .pf-c-tabs__scroll-button:nth-of-type(2) {
+    &::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin-left: var(--pf-c-tabs__item--BorderWidth);
+      content: "";
+      border-top: var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--m-current--Color);
+    }
+  }
+
+  // Scroll button current state
+  &.pf-m-start-current.pf-m-tabs-secondary .pf-c-tabs__scroll-button:nth-of-type(1),
+  &.pf-m-end-current.pf-m-tabs-secondary .pf-c-tabs__scroll-button:nth-of-type(2) {
+    color: var(--pf-c-tabs__scroll-button--m-secondary-right--m-start-current--Color);
+  }
+
+  // Primary with secondary tabs style
+  + &.pf-m-tabs-secondary {
+    margin-top: calc(-1 * var(--pf-c-tabs__item--BorderWidth));
+    border-top: var(--pf-c-tabs__item--BorderWidth) solid var(--pf-c-tabs__item--BorderColor);
+
+    .pf-c-tabs__scroll-button {
+      margin-top: calc(-1 * var(--pf-c-tabs__item--BorderWidth));
+    }
   }
 
   // Filled style
   &.pf-m-fill {
     .pf-c-tabs__list {
-      flex-basis: 100%;
+      width: 100%;
     }
 
     .pf-c-tabs__item {
-      flex-grow: 1;
+      flex: 1;
+      white-space: nowrap;
+
+      &:first-of-type .pf-c-tabs__button::before {
+        border-left: none;
+      }
+
+      &:last-of-type .pf-c-tabs__button::before {
+        border-right: none;
+      }
+
+      .pf-c-tabs__button {
+        width: 100%;
+      }
     }
-
-    .pf-c-tabs__link {
-      flex-basis: 100%;
-      justify-content: center;
-    }
-  }
-
-  // Scroll buttons enabled
-  &.pf-m-scrollable {
-    .pf-c-tabs__scroll-button {
-      opacity: 1;
-    }
-
-    // Scroll buttons
-    .pf-c-tabs__scroll-button:nth-of-type(1) {
-      margin-right: 0;
-      transform: translateX(0);
-    }
-
-    .pf-c-tabs__scroll-button:nth-of-type(2) {
-      margin-left: 0;
-      transform: translateX(0);
-    }
-
-    &.pf-m-secondary,
-    &.pf-m-no-border {
-      --pf-c-tabs--before--BorderWidth: 0;
-    }
-  }
-
-  // Remove bottom border for variants
-  &.pf-m-box,
-  &.pf-m-vertical {
-    .pf-c-tabs__link {
-      --pf-c-tabs__link--after--BorderBottomWidth: 0;
-    }
-  }
-
-  // Box
-  &.pf-m-box {
-    --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor);
-    --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
-
-    // Set hover on top border
-    .pf-c-tabs__link {
-      --pf-c-tabs__link--after--BorderTopWidth: var(--pf-c-tabs__link--after--BorderWidth);
-    }
-
-    // Remove border from last-child
-    .pf-c-tabs__item:last-child {
-      --pf-c-tabs__link--before--BorderRightWidth: 0;
-    }
-
-    .pf-c-tabs__item.pf-m-current {
-      --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__item--m-current__link--Background);
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
-      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--BackgroundColor);
-    }
-
-    // Add border to first-child
-    .pf-c-tabs__item.pf-m-current:first-child {
-      --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    }
-
-    // stylelint-disable selector-max-class
-    // Remove offset from current adjacent item
-    .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item {
-      --pf-c-tabs__link--before--Left: 0;
-    }
-    // stylelint-enable
-  }
-
-  // Vertical
-  &.pf-m-vertical {
-    --pf-c-tabs--Inset: var(--pf-c-tabs--m-vertical--Inset);
-    --pf-c-tabs--before--BorderBottomWidth: 0;
-    --pf-c-tabs--before--BorderLeftWidth: var(--pf-c-tabs--before--BorderWidth);
-    --pf-c-tabs__link--before--Left: 0;
-    --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
-    --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
-
-    display: inline-flex;
-    flex-direction: column;
-
-    // If not a flex child, set height
-    height: 100%;
-
-    // Because vertical variant has no scroll buttons, reset padding
-    padding: 0;
-
-    .pf-c-tabs__list {
-      flex-direction: column;
-      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
-    }
-
-    // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
-    .pf-c-tabs__item:first-child {
-      margin-top: var(--pf-c-tabs--Inset);
-    }
-
-    .pf-c-tabs__item:last-child {
-      margin-bottom: var(--pf-c-tabs--Inset);
-    }
-
-    // Set hover on left border
-    .pf-c-tabs__link {
-      --pf-c-tabs__link--after--BorderTopWidth: 0;
-      --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth);
-
-      max-width: 100%;
-      text-align: left;
-    }
-
-    .pf-c-tabs__item-text {
-      max-width: 100%;
-      overflow-wrap: break-word;
-    }
-  }
-
-  // Box, vertical
-  &.pf-m-box.pf-m-vertical {
-    --pf-c-tabs--Inset: var(--pf-c-tabs--m-vertical--m-box--Inset);
-    --pf-c-tabs--before--BorderLeftWidth: 0;
-    --pf-c-tabs--before--BorderRightWidth: var(--pf-c-tabs--before--BorderWidth);
-
-    // stylelint-disable selector-max-class
-    // Remove border from last-child
-    .pf-c-tabs__item:last-child {
-      --pf-c-tabs__link--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    }
-
-    // Add border right color and weight
-    .pf-c-tabs__item.pf-m-current {
-      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--Background);
-      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--BorderColor);
-      --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    }
-
-    // Add border right color and weight
-    .pf-c-tabs__item:first-child.pf-m-current {
-      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    }
-
-    // Offset vertical border to overlap horizontal border
-    .pf-c-tabs__link::after {
-      top: calc(var(--pf-c-tabs__link--before--BorderWidth) * -1);
-    }
-
-    // Undo offset to .pf-m-current adjacent item
-    .pf-c-tabs__item:first-child .pf-c-tabs__link::after,
-    .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item .pf-c-tabs__link::after {
-      top: 0;
-    }
-    // stylelint-enable
   }
 }
 
@@ -265,140 +112,167 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+
+  // Right border on last tab
+  .pf-c-tabs__item:last-of-type .pf-c-tabs__button::before {
+    border-right-width: var(--pf-c-tabs__item--BorderWidth);
+  }
 }
 
-// Tabs item
+// Tab items
 .pf-c-tabs__item {
-  display: flex;
   flex: none;
 
-  // Current
-  &.pf-m-current {
-    --pf-c-tabs__link--Color: var(--pf-c-tabs__item--m-current__link--Color);
-    --pf-c-tabs__link--after--BorderColor: var(--pf-c-tabs__item--m-current__link--after--BorderColor);
-    --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__item--m-current__link--after--BorderWidth);
-  }
-}
-
-.pf-c-tabs__link,
-.pf-c-tabs__scroll-button {
-  border: 0;
-}
-
-.pf-c-tabs::before,
-.pf-c-tabs__link::before,
-.pf-c-tabs__link::after,
-.pf-c-tabs__scroll-button::before {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  content: "";
-}
-
-// Tab link
-.pf-c-tabs__link {
-  // Set default border target
-  --pf-c-tabs__link--after--BorderBottomWidth: var(--pf-c-tabs__link--after--BorderWidth);
-
-  position: relative;
-  display: flex;
-  flex: 1;
-  padding: var(--pf-c-tabs__link--PaddingTop) var(--pf-c-tabs__link--PaddingRight) var(--pf-c-tabs__link--PaddingBottom) var(--pf-c-tabs__link--PaddingLeft);
-  color: var(--pf-c-tabs__link--Color);
-  user-select: none;
-  background-color: var(--pf-c-tabs__link--BackgroundColor);
-  outline-offset: var(--pf-c-tabs__link--OutlineOffset);
-
-  &::before {
-    border-color: var(--pf-c-tabs__link--before--BorderColor);
-    border-style: var(--pf-c-tabs__link--before--BorderStyle);
-    border-width: var(--pf-c-tabs__link--before--BorderTopWidth) var(--pf-c-tabs__link--before--BorderRightWidth) var(--pf-c-tabs__link--before--BorderBottomWidth) var(--pf-c-tabs__link--before--BorderLeftWidth);
-    border-right-color: var(--pf-c-tabs__link--before--BorderRightColor);
-    border-bottom-color: var(--pf-c-tabs__link--before--BorderBottomColor);
-  }
-
-  &::after {
-    left: var(--pf-c-tabs__link--before--Left);
-    border-color: var(--pf-c-tabs__link--after--BorderColor);
-    border-style: var(--pf-c-tabs__link--after--BorderStyle);
-    border-width: var(--pf-c-tabs__link--after--BorderTopWidth) var(--pf-c-tabs__link--after--BorderRightWidth) var(--pf-c-tabs__link--after--BorderBottomWidth) var(--pf-c-tabs__link--after--BorderLeftWidth);
-  }
-
   // Tab item hover state
-  &:hover {
-    --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--hover--after--BorderWidth);
+  &:not(.pf-m-current):hover .pf-c-tabs__button::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin-left: var(--pf-c-tabs__item--BorderWidth);
+    content: "";
+    border-top: var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--hover--Color);
+  }
 
+  // Tab item current state
+  &.pf-m-current .pf-c-tabs__button {
+    color: var(--pf-c-tabs__item--m-current--Color);
+
+    &::before {
+      border-bottom-color: var(--pf-c-tabs__item--BackgroundColor);
+    }
+
+    &::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin-left: var(--pf-c-tabs__item--BorderWidth);
+      content: "";
+      border-top: var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--m-current--Color);
+    }
+  }
+
+  // Secondary tab states
+  .pf-m-tabs-secondary & .pf-c-tabs__button {
+    // Remove current state and hover state
+    &::before,
+    &::after,
+    &:hover::after {
+      content: none;
+    }
+  }
+
+  // Secondary tab hover state
+  .pf-m-tabs-secondary &:not(.pf-m-current) .pf-c-tabs__button:hover {
+    color: var(--pf-c-tabs__item--hover--Color);
+  }
+}
+
+
+// Tab button
+.pf-c-tabs__button {
+  position: relative;
+  display: inline-block;
+  padding: var(--pf-c-tabs__button--PaddingTop) var(--pf-c-tabs__button--PaddingRight) var(--pf-c-tabs__button--PaddingBottom) var(--pf-c-tabs__button--PaddingLeft);
+  font-weight: var(--pf-c-tabs__button--FontWeight);
+  color: var(--pf-c-tabs__button--Color);
+  user-select: none;
+  background: var(--pf-c-tabs__button--Background);
+  border: 0;
+  outline-offset: var(--pf-c-tabs__button--OutlineOffset);
+
+  // Tab button borders
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+    border: solid var(--pf-c-tabs__item--BorderColor);
+    border-width: var(--pf-c-tabs__item--BorderWidth) 0 var(--pf-c-tabs__item--BorderWidth) var(--pf-c-tabs__item--BorderWidth);
+  }
+
+  &.pf-m-hover,
+  &:hover {
     text-decoration: none;
   }
+}
 
-  .pf-c-tabs__item-icon,
-  .pf-c-tabs__item-text {
-    margin-right: var(--pf-c-tabs__link--child--MarginRight);
+.pf-c-tabs__scroll-item {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--pf-c-tabs__scroll-button--Width);
 
-    &:last-child {
-      --pf-c-tabs__link--child--MarginRight: 0;
-    }
+  &:first-of-type {
+    left: 0;
+  }
+
+  &:last-of-type {
+    right: 0;
   }
 }
 
 // Scroll buttons
 .pf-c-tabs__scroll-button {
-  flex: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: var(--pf-c-tabs__scroll-button--ZIndex);
   width: var(--pf-c-tabs__scroll-button--Width);
   line-height: 1;
-  color: var(--pf-c-tabs__scroll-button--Color);
-  background-color: var(--pf-c-tabs__scroll-button--BackgroundColor);
-  outline-offset: var(--pf-c-tabs__scroll-button--OutlineOffset);
-  opacity: 0;
-  transition: var(--pf-c-tabs__scroll-button--Transition);
+  background-color: var(--pf-c-tabs__item--BackgroundColor);
+  border: 0;
 
-  &:hover,
-  &:active,
-  &:focus {
-    --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--hover--Color);
-  }
-
-  &::before {
-    border-color: var(--pf-c-tabs__scroll-button--before--BorderColor);
-    border-style: var(--pf-c-tabs__scroll-button--BorderStyle);
-    border-width: 0 var(--pf-c-tabs__scroll-button--before--BorderRightWidth) var(--pf-c-tabs__scroll-button--before--BorderBottomWidth) var(--pf-c-tabs__scroll-button--before--BorderLeftWidth);
-  }
-
-  &:nth-of-type(1) {
-    --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
-
-    margin-right: calc(var(--pf-c-tabs__scroll-button--Width) * -1);
-    transform: translateX(-100%);
-  }
-
+  // Align right scroll button
   &:nth-of-type(2) {
-    --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
-
-    margin-left: calc(var(--pf-c-tabs__scroll-button--Width) * -1);
-    transform: translateX(100%);
+    right: 0;
   }
 
-  &:disabled {
-    --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--disabled--Color);
+  // Scroll button borders
+  &:not(.pf-m-secondary) {
+    &::before {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      content: "";
+      border: var(--pf-c-tabs__item--BorderWidth) solid var(--pf-c-tabs__item--BorderColor);
+    }
 
-    pointer-events: none;
+    &:hover::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      content: "";
+      border-top: var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--hover--Color);
+    }
   }
-}
 
-// stylelint-disable no-duplicate-selectors, max-nesting-depth
-.pf-c-tabs {
-  @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
-    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-tabs--breakpoint-map) {
-      @each $spacer, $spacer-value in $pf-c-tabs--spacer-map {
-        &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
-          --pf-c-tabs--Inset: #{$spacer-value};
-        }
-      }
+  &.pf-m-secondary {
+    &.pf-m-hover,
+    &:hover,
+    &.pf-m-active,
+    &:active,
+    &.pf-m-focus,
+    &:focus {
+      color: var(--pf-c-tabs__scroll-button--m-secondary--hover--Color);
+    }
+
+    &:nth-of-type(1) {
+      box-shadow: var(--pf-c-tabs__scroll-button--m-secondary--nth-of-type-1--BoxShadow);
+    }
+
+    &:nth-of-type(2) {
+      box-shadow: var(--pf-c-tabs__scroll-button--m-secondary--nth-of-type-2--BoxShadow);
     }
   }
 }
-// stylelint-enable


### PR DESCRIPTION
closes #2920 
relates to #2893 

## Breaking changes
This PR updates tab `:focus` and `:active` states to reflect hover state. It also resizes the tab `::after` pseudo element to not consume the entirety of the button. 

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--pf-c-tabs--before--BorderStyle`
* `--pf-c-tabs__link--before--BorderStyle`
* `--pf-c-tabs__link--after--BorderStyle`
* `--pf-c-tabs__scroll-button--BorderStyle`
* `--pf-c-tabs__link--child--MarginRight`
* `--pf-c-tabs--m-vertical--m-box__link--after--Top`