### PR TITLE
fix(global): hid vertical nav at 1200px, updated component spacing

### DIFF
--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -50,12 +50,12 @@
   // Data list item row
   --pf-c-data-list__item-row--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-data-list__item-row--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-data-list__item-row--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-data-list__item-row--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-data-list__item-row--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-data-list__item-row--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-data-list__item-row--PaddingRight: var(--pf-c-data-list__item-row--md--PaddingRight);
-    --pf-c-data-list__item-row--PaddingLeft: var(--pf-c-data-list__item-row--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-data-list__item-row--PaddingRight: var(--pf-c-data-list__item-row--xl--PaddingRight);
+    --pf-c-data-list__item-row--PaddingLeft: var(--pf-c-data-list__item-row--xl--PaddingLeft);
   }
 
   // Data list item content
@@ -123,15 +123,18 @@
   --pf-c-data-list__expandable-content-body--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-data-list__expandable-content-body--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-data-list__expandable-content-body--md--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-data-list__expandable-content-body--md--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-data-list__expandable-content-body--xl--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-data-list__expandable-content-body--md--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-data-list__expandable-content-body--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-data-list__expandable-content-body--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-data-list__expandable-content-body--PaddingTop: var(--pf-c-data-list__expandable-content-body--md--PaddingTop);
-    --pf-c-data-list__expandable-content-body--PaddingRight: var(--pf-c-data-list__expandable-content-body--md--PaddingRight);
     --pf-c-data-list__expandable-content-body--PaddingBottom: var(--pf-c-data-list__expandable-content-body--md--PaddingBottom);
-    --pf-c-data-list__expandable-content-body--PaddingLeft: var(--pf-c-data-list__expandable-content-body--md--PaddingLeft);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-data-list__expandable-content-body--PaddingRight: var(--pf-c-data-list__expandable-content-body--xl--PaddingRight);
+    --pf-c-data-list__expandable-content-body--PaddingLeft: var(--pf-c-data-list__expandable-content-body--xl--PaddingLeft);
   }
 
   // Compact

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,5 +1,4 @@
 .pf-c-nav {
-  --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);
   --pf-c-nav__item--m-expanded__toggle-icon--Transform: rotate(90deg);
   --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
@@ -33,8 +32,8 @@
   --pf-c-nav__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__link--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-nav__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-nav__link--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__link--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-nav__link--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__link--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--hover--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__link--focus--Color: var(--pf-global--Color--dark-100);
@@ -123,7 +122,7 @@
 
   // Sub nav
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav__subnav--md--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
+  --pf-c-nav__subnav--xl--PaddingLeft: var(--pf-c-nav__link--PaddingLeft);
   --pf-c-nav__subnav__link--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__subnav__link--hover--after--BorderColor: var(--pf-global--BorderColor--dark-100);
   --pf-c-nav__subnav__link--focus--after--BorderColor: var(--pf-global--BorderColor--dark-100);
@@ -147,8 +146,8 @@
   --pf-c-nav__section-title--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-nav__section-title--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-nav__section-title--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-nav__section-title--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-nav__section-title--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-nav__section-title--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-nav__section-title--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__section-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-nav__section-title--Color: var(--pf-global--Color--dark-200);
   --pf-c-nav__section-title--BorderBottomColor: var(--pf-global--BorderColor--300);
@@ -186,14 +185,14 @@
   --pf-c-nav--c-divider--PaddingLeft: 0;
   --pf-c-nav--c-divider--BackgroundColor: var(--pf-global--BorderColor--300);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-nav__link--PaddingRight: var(--pf-c-nav__link--md--PaddingRight);
-    --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__link--md--PaddingLeft);
-    --pf-c-nav__list__link--PaddingRight: var(--pf-c-nav__list__link--md--PaddingRight);
-    --pf-c-nav__list__link--PaddingLeft: var(--pf-c-nav__list__link--md--PaddingLeft);
-    --pf-c-nav__section-title--PaddingRight: var(--pf-c-nav__section-title--md--PaddingRight);
-    --pf-c-nav__section-title--PaddingLeft: var(--pf-c-nav__section-title--md--PaddingLeft);
-    --pf-c-nav__subnav--PaddingLeft: var(--pf-c-nav__subnav--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-nav__link--PaddingRight: var(--pf-c-nav__link--xl--PaddingRight);
+    --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__link--xl--PaddingLeft);
+    --pf-c-nav__list__link--PaddingRight: var(--pf-c-nav__list__link--xl--PaddingRight);
+    --pf-c-nav__list__link--PaddingLeft: var(--pf-c-nav__list__link--xl--PaddingLeft);
+    --pf-c-nav__section-title--PaddingRight: var(--pf-c-nav__section-title--xl--PaddingRight);
+    --pf-c-nav__section-title--PaddingLeft: var(--pf-c-nav__section-title--xl--PaddingLeft);
+    --pf-c-nav__subnav--PaddingLeft: var(--pf-c-nav__subnav--xl--PaddingLeft);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
@@ -243,13 +242,6 @@
     padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
     margin-top: var(--pf-c-nav--c-divider--MarginTop);
     margin-bottom: var(--pf-c-nav--c-divider--MarginBottom);
-  }
-}
-
-// Set width when nav is child of sidebar to prevent collapsing
-.pf-c-page__sidebar .pf-c-nav {
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    width: var(--pf-c-nav--Width);
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -127,8 +127,8 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--xl--Right: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the right
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left);
-    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right);
+    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--xl--Left);
+    --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--xl--Right);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -11,11 +11,11 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
   // Header brand
   --pf-c-page__header-brand--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__header-brand--md--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-page__header-brand--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-page__header-brand--xl--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-page__header-brand--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
-  @media (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__header-brand--PaddingLeft: var(--pf-c-page__header-brand--md--PaddingLeft);
+  @media (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__header-brand--PaddingLeft: var(--pf-c-page__header-brand--xl--PaddingLeft);
   }
 
   // Toggle
@@ -25,32 +25,32 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-sidebar-toggle__c-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-page__header-sidebar-toggle__c-button--MarginRight: var(--pf-global--spacer--md);
   --pf-c-page__header-sidebar-toggle__c-button--MarginLeft: calc(var(--pf-c-page__header-sidebar-toggle__c-button--PaddingLeft) * -1);
-  --pf-c-page__header-sidebar-toggle__c-button--md--MarginLeft: calc(var(--pf-c-page__header-sidebar-toggle__c-button--PaddingLeft) * -1); // remove in breaking change release
+  --pf-c-page__header-sidebar-toggle__c-button--xl--MarginLeft: calc(var(--pf-c-page__header-sidebar-toggle__c-button--PaddingLeft) * -1); // remove in breaking change release
   --pf-c-page__header-sidebar-toggle__c-button--FontSize: var(--pf-global--FontSize--2xl);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__header-sidebar-toggle__c-button--MarginLeft: var(--pf-c-page__header-sidebar-toggle__c-button--md--MarginLeft); // remove in breaking change release
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__header-sidebar-toggle__c-button--MarginLeft: var(--pf-c-page__header-sidebar-toggle__c-button--xl--MarginLeft); // remove in breaking change release
   }
 
   // Header brand link
   --pf-c-page__header-brand-link--c-brand--MaxHeight: #{pf-size-prem(60px)};
 
   // Header nav
-  --pf-c-page__header-nav--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-page__header-nav--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-page__header-nav--lg--PaddingLeft: 0;
   --pf-c-page__header-nav--lg--MarginRight: var(--pf-global--spacer--xl);
   --pf-c-page__header-nav--lg--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-nav--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
   --pf-c-page__header-nav--lg--BackgroundColor: transparent;
   --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs))); // This sets the the button to the edge of its container with 4px clearance on the left
-  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--md--Left: var(--pf-global--spacer--xl);
+  --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--xl--Left: var(--pf-global--spacer--xl);
   --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--lg--Left: 0;
   --pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor: var(--pf-c-page__header-nav--BackgroundColor);
   --pf-c-page__header-nav--c-nav__scroll-button--lg--Top: 0;
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--md--PaddingLeft);
-    --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--md--Left);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__header-nav--PaddingLeft: var(--pf-c-page__header-nav--xl--PaddingLeft);
+    --pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__header-nav--c-nav__scroll-button--nth-of-type-1--xl--Left);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
@@ -61,7 +61,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
   // Header tools
   --pf-c-page__header-tools--MarginRight: var(--pf-global--spacer--md);
-  --pf-c-page__header-tools--md--MarginRight: var(--pf-global--spacer--lg);
+  --pf-c-page__header-tools--xl--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-page__header-tools--c-avatar--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-tools-group--MarginLeft: var(--pf-global--spacer--xl);
 
@@ -72,27 +72,26 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__header-tools--c-button--m-selected--before--BorderRadius: var(--pf-global--BorderRadius--lg);
   --pf-c-page__header-tools--c-button--m-selected--c-notification-badge--m-unread--after--BorderColor: var(--pf-global--BackgroundColor--dark-200);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__header-tools--MarginRight: var(--pf-c-page__header-tools--md--MarginRight);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__header-tools--MarginRight: var(--pf-c-page__header-tools--xl--MarginRight);
   }
 
   // Sidebar
   --pf-c-page__sidebar--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-page__sidebar--Width: 80%;
-  --pf-c-page__sidebar--md--Width: #{pf-size-prem(290px)};
+  --pf-c-page__sidebar--Width: #{pf-size-prem(290px)};
   --pf-c-page__sidebar--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__sidebar--BoxShadow: var(--pf-global--BoxShadow--lg-right);
   --pf-c-page__sidebar--Transition: var(--pf-global--Transition);
   --pf-c-page__sidebar--Transform: translate3d(-100%, 0, 0);
   --pf-c-page__sidebar--m-expanded--Transform: translate3d(0, 0, 0);
-  --pf-c-page__sidebar--md--Transform: translate3d(0, 0, 0);
+  --pf-c-page__sidebar--xl--Transform: translate3d(0, 0, 0);
   --pf-c-page__sidebar--m-dark--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
   --pf-c-page__sidebar-body--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-page__sidebar-body--PaddingBottom: var(--pf-global--spacer--md);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__sidebar--Width: var(--pf-c-page__sidebar--md--Width); // hardcode sidebar based on design spec, must match pf-n-nav--Width
-    --pf-c-page__sidebar--Transform: var(--pf-c-page__sidebar--md--Transform);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__sidebar--Transform: var(--pf-c-page__sidebar--xl--Transform);
   }
 
   // Main section
@@ -100,19 +99,19 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-section--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-section--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-page__main-section--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-section--md--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-page__main-section--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-page__main-section--md--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-page__main-section--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-page__main-section--xl--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-page__main-section--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-page__main-section--xl--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-page__main-section--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-page__main-section--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-page__main--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-page__main-breadcrumb--main-section--PaddingTop: var(--pf-global--spacer--md);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--md--PaddingTop);
-    --pf-c-page__main-section--PaddingRight: var(--pf-c-page__main-section--md--PaddingRight);
-    --pf-c-page__main-section--PaddingBottom: var(--pf-c-page__main-section--md--PaddingBottom);
-    --pf-c-page__main-section--PaddingLeft: var(--pf-c-page__main-section--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--xl--PaddingTop);
+    --pf-c-page__main-section--PaddingRight: var(--pf-c-page__main-section--xl--PaddingRight);
+    --pf-c-page__main-section--PaddingBottom: var(--pf-c-page__main-section--xl--PaddingBottom);
+    --pf-c-page__main-section--PaddingLeft: var(--pf-c-page__main-section--xl--PaddingLeft);
   }
 
   // Main section horizontal nav
@@ -120,21 +119,21 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-nav--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-nav--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-nav--md--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-page__main-nav--md--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-page__main-nav--xl--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-page__main-nav--xl--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the left
+  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--xl--Left: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the left
   --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: calc(-1 * (var(--pf-global--spacer--md) - var(--pf-global--spacer--xs)));
-  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the right
+  --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--xl--Right: calc(-1 * var(--pf-global--spacer--xs)); // This sets the the button to the edge of its container with 4px clearance on the right
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--Left: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-1--md--Left);
     --pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--Right: var(--pf-c-page__main-nav--c-nav__scroll-button--nth-of-type-2--md--Right);
   }
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__main-nav--PaddingRight: var(--pf-c-page__main-nav--md--PaddingRight);
-    --pf-c-page__main-nav--PaddingLeft: var(--pf-c-page__main-nav--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__main-nav--PaddingRight: var(--pf-c-page__main-nav--xl--PaddingRight);
+    --pf-c-page__main-nav--PaddingLeft: var(--pf-c-page__main-nav--xl--PaddingLeft);
   }
 
   // Main section breadcrumb
@@ -143,12 +142,12 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-breadcrumb--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-page__main-breadcrumb--PaddingBottom: 0;
   --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-page__main-breadcrumb--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-page__main-breadcrumb--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-page__main-breadcrumb--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-page__main-breadcrumb--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-page__main-breadcrumb--PaddingRight: var(--pf-c-page__main-breadcrumb--md--PaddingRight);
-    --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-c-page__main-breadcrumb--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-page__main-breadcrumb--PaddingRight: var(--pf-c-page__main-breadcrumb--xl--PaddingRight);
+    --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-c-page__main-breadcrumb--xl--PaddingLeft);
   }
 
   // Main section modifiers
@@ -170,7 +169,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
     "main";
   background-color: var(--pf-c-page--BackgroundColor);
 
-  @media (min-width: $pf-global--breakpoint--md) {
+  @media (min-width: $pf-global--breakpoint--xl) {
     grid-template-columns: max-content 1fr;
     grid-template-areas:
       "header header"
@@ -207,8 +206,8 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   grid-column: 1 / 2;
   padding-left: var(--pf-c-page__header-brand--PaddingLeft);
 
-  @media (min-width: $pf-global--breakpoint--md) {
-    padding-right: var(--pf-c-page__header-brand--md--PaddingRight); // set padding right here to allow mobile view to accomodate tools
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-right: var(--pf-c-page__header-brand--xl--PaddingRight); // set padding right here to allow mobile view to accomodate tools
   }
 }
 
@@ -365,8 +364,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   transition: var(--pf-c-page__sidebar--Transition);
   transform: var(--pf-c-page__sidebar--Transform);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    max-width: var(--pf-c-page__sidebar--md--Width); // max-width value set for browser to calculate max-width while transitioning. sharing value to keep consistent
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
     box-shadow: var(--pf-c-page__sidebar--BoxShadow);
   }
 
@@ -425,7 +423,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
       .pf-c-nav__link {
         padding-left: 0;
 
-        @media screen and (min-width: $pf-global--breakpoint--md) {
+        @media screen and (min-width: $pf-global--breakpoint--xl) {
           padding-left: var(--pf-c-nav__link--PaddingLeft);
         }
       }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -55,14 +55,14 @@
   --pf-c-table-tr--responsive--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-table-tr--responsive--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-table-tr--responsive--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-table-tr--responsive--md--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table-tr--responsive--xl--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table-tr--responsive--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-table-tr--responsive--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-table-tr--responsive--md--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table-tr--responsive--xl--PaddingLeft: var(--pf-global--spacer--md);
 
-  @media screen and (max-width: $pf-global--breakpoint--md) {
-    --pf-c-table-tr--responsive--PaddingRight: var(--pf-c-table-tr--responsive--md--PaddingRight);
-    --pf-c-table-tr--responsive--PaddingLeft: var(--pf-c-table-tr--responsive--md--PaddingLeft);
+  @media screen and (max-width: $pf-global--breakpoint--xl) {
+    --pf-c-table-tr--responsive--PaddingRight: var(--pf-c-table-tr--responsive--xl--PaddingRight);
+    --pf-c-table-tr--responsive--PaddingLeft: var(--pf-c-table-tr--responsive--xl--PaddingLeft);
   }
 
   --pf-c-table-tr--responsive--nested-table--PaddingTop: var(--pf-global--spacer--xl);
@@ -93,7 +93,14 @@
   // Expandable row content
   --pf-c-table__expandable-row-content--responsive--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-table__expandable-row-content--responsive--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-table__expandable-row-content--responsive--xl--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table__expandable-row-content--responsive--xl--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-table__expandable-row-content--BackgroundColor: var(--pf-global--BackgroundColor--100);
+
+  @media screen and (max-width: $pf-global--breakpoint--xl) {
+    --pf-c-table__expandable-row-content--responsive--PaddingRight: var(--pf-c-table__expandable-row-content--responsive--xl--PaddingRight);
+    --pf-c-table__expandable-row-content--responsive--PaddingLeft: var(--pf-c-table__expandable-row-content--responsive--xl--PaddingLeft);
+  }
 
   // Table check
   --pf-c-table__check--responsive--MarginLeft: var(--pf-global--spacer--sm);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -19,14 +19,14 @@
   --pf-c-table-caption--Color: var(--pf-global--Color--200);
   --pf-c-table-caption--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-table-caption--md--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table-caption--xl--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-table-caption--md--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table-caption--xl--PaddingLeft: var(--pf-global--spacer--md);
 
-  @media screen and (max-width: $pf-global--breakpoint--md) {
+  @media screen and (max-width: $pf-global--breakpoint--xl) {
     --pf-c-table-caption--PaddingRight: var(--pf-c-table-caption--md--PaddingRight);
-    --pf-c-table-caption--PaddingLeft: var(--pf-c-table-caption--md--PaddingLeft);
+    --pf-c-table-caption--PaddingLeft: var(--pf-c-table-caption--xl--PaddingLeft);
   }
 
   // Thead
@@ -53,6 +53,8 @@
   --pf-c-table-cell--FontSize: var(--pf-global--FontSize--md);
   --pf-c-table-cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-table-cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-table-cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table-cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--md);
 
   // ============================================================ //
   // End non-conformant variables
@@ -122,6 +124,8 @@
   --pf-c-table--m-compact-cell--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-table--m-compact-cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-table--m-compact-cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-table--m-compact-cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table--m-compact-cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table--m-compact--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-table--m-compact__expandable-row-content--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-table--m-compact__expandable-row-content--PaddingRight: var(--pf-global--spacer--lg);
@@ -187,11 +191,19 @@
     // First child padding left
     &:first-child {
       --pf-c-table-cell--PaddingLeft: var(--pf-c-table-cell--first-last-child--PaddingLeft);
+
+      @media screen and (max-width: $pf-global--breakpoint--xl) {
+        --pf-c-table-cell--PaddingLeft: var(--pf-c-table-cell--first-last-child--xl--PaddingLeft);
+      }
     }
 
     // Last child padding right
     &:last-child {
       --pf-c-table-cell--PaddingRight: var(--pf-c-table-cell--first-last-child--PaddingRight);
+
+      @media screen and (max-width: $pf-global--breakpoint--xl) {
+        --pf-c-table-cell--PaddingRight: var(--pf-c-table-cell--first-last-child--xl--PaddingRight);
+      }
     }
 
     &.pf-m-center {
@@ -514,10 +526,18 @@
       > * {
         &:first-child {
           --pf-c-table-cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--PaddingLeft);
+
+          @media screen and (max-width: $pf-global--breakpoint--xl) {
+            --pf-c-table-cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--xl--PaddingLeft);
+          }
         }
 
         &:last-child {
           --pf-c-table-cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--PaddingRight);
+
+          @media screen and (max-width: $pf-global--breakpoint--xl) {
+            --pf-c-table-cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--xl--PaddingRight);
+          }
         }
       }
       // stylelint-enable

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -22,8 +22,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-tabs__link--md--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-tabs__link--md--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
   --pf-c-tabs__item--m-current__link--Background: var(--pf-global--BackgroundColor--100);
   --pf-c-tabs--m-vertical__link--PaddingTop: var(--pf-global--spacer--md);
@@ -63,7 +61,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-tabs__scroll-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-tabs__scroll-button--Width: var(--pf-global--spacer--2xl);
-  --pf-c-tabs__scroll-button--md--Width: var(--pf-global--spacer--3xl);
+  --pf-c-tabs__scroll-button--xl--Width: var(--pf-global--spacer--3xl);
   --pf-c-tabs__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
   --pf-c-tabs__scroll-button--Transition: margin .125s, transform .125s, opacity .125s;
 
@@ -74,10 +72,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__scroll-button--before--BorderBottomWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
   --pf-c-tabs__scroll-button--before--BorderLeftWidth: 0;
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs__link--md--PaddingTop);
-    --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs__link--md--PaddingBottom);
-    --pf-c-tabs__scroll-button--Width: var(--pf-c-tabs__scroll-button--md--Width);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-tabs__scroll-button--Width: var(--pf-c-tabs__scroll-button--xl--Width);
   }
 
   position: relative;

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -4,13 +4,13 @@
   --pf-c-toolbar--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-toolbar--md--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-toolbar--md--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-toolbar--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-toolbar--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-toolbar--child--MarginLeft: var(--pf-global--spacer--md);
 
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-toolbar--PaddingRight: var(--pf-c-toolbar--md--PaddingRight);
-    --pf-c-toolbar--PaddingLeft: var(--pf-c-toolbar--md--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-toolbar--PaddingRight: var(--pf-c-toolbar--xl--PaddingRight);
+    --pf-c-toolbar--PaddingLeft: var(--pf-c-toolbar--xl--PaddingLeft);
   }
 
   // Bulk select

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -85,7 +85,7 @@
   --pf-c-wizard__toggle--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
   --pf-c-wizard__toggle--m-expanded--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-wizard__toggle--m-expanded--BorderBottomColor: var(--pf-global--BorderColor--100);
-  --pf-c-wizard--m-in-page__toggle--md--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard--m-in-page__toggle--xl--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
 
   // Toggle number
   --pf-c-wizard__toggle-num--before--Top: 0;
@@ -132,7 +132,8 @@
   --pf-c-wizard__nav-list--lg--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
   --pf-c-wizard__nav-list--nested--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-wizard__nav-list--nested--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__nav-list--md--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard--m-in-page__nav-list--md--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard--m-in-page__nav-list--xl--PaddingLeft: calc(var(--pf-global--spacer--lg) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-wizard__nav-list--PaddingRight: var(--pf-c-wizard__nav-list--lg--PaddingRight);
@@ -144,7 +145,7 @@
 
   // Outer wrap
   --pf-c-wizard__outer-wrap--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-wizard__outer-wrap--lg--PaddingLeft: var(--pf-c-wizard__nav--lg--Width);
+  --pf-c-wizard__outer-wrap--lg--PaddingLeft: var(--pf-c-wizard__nav--Width);
 
   // Main
   --pf-c-wizard__main--ZIndex: var(--pf-global--ZIndex--xs);
@@ -158,10 +159,12 @@
   --pf-c-wizard__main-body--lg--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-wizard__main-body--lg--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-wizard__main-body--lg--PaddingLeft: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard--m-in-page__main-body--md--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__main-body--md--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__main-body--md--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__main-body--md--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__main-body--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard--m-in-page__main-body--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-wizard__main-body--PaddingTop: var(--pf-c-wizard__main-body--lg--PaddingTop);
@@ -181,10 +184,12 @@
   --pf-c-wizard__footer--lg--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-wizard__footer--child--MarginRight: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--child--MarginBottom: var(--pf-global--spacer--sm);
-  --pf-c-wizard--m-in-page__footer--md--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__footer--md--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-wizard--m-in-page__footer--md--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__footer--md--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard--m-in-page__footer--md--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-wizard--m-in-page__footer--md--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard--m-in-page__footer--md--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard--m-in-page__footer--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard--m-in-page__footer--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-wizard__footer--PaddingTop: var(--pf-c-wizard__footer--lg--PaddingTop);
@@ -246,8 +251,16 @@
       --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard--m-in-page__footer--md--PaddingRight);
       --pf-c-wizard__footer--PaddingBottom: var(--pf-c-wizard--m-in-page__footer--md--PaddingBottom);
       --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard--m-in-page__footer--md--PaddingLeft);
-      --pf-c-wizard__toggle--PaddingLeft: var(--pf-c-wizard--m-in-page__toggle--md--PaddingLeft);
       --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard--m-in-page__nav-list--md--PaddingLeft);
+    }
+
+    @media screen and (min-width: $pf-global--breakpoint--xl) {
+      --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard--m-in-page__main-body--xl--PaddingRight);
+      --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard--m-in-page__main-body--xl--PaddingLeft);
+      --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard--m-in-page__footer--xl--PaddingRight);
+      --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard--m-in-page__footer--xl--PaddingLeft);
+      --pf-c-wizard__toggle--PaddingLeft: var(--pf-c-wizard--m-in-page__toggle--xl--PaddingLeft);
+      --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard--m-in-page__nav-list--xl--PaddingLeft);
     }
 
     @media screen and (min-width: $pf-global--breakpoint--lg) {

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a table with checkboxes"'}}
+{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with checkboxes"'}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-td table-td--check="true"}}

--- a/src/patternfly/layouts/Gallery/gallery.scss
+++ b/src/patternfly/layouts/Gallery/gallery.scss
@@ -1,12 +1,7 @@
 .pf-l-gallery {
   --pf-l-gallery--m-gutter--GridGap: var(--pf-global--gutter);
-  --pf-l-gallery--m-gutter--md--GridGap: var(--pf-global--gutter--md);
   --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, minmax(250px, 1fr)); // The 250px value is here just so that the grid has a width to use in the minmax() for laying out the gallery columns.
   --pf-l-gallery--GridTemplateRows: auto;
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-l-gallery--m-gutter--GridGap: var(--pf-l-gallery--m-gutter--md--GridGap);
-  }
 
   display: grid;
   grid-template-columns: var(--pf-l-gallery--GridTemplateColumns);

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -40,13 +40,8 @@
 // Grid base
 .pf-l-grid {
   --pf-l-grid--m-gutter--GridGap: var(--pf-global--gutter);
-  --pf-l-grid--m-gutter--md--GridGap: var(--pf-global--gutter--md);
   --pf-l-grid__item--GridColumnStart: auto;
   --pf-l-grid__item--GridColumnEnd: span 12;
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-l-grid--m-gutter--GridGap: var(--pf-l-grid--m-gutter--md--GridGap);
-  }
 
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);

--- a/src/patternfly/layouts/Level/level.scss
+++ b/src/patternfly/layouts/Level/level.scss
@@ -1,10 +1,5 @@
 .pf-l-level {
   --pf-l-level--m-gutter--MarginRight: var(--pf-global--gutter);
-  --pf-l-level--m-gutter--md--MarginRight: var(--pf-global--gutter--md);
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-l-level--m-gutter--MarginRight: var(--pf-l-level--m-gutter--md--MarginRight);
-  }
 
   display: flex;
   flex-wrap: wrap;

--- a/src/patternfly/layouts/Split/split.scss
+++ b/src/patternfly/layouts/Split/split.scss
@@ -1,10 +1,5 @@
 .pf-l-split {
   --pf-l-split--m-gutter--MarginRight: var(--pf-global--gutter);
-  --pf-l-split--m-gutter--md--MarginRight: var(--pf-global--gutter--md);
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-l-split--m-gutter--MarginRight: var(--pf-l-split--m-gutter--md--MarginRight);
-  }
 
   display: flex;
   flex-wrap: nowrap;

--- a/src/patternfly/layouts/Stack/stack.scss
+++ b/src/patternfly/layouts/Stack/stack.scss
@@ -1,10 +1,5 @@
 .pf-l-stack {
   --pf-l-stack--m-gutter--MarginBottom: var(--pf-global--gutter);
-  --pf-l-stack--m-gutter--md--MarginBottom: var(--pf-global--gutter--md);
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-l-stack--m-gutter--MarginBottom: var(--pf-l-stack--m-gutter--md--MarginBottom);
-  }
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2907

Testing notes:
The components that changed: data-list, nav, page, table, tabs (removed the top/bottom padding change that happened at 768px), wizard. We just need to test the spacing in these components in general, but specifically to make sure the horizontal spacing aligns with the overall page chrome so that when they're used in a page main section, their horizontal padding aligns with the page chrome. For example...

desktop table
<img width="429" alt="Screen Shot 2020-04-14 at 5 25 42 PM" src="https://user-images.githubusercontent.com/35148959/79280056-0813a500-7e75-11ea-91bd-41fdc8a1da00.png">

mobile table
<img width="423" alt="Screen Shot 2020-04-14 at 5 25 27 PM" src="https://user-images.githubusercontent.com/35148959/79280064-0c3fc280-7e75-11ea-9adb-65d4abff6ed7.png">

## Breaking changes
This PR changes the CSS breakpoint at which the page component's sidebar shows and hides. This used to be defined at `$pf-global--breakpoint--md` (768px) and is now defined at `$pf-global--breakpoint--xl` (1200px). This change results in a wider main content area of the page, so this may impact an application's UI. No code changes are needed to allow the breakpoint change, since the breakpoint is defined in CSS.

The overall page chrome and some individual components' horizontal spacing becomes more compact at this breakpoint (true of the old breakpoint and the new), so applications may find that custom elements that aligned with the old page chrome may not align now since the chrome spacing changes at 1200px instead of 768px. An application may need to make updates to match the chrome's spacing at the new breakpoint.

There is a long list of variable names that have changed across individual components that you can find in this PR's [file changeset](https://github.com/patternfly/patternfly/pull/2962/files). 

This PR also changes the gutter in patternfly layouts (gallery, grid, level, split, stack) to have a single gutter instead of responsive, so the gutter is always 16px, instead of being 16px on mobile and 24px on desktop. No futher changes are needed to consume this update, though applications may find that custom elements that may have aligned with the spacing at the old breakpoint no longer align. An application may need to make updates to match spacing at the new breakpoint.

The page sidebar and vertical navigation are now always the same size between mobile and desktop. No further updates are needed to consume this change.