### PR TITLE
fix(wizard): reworked wizard so it can be used in modal

### DIFF
--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -6,7 +6,7 @@
   --pf-c-modal-box--MaxWidth: calc(100% - var(--pf-global--spacer--xl)); // Ensure modal has gutters at full width
   --pf-c-modal-box--m-sm--sm--MaxWidth: #{pf-size-prem(560px)}; // MaxWidth is based on optimal line length for reading
   --pf-c-modal-box--m-lg--lg--MaxWidth: #{pf-size-prem(1120px)};
-  --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
+  --pf-c-modal-box--MaxHeight: calc(100% - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
   // Header
   --pf-c-modal-box__title--LineHeight: var(--pf-global--LineHeight--sm);

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -283,169 +283,6 @@ import './Wizard.css'
 {{/wizard}}
 ```
 
-```hbs title=Full-width/height isFullscreen
-{{#> wizard wizard--modifier="pf-m-full-width pf-m-full-height"}}
-  {{#> wizard-header}}
-    {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-    {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
-    {{#> wizard-description}}
-      Here is where the description goes
-    {{/wizard-description}}
-  {{/wizard-header}}
-  {{#> wizard-toggle}}
-    {{#> wizard-toggle-list}}
-        {{#> wizard-toggle-list-item}}
-          {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
-          Configuration
-          {{> wizard-toggle-separator}}
-        {{/wizard-toggle-list-item}}
-        {{#> wizard-toggle-list-item}}
-          Substep B
-        {{/wizard-toggle-list-item}}
-      {{/wizard-toggle-list}}
-      {{> wizard-toggle-icon}}
-    {{/wizard-toggle}}
-    {{#> wizard-outer-wrap}}
-      {{#> wizard-inner-wrap}}
-        {{#> wizard-nav}}
-          {{#> wizard-nav-list}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Information
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
-                Configuration
-              {{/wizard-nav-link}}
-              {{#> wizard-nav-list}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep A
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrent="true"}}
-                    Substep B
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep C
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-              {{/wizard-nav-list}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Additional
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-disabled" wizard-nav-link--attribute='aria-disabled="true" tabindex="-1"'}}
-                Review
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-          {{/wizard-nav-list}}
-        {{/wizard-nav}}
-      {{#> wizard-main}}
-        <p>Wizard content goes here</p>
-      {{/wizard-main}}
-    {{/wizard-inner-wrap}}
-    {{#> wizard-footer}}
-      {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-        Next
-      {{/button}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Back
-      {{/button}}
-      {{#> button button--modifier="pf-m-link"}}
-        Cancel
-      {{/button}}
-    {{/wizard-footer}}
-  {{/wizard-outer-wrap}}
-{{/wizard}}
-```
-
-```hbs title=In-page
-{{#> wizard wizard--modifier="pf-m-in-page"}}
-  {{#> wizard-toggle}}
-    {{#> wizard-toggle-list}}
-        {{#> wizard-toggle-list-item}}
-          {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
-          Configuration
-          {{> wizard-toggle-separator}}
-        {{/wizard-toggle-list-item}}
-        {{#> wizard-toggle-list-item}}
-          Substep B
-        {{/wizard-toggle-list-item}}
-      {{/wizard-toggle-list}}
-      {{> wizard-toggle-icon}}
-    {{/wizard-toggle}}
-    {{#> wizard-outer-wrap}}
-      {{#> wizard-inner-wrap}}
-        {{#> wizard-nav}}
-          {{#> wizard-nav-list}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Information
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
-                Configuration
-              {{/wizard-nav-link}}
-              {{#> wizard-nav-list}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep A
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrent="true"}}
-                    Substep B
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-                {{#> wizard-nav-item}}
-                  {{#> wizard-nav-link}}
-                    Substep C
-                  {{/wizard-nav-link}}
-                {{/wizard-nav-item}}
-              {{/wizard-nav-list}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link}}
-                Additional
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-            {{#> wizard-nav-item}}
-              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-disabled" wizard-nav-link--attribute='aria-disabled="true" tabindex="-1"'}}
-                Review
-              {{/wizard-nav-link}}
-            {{/wizard-nav-item}}
-          {{/wizard-nav-list}}
-        {{/wizard-nav}}
-      {{#> wizard-main}}
-        <p>Wizard content goes here</p>
-      {{/wizard-main}}
-    {{/wizard-inner-wrap}}
-    {{#> wizard-footer}}
-      {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-        Next
-      {{/button}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Back
-      {{/button}}
-      {{#> button button--modifier="pf-m-link"}}
-        Cancel
-      {{/button}}
-    {{/wizard-footer}}
-  {{/wizard-outer-wrap}}
-{{/wizard}}
-```
-
 ## Documentation
 ### Accessibility
 | Attribute | Applied to | Outcome |
@@ -463,7 +300,7 @@ import './Wizard.css'
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-wizard` | `<div>` | Initiates the wizard component. **Required** |
-| `.pf-c-wizard__header` | `<header>` | Initiates the header. **Required** |
+| `.pf-c-wizard__header` | `<header>` | Initiates the header. **Required** when the wizard is in a modal. Not recommended to use when the wizard is placed on a page. |
 | `.pf-c-wizard__close` | `.pf-c-button.pf-m-plain` | Initiates the close button. **Required** |
 | `.pf-c-wizard__title` | `.pf-c-title.pf-m-3xl` | Initiates the title. **Required** |
 | `.pf-c-wizard__description` | `<p>` | Initiates the description. |
@@ -484,9 +321,6 @@ import './Wizard.css'
 | `.pf-c-wizard__footer` | `<footer>` | Initiates the footer. **Required** |
 | `.pf-m-expanded` | `.pf-c-wizard__toggle`, `.pf-c-wizard__nav` | Modifies the mobile steps toggle and steps menu for the expanded state. |
 | `.pf-m-finished` | `.pf-c-wizard` | Modifies the wizard for the finished state. |
-| `.pf-m-full-width` | `.pf-c-wizard` | Modifies the wizard to expand the full width of the viewport. |
-| `.pf-m-full-height` | `.pf-c-wizard` | Modifies the wizard to expand the full height of the viewport. |
-| `.pf-m-in-page` | `.pf-c-wizard` | Modifies wizard for use outside of a modal. |
 | `.pf-m-current` | `.pf-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |
 | `.pf-m-disabled` | `.pf-c-wizard__nav-link` | Modifies a step link for the disabled state. |
 | `.pf-m-no-padding` | `.pf-c-wizard__main-body` | Modifies the main container body to remove the padding. |

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,6 +1,6 @@
 .pf-c-wizard {
   --pf-c-wizard--Height: 100%;
-  --pf-c-modal-box--c-wizard--Height: #{pf-size-prem(762px)}; // this is a specific height from design for the wizard in a modal
+  --pf-c-modal-box--c-wizard--FlexBasis: #{pf-size-prem(762px)}; // this is a specific height from design for the wizard in a modal
 
   // Header
   --pf-c-wizard__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
@@ -192,9 +192,7 @@
 
   // When the wizard is used in a modal
   .pf-c-modal-box & {
-    --pf-c-wizard--Height: var(--pf-c-modal-box--c-wizard--Height);
-
-    max-height: var(--pf-c-modal-box--c-wizard--MaxHeight, inherit);
+    flex: 1 1 var(--pf-c-modal-box--c-wizard--FlexBasis);
   }
 
   > *:not(.pf-c-wizard__outer-wrap) {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,23 +1,6 @@
 .pf-c-wizard {
-  --pf-c-wizard--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-wizard--Height: 100%;
-  --pf-c-wizard--Width: 100vw;
-  --pf-c-wizard--lg--Width: calc(100% - (var(--pf-global--spacer--2xl) * 2));
-  --pf-c-wizard--lg--MaxWidth: #{pf-size-prem(1232px)}; // Shares with with about modal
-  --pf-c-wizard--lg--Height: #{pf-size-prem(762px)}; // Shares height with about modal
-  --pf-c-wizard--lg--MaxHeight: calc(100% - (var(--pf-global--spacer--2xl) * 2));
-  --pf-c-wizard--m-full-width--lg--MaxWidth: auto;
-  --pf-c-wizard--m-full-height--lg--Height: 100%;
-  --pf-c-wizard--m-in-page--BoxShadow: none;
-  --pf-c-wizard--m-in-page--Height: 100%;
-  --pf-c-wizard--m-in-page--Width: auto;
-  --pf-c-wizard--m-in-page--lg--MaxWidth: none;
-  --pf-c-wizard--m-in-page--lg--MaxHeight: none;
-
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-wizard--Width: var(--pf-c-wizard--lg--Width);
-    --pf-c-wizard--Height: var(--pf-c-wizard--lg--Height);
-  }
+  --pf-c-modal-box--c-wizard--Height: #{pf-size-prem(762px)};
 
   // Header
   --pf-c-wizard__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
@@ -26,22 +9,29 @@
   --pf-c-wizard__header--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard__header--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-wizard__header--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-wizard__header--lg--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-wizard__header--lg--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard__header--lg--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__header--lg--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-wizard__header--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard__header--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     --pf-c-wizard__header--PaddingRight: var(--pf-c-wizard__header--lg--PaddingRight);
     --pf-c-wizard__header--PaddingLeft: var(--pf-c-wizard__header--lg--PaddingLeft);
   }
 
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-wizard__header--PaddingRight: var(--pf-c-wizard__header--xl--PaddingRight);
+    --pf-c-wizard__header--PaddingLeft: var(--pf-c-wizard__header--xl--PaddingLeft);
+  }
+
   // Close
   --pf-c-wizard__close--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element));
   --pf-c-wizard__close--Right: 0;
-  --pf-c-wizard__close--lg--Right: var(--pf-global--spacer--md);
+  --pf-c-wizard__close--xl--Right: var(--pf-global--spacer--lg);
   --pf-c-wizard__close--FontSize: var(--pf-global--FontSize--xl);
 
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-wizard__close--Right: var(--pf-c-wizard__close--lg--Right);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-wizard__close--Right: var(--pf-c-wizard__close--xl--Right);
   }
 
   // Title
@@ -122,20 +112,31 @@
   }
 
   // Nav list (nested)
-  --pf-c-wizard__nav-list--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-wizard__nav-list--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-wizard__nav-list--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-wizard__nav-list--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-wizard__nav-list--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-wizard__nav-list--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
-  --pf-c-wizard__nav-list--lg--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-wizard__nav-list--lg--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
+  --pf-c-wizard__nav-list--lg--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-list--lg--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-list--lg--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-wizard__nav-list--xl--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-wizard__nav-list--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard__nav-list--xl--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-wizard__nav-list--xl--PaddingLeft: calc(var(--pf-global--spacer--lg) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
   --pf-c-wizard__nav-list--nested--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-wizard__nav-list--nested--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__nav-list--md--PaddingLeft: calc(var(--pf-global--spacer--md) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
-  --pf-c-wizard--m-in-page__nav-list--xl--PaddingLeft: calc(var(--pf-global--spacer--lg) + var(--pf-c-wizard__nav-link--before--Width) + var(--pf-global--spacer--sm));
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
+    --pf-c-wizard__nav-list--PaddingTop: var(--pf-c-wizard__nav-list--lg--PaddingTop);
     --pf-c-wizard__nav-list--PaddingRight: var(--pf-c-wizard__nav-list--lg--PaddingRight);
-    --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard__nav-list--lg--PaddingLeft);
+    --pf-c-wizard__nav-list--PaddingBottom: var(--pf-c-wizard__nav-list--lg--PaddingBottom);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-wizard__nav-list--PaddingTop: var(--pf-c-wizard__nav-list--xl--PaddingTop);
+    --pf-c-wizard__nav-list--PaddingRight: var(--pf-c-wizard__nav-list--xl--PaddingRight);
+    --pf-c-wizard__nav-list--PaddingBottom: var(--pf-c-wizard__nav-list--xl--PaddingBottom);
+    --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard__nav-list--xl--PaddingLeft);
   }
 
   // Nav item
@@ -153,22 +154,16 @@
   --pf-c-wizard__main-body--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard__main-body--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-wizard__main-body--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-wizard__main-body--lg--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-wizard__main-body--lg--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-wizard__main-body--lg--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-wizard__main-body--lg--PaddingLeft: var(--pf-global--spacer--xl);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__main-body--md--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__main-body--xl--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-wizard--m-in-page__main-body--xl--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-wizard__main-body--xl--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-wizard__main-body--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard__main-body--xl--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-wizard__main-body--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-wizard__main-body--PaddingTop: var(--pf-c-wizard__main-body--lg--PaddingTop);
-    --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard__main-body--lg--PaddingRight);
-    --pf-c-wizard__main-body--PaddingBottom: var(--pf-c-wizard__main-body--lg--PaddingBottom);
-    --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard__main-body--lg--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-wizard__main-body--PaddingTop: var(--pf-c-wizard__main-body--xl--PaddingTop);
+    --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard__main-body--xl--PaddingRight);
+    --pf-c-wizard__main-body--PaddingBottom: var(--pf-c-wizard__main-body--xl--PaddingBottom);
+    --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard__main-body--xl--PaddingLeft);
   }
 
   // Footer
@@ -176,44 +171,30 @@
   --pf-c-wizard__footer--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-wizard__footer--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-wizard__footer--lg--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-wizard__footer--lg--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-wizard__footer--lg--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-wizard__footer--lg--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-wizard__footer--xl--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-wizard__footer--xl--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-wizard__footer--xl--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-wizard__footer--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-wizard__footer--child--MarginRight: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--child--MarginBottom: var(--pf-global--spacer--sm);
-  --pf-c-wizard--m-in-page__footer--md--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__footer--md--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__footer--md--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-wizard--m-in-page__footer--md--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-wizard--m-in-page__footer--xl--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-wizard--m-in-page__footer--xl--PaddingLeft: var(--pf-global--spacer--lg);
 
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    --pf-c-wizard__footer--PaddingTop: var(--pf-c-wizard__footer--lg--PaddingTop);
-    --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard__footer--lg--PaddingRight);
-    --pf-c-wizard__footer--PaddingBottom: var(--pf-c-wizard__footer--lg--PaddingBottom);
-    --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard__footer--lg--PaddingLeft);
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-wizard__footer--PaddingTop: var(--pf-c-wizard__footer--xl--PaddingTop);
+    --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard__footer--xl--PaddingRight);
+    --pf-c-wizard__footer--PaddingBottom: var(--pf-c-wizard__footer--xl--PaddingBottom);
+    --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard__footer--xl--PaddingLeft);
   }
 
   position: relative;
   display: flex;
   flex-direction: column;
-  width: var(--pf-c-wizard--Width);
   height: var(--pf-c-wizard--Height);
-  box-shadow: var(--pf-c-wizard--BoxShadow);
 
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    max-width: var(--pf-c-wizard--lg--MaxWidth);
-    max-height: var(--pf-c-wizard--lg--MaxHeight);
+  // When the wizard is used in a modal
+  .pf-c-modal-box & {
+    --pf-c-wizard--Height: var(--pf-c-modal-box--c-wizard--Height);
 
-    &.pf-m-full-width {
-      --pf-c-wizard--lg--MaxWidth: var(--pf-c-wizard--m-full-width--lg--MaxWidth);
-    }
-
-    &.pf-m-full-height {
-      --pf-c-wizard--lg--Height: var(--pf-c-wizard--m-full-height--lg--Height);
-    }
+    max-height: var(--pf-c-modal-box--c-wizard--MaxHeight, inherit);
   }
 
   > *:not(.pf-c-wizard__outer-wrap) {
@@ -228,38 +209,6 @@
     .pf-c-wizard__toggle {
       display: none;
       visibility: hidden;
-    }
-  }
-
-  &.pf-m-in-page {
-    --pf-c-wizard--Height: var(--pf-c-wizard--m-in-page--Height);
-    --pf-c-wizard--BoxShadow: var(--pf-c-wizard--m-in-page--BoxShadow);
-    --pf-c-wizard--Width: var(--pf-c-wizard--m-in-page--Width);
-
-    @media screen and (min-width: $pf-global--breakpoint--md) {
-      --pf-c-wizard__main-body--PaddingTop: var(--pf-c-wizard--m-in-page__main-body--md--PaddingTop);
-      --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard--m-in-page__main-body--md--PaddingRight);
-      --pf-c-wizard__main-body--PaddingBottom: var(--pf-c-wizard--m-in-page__main-body--md--PaddingBottom);
-      --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard--m-in-page__main-body--md--PaddingLeft);
-      --pf-c-wizard__footer--PaddingTop: var(--pf-c-wizard--m-in-page__footer--md--PaddingTop);
-      --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard--m-in-page__footer--md--PaddingRight);
-      --pf-c-wizard__footer--PaddingBottom: var(--pf-c-wizard--m-in-page__footer--md--PaddingBottom);
-      --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard--m-in-page__footer--md--PaddingLeft);
-      --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard--m-in-page__nav-list--md--PaddingLeft);
-    }
-
-    @media screen and (min-width: $pf-global--breakpoint--xl) {
-      --pf-c-wizard__main-body--PaddingRight: var(--pf-c-wizard--m-in-page__main-body--xl--PaddingRight);
-      --pf-c-wizard__main-body--PaddingLeft: var(--pf-c-wizard--m-in-page__main-body--xl--PaddingLeft);
-      --pf-c-wizard__footer--PaddingRight: var(--pf-c-wizard--m-in-page__footer--xl--PaddingRight);
-      --pf-c-wizard__footer--PaddingLeft: var(--pf-c-wizard--m-in-page__footer--xl--PaddingLeft);
-      --pf-c-wizard__toggle--PaddingLeft: var(--pf-c-wizard--m-in-page__toggle--xl--PaddingLeft);
-      --pf-c-wizard__nav-list--PaddingLeft: var(--pf-c-wizard--m-in-page__nav-list--xl--PaddingLeft);
-    }
-
-    @media screen and (min-width: $pf-global--breakpoint--lg) {
-      --pf-c-wizard--lg--MaxWidth: var(--pf-c-wizard--m-in-page--lg--MaxWidth);
-      --pf-c-wizard--lg--MaxHeight: var(--pf-c-wizard--m-in-page--lg--MaxHeight);
     }
   }
 }
@@ -477,13 +426,11 @@
     counter-increment: wizard-nav-count;
   }
 
-  &:hover,
-  &.pf-m-hover {
+  &:hover {
     --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--hover--Color);
   }
 
-  &:focus,
-  &.pf-m-focus {
+  &:focus {
     --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--focus--Color);
   }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,6 +1,6 @@
 .pf-c-wizard {
   --pf-c-wizard--Height: 100%;
-  --pf-c-modal-box--c-wizard--Height: #{pf-size-prem(762px)};
+  --pf-c-modal-box--c-wizard--Height: #{pf-size-prem(762px)}; // this is a specific height from design for the wizard in a modal
 
   // Header
   --pf-c-wizard__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -12,9 +12,9 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header modal-box-header--attribute='id="modal-title"'}}
+        {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
           Overwrite existing file?
-        {{/modal-box-header}}
+        {{/modal-box-title}}
         {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
@@ -41,9 +41,9 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header  modal-box-header--attribute='id="modal-scroll-title"'}}
+        {{#> modal-box-title  modal-box-title--attribute='id="modal-scroll-title"'}}
           This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/modal-box-header}}
+        {{/modal-box-title}}
         {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
           This is a modal description. The description will not scroll with the body contents.
         {{/modal-box-description}}
@@ -80,9 +80,9 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header modal-box-header--attribute='id="modal-lg-title"'}}
+        {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
           This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/modal-box-header}}
+        {{/modal-box-title}}
         {{#> modal-box-body}}
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
           <p>Form here</p>

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -330,7 +330,7 @@ section: demos
       {{/button}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
         Manage columns
-      {{/modal-box-header}}
+      {{/modal-box-title}}
       {{#> modal-box-description}}
         {{#> content}}
           <p>Selected categories will be displayed in the table.</p>

--- a/src/patternfly/demos/Wizard/examples/Wizard.md
+++ b/src/patternfly/demos/Wizard/examples/Wizard.md
@@ -7,18 +7,111 @@ section: demos
 ```hbs title=Basic isFullscreen
 {{#> backdrop}}
   {{#> bullseye}}
-    {{#> wizard}}
-      {{#> wizard-header}}
-        {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
-          <i class="fas fa-times" aria-hidden="true"></i>
-        {{/button}}
-        {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
-        {{#> wizard-description}}
-          Here is where the description goes
-        {{/wizard-description}}
-      {{/wizard-header}}
-      {{#> wizard-toggle}}
-        {{#> wizard-toggle-list}}
+    {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-label="Basic wizard"'}}
+      {{#> wizard}}
+        {{#> wizard-header}}
+          {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
+            <i class="fas fa-times" aria-hidden="true"></i>
+          {{/button}}
+          {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
+          {{#> wizard-description}}
+            Here is where the description goes
+          {{/wizard-description}}
+        {{/wizard-header}}
+        {{#> wizard-toggle}}
+          {{#> wizard-toggle-list}}
+              {{#> wizard-toggle-list-item}}
+                {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
+                Configuration
+                {{> wizard-toggle-separator}}
+              {{/wizard-toggle-list-item}}
+              {{#> wizard-toggle-list-item}}
+                Substep B
+              {{/wizard-toggle-list-item}}
+            {{/wizard-toggle-list}}
+            {{> wizard-toggle-icon}}
+          {{/wizard-toggle}}
+          {{#> wizard-outer-wrap}}
+            {{#> wizard-inner-wrap}}
+              {{#> wizard-nav}}
+                {{#> wizard-nav-list}}
+                  {{#> wizard-nav-item}}
+                    {{#> wizard-nav-link}}
+                      Information
+                    {{/wizard-nav-link}}
+                  {{/wizard-nav-item}}
+                  {{#> wizard-nav-item}}
+                    {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
+                      Configuration
+                    {{/wizard-nav-link}}
+                    {{#> wizard-nav-list}}
+                      {{#> wizard-nav-item}}
+                        {{#> wizard-nav-link}}
+                          Substep A
+                        {{/wizard-nav-link}}
+                      {{/wizard-nav-item}}
+                      {{#> wizard-nav-item}}
+                        {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrent="true"}}
+                          Substep B
+                        {{/wizard-nav-link}}
+                      {{/wizard-nav-item}}
+                      {{#> wizard-nav-item}}
+                        {{#> wizard-nav-link}}
+                          Substep C
+                        {{/wizard-nav-link}}
+                      {{/wizard-nav-item}}
+                    {{/wizard-nav-list}}
+                  {{/wizard-nav-item}}
+                  {{#> wizard-nav-item}}
+                    {{#> wizard-nav-link}}
+                      Additional
+                    {{/wizard-nav-link}}
+                  {{/wizard-nav-item}}
+                  {{#> wizard-nav-item}}
+                    {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-disabled" wizard-nav-link--attribute='aria-disabled="true" tabindex="-1"'}}
+                      Review
+                    {{/wizard-nav-link}}
+                  {{/wizard-nav-item}}
+                {{/wizard-nav-list}}
+              {{/wizard-nav}}
+            {{#> wizard-main}}
+              <p>Wizard content goes here</p>
+            {{/wizard-main}}
+          {{/wizard-inner-wrap}}
+          {{#> wizard-footer}}
+            {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+              Next
+            {{/button}}
+            {{#> button button--modifier="pf-m-secondary"}}
+              Back
+            {{/button}}
+            {{#> button button--modifier="pf-m-link"}}
+              Cancel
+            {{/button}}
+          {{/wizard-footer}}
+        {{/wizard-outer-wrap}}
+      {{/wizard}}
+    {{/modal-box}}
+  {{/bullseye}}
+{{/backdrop}}
+```
+
+```hbs title=Nav-expanded-(mobile) isFullscreen
+{{#> backdrop}}
+  {{#> bullseye}}
+    {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-label="Wizard with expanded mobile nav"'}}
+      {{#> wizard wizard--IsExpanded="true"}}
+        {{#> wizard-header}}
+          {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
+            <i class="fas fa-times" aria-hidden="true"></i>
+          {{/button}}
+          {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
+          {{#> wizard-description}}
+            Here is where the description goes
+          {{/wizard-description}}
+        {{/wizard-header}}
+        {{#> wizard-toggle}}
+          {{#> wizard-toggle-list}}
             {{#> wizard-toggle-list-item}}
               {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
               Configuration
@@ -73,113 +166,24 @@ section: demos
                 {{/wizard-nav-item}}
               {{/wizard-nav-list}}
             {{/wizard-nav}}
-          {{#> wizard-main}}
-            <p>Wizard content goes here</p>
-          {{/wizard-main}}
-        {{/wizard-inner-wrap}}
-        {{#> wizard-footer}}
-          {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Next
-          {{/button}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Back
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Cancel
-          {{/button}}
-        {{/wizard-footer}}
-      {{/wizard-outer-wrap}}
-    {{/wizard}}
-  {{/bullseye}}
-{{/backdrop}}
-```
-
-```hbs title=Nav-expanded-(mobile) isFullscreen
-{{#> backdrop}}
-  {{#> bullseye}}
-    {{#> wizard wizard--IsExpanded="true"}}
-      {{#> wizard-header}}
-        {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
-          <i class="fas fa-times" aria-hidden="true"></i>
-        {{/button}}
-        {{#> title title--modifier="pf-m-3xl pf-c-wizard__title"}}Wizard title{{/title}}
-        {{#> wizard-description}}
-          Here is where the description goes
-        {{/wizard-description}}
-      {{/wizard-header}}
-      {{#> wizard-toggle}}
-        {{#> wizard-toggle-list}}
-          {{#> wizard-toggle-list-item}}
-            {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
-            Configuration
-            {{> wizard-toggle-separator}}
-          {{/wizard-toggle-list-item}}
-          {{#> wizard-toggle-list-item}}
-            Substep B
-          {{/wizard-toggle-list-item}}
-        {{/wizard-toggle-list}}
-        {{> wizard-toggle-icon}}
-      {{/wizard-toggle}}
-      {{#> wizard-outer-wrap}}
-        {{#> wizard-inner-wrap}}
-          {{#> wizard-nav}}
-            {{#> wizard-nav-list}}
-              {{#> wizard-nav-item}}
-                {{#> wizard-nav-link}}
-                  Information
-                {{/wizard-nav-link}}
-              {{/wizard-nav-item}}
-              {{#> wizard-nav-item}}
-                {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
-                  Configuration
-                {{/wizard-nav-link}}
-                {{#> wizard-nav-list}}
-                  {{#> wizard-nav-item}}
-                    {{#> wizard-nav-link}}
-                      Substep A
-                    {{/wizard-nav-link}}
-                  {{/wizard-nav-item}}
-                  {{#> wizard-nav-item}}
-                    {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrent="true"}}
-                      Substep B
-                    {{/wizard-nav-link}}
-                  {{/wizard-nav-item}}
-                  {{#> wizard-nav-item}}
-                    {{#> wizard-nav-link}}
-                      Substep C
-                    {{/wizard-nav-link}}
-                  {{/wizard-nav-item}}
-                {{/wizard-nav-list}}
-              {{/wizard-nav-item}}
-              {{#> wizard-nav-item}}
-                {{#> wizard-nav-link}}
-                  Additional
-                {{/wizard-nav-link}}
-              {{/wizard-nav-item}}
-              {{#> wizard-nav-item}}
-                {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-disabled" wizard-nav-link--attribute='aria-disabled="true" tabindex="-1"'}}
-                  Review
-                {{/wizard-nav-link}}
-              {{/wizard-nav-item}}
-            {{/wizard-nav-list}}
-          {{/wizard-nav}}
-          {{#> wizard-main}}
-            <p>Wizard content goes here</p>
-          {{/wizard-main}}
-        {{/wizard-inner-wrap}}
-        {{#> wizard-footer}}
-          {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Next
-          {{/button}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Back
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Cancel
-          {{/button}}
-        {{/wizard-footer}}
-      {{/wizard-outer-wrap}}
-    {{/wizard}}
+            {{#> wizard-main}}
+              <p>Wizard content goes here</p>
+            {{/wizard-main}}
+          {{/wizard-inner-wrap}}
+          {{#> wizard-footer}}
+            {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+              Next
+            {{/button}}
+            {{#> button button--modifier="pf-m-secondary"}}
+              Back
+            {{/button}}
+            {{#> button button--modifier="pf-m-link"}}
+              Cancel
+            {{/button}}
+          {{/wizard-footer}}
+        {{/wizard-outer-wrap}}
+      {{/wizard}}
+    {{/modal-box}}
   {{/bullseye}}
 {{/backdrop}}
 ```
@@ -243,7 +247,7 @@ section: demos
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-main-wizard}}
-      {{#> wizard wizard--modifier="pf-m-in-page"}}
+      {{#> wizard}}
         {{#> wizard-toggle}}
           {{#> wizard-toggle-list}}
               {{#> wizard-toggle-list-item}}
@@ -381,7 +385,7 @@ section: demos
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-main-wizard}}
-      {{#> wizard wizard--modifier="pf-m-in-page" wizard--IsExpanded="true"}}
+      {{#> wizard wizard--IsExpanded="true"}}
         {{#> wizard-toggle}}
           {{#> wizard-toggle-list}}
               {{#> wizard-toggle-list-item}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2046

@tlabaj @mcarrano this is pretty straight forward except for one thing. The wizard when used in a modal needs a defined height, otherwise the height will be defined by the wizard contents and will change as a user progresses through the wizard. There are a couple of ways we can do this.

1) Assign a height to the wizard for use when it's in a modal, then modify that height when the wizard is used in context of the page (the "in page" variation). This seems to work just fine and allows us to define a specific height for the wizard (that the user can override), but it means that we need to maintain separate variations of the wizard for use in the page and in a modal. The user impact is that the user has to specify the modal width when using a modal, and they have to specify the "in page" variation when using the modal in a page.

2) Add an enhancement to the modal to define a modal height (that is overridable by the user, similar to the height variations we currently offer) and allow that to set the wizard modal height. The wizard can then simply occupy the height of the container it's in both the modal and in page variations, meaning we could do away with the in page wizard variation. The user impact of this is that the user must specify both the width and height when using a modal, but doesn't have to specify a variation of the wizard to use in either context.

WDYT?