### PR TITLE
fix(components): removed transparent borders

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -4,7 +4,6 @@
 .pf-c-app-launcher {
   // Menu
   --pf-c-app-launcher__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-app-launcher__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-app-launcher__menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-app-launcher__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-app-launcher__menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -140,7 +139,6 @@
   padding-bottom: var(--pf-c-app-launcher__menu--PaddingBottom);
   background-color: var(--pf-c-app-launcher__menu--BackgroundColor);
   background-clip: padding-box;
-  border: var(--pf-c-app-launcher__menu--BorderWidth) solid transparent; // this is for high contrast mode in windows
   box-shadow: var(--pf-c-app-launcher__menu--BoxShadow);
 
   &.pf-m-align-right {

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -33,7 +33,6 @@
   --pf-c-context-selector__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-context-selector__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-context-selector__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-context-selector__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-context-selector__menu--BoxShadow: var(--pf-global--BoxShadow--md);
 
   // Menu input
@@ -137,7 +136,6 @@
   padding-top: var(--pf-c-context-selector__menu--PaddingTop);
   background-color: var(--pf-c-context-selector__menu--BackgroundColor);
   background-clip: padding-box;
-  border: var(--pf-c-context-selector__menu--BorderWidth) solid transparent;
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -58,7 +58,6 @@
 
   // Menu
   --pf-c-dropdown__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-dropdown__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-dropdown__menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-dropdown__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -358,7 +357,6 @@
   padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
   background: var(--pf-c-dropdown__menu--BackgroundColor);
   background-clip: padding-box;
-  border: var(--pf-c-dropdown__menu--BorderWidth) solid transparent;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
   &.pf-m-align-right {

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,11 +1,9 @@
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-modal-box--BorderColor: transparent;
   --pf-c-modal-box--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-modal-box--Width: 100%;
@@ -46,7 +44,6 @@
   max-height: var(--pf-c-modal-box--MaxHeight);
   padding: var(--pf-c-modal-box--PaddingTop) var(--pf-c-modal-box--PaddingRight) var(--pf-c-modal-box--PaddingBottom) var(--pf-c-modal-box--PaddingLeft);
   background-color: var(--pf-c-modal-box--BackgroundColor);
-  border: var(--pf-c-modal-box--BorderSize) solid var(--pf-c-modal-box--BorderColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
   // At breakpoint--sm, set max width to variable value and ignore margins

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -39,7 +39,6 @@
 
   // Menu
   --pf-c-options-menu__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-options-menu__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-options-menu__menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-options-menu__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-options-menu__menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -234,7 +233,6 @@
   padding-bottom: var(--pf-c-options-menu__menu--PaddingBottom);
   background-color: var(--pf-c-options-menu__menu--BackgroundColor);
   background-clip: padding-box;
-  border: var(--pf-c-options-menu__menu--BorderWidth) solid transparent; // this is for high contrast mode in windows
   box-shadow: var(--pf-c-options-menu__menu--BoxShadow);
 
   &.pf-m-align-right {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -79,7 +79,6 @@
 
   // Menu
   --pf-c-select__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-select__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-select__menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-select__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-select__menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -368,7 +367,6 @@
   padding-bottom: var(--pf-c-select__menu--PaddingBottom);
   background-color: var(--pf-c-select__menu--BackgroundColor);
   background-clip: padding-box;
-  border: var(--pf-c-select__menu--BorderWidth) solid transparent;
   box-shadow: var(--pf-c-select__menu--BoxShadow);
 
   &.pf-m-align-right {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2019

## Breaking changes
This PR removes a transparent border from a handful of components that was used to serve as a border in Windows high contrast mode. We no longer support specific styling for high contrast mode.

This PR removes the following variables. Any references to them should be removed as they are no longer used in patternfly:

* `--pf-c-app-launcher__menu--BorderWidth`
* `--pf-c-context-selector__menu--BorderWidth`
* `--pf-c-dropdown__menu--BorderWidth`
* `--pf-c-modal-box--BorderColor`
* `--pf-c-modal-box--BorderSize`
* `--pf-c-options-menu__menu--BorderWidth`
* `--pf-c-select__menu--BorderWidth`