### PR TITLE
fix(table-row-height): fixed borders, row height, focus

### DIFF
--- a/src/patternfly/components/Table/examples/Table.css
+++ b/src/patternfly/components/Table/examples/Table.css
@@ -5,6 +5,6 @@
 
 #ws-core-c-table-th-truncation .pf-c-tooltip {
   position: absolute;
-  left: 486px;
+  left: 458px;
   top: -20px;
 }

--- a/src/patternfly/components/Table/examples/Table.css
+++ b/src/patternfly/components/Table/examples/Table.css
@@ -1,0 +1,10 @@
+#ws-core-c-table-th-truncation {
+  position: relative;
+  width: 800px;
+}
+
+#ws-core-c-table-th-truncation .pf-c-tooltip {
+  position: absolute;
+  left: 486px;
+  top: -20px;
+}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -299,10 +299,10 @@ import './Table.css'
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -327,10 +327,10 @@ import './Table.css'
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -355,10 +355,10 @@ import './Table.css'
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -435,10 +435,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{concat table--id '-node1'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node1">Node 1</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -474,10 +474,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -511,10 +511,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -547,10 +547,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1372,10 +1372,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{table--id}}-node2">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1396,10 +1396,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{table--id}}-node3">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1420,10 +1420,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{table--id}}-node4">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        {{#> table-cell-content}}
+        <div>
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        {{/table-cell-content}}
+        </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1603,40 +1603,6 @@ To better control table cell behavior, PatternFly provides a series of modifiers
       {{/table-td}}
       {{#> table-td table-td--modifier="pf-m-nowrap" table-td--data-label="No wrap"}}
         <a href="#">No wrap</a>
-      {{/table-td}}
-    {{/table-tr}}
-  {{/table-tbody}}
-{{/table}}
-```
-
-## Custom text control `.pf-c-table__cell-content`
-
-For granular control over text elements, `.pf-c-table__cell-content` is available. The `.pf-c-table__cell-content` element breaks content text out of the table flow and allows content to respond to `.pf-m-width-` modifiers set on parent elements. It also allows for content customization and individual `.pf-c-table__text` modifications. Modifiers can be applied to the parent `cell` or individual `.pf-c-table__text` elements.
-
-```hbs title=Controlling-text-elements-individually
-{{#> table table--id="controlling-text-elements-individually" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with custom text wrappers example."'}}
-  {{#> table-thead}}
-    {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Custom text cells
-      {{/table-th}}
-    {{/table-tr}}
-  {{/table-thead}}
-
-  {{#> table-tbody}}
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="No wrapping"}}
-        {{#> table-cell-content}}
-          {{#> table-text table-text--type="div" table-text--modifier="pf-m-truncate"}}
-            This cell's contents will truncate. Here's some more text to demonstrate how.
-          {{/table-text}}
-          {{#> table-text table-text--type="div" table-text--modifier="pf-m-nowrap"}}
-            <a href="#">No wrap link example</a>
-          {{/table-text}}
-          {{#> table-text table-text--type="div"}}
-            This cell's contents will wrap. Here's some more text to demonstrate how.
-          {{/table-text}}
-        {{/table-cell-content}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -625,11 +625,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
     {{/table-tr}}
   {{/table-thead}}
 
-  {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
+  {{#> table-tbody}}
     {{#> table-tr table-tr--expanded="true"}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
-      {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;10
       {{/table-td}}
@@ -641,6 +638,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         4
       {{/table-td}}
+      {{#> table-th table-th--data-label="Repository name"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>20 minutes</span>
       {{/table-td}}
@@ -677,9 +677,6 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
-      {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-4"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
         2
@@ -692,6 +689,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         1
       {{/table-td}}
+      {{#> table-th table-th--data-label="Repository name"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>1 day ago</span>
       {{/table-td}}
@@ -728,9 +728,6 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-th table-th--data-label="Repository name"}}
-        <a href="#">siemur/test-space</a>
-      {{/table-th}}
       {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-7"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
         4
@@ -743,6 +740,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         1
       {{/table-td}}
+      {{#> table-th table-th--data-label="Repository name"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>2 days ago</span>
       {{/table-td}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -4,8 +4,11 @@ section: components
 cssPrefix: pf-c-table
 ---
 
+import './Table.css'
+
 ## Examples
-```hbs title=Basic
+
+```hbs title=Basic-table
 {{#> table table--id="table-basic" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a simple table example"'}}
   {{#> table-caption}}
     This is the table caption
@@ -105,7 +108,9 @@ cssPrefix: pf-c-table
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `role="grid"` | `.pf-c-table` | Identifies the element that serves as the grid widget container. **Required** |
@@ -118,7 +123,6 @@ cssPrefix: pf-c-table
 | -- | -- | -- |
 | `.pf-c-table` | `<table>` | Initiates a table element. **Required** |
 | `.pf-c-table__caption` | `<caption>` | Initiates a table caption. |
-| `.pf-m-height-auto` | `<tr>` | Modifies a `<tr>` to have `height: auto`, which undoes the `height` declaration currently on `<tr>` elements. |
 | `.pf-m-center` | `<th>`, `<td>` | Modifies cell to center its contents. |
 
 ```hbs title=Sortable
@@ -219,62 +223,21 @@ cssPrefix: pf-c-table
 {{/table}}
 ```
 
-```hbs title=Sortable-with-headers-that-wrap
-{{#> table table--id="table-sortable-wrap" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="This is a sortable table example with headers that wrap"'}}
-  {{#> table-thead}}
-    {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--sortable-wrap="true" table-th--selected="true" table-th--asc="true"}}
-        This is a really long sortable table header.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--sortable-wrap="true"}}
-        This is a really long sortable table header.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--sortable-wrap="true"}}
-        This is a really long sortable table header.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header.
-      {{/table-th}}
-    {{/table-tr}}
-  {{/table-thead}}
-
-  {{#> table-tbody}}
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="Repository name"}}
-        Repository 1
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Branches"}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Pull requests"}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Last commit"}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-  {{/table-tbody}}
-{{/table}}
-```
-
 ### Accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-sort=[ascending or descending]` | `.pf-c-table__sort` | Indicates if columns in a table are sorted in ascending or descending order. For each table, authors __SHOULD__ apply aria-sort to only one header at a time. **Required** |
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-table__sort` | `<th>` | Initiates a sort table cell. **Required for sortable table columns** |
-| `.pf-c-table__sort-text` | `.pf-c-table__sort > button > span` | Initiates the text wrapper inside of a sortable table cell. **Required for sortable table columns** |
+| `.pf-c-table__sort` | `<th>` | Initiates a table header sort cell. **Required for sortable table columns** |
+| `.pf-c-table__button` | `<button>` | Initiates a table header sort cell button. **Required for sortable table columns** |
+| `.pf-c-table__button-content` | `.pf-c-table__button` | Initiates a table header sort cell button content container. **Required for sortable table columns** Note: this is only necessary because `<button>` does not support`display: grid`. |
 | `.pf-c-table__sort-indicator` | `.pf-c-table__sort > button > span` | Initiates a sort indicator. **Required for sortable table columns** |
 | `.pf-m-selected` | `.pf-c-table__sort` | Modifies for sort selected state. **Required for sortable table columns** |
-| `.pf-m-wrap` | `.pf-c-table__sort`| Modifies the sortable table header to wrap. |
 | `.fa-arrows-alt-v` | `.pf-c-table__sort > button > span > .fas` | Initiates icon within unsorted, sortable table header. **Required for sortable table columns** |
 | `.fa-long-arrow-alt-up` | `.pf-c-table__sort > button > span > .fas` | Initiates icon within ascending sorted and selected, sortable table header. **Required for sortable table columns** |
 | `.fa-long-arrow-alt-down` | `.pf-c-table__sort > button > span > .fas` | Initiates icon within descending sorted and selected, sortable table header. **Required for sortable table columns** |
@@ -301,7 +264,7 @@ cssPrefix: pf-c-table
       {{#> table-th table-th--attribute='scope="col"'}}
         Last commit
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -336,10 +299,10 @@ cssPrefix: pf-c-table
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -364,10 +327,10 @@ cssPrefix: pf-c-table
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -392,10 +355,10 @@ cssPrefix: pf-c-table
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -417,19 +380,26 @@ cssPrefix: pf-c-table
   {{/table-tbody}}
 {{/table}}
 ```
+
 When including interactive elements in a table, the primary, descriptive cell in the corresponding row is a `<th>`, rather than a `<td>`. In this example, 'Node 1' and 'Node 2 siemur/test-space' are `<th>`s.
 
 When header cells are empty or they contain interactive elements, `<th>` should be replaced with `<td>`.
+
 ### Thead accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-label="[descriptive text]"` | `.pf-c-table__check input[type="checkbox"]` | Provides an accessible name for the checkbox. **Required** |
+
 ### Tbody accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-labelledby="[row_header_id]"` or `aria-label="[descriptive text]` | `.pf-c-table__check input[type="checkbox"]` | Provides an accessible name for the checkbox. **Required** |
 | `id` | row header `<th>` > `*` | Provides an accessible description for the checkbox. **Required if using `aria-labelledby` for `.pf-c-table__check input[type="checkbox"]`** |
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-table__check` | `<th>`, `<td>` | Initiates a check table cell. |
@@ -440,7 +410,7 @@ When header cells are empty or they contain interactive elements, `<th>` should 
 {{#> table table--id="table-expandable" table--grid="true" table--modifier="pf-m-grid-lg" table--expandable="true" table--attribute='aria-label="Expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-check-all" aria-label="Select all rows">
       {{/table-td}}
@@ -453,8 +423,8 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}
         Pull requests
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -465,10 +435,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow1" aria-labelledby="{{concat table--id '-node1'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node1">Node 1</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -486,14 +456,14 @@ When header cells are empty or they contain interactive elements, `<th>` should 
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content1"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
       {{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-tbody}}
 
@@ -504,10 +474,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{concat table--id '-node2'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -541,10 +511,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -577,10 +547,10 @@ When header cells are empty or they contain interactive elements, `<th>` should 
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{concat table--id '-node4'}}">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -607,9 +577,11 @@ When header cells are empty or they contain interactive elements, `<th>` should 
   {{/table-tbody}}
 {{/table}}
 ```
+
 Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.pf-c-table__expandable-row-content`. For no padding add `.pf-m-no-padding` to `.pf-c-table__expandable-row` > `<td>`
 
 ### Accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `hidden` | `.pf-c-table__expandable-row` | Indicates that the expandable content is hidden. **Required** |
@@ -620,6 +592,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 | `aria-controls="[id of element the button controls]"` | `.pf-c-table__toggle` > `.pf-c-button` | Identifies the expanded content controlled by the toggle button. **Required** |
 
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-table__toggle-icon` | `<span>` | Initiates the table toggle icon wrapper. |
@@ -632,7 +605,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{#> table table--id="table-compound-expansion" table--grid="true" table--modifier="pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Compound expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true" table-th--modifier="pf-m-width-30"}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true"}}
         Repositories
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}
@@ -647,8 +620,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--attribute='scope="col"'}}
        Last commit
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -657,29 +630,16 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          10
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;10
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        234
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-3"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        4
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>20 minutes</span>
@@ -720,29 +680,17 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          3
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-4"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
+        2
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-5"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        82
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          2
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-6"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        1
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>1 day ago</span>
@@ -780,32 +728,20 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-       {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          70
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-7"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
+        4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          15
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-8"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          12
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-9"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        1
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>2 days ago</span>
@@ -842,13 +778,17 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Accessibility
+
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `hidden` | `.pf-c-table__expandable-row` | Indicates that the expandable content is hidden. **Required** |
 | `aria-expanded="true"` | `.pf-c-table__compound-expansion-toggle` > `.pf-c-button` | Indicates that the row is visible. **Required**|
 | `aria-controls="[id of element the button controls]"` | `.pf-c-table__compound-expansion-toggle` > `.pf-c-button` | Identifies the expanded content controlled by the toggle button. **Required** |
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-expanded` | `<tbody>`, `.pf-c-table__compound-expansion-toggle` > `.pf-c-button` | Modifies a tbody with a row and an expandable row. |
@@ -879,8 +819,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--attribute='scope="col"' table-th--icon="true"}}
         Icons
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -1011,7 +951,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-compact` | `.pf-c-table` | Modifies for a compact table. |
@@ -1041,8 +983,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--attribute='scope="col"' table-th--icon="true"}}
         Icons
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -1173,7 +1115,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-no-border-rows` | `.pf-c-table.pf-m-compact` | Modifies to remove borders between rows. **Note: Can not be used with `.pf-m-expandable`.** |
@@ -1182,7 +1126,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{#> table table--id="table-compact-expandable" table--grid="true" table--modifier="pf-m-compact pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Compact expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-check-all" aria-label="Select all rows">
       {{/table-td}}
@@ -1195,8 +1139,8 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-th table-th--attribute='scope="col"'}}
         Pull requests
       {{/table-th}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
-      {{#> table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -1232,7 +1176,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
       {{/table-td}}
-      {{#> table-td table-td table-td--IsEmpty="true"}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-tbody}}
 
@@ -1369,7 +1313,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-expandable` | `.pf-c-table.pf-m-compact` | Indicates that the table has expandable rows. **Note: Can not be used with `.pf-m-no-border-rows`.** |
@@ -1381,7 +1327,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-check-all" aria-label="Check all rows">
       {{/table-td}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true" table-th--modifier="pf-m-width-40"}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true" table-th--modifier="pf-m-width-30"}}
         Repositories
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}
@@ -1426,10 +1372,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow2" aria-labelledby="{{table--id}}-node2">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1450,10 +1396,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow3" aria-labelledby="{{table--id}}-node3">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1474,10 +1420,10 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
         <input type="checkbox" name="{{table--id}}-checkrow4" aria-labelledby="{{table--id}}-node4">
       {{/table-td}}
       {{#> table-th table-th--data-label="Repository name"}}
-        <div>
+        {{#> table-cell-content}}
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
-        </div>
+        {{/table-cell-content}}
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -1495,7 +1441,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-width-[10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, or 90]` | `<th>`, `<td>` | Percentage based modifier for `th` and `td` widths. **Recommended for sortable title cell** |
@@ -1599,7 +1547,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
 ### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-hidden{-on-[breakpoint]}` | `.pf-c-table tr > *` | Hides a table cell at a given breakpoint, or hides it at all breakpoints with `.pf-m-hidden`. **Note: Needs to apply to all cells in the column you want to hide.** |
@@ -1705,12 +1655,293 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-tbody}}
 {{/table}}
 ```
+
+## Controlling text
+
+To better control table cell behavior, PatternFly provides a series of modifiers to help contextually control layout. By default, `thead` cells are set to truncate, whereas `tbody` cells are set to wrap. Both `th` and `td` cells use a set of shared css properties mapped to customizable css variable values. Because only the shared css variables are changed by the modifier selector and not the properties, the modifier can be applied to any parent element up until `.pf-c-table` itself [`thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text`].
+
+<ul>
+  <li>
+    <b>pf-m-wrap:</b> Sets text to wrap. This is the default behavior for <code>tbody</code> cells.
+  </li>
+  <li>
+    <b>pf-m-truncate:</b> Sets text to truncate based on a minimum width and available space adjacent table cells. This is the default behavior for <code>thead</code> cells.
+  </li>
+  <li>
+    <b>pf-m-no-wrap:</b> Unsets min/max width and sets whitespace to nowrap. This is specifically beneficial for cell's whose <code>thead th</code> cells are blank. The following example highlights link text that should display inline. Be careful with this modifier, it will prioritize its cell's content above all other cell's contents.
+  </li>
+  <li>
+    <b>pf-m-fit-content:</b> Fit column width to cell content.
+  </li>
+  <li>
+    <b>pf-m-break-word:</b> Breaks long strings wherever necessary as defined by the table layout.
+  </li>
+</ul>
+
+```hbs title=Modifiers-without-text-wrapper
+{{#> table table--id="modifiers-without-text-wrapper-example" table--attribute='aria-label="This is a simple table example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-width-20"}}
+        Truncate (width 20%)
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Break word
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
+        Wrapping table header text. This <code>th</code> text will wrap instead of truncate.
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-fit-content"}}
+        Fit content
+      {{/table-th}}
+      {{> table-td table-td--IsEmpty="true"}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-truncate" table-td--data-label="Truncating text"}}
+        This text will truncate instead of wrap.
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-break-word" table-td--data-label="Break word"}}
+        <a href="#">http://thisisaverylongurlthatneedstobreakusethebreakwordmodifier.org</a>
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Wrapping"}}
+        <p>By default, <code>thead</code> cells will truncate and <code>tbody</code> cells will wrap. Use <code>.pf-m-wrap</code> on a <code>th</code> to change its behavior.</p>
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Fit content"}}
+        This cell's content will adjust itself to the parent th width. This modifier only affects table layouts.
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-no-wrap" table-td--data-label="No wrap"}}
+        <a href="#">No wrap</a>
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+## `.pf-c-table__text`: Table text element. For `.pf-m-truncate` and `.pf-m-no-wrap` modifiers to apply to the grid layout, `td` content must be wrapped with `.pf-c-table__text`.
+
+```hbs title=Modifiers-with-text-wrapper
+{{#> table table--id="modifiers-with-text-wrapper-example" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="This is a simple table example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-width-30"}}
+        Truncating text
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
+        Wrapping table header text. This <code>th</code> text will wrap instead of truncate.
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-truncate" table-td--data-label="Truncating text"}}
+        {{#> table-text}}
+          This text will truncate instead of wrap.
+        {{/table-text}}
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-no-wrap" table-td--data-label="No wrap"}}
+        {{#> table-text}}
+          <a href="#">This is a link that needs to be on one line and fully readable.</a>
+        {{/table-text}}
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
 ### Usage
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-table__text` | `th > *`, `td > *`, `.pf-c-table__text-content > *` | Initiates a table text element. |
+| `.pf-m-truncate` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to truncate. |
+| `.pf-m-no-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to not wrap. |
+| `.pf-m-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to wrap. |
+| `.pf-m-fit-content` | `thead`, `tr`, `th`, `.pf-c-table__text` | Modifies `th` to fit its contents. |
+| `.pf-m-break-word` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text strings to break. |
+
+```hbs title=th-truncation
+{{#> tooltip tooltip--modifier="pf-m-top"}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-top-content"'}}
+    Pull Requests
+  {{/tooltip-content}}
+{{/tooltip}}
+{{#> table table--id="th-truncation-example" table--attribute='aria-label="This is a simple table example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier=""}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Workspaces
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Last commit
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Long lines of text will shrink adjacent column widths.
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        This example is not responsive. Adjacent <code>tbody</code> cells will shrink as a result of this text being a longer string and adjacent text being shorter in length. Truncation can be overridden in <code>th</code> cells with the addition of <code>.pf-m-wrap</code>, <code>.pf-m-no-wrap</code> or <code>.pf-m-fit-content</code>.
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+## Long strings in table cells will push content. Add a width modifier to `thead th` to limit string length or add `.pf-m-truncate` to `tbody td`.
+
+```hbs title=Width-constrained
+{{#> table table--id="width-constrained-example" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a simple table example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-width-40"}}
+        Width 40
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-fit-content" table-th--attribute='scope="col"'}}
+        Fit content th
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Last commit
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Since this is a long string of text and the other cells contain short strings (narrower than their table header), we'll need to control width this table header's width. Let's set width to 40%.
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-truncate" table-td--data-label="Repository name"}}
+        This string will truncate in table mode only. Since this is a long string of text and the other cells contain short strings (narrower than their table header), we'll need to control width this table header's width. Let's set width to 40%.
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+## Custom text control `.pf-c-table__cell-content`
+
+For granular control over text elements, `.pf-c-table__cell-content` is available. The `.pf-c-table__cell-content` element breaks content text out of the table flow and allows content to respond to `.pf-m-width-` modifiers set on parent elements. It also allows for content customization and individual `.pf-c-table__text` modifications. Modifiers can be applied to the parent `cell` or individual `.pf-c-table__text` elements.
+
+```hbs title=Controlling-text-elements-individually
+{{#> table table--id="controlling-text-elements-individually" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with custom text wrappers example."'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Custom text cells
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="No wrapping"}}
+        {{#> table-cell-content}}
+          {{#> table-text table-text--type="div" table-text--modifier="pf-m-truncate"}}
+            This cell's contents will truncate. Here's some more text to demonstrate how.
+          {{/table-text}}
+          {{#> table-text table-text--type="div" table-text--modifier="pf-m-no-wrap"}}
+            <a href="#">No wrap link example</a>
+          {{/table-text}}
+          {{#> table-text table-text--type="div"}}
+            This cell's contents will wrap. Here's some more text to demonstrate how.
+          {{/table-text}}
+        {{/table-cell-content}}
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+### Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-wrap` | `<th>`, `<td>` | Modifies content to wrap. |
+| `.pf-c-table__text-content` | `div` | Initiates a table text content element. |
+
 
 ## Documentation
+
 ### Overview
 
 Because the table component is not used for layout and presents tabular data only, it requires the use of `role="grid"`. Expandable table content (`.pf-c-table__expandable-content`) is placed within a singular `<td>` per expandable row, that can span multiple columns.
@@ -1724,9 +1955,11 @@ Applying `role="grid"` to tables enhances accessible interaction while in table 
 Table columns may shift when expanding/collapsing. To address this, set `.pf-m-fit-content`, or assign a width `.pf-m-width-[width]` to the corresponding `<th>` defining the column or `<td>` within the column. Width values are `[10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90]` or `max`.
 
 ### Table header cells
+
 By default, all table header cells are set to `white-space: nowrap`. If a `<th>`'s content needs to wrap, apply `.pf-m-wrap`.
 
 ### Implementation support
+
 - One expandable toggle button, positioned in the first cell of a non-expandable row, preceding an expandable row.
 - One checkbox, positioned in the first or second cell of a non-expandable row.
 - One action button, positioned in the last cell of a non-expandable row.
@@ -1734,6 +1967,7 @@ By default, all table header cells are set to `white-space: nowrap`. If a `<th>`
 - Compact presentation modifier (not compatible with expandable table).
 
 ### Responsive layout modifiers
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-grid-md`, `.pf-m-grid-lg`, `.pf-m-grid-xl`, `.pf-m-grid-2xl` | `.pf-c-table` | Changes tabular layout to responsive, grid based layout at suffixed breakpoint. |

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -1563,7 +1563,7 @@ To better control table cell behavior, PatternFly provides a series of modifiers
 | -- | -- | -- |
 | `.pf-m-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Sets table cell content to wrap. If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is the default behavior for <code>tbody</code> cells. |
 | `.pf-m-truncate` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Sets text to truncate based on a minimum width and available space adjacent table cells.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is the default behavior for <code>thead</code> cells. |
-| `.pf-m-no-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Unsets min/max width and sets whitespace to nowrap.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is specifically beneficial for cell's whose <code>thead th</code> cells are blank. The following example highlights link text that should display inline. Be careful with this modifier, it will prioritize its cell's content above all other cell's contents. |
+| `.pf-m-nowrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Unsets min/max width and sets whitespace to nowrap.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is specifically beneficial for cell's whose <code>thead th</code> cells are blank. The following example highlights link text that should display inline. Be careful with this modifier, it will prioritize its cell's content above all other cell's contents. |
 | `.pf-m-fit-content` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Fit column width to cell content.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. |
 | `.pf-m-break-word` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Breaks long strings wherever necessary as defined by the table layout. If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. |
 
@@ -1601,7 +1601,7 @@ To better control table cell behavior, PatternFly provides a series of modifiers
       {{#> table-td table-td--data-label="Fit content"}}
         This cell's content will adjust itself to the parent th width. This modifier only affects table layouts.
       {{/table-td}}
-      {{#> table-td table-td--modifier="pf-m-no-wrap" table-td--data-label="No wrap"}}
+      {{#> table-td table-td--modifier="pf-m-nowrap" table-td--data-label="No wrap"}}
         <a href="#">No wrap</a>
       {{/table-td}}
     {{/table-tr}}
@@ -1630,7 +1630,7 @@ For granular control over text elements, `.pf-c-table__cell-content` is availabl
           {{#> table-text table-text--type="div" table-text--modifier="pf-m-truncate"}}
             This cell's contents will truncate. Here's some more text to demonstrate how.
           {{/table-text}}
-          {{#> table-text table-text--type="div" table-text--modifier="pf-m-no-wrap"}}
+          {{#> table-text table-text--type="div" table-text--modifier="pf-m-nowrap"}}
             <a href="#">No wrap link example</a>
           {{/table-text}}
           {{#> table-text table-text--type="div"}}
@@ -1643,7 +1643,7 @@ For granular control over text elements, `.pf-c-table__cell-content` is availabl
 {{/table}}
 ```
 
-## `.pf-c-table__text`: Table text element. For `.pf-m-truncate` and `.pf-m-no-wrap` modifiers to apply to the grid layout, `td` content must be wrapped with `.pf-c-table__text`.
+## `.pf-c-table__text`: Table text element. For `.pf-m-truncate` and `.pf-m-nowrap` modifiers to apply to the grid layout, `td` content must be wrapped with `.pf-c-table__text`.
 
 ```hbs title=Modifiers-with-text-wrapper
 {{#> table table--id="modifiers-with-text-wrapper-example" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="This is a simple table example"'}}
@@ -1665,7 +1665,7 @@ For granular control over text elements, `.pf-c-table__cell-content` is availabl
           This text will truncate instead of wrap.
         {{/table-text}}
       {{/table-td}}
-      {{#> table-td table-td--modifier="pf-m-no-wrap" table-td--data-label="No wrap"}}
+      {{#> table-td table-td--modifier="pf-m-nowrap" table-td--data-label="No wrap"}}
         {{#> table-text}}
           <a href="#">This is a link that needs to be on one line and fully readable.</a>
         {{/table-text}}
@@ -1681,7 +1681,7 @@ For granular control over text elements, `.pf-c-table__cell-content` is availabl
 | -- | -- | -- |
 | `.pf-c-table__text` | `th > *`, `td > *`, `.pf-c-table__text-content > *` | Initiates a table text element. |
 | `.pf-m-truncate` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to truncate. |
-| `.pf-m-no-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to not wrap. |
+| `.pf-m-nowrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to not wrap. |
 | `.pf-m-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text to wrap. |
 | `.pf-m-fit-content` | `thead`, `tr`, `th`, `.pf-c-table__text` | Modifies `th` to fit its contents. |
 | `.pf-m-break-word` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text-content`, `.pf-c-table__text` | Modifies text strings to break. |
@@ -1736,7 +1736,7 @@ For granular control over text elements, `.pf-c-table__cell-content` is availabl
   {{#> table-tbody}}
     {{#> table-tr}}
       {{#> table-td table-td--data-label="Repository name"}}
-        This example is not responsive. Adjacent <code>tbody</code> cells will shrink as a result of this text being a longer string and adjacent text being shorter in length. Truncation can be overridden in <code>th</code> cells with the addition of <code>.pf-m-wrap</code>, <code>.pf-m-no-wrap</code> or <code>.pf-m-fit-content</code>.
+        This example is not responsive. Adjacent <code>tbody</code> cells will shrink as a result of this text being a longer string and adjacent text being shorter in length. Truncation can be overridden in <code>th</code> cells with the addition of <code>.pf-m-wrap</code>, <code>.pf-m-nowrap</code> or <code>.pf-m-fit-content</code>.
       {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         10

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -235,7 +235,7 @@ import './Table.css'
 | -- | -- | -- |
 | `.pf-c-table__sort` | `<th>` | Initiates a table header sort cell. **Required for sortable table columns** |
 | `.pf-c-table__button` | `<button>` | Initiates a table header sort cell button. **Required for sortable table columns** |
-| `.pf-c-table__button-content` | `.pf-c-table__button` | Initiates a table header sort cell button content container. **Required for sortable table columns** Note: this is only necessary because `<button>` does not support`display: grid`. |
+| `.pf-c-table__button-content` | `<div>` | Initiates a table header sort cell button content container. **Required for sortable table columns** Note: this is only necessary because `<button>` does not support`display: grid`. |
 | `.pf-c-table__sort-indicator` | `.pf-c-table__sort > button > span` | Initiates a sort indicator. **Required for sortable table columns** |
 | `.pf-m-selected` | `.pf-c-table__sort` | Modifies for sort selected state. **Required for sortable table columns** |
 | `.fa-arrows-alt-v` | `.pf-c-table__sort > button > span > .fas` | Initiates icon within unsorted, sortable table header. **Required for sortable table columns** |
@@ -1555,128 +1555,17 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 | `.pf-m-hidden{-on-[breakpoint]}` | `.pf-c-table tr > *` | Hides a table cell at a given breakpoint, or hides it at all breakpoints with `.pf-m-hidden`. **Note: Needs to apply to all cells in the column you want to hide.** |
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-table tr > *` | Shows a table cell at a given breakpoint. |
 
-```hbs title=With-headers-that-wrap
-{{#> table table--id="table-headers-wrap" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is an example of the table that has headers that wrap"'}}
-  {{#> table-caption}}
-    This is the table caption
-  {{/table-caption}}
-  {{#> table-thead}}
-    {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-wrap"}}
-        This is a really long table header that goes on for a long time.
-      {{/table-th}}
-    {{/table-tr}}
-  {{/table-thead}}
-
-  {{#> table-tbody}}
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        Repository 1
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        Repository 2
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        Repository 3
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        Repository 4
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-  {{/table-tbody}}
-{{/table}}
-```
-
 ## Controlling text
 
 To better control table cell behavior, PatternFly provides a series of modifiers to help contextually control layout. By default, `thead` cells are set to truncate, whereas `tbody` cells are set to wrap. Both `th` and `td` cells use a set of shared css properties mapped to customizable css variable values. Because only the shared css variables are changed by the modifier selector and not the properties, the modifier can be applied to any parent element up until `.pf-c-table` itself [`thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text`].
 
-<ul>
-  <li>
-    <b>pf-m-wrap:</b> Sets text to wrap. This is the default behavior for <code>tbody</code> cells.
-  </li>
-  <li>
-    <b>pf-m-truncate:</b> Sets text to truncate based on a minimum width and available space adjacent table cells. This is the default behavior for <code>thead</code> cells.
-  </li>
-  <li>
-    <b>pf-m-no-wrap:</b> Unsets min/max width and sets whitespace to nowrap. This is specifically beneficial for cell's whose <code>thead th</code> cells are blank. The following example highlights link text that should display inline. Be careful with this modifier, it will prioritize its cell's content above all other cell's contents.
-  </li>
-  <li>
-    <b>pf-m-fit-content:</b> Fit column width to cell content.
-  </li>
-  <li>
-    <b>pf-m-break-word:</b> Breaks long strings wherever necessary as defined by the table layout.
-  </li>
-</ul>
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-m-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Sets table cell content to wrap. If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is the default behavior for <code>tbody</code> cells. |
+| `.pf-m-truncate` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Sets text to truncate based on a minimum width and available space adjacent table cells.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is the default behavior for <code>thead</code> cells. |
+| `.pf-m-no-wrap` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Unsets min/max width and sets whitespace to nowrap.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. This is specifically beneficial for cell's whose <code>thead th</code> cells are blank. The following example highlights link text that should display inline. Be careful with this modifier, it will prioritize its cell's content above all other cell's contents. |
+| `.pf-m-fit-content` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Fit column width to cell content.  If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. |
+| `.pf-m-break-word` | `thead`, `tbody`, `tr`, `th`, `td`, `.pf-c-table__text` | Breaks long strings wherever necessary as defined by the table layout. If applied to `thead`, `tbody` or `tr`, then all child cells will be affected. |
 
 ```hbs title=Modifiers-without-text-wrapper
 {{#> table table--id="modifiers-without-text-wrapper-example" table--attribute='aria-label="This is a simple table example"'}}
@@ -1714,6 +1603,40 @@ To better control table cell behavior, PatternFly provides a series of modifiers
       {{/table-td}}
       {{#> table-td table-td--modifier="pf-m-no-wrap" table-td--data-label="No wrap"}}
         <a href="#">No wrap</a>
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+## Custom text control `.pf-c-table__cell-content`
+
+For granular control over text elements, `.pf-c-table__cell-content` is available. The `.pf-c-table__cell-content` element breaks content text out of the table flow and allows content to respond to `.pf-m-width-` modifiers set on parent elements. It also allows for content customization and individual `.pf-c-table__text` modifications. Modifiers can be applied to the parent `cell` or individual `.pf-c-table__text` elements.
+
+```hbs title=Controlling-text-elements-individually
+{{#> table table--id="controlling-text-elements-individually" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with custom text wrappers example."'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Custom text cells
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="No wrapping"}}
+        {{#> table-cell-content}}
+          {{#> table-text table-text--type="div" table-text--modifier="pf-m-truncate"}}
+            This cell's contents will truncate. Here's some more text to demonstrate how.
+          {{/table-text}}
+          {{#> table-text table-text--type="div" table-text--modifier="pf-m-no-wrap"}}
+            <a href="#">No wrap link example</a>
+          {{/table-text}}
+          {{#> table-text table-text--type="div"}}
+            This cell's contents will wrap. Here's some more text to demonstrate how.
+          {{/table-text}}
+        {{/table-cell-content}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
@@ -1892,40 +1815,6 @@ To better control table cell behavior, PatternFly provides a series of modifiers
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-  {{/table-tbody}}
-{{/table}}
-```
-
-## Custom text control `.pf-c-table__cell-content`
-
-For granular control over text elements, `.pf-c-table__cell-content` is available. The `.pf-c-table__cell-content` element breaks content text out of the table flow and allows content to respond to `.pf-m-width-` modifiers set on parent elements. It also allows for content customization and individual `.pf-c-table__text` modifications. Modifiers can be applied to the parent `cell` or individual `.pf-c-table__text` elements.
-
-```hbs title=Controlling-text-elements-individually
-{{#> table table--id="controlling-text-elements-individually" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with custom text wrappers example."'}}
-  {{#> table-thead}}
-    {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Custom text cells
-      {{/table-th}}
-    {{/table-tr}}
-  {{/table-thead}}
-
-  {{#> table-tbody}}
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="No wrapping"}}
-        {{#> table-cell-content}}
-          {{#> table-text table-text--type="div" table-text--modifier="pf-m-truncate"}}
-            This cell's contents will truncate. Here's some more text to demonstrate how.
-          {{/table-text}}
-          {{#> table-text table-text--type="div" table-text--modifier="pf-m-no-wrap"}}
-            <a href="#">No wrap link example</a>
-          {{/table-text}}
-          {{#> table-text table-text--type="div"}}
-            This cell's contents will wrap. Here's some more text to demonstrate how.
-          {{/table-text}}
-        {{/table-cell-content}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/table-button-content.hbs
+++ b/src/patternfly/components/Table/table-button-content.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-table__button-content{{#if table-button-content--modifier}} {{table-button-content--modifier}}{{/if}}"
+  {{#if table-button-content--attribute}}
+    {{{table-button-content--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Table/table-button.hbs
+++ b/src/patternfly/components/Table/table-button.hbs
@@ -1,0 +1,6 @@
+<button class="pf-c-table__button{{#if table-button--modifier}} {{table-button--modifier}}{{/if}}"
+  {{#if table-button--attribute}}
+    {{{table-button--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</button>

--- a/src/patternfly/components/Table/table-cell-content.hbs
+++ b/src/patternfly/components/Table/table-cell-content.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-table__cell-content{{#if table-cell-content--modifier}} {{table-cell-content--modifier}}{{/if}}"
-  {{#if table-cell-content--attribute}}
-    {{{table-cell-content--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Table/table-cell-content.hbs
+++ b/src/patternfly/components/Table/table-cell-content.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-table__cell-content{{#if table-cell-content--modifier}} {{table-cell-content--modifier}}{{/if}}"
+  {{#if table-cell-content--attribute}}
+    {{{table-cell-content--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -37,9 +37,6 @@
   // this is purposeful and necessary to avoid adding selectors to each td/th
   // ============================================================ //
 
-  // Responsive vars
-  // ==================================================================
-
   // Table
   --pf-c-table--responsive--BorderColor: var(--pf-global--BorderColor--300);
 
@@ -47,6 +44,9 @@
   --pf-c-table-tbody--responsive--MarginTop: var(--pf-global--spacer--xs);
   --pf-c-table-tbody--m-expanded--before--Top: var(--pf-global--spacer--sm);
   --pf-c-table-tbody--responsive--BorderWidth: var(--pf-global--spacer--sm);
+  --pf-c-table--tbody--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table--tbody--after--BorderLeftWidth: 0;
+  --pf-c-table--tbody--after--BorderColor: var(--pf-global--active-color--100);
 
   // Row
   --pf-c-table-tr--responsive--BorderWidth: var(--pf-global--spacer--sm);
@@ -70,8 +70,14 @@
   --pf-c-table-tr--responsive--nested-table--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-table-tr--responsive--nested-table--PaddingLeft: var(--pf-global--spacer--lg);
 
-  // Cell
+  // Cell display
   --pf-c-table-cell--m-grid--hidden-visible--Display: grid;
+
+  // Cell
+  --pf-c-table--m-grid--cell--PaddingTop: 0;
+  --pf-c-table--m-grid--cell--PaddingRight: 0;
+  --pf-c-table--m-grid--cell--PaddingBottom: 0;
+  --pf-c-table--m-grid--cell--PaddingLeft: 0;
 
   // Td
   --pf-c-table-td--responsive--GridColumnGap: var(--pf-global--spacer--md);
@@ -112,15 +118,39 @@
   // Table toggle icons
   --pf-c-table__toggle__icon--Transition: .2s ease-in 0s;
   --pf-c-table__toggle--m-expanded__icon--Transform: rotate(180deg);
-
-  // End responsive vars
-  // ==================================================================
 }
 
 // Check table cell
 @include pf-mobile-layout {
+  --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-grid--cell--PaddingTop);
+  --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-grid--cell--PaddingRight);
+  --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-grid--cell--PaddingBottom);
+  --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-grid--cell--PaddingLeft);
+
   display: grid;
   border: none;
+
+  // reset cell modifications
+  &.pf-c-table tr > * {
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  // apply modifications to text
+  .pf-c-table__text {
+    position: relative;
+    display: block;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    overflow: var(--pf-c-table--cell--Overflow);
+    text-overflow: var(--pf-c-table--cell--TextOverflow);
+    white-space: var(--pf-c-table--cell--WhiteSpace);
+  }
 
   // Thead
   thead {
@@ -222,7 +252,7 @@
   // Standard td, in standard row (non-expandable)
   [data-label] {
     // default pf-hidden-visible() mixin is called in table.scss. redefining variable here
-    --pf-c-table-cell--hidden-visible--Display: var(--pf-c-table-cell--m-grid--hidden-visible--Display);
+    --pf-c-table--cell--hidden-visible--Display: var(--pf-c-table-cell--m-grid--hidden-visible--Display);
 
     // responsive layout, set td to two column grid
     grid-column: 1;
@@ -252,12 +282,12 @@
   tr > * {
     // Remove first child padding left
     &:first-child {
-      --pf-c-table-cell--PaddingLeft: 0;
+      --pf-c-table--cell--PaddingLeft: 0;
     }
 
     // Remove last child padding right
     &:last-child {
-      --pf-c-table-cell--PaddingRight: 0;
+      --pf-c-table--cell--PaddingRight: 0;
     }
   }
 
@@ -276,41 +306,9 @@
   }
 
   .pf-c-table__compound-expansion-toggle {
-    // Compound expansion toggle
-    // reset compound expansion toggle::before
-    &::before {
-      position: static;
-      border: 0;
-    }
-
-    // reset compound expansion toggle::after
-    &::after {
-      top: auto;
-      right: 0;
-      left: 0;
-    }
-
-    // add bottom border to expansion toggle::after
-    &.pf-m-expanded::after {
-      border-bottom: var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderColor);
-    }
-
-    // reset button padding
-    .pf-c-button {
-      padding: 0;
-    }
-
-    &.pf-m-expanded .pf-c-button::after,
-    &:hover .pf-c-button::after {
-      border-right: 0;
-      border-left: 0;
-    }
-
-    &.pf-m-expanded .pf-c-button::before,
-    &:hover .pf-c-button::before {
-      top: auto;
-      bottom: 0;
-    }
+    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: 0;
+    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
+    --pf-c-table__compound-expansion-toggle__button--after--Top: 100%;
   }
 
   // Compound expansion responsive
@@ -323,24 +321,27 @@
       top: 0;
       bottom: 0;
       left: 0;
-      width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
+      border: 0;
+      border-left: var(--pf-c-table--tbody--after--BorderColor) solid var(--pf-c-table--tbody--after--BorderLeftWidth);
     }
 
     &.pf-m-expanded {
-      &::after {
-        background-color: var(--pf-c-table__expandable-row--before--BackgroundColor);
-      }
+      --pf-c-table--tbody--after--BorderLeftWidth: var(--pf-c-table--tbody--after--BorderWidth);
+    }
+
+    > tr > * {
+      overflow: hidden;
     }
 
     > tr > :first-child:not(.pf-c-table__check)::before {
+      --pf-c-table__expandable-row--before--BorderLeftWidth: 0;
+
       position: static;
       width: auto;
       background-color: transparent;
     }
   }
-  // Compound expansion responsive end
-
 
   // Expandable row
   .pf-c-table__expandable-row {
@@ -348,8 +349,8 @@
     --pf-c-table-cell--responsive--PaddingRight: 0;
     --pf-c-table-cell--responsive--PaddingBottom: 0;
     --pf-c-table-cell--responsive--PaddingLeft: 0;
-    --pf-c-table-cell--PaddingRight: 0;
-    --pf-c-table-cell--PaddingLeft: 0;
+    --pf-c-table--cell--PaddingRight: 0;
+    --pf-c-table--cell--PaddingLeft: 0;
 
     display: block;
     max-height: var(--pf-c-table__expandable-row--MaxHeight);  // Overflow scroll should only happen on responsive
@@ -410,6 +411,13 @@
     padding-right: 0;
   }
 
+  .pf-c-table__button {
+    --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-grid--cell--PaddingTop);
+    --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-grid--cell--PaddingRight);
+    --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-grid--cell--PaddingBottom);
+    --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-grid--cell--PaddingLeft);
+  }
+
   // Check table cell
   .pf-c-table__check {
     margin-top: var(--pf-c-table__check--responsive--MarginTop);
@@ -450,10 +458,23 @@
     }
   }
 
+  // No wrap
+  .pf-m-no-wrap {
+    --pf-c-table--cell--Overflow: auto;
+  }
+
   // Fit content
   .pf-m-fit-content {
     width: auto;
     white-space: normal;
+  }
+
+  .pf-m-truncate {
+    --pf-c-table--cell--MaxWidth: 100%;
+  }
+
+  [class*="pf-m-width"] {
+    --pf-c-table--cell--Width: auto;
   }
 }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -459,7 +459,7 @@
   }
 
   // No wrap
-  .pf-m-no-wrap {
+  .pf-m-nowrap {
     --pf-c-table--cell--Overflow: auto;
   }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -323,7 +323,7 @@
       left: 0;
       content: "";
       border: 0;
-      border-left: var(--pf-c-table--tbody--after--BorderColor) solid var(--pf-c-table--tbody--after--BorderLeftWidth);
+      border-left: var(--pf-c-table--tbody--after--BorderLeftWidth) solid var(--pf-c-table--tbody--after--BorderColor);
     }
 
     &.pf-m-expanded {

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -71,7 +71,7 @@
   --pf-c-table-tr--responsive--nested-table--PaddingLeft: var(--pf-global--spacer--lg);
 
   // Cell display
-  --pf-c-table-cell--m-grid--hidden-visible--Display: grid;
+  --pf-c-table--m-grid--cell--hidden-visible--Display: grid;
 
   // Cell
   --pf-c-table--m-grid--cell--PaddingTop: 0;
@@ -81,11 +81,11 @@
 
   // Td
   --pf-c-table-td--responsive--GridColumnGap: var(--pf-global--spacer--md);
-  --pf-c-table-cell--responsive--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-table-cell--responsive--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-table--cell--responsive--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-table--cell--responsive--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-table-cell-th--responsive--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-table-cell--responsive--PaddingRight: 0;
-  --pf-c-table-cell--responsive--PaddingLeft: 0;
+  --pf-c-table--cell--responsive--PaddingRight: 0;
+  --pf-c-table--cell--responsive--PaddingLeft: 0;
 
   // Compact table
   --pf-c-table--m-compact-tr--responsive--PaddingTop: var(--pf-global--spacer--sm);
@@ -211,7 +211,7 @@
 
     // Reset td padding
     & > * {
-      padding: var(--pf-c-table-cell--responsive--PaddingTop) var(--pf-c-table-cell--responsive--PaddingRight) var(--pf-c-table-cell--responsive--PaddingBottom) var(--pf-c-table-cell--responsive--PaddingLeft);
+      padding: var(--pf-c-table--cell--responsive--PaddingTop) var(--pf-c-table--cell--responsive--PaddingRight) var(--pf-c-table--cell--responsive--PaddingBottom) var(--pf-c-table--cell--responsive--PaddingLeft);
     }
 
     // remove padding from first th to align with kebab
@@ -231,8 +231,8 @@
   &.pf-m-compact {
     --pf-c-table-tr--responsive--PaddingTop: var(--pf-c-table--m-compact-tr--responsive--PaddingTop);
     --pf-c-table-tr--responsive--PaddingBottom: var(--pf-c-table--m-compact-tr--responsive--PaddingBottom);
-    --pf-c-table-cell--responsive--PaddingTop: var(--pf-c-table--m-compact-tr-td--responsive--PaddingTop);
-    --pf-c-table-cell--responsive--PaddingBottom: var(--pf-c-table--m-compact-tr-td--responsive--PaddingBottom);
+    --pf-c-table--cell--responsive--PaddingTop: var(--pf-c-table--m-compact-tr-td--responsive--PaddingTop);
+    --pf-c-table--cell--responsive--PaddingBottom: var(--pf-c-table--m-compact-tr-td--responsive--PaddingBottom);
     --pf-c-table__check--input--MarginTop: 0;
 
     .pf-c-table__action {
@@ -252,7 +252,7 @@
   // Standard td, in standard row (non-expandable)
   [data-label] {
     // default pf-hidden-visible() mixin is called in table.scss. redefining variable here
-    --pf-c-table--cell--hidden-visible--Display: var(--pf-c-table-cell--m-grid--hidden-visible--Display);
+    --pf-c-table--cell--hidden-visible--Display: var(--pf-c-table--m-grid--cell--hidden-visible--Display);
 
     // responsive layout, set td to two column grid
     grid-column: 1;
@@ -345,10 +345,10 @@
 
   // Expandable row
   .pf-c-table__expandable-row {
-    --pf-c-table-cell--responsive--PaddingTop: 0;
-    --pf-c-table-cell--responsive--PaddingRight: 0;
-    --pf-c-table-cell--responsive--PaddingBottom: 0;
-    --pf-c-table-cell--responsive--PaddingLeft: 0;
+    --pf-c-table--cell--responsive--PaddingTop: 0;
+    --pf-c-table--cell--responsive--PaddingRight: 0;
+    --pf-c-table--cell--responsive--PaddingBottom: 0;
+    --pf-c-table--cell--responsive--PaddingLeft: 0;
     --pf-c-table--cell--PaddingRight: 0;
     --pf-c-table--cell--PaddingLeft: 0;
 

--- a/src/patternfly/components/Table/table-sort-indicator.hbs
+++ b/src/patternfly/components/Table/table-sort-indicator.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-table__sort-indicator{{#if table-sort-indicator--modifier}} {{table-sort-indicator--modifier}}{{/if}}"
+  {{#if table-sort-indicator--attribute}}
+    {{{table-sort-indicator--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -15,10 +15,17 @@
   {{#if table-td--data-label}}
     data-label="{{table-td--data-label}}"
   {{/if}}>
-  {{#if table-td--toggle}}
-    <button class="pf-c-button pf-m-plain{{#if table-tr--expanded}} pf-m-expanded{{/if}}" {{#if table-td--button--attribute}}{{{table-td--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
-      {{#> table-toggle-icon}}{{/table-toggle-icon}}
-    </button>
-  {{/if}}
-  {{> @partial-block}}
+  {{#unless table-td--IsEmpty}}
+    {{#if table-td--toggle}}
+      <button class="pf-c-button pf-m-plain{{#if table-tr--expanded}} pf-m-expanded{{/if}}" {{#if table-td--button--attribute}}{{{table-td--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
+        {{#> table-toggle-icon}}{{/table-toggle-icon}}
+      </button>
+    {{else if table-td--compound-expansion-toggle}}
+      {{#> table-button table-button--attribute=table-th--button--attribute}}
+        {{> @partial-block}}
+      {{/table-button}}
+    {{else}}
+      {{> @partial-block}}
+    {{/if}}
+  {{/unless}}
 </td>

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -22,7 +22,9 @@
       </button>
     {{else if table-td--compound-expansion-toggle}}
       {{#> table-button table-button--attribute=table-th--button--attribute}}
-        {{> @partial-block}}
+        {{#> table-text}}
+          {{> @partial-block}}
+        {{/table-text}}
       {{/table-button}}
     {{else}}
       {{> @partial-block}}

--- a/src/patternfly/components/Table/table-text.hbs
+++ b/src/patternfly/components/Table/table-text.hbs
@@ -1,0 +1,6 @@
+<{{# if table-text--type}}{{table-text--type}}{{else}}span{{/if}} class="pf-c-table__text{{#if table-text--modifier}} {{table-text--modifier}}{{/if}}"
+  {{#if table-text--attribute}}
+    {{{table-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{# if table-text--type}}{{table-text--type}}{{else}}span{{/if}}>

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -1,11 +1,12 @@
-<th{{#if table-th--toggle}} class="pf-c-table__toggle {{table-th--modifier}}"
-    {{else if table-th--check}} class="pf-c-table__check {{table-th--modifier}}"
-    {{else if table-th--action}} class="pf-c-table__action {{table-th--modifier}}"
-    {{else if table-th--icon}} class="pf-c-table__icon {{table-th--modifier}}"
-    {{else if table-th--sortable}} class="pf-c-table__sort {{#if table-th--sortable-wrap}} pf-m-wrap{{/if}}{{#if table-th--selected}} pf-m-selected{{/if}} {{table-th--modifier}}"
-    {{else if table-th--compound-expansion-toggle}} class="pf-c-table__compound-expansion-toggle {{table-th--modifier}}"
-    {{else if table-th--modifier}} class="{{table-th--modifier}}"
-  {{/if}}
+<th class="{{#if table-th--modifier}} {{table-th--modifier}}{{/if}}
+  {{#if table-th--compound-expansion-toggle}} pf-c-table__compound-expansion-toggle{{/if}}
+  {{#if table-th--sortable}} pf-c-table__sort{{/if}}
+  {{#if table-th--toggle}} pf-c-table__toggle{{/if}}
+  {{#if table-th--check}} pf-c-table__check{{/if}}
+  {{#if table-th--action}} pf-c-table__action{{/if}}
+  {{#if table-th--icon}} pf-c-table__icon{{/if}}
+  {{#if table-th--sortable-wrap}} pf-m-wrap{{/if}}
+  {{#if table-th--selected}} pf-m-selected{{/if}}"
   {{#if table--grid}}
     role="columnheader"
   {{/if}}
@@ -25,26 +26,30 @@
     {{{table-th--attribute}}}
   {{/if}}>
   {{#if table-th--sortable}}
-    {{#> button button--modifier="pf-m-plain"}}
-      {{#if table-th--sortable-wrap}}
-        <span class="pf-c-table__sort-text">
+    {{#> table-button}}
+      {{#> table-button-content}}
+        {{#> table-text}}
           {{> @partial-block}}
-        </span>
-      {{else}}
-        {{> @partial-block}}
-      {{/if}}
-      <span class="pf-c-table__sort-indicator">
-        {{#if table-th--selected}}
-          {{#if table-th--asc}}
-            <i class="fas fa-long-arrow-alt-up"></i>
+        {{/table-text}}
+        {{#> table-sort-indicator}}
+          {{#if table-th--selected}}
+            {{#if table-th--asc}}
+              <i class="fas fa-long-arrow-alt-up"></i>
+            {{else}}
+              <i class="fas fa-long-arrow-alt-down"></i>
+            {{/if}}
           {{else}}
-            <i class="fas fa-long-arrow-alt-down"></i>
+            <i class="fas fa-arrows-alt-v"></i>
           {{/if}}
-        {{else}}
-          <i class="fas fa-arrows-alt-v"></i>
-        {{/if}}
-      </span>
-    {{/button}}
+        {{/table-sort-indicator}}
+      {{/table-button-content}}
+    {{/table-button}}
+  {{else if table-th--compound-expansion-toggle}}
+    {{#> table-button table-button--attribute=table-th--button--attribute}}
+      {{#> table-text}}
+        {{> @partial-block}}
+      {{/table-text}}
+    {{/table-button}}
   {{else}}
     {{> @partial-block}}
   {{/if}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -287,11 +287,6 @@
       background-color: transparent;
       border-left: var(--pf-c-table__expandable-row--before--BorderLeftWidth) solid var(--pf-c-table__expandable-row--before--BorderColor);
     }
-
-    // add background color when active
-    &.pf-m-expanded > tr > :first-child::before {
-      --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
-    }
   }
   // stylelint-enable
 
@@ -668,7 +663,12 @@
     border-bottom-color: var(--pf-c-table__expandable-row--m-expanded--BorderBottomColor);
     border-bottom-width: var(--pf-c-table--BorderWidth);
     box-shadow: var(--pf-c-table__expandable-row--m-expanded--BoxShadow);
+
+    :first-child::before {
+      --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
+    }
   }
+
 
   &:not(.pf-m-expanded) {
     display: none;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -162,14 +162,14 @@
   // Compact table
   --pf-c-table--m-compact-th--PaddingTop: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--xs));
   --pf-c-table--m-compact-th--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-cell--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-cell--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-cell--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-cell--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-table--m-compact-cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-table--m-compact-cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-table--m-compact-cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-table--m-compact-cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table--m-compact--cell--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact--cell--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact--cell--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact--cell--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-table--m-compact--cell--first-last-child--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table--m-compact--cell--first-last-child--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table--m-compact--cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-table--m-compact--cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-table--m-compact--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-table--m-compact__expandable-row-content--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-table--m-compact__expandable-row-content--PaddingRight: var(--pf-global--spacer--lg);
@@ -186,6 +186,8 @@
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-c-table--cell--first-last-child--xl--PaddingRight);
     --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-c-table--cell--first-last-child--xl--PaddingLeft);
+    --pf-c-table--m-compact--cell--first-last-child--PaddingLeft: var(--pf-c-table--m-compact--cell--first-last-child--xl--PaddingLeft);
+    --pf-c-table--m-compact--cell--first-last-child--PaddingRight: var(--pf-c-table--m-compact--cell--first-last-child--xl--PaddingRight);
   }
 
   @include pf-t-light; // This component always needs to be light
@@ -719,22 +721,22 @@
   }
 
   tr {
-    --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact-cell--PaddingLeft);
-    --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact-cell--PaddingRight);
+    --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact--cell--PaddingLeft);
+    --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact--cell--PaddingRight);
 
     &:not(.pf-c-table__expandable-row) {
       --pf-c-table--cell--FontSize: var(--pf-c-table--m-compact--FontSize);
-      --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact-cell--PaddingTop);
-      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact-cell--PaddingBottom);
+      --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact--cell--PaddingTop);
+      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact--cell--PaddingBottom);
 
       // stylelint-disable
       > * {
         &:first-child {
-          --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--PaddingLeft);
+          --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact--cell--first-last-child--PaddingLeft);
         }
 
         &:last-child {
-          --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--PaddingRight);
+          --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact--cell--first-last-child--PaddingRight);
         }
       }
       // stylelint-enable
@@ -743,8 +745,8 @@
 
   // Thead only
   thead {
-    --pf-c-table--m-compact-cell--PaddingTop: var(--pf-c-table--m-compact-th--PaddingTop);
-    --pf-c-table--m-compact-cell--PaddingBottom: var(--pf-c-table--m-compact-th--PaddingBottom);
+    --pf-c-table--m-compact--cell--PaddingTop: var(--pf-c-table--m-compact-th--PaddingTop);
+    --pf-c-table--m-compact--cell--PaddingBottom: var(--pf-c-table--m-compact-th--PaddingBottom);
   }
 
   .pf-c-table__action {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -333,7 +333,7 @@
     --pf-c-table--cell--WhiteSpace: normal;
   }
 
-  .pf-m-no-wrap {
+  .pf-m-nowrap {
     --pf-c-table--cell--MinWidth: 0;
     --pf-c-table--cell--MaxWidth: none;
     --pf-c-table--cell--Overflow: visible;
@@ -359,7 +359,7 @@
   // Only apply these settings if specifically modified
   &.pf-m-truncate,
   &.pf-m-wrap,
-  &.pf-m-no-wrap,
+  &.pf-m-nowrap,
   &.pf-m-fit-content,
   &.pf-m-break-word {
     --pf-c-table--m-truncate--cell--MinWidth: 100%;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -18,20 +18,19 @@
   --pf-c-table-caption--Color: var(--pf-global--Color--200);
   --pf-c-table-caption--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-table-caption--xl--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-table-caption--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-table-caption--xl--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table-caption--xl--PaddingLeft: var(--pf-global--spacer--md);
 
   @media screen and (max-width: $pf-global--breakpoint--xl) {
-    --pf-c-table-caption--PaddingRight: var(--pf-c-table-caption--md--PaddingRight);
+    --pf-c-table-caption--PaddingRight: var(--pf-c-table-caption--xl--PaddingRight);
     --pf-c-table-caption--PaddingLeft: var(--pf-c-table-caption--xl--PaddingLeft);
   }
 
   // Thead
   --pf-c-table--thead--cell--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-table--thead--cell--FontWeight: var(--pf-global--FontWeight--bold);
-  --pf-c-table--m-no-wrap--thead--cell--Overflow: visible;
 
   // Tbody cell
   --pf-c-table--tbody--cell--PaddingTop: var(--pf-global--spacer--lg);
@@ -60,27 +59,6 @@
   // Truncate
   --pf-c-table--m-truncate--cell--MinWidth: 10ch;
   --pf-c-table--m-truncate--cell--MaxWidth: 1px;
-  --pf-c-table--m-truncate--cell--Overflow: hidden;
-  --pf-c-table--m-truncate--cell--TextOverflow: ellipsis;
-  --pf-c-table--m-truncate--cell--WhiteSpace: nowrap;
-
-  // Wrap
-  --pf-c-table--m-wrap--cell--MinWidth: 0;
-  --pf-c-table--m-wrap--cell--MaxWidth: none;
-  --pf-c-table--m-wrap--cell--Overflow: visible;
-  --pf-c-table--m-wrap--cell--TextOverflow: clip;
-  --pf-c-table--m-wrap--cell--WhiteSpace: normal;
-
-  // No wrap
-  --pf-c-table--m-no-wrap--cell--MinWidth: 0;
-  --pf-c-table--m-no-wrap--cell--MaxWidth: none;
-  --pf-c-table--m-no-wrap--cell--WhiteSpace: nowrap;
-
-  // Fit content
-  --pf-c-table--m-fit-content--cell--MinWidth: fit-content;
-  --pf-c-table--m-fit-content--cell--MaxWidth: fit-content;
-  --pf-c-table--m-fit-content--cell--Width: 1%;
-  --pf-c-table--m-fit-content--cell--WhiteSpace: nowrap;
 
   // Hidden visible
   --pf-c-table--cell--hidden-visible--Display: table-cell;
@@ -89,9 +67,6 @@
   // ============================================================ //
   // End non-conformant variables
   // ============================================================ //
-
-  // Text
-  --pf-c-table__text--MaxWidth: auto;
 
   // Table cell - toggle
   --pf-c-table__toggle--c-button--MarginTop: calc(#{pf-size-prem(6px)} * -1);
@@ -280,16 +255,6 @@
     --pf-c-table--cell--FontWeight: var(--pf-c-table--thead--cell--FontWeight);
     --pf-c-table--cell--Width: var(--pf-c-table--thead--cell--Width);
 
-    // Set default th behavior to truncate
-    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-truncate--cell--MinWidth);
-    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-truncate--cell--MaxWidth);
-    --pf-c-table--cell--Overflow: var(--pf-c-table--m-truncate--cell--Overflow);
-    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
-    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
-
-    // show overflow for thead cells
-    --pf-c-table--m-no-wrap--cell--Overflow: var(--pf-c-table--m-no-wrap--thead--cell--Overflow);
-
     th,
     td {
       vertical-align: bottom;
@@ -349,34 +314,34 @@
     min-width: var(--pf-c-table__sort--MinWidth);
   }
 
+  thead,
   .pf-m-truncate {
     --pf-c-table--cell--MinWidth: var(--pf-c-table--m-truncate--cell--MinWidth);
     --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-truncate--cell--MaxWidth);
-    --pf-c-table--cell--Overflow: var(--pf-c-table--m-truncate--cell--Overflow);
-    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
-    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
-    --pf-c-table__text--MaxWidth: var(--pf-c-table__text--m-truncate--MaxWidth);
+    --pf-c-table--cell--Overflow: hidden;
+    --pf-c-table--cell--TextOverflow: ellipsis;
+    --pf-c-table--cell--WhiteSpace: nowrap;
   }
 
   .pf-m-wrap {
-    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-wrap--cell--MinWidth);
-    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-wrap--cell--MaxWidth);
-    --pf-c-table--cell--Overflow: var(--pf-c-table--m-wrap--cell--Overflow);
-    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-wrap--cell--TextOverflow);
-    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-wrap--cell--WhiteSpace);
+    --pf-c-table--cell--MinWidth: 0;
+    --pf-c-table--cell--MaxWidth: none;
+    --pf-c-table--cell--Overflow: visible;
+    --pf-c-table--cell--TextOverflow: clip;
+    --pf-c-table--cell--WhiteSpace: normal;
   }
 
   .pf-m-no-wrap {
-    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-no-wrap--cell--MinWidth);
-    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-no-wrap--cell--MaxWidth);
-    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-no-wrap--cell--WhiteSpace);
+    --pf-c-table--cell--MinWidth: 0;
+    --pf-c-table--cell--MaxWidth: none;
+    --pf-c-table--cell--WhiteSpace: nowrap;
   }
 
   .pf-m-fit-content {
-    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-fit-content--cell--MinWidth);
-    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-fit-content--cell--MaxWidth);
-    --pf-c-table--cell--Width: var(--pf-c-table--m-fit-content--cell--Width);
-    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-fit-content--cell--WhiteSpace);
+    --pf-c-table--cell--MinWidth: fit-content;
+    --pf-c-table--cell--MaxWidth: fit-content;
+    --pf-c-table--cell--Width: 1%;
+    --pf-c-table--cell--WhiteSpace: nowrap;
   }
 
   .pf-m-break-word {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -608,14 +608,6 @@
   }
 }
 
-// stylelint-disable selector-no-qualifying-type
-.pf-c-table tbody.pf-m-expanded,
-.pf-c-table__expandable-row.pf-m-expanded,
-.pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child {
-  --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
-}
-// stylelint-enable
-
 // Table sort
 // ==================================================================
 .pf-c-table__sort {
@@ -665,7 +657,7 @@
   // stylelint-disable
   td {
     &.pf-m-no-padding {
-      padding: 0 0 0 var(--pf-c-table__expandable-row--before--Width); // set padding-left to adjust for left border.
+      padding: 0 0 0 var(--pf-c-table__expandable-row--before--BorderWidth); // set padding-left to adjust for left border.
 
       .pf-c-table__expandable-row-content {
         padding: 0;
@@ -692,6 +684,14 @@
     visibility: hidden;
   }
 }
+
+// stylelint-disable selector-no-qualifying-type
+.pf-c-table tbody.pf-m-expanded,
+.pf-c-table__expandable-row.pf-m-expanded,
+.pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child {
+  --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
+}
+// stylelint-enable
 
 // Nested table
 // ==================================================================

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -44,8 +44,10 @@
   --pf-c-table--cell--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-table--cell--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-table--cell--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table--cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-table--cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--lg);
 
   // Default cell variables
   --pf-c-table--cell--MinWidth: 0;
@@ -57,8 +59,8 @@
   --pf-c-table--cell--WordBreak: normal;
 
   // Truncate
-  --pf-c-table--m-truncate--cell--MinWidth: 10ch;
   --pf-c-table--m-truncate--cell--MaxWidth: 1px;
+  --pf-c-table--m-truncate--cell--MinWidth: 10ch;
 
   // Hidden visible
   --pf-c-table--cell--hidden-visible--Display: table-cell;
@@ -180,6 +182,11 @@
 
   // Modifier - expandable row expanded
   --pf-c-table__expandable-row--m-expanded--BorderBottomColor: var(--pf-global--BorderColor--100);
+
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-c-table--cell--first-last-child--xl--PaddingRight);
+    --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-c-table--cell--first-last-child--xl--PaddingLeft);
+  }
 
   @include pf-t-light; // This component always needs to be light
 
@@ -329,6 +336,8 @@
   .pf-m-no-wrap {
     --pf-c-table--cell--MinWidth: 0;
     --pf-c-table--cell--MaxWidth: none;
+    --pf-c-table--cell--Overflow: visible;
+    --pf-c-table--cell--TextOverflow: clip;
     --pf-c-table--cell--WhiteSpace: nowrap;
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -12,7 +12,6 @@
   --pf-c-table--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-table--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-table--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table-cell--FontWeight: var(--pf-global--FontWeight--normal);
 
   // Caption
   --pf-c-table-caption--FontSize: var(--pf-global--FontSize--sm);
@@ -30,55 +29,100 @@
   }
 
   // Thead
-  --pf-c-table-thead--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-table-thead--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-table--thead--cell--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-table--thead--cell--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-table--m-no-wrap--thead--cell--Overflow: visible;
+  --pf-c-table--thead__button-content--AlignItems: end;
 
-  // Thead cell
-  --pf-c-table-thead-cell--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-table-thead-cell--PaddingBottom: var(--pf-global--spacer--md);
-
-  // Cell
-  --pf-c-table-cell--hidden-visible--Display: table-cell;
-
-  // Td
-  --pf-c-table-tbody-cell--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-table-tbody-cell--PaddingBottom: var(--pf-global--spacer--lg);
+  // Tbody cell
+  --pf-c-table--tbody--cell--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-table--tbody--cell--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Th / td shared variables
-  // Padding vars must be individual as they are contextually reset
-  --pf-c-table-cell--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-table-cell--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-table-cell--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-table-cell--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-table-cell--FontSize: var(--pf-global--FontSize--md);
-  --pf-c-table-cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-table-cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-table-cell--first-last-child--xl--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-table-cell--first-last-child--xl--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table--cell--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-table--cell--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-table--cell--Color: var(--pf-global--Color--100);
+  --pf-c-table--cell--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-table--cell--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-table--cell--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-table--cell--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-global--spacer--lg);
+
+  // Default cell variables
+  --pf-c-table--cell--MinWidth: 0;
+  --pf-c-table--cell--MaxWidth: none;
+  --pf-c-table--cell--Width: auto;
+  --pf-c-table--cell--Overflow: visible;
+  --pf-c-table--cell--TextOverflow: clip;
+  --pf-c-table--cell--WhiteSpace: normal;
+  --pf-c-table--cell--WordBreak: normal;
+
+  // Truncate
+  --pf-c-table--m-truncate--cell--MinWidth: 10ch;
+  --pf-c-table--m-truncate--cell--MaxWidth: 1px;
+  --pf-c-table--m-truncate--cell--Overflow: hidden;
+  --pf-c-table--m-truncate--cell--TextOverflow: ellipsis;
+  --pf-c-table--m-truncate--cell--WhiteSpace: nowrap;
+
+  // Wrap
+  --pf-c-table--m-wrap--cell--MinWidth: 0;
+  --pf-c-table--m-wrap--cell--MaxWidth: none;
+  --pf-c-table--m-wrap--cell--Overflow: visible;
+  --pf-c-table--m-wrap--cell--TextOverflow: clip;
+  --pf-c-table--m-wrap--cell--WhiteSpace: normal;
+
+  // No wrap
+  --pf-c-table--m-no-wrap--cell--MinWidth: 0;
+  --pf-c-table--m-no-wrap--cell--MaxWidth: none;
+  --pf-c-table--m-no-wrap--cell--WhiteSpace: nowrap;
+
+  // Fit content
+  --pf-c-table--m-fit-content--cell--MinWidth: fit-content;
+  --pf-c-table--m-fit-content--cell--MaxWidth: fit-content;
+  --pf-c-table--m-fit-content--cell--Width: 1%;
+  --pf-c-table--m-fit-content--cell--WhiteSpace: nowrap;
+
+  // Hidden visible
+  --pf-c-table--cell--hidden-visible--Display: table-cell;
+  // stylelint-enable
 
   // ============================================================ //
   // End non-conformant variables
   // ============================================================ //
+
+  // Text
+  --pf-c-table__text--MaxWidth: auto;
 
   // Table cell - toggle
   --pf-c-table__toggle--c-button--MarginTop: calc(#{pf-size-prem(6px)} * -1);
   --pf-c-table__toggle--c-button__toggle-icon--Transform: rotate(270deg);
   --pf-c-table__toggle--c-button__toggle-icon--Transition: .2s ease-in 0s;
   --pf-c-table__toggle--c-button--m-expanded__toggle-icon--Transform: rotate(360deg);
+
+  // Button
+  --pf-c-table__button--BackgroundColor: transparent;
+  --pf-c-table__button--Color: var(--pf-global--Color--100);
+  --pf-c-table__button--hover--Color: var(--pf-global--Color--100);
+  --pf-c-table__button--focus--Color: var(--pf-global--Color--100);
+  --pf-c-table__button--active--Color: var(--pf-global--Color--100);
+  --pf-c-table__button--OutlineOffset: calc(var(--pf-global--BorderWidth--lg) * -1);
+
+  // Compact
   --pf-c-table--m-compact__toggle--PaddingTop: 0;
   --pf-c-table--m-compact__toggle--PaddingBottom: 0;
 
-  // Table cell - check
+  // Check
   --pf-c-table__check--input--MarginTop: #{pf-size-prem(3px)};
   --pf-c-table__check--input--FontSize: var(--pf-global--FontSize--md);
 
-  // Table cell - action
+  // Action
   --pf-c-table__action--PaddingTop: 0;
   --pf-c-table__action--PaddingRight: 0;
   --pf-c-table__action--PaddingBottom: 0;
   --pf-c-table__action--PaddingLeft: 0;
 
-  // Table cell - action
+  // Inline edit
   --pf-c-table__inline-edit-action--PaddingTop: 0;
   --pf-c-table__inline-edit-action--PaddingRight: 0;
   --pf-c-table__inline-edit-action--PaddingBottom: 0;
@@ -87,35 +131,60 @@
   // Expandable row
   // hardcoding to match design spec
   --pf-c-table__expandable-row--Transition: var(--pf-global--Transition);
-  --pf-c-table__expandable-row--before--Width: var(--pf-global--BorderWidth--lg);
-  --pf-c-table__expandable-row--before--BackgroundColor: var(--pf-global--active-color--100);
-  --pf-c-table__expandable-row--before--ZIndex: var(--pf-global--ZIndex--sm);
-  --pf-c-table__expandable-row--before--Top: calc(var(--pf-c-table--BorderWidth) * -1);
-  --pf-c-table__expandable-row--before--Bottom: calc(var(--pf-c-table--BorderWidth) * -1);
   --pf-c-table__expandable-row--MaxHeight: #{pf-size-prem(450px)};
   --pf-c-table__expandable-row-content--Transition: var(--pf-global--Transition);
   --pf-c-table__expandable-row-content--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-table__expandable-row-content--PaddingBottom: var(--pf-global--spacer--lg);
 
-  // Sort indicator
-  --pf-c-table__sort-indicator--MarginLeft: var(--pf-global--spacer--md);
-  --pf-c-table__sort-indicator--Color: var(--pf-global--disabled-color--200);
-  --pf-c-table__sort-indicator--hover--Color: var(--pf-global--Color--100);
-  --pf-c-table__sort--c-button--Color: var(--pf-global--Color--100);
-  --pf-c-table__sort-indicator--LineHeight: var(--pf-c-button--LineHeight);
+  // ::before border
+  --pf-c-table__expandable-row--before--Top: calc(var(--pf-c-table--BorderWidth) * -1);
+  --pf-c-table__expandable-row--before--Bottom: calc(var(--pf-c-table--BorderWidth) * -1);
+  --pf-c-table__expandable-row--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table__expandable-row--before--BorderRightWidth: 0;
+  --pf-c-table__expandable-row--before--BorderLeftWidth: 0;
+  --pf-c-table__expandable-row--before--BorderColor: var(--pf-global--active-color--100);
 
   // Icon inline
   --pf-c-table__icon-inline--MarginRight: var(--pf-global--spacer--sm);
 
-  // Nested table
-  --pf-c-table--nested--first-last-child--PaddingRight: var(--pf-global--spacer--3xl);
-  --pf-c-table--nested--first-last-child--PaddingLeft: var(--pf-global--spacer--3xl);
+  // Sort cell
+  --pf-c-table__sort--MinWidth: 12ch;
 
-  // ============================================================ //
-  // Modifiers
-  // ============================================================ //
+  // Sort button
+  --pf-c-table__sort__button--Color: var(--pf-global--Color--100);
+  --pf-c-table__sort--m-selected__button--Color: var(--pf-global--active-color--100);
+  --pf-c-table__sort--m-selected--Color: var(--pf-global--active-color--100);
+  --pf-c-table__sort--m-selected__sort-indicator--Color: var(--pf-global--active-color--100);
 
-  // Modifier - compact table
+  // Sort indicator
+  --pf-c-table__sort-indicator--Color: var(--pf-global--disabled-color--200);
+  --pf-c-table__sort__button--hover__sort-indicator--Color: var(--pf-global--Color--100);
+  --pf-c-table__sort__button--active__sort-indicator--Color: var(--pf-global--Color--100);
+  --pf-c-table__sort__button--focus__sort-indicator--Color: var(--pf-global--Color--100);
+  --pf-c-table__sort-indicator--MarginLeft: var(--pf-global--spacer--md);
+
+  // Compound expansion toggle button
+  --pf-c-table__compound-expansion-toggle__button--Color: var(--pf-global--active-color--100);
+  --pf-c-table__compound-expansion-toggle__button--hover--Color: var(--pf-global--link--Color--hover);
+  --pf-c-table__compound-expansion-toggle__button--focus--Color: var(--pf-global--link--Color--hover);
+  --pf-c-table__compound-expansion-toggle__button--active--Color: var(--pf-global--link--Color--hover);
+
+  // ::before border treatment
+  --pf-c-table__compound-expansion-toggle__button--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__compound-expansion-toggle__button--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: 0;
+  --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
+  --pf-c-table__compound-expansion-toggle__button--before--Bottom: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+  --pf-c-table__compound-expansion-toggle__button--before--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+
+  // ::before border treatment
+  --pf-c-table__compound-expansion-toggle__button--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table__compound-expansion-toggle__button--after--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth: 0;
+  --pf-c-table__compound-expansion-toggle__button--after--Top: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+  --pf-c-table__compound-expansion-toggle__button--after--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+
+  // Compact table
   --pf-c-table--m-compact-th--PaddingTop: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--xs));
   --pf-c-table--m-compact-th--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-table--m-compact-cell--PaddingTop: var(--pf-global--spacer--sm);
@@ -132,23 +201,12 @@
   --pf-c-table--m-compact__expandable-row-content--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-table--m-compact__expandable-row-content--PaddingLeft: var(--pf-global--spacer--lg);
 
-  // Modifier - compound expansion toggle
-  --pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-table__compound-expansion-toggle--BorderTop--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-table__compound-expansion-toggle--BorderRight--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__compound-expansion-toggle--BorderLeft--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__compound-expansion-toggle--BorderRight--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-table__compound-expansion-toggle--BorderLeft--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-table__compound-expansion-toggle--BorderBottom--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__compound-expansion-toggle--BorderBottom--BorderColor: var(--pf-global--BackgroundColor--light-100);
+  // Nested table
+  --pf-c-table--nested--first-last-child--PaddingRight: var(--pf-global--spacer--3xl);
+  --pf-c-table--nested--first-last-child--PaddingLeft: var(--pf-global--spacer--3xl);
 
   // Modifier - expandable row expanded
   --pf-c-table__expandable-row--m-expanded--BorderBottomColor: var(--pf-global--BorderColor--100);
-
-  // Modifier - sort
-  --pf-c-table__sort--sorted--Color: var(--pf-global--active-color--100);
-
-  // stylelint-enable
 
   @include pf-t-light; // This component always needs to be light
 
@@ -156,58 +214,54 @@
   width: 100%;
   background-color: var(--pf-c-table--BackgroundColor);
 
+  &.pf-m-fixed {
+    table-layout: fixed;
+  }
+
   // Standard table row (non-expandable)
   // exclude expandable rows
   tr:not(.pf-c-table__expandable-row) {
-    // hack: buttons inside table cells will not occupy full height of parent when adjacent cells'
-    // content wraps. for those special cases, there must be an explicit height set on tr and table cell
-    // for button height: 100% to work
-    height: 1px;
     border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
-
-    // stylelint-disable-next-line
-    &.pf-m-height-auto {
-      height: auto;
-    }
   }
 
-  // Table row
+  // Table cell
   tr > * {
-    @include pf-hidden-visible(var(--pf-c-table-cell--hidden-visible--Display));
+    @include pf-hidden-visible(var(--pf-c-table--cell--hidden-visible--Display));
 
     // set position relative for ::before borders
     position: relative;
+    width: var(--pf-c-table--cell--Width);
+    min-width: var(--pf-c-table--cell--MinWidth);
+    max-width: var(--pf-c-table--cell--MaxWidth);
+    padding: var(--pf-c-table--cell--PaddingTop) var(--pf-c-table--cell--PaddingRight) var(--pf-c-table--cell--PaddingBottom) var(--pf-c-table--cell--PaddingLeft);
 
-    // hack: set table cell height to inherit, then buttons within to height: 100%
-    height: inherit;
-
-    // each value must be set individually as each of these values may be reset contextually
-    padding: var(--pf-c-table-cell--PaddingTop) var(--pf-c-table-cell--PaddingRight) var(--pf-c-table-cell--PaddingBottom) var(--pf-c-table-cell--PaddingLeft);
-    font-size: var(--pf-c-table-cell--FontSize);
-    font-weight: var(--pf-c-table-cell--FontWeight);
-    overflow-wrap: break-word;
-    vertical-align: baseline;
+    // default settings
+    overflow: var(--pf-c-table--cell--Overflow);
+    font-size: var(--pf-c-table--cell--FontSize);
+    font-weight: var(--pf-c-table--cell--FontWeight);
+    color: var(--pf-c-table--cell--Color);
+    text-overflow: var(--pf-c-table--cell--TextOverflow);
+    word-break: var(--pf-c-table--cell--WordBreak);
+    white-space: var(--pf-c-table--cell--WhiteSpace);
 
     // First child padding left
     &:first-child {
-      --pf-c-table-cell--PaddingLeft: var(--pf-c-table-cell--first-last-child--PaddingLeft);
-
-      @media screen and (max-width: $pf-global--breakpoint--xl) {
-        --pf-c-table-cell--PaddingLeft: var(--pf-c-table-cell--first-last-child--xl--PaddingLeft);
-      }
+      --pf-c-table--cell--PaddingLeft: var(--pf-c-table--cell--first-last-child--PaddingLeft);
     }
 
     // Last child padding right
     &:last-child {
-      --pf-c-table-cell--PaddingRight: var(--pf-c-table-cell--first-last-child--PaddingRight);
-
-      @media screen and (max-width: $pf-global--breakpoint--xl) {
-        --pf-c-table-cell--PaddingRight: var(--pf-c-table-cell--first-last-child--xl--PaddingRight);
-      }
+      --pf-c-table--cell--PaddingRight: var(--pf-c-table--cell--first-last-child--PaddingRight);
     }
 
     &.pf-m-center {
       text-align: center;
+    }
+
+    &:empty {
+      width: 0;
+      min-width: 0;
+      padding: 0;
     }
   }
 
@@ -224,20 +278,37 @@
 
   // Table header cell
   thead {
-    --pf-c-table-cell--PaddingTop: var(--pf-c-table-thead-cell--PaddingTop);
-    --pf-c-table-cell--PaddingBottom: var(--pf-c-table-thead-cell--PaddingBottom);
-    --pf-c-table-cell--FontSize: var(--pf-c-table-thead--FontSize);
-    --pf-c-table-cell--FontWeight: var(--pf-c-table-thead--FontWeight);
+    --pf-c-table--cell--FontSize: var(--pf-c-table--thead--cell--FontSize);
+    --pf-c-table--cell--FontWeight: var(--pf-c-table--thead--cell--FontWeight);
+    --pf-c-table--cell--Width: var(--pf-c-table--thead--cell--Width);
+    --pf-c-table__button-content--AlignItems: var(--pf-c-table--thead__button-content--AlignItems);
 
-    white-space: nowrap;
-    vertical-align: top;
+    // Set default th behavior to truncate
+    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-truncate--cell--MinWidth);
+    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-truncate--cell--MaxWidth);
+    --pf-c-table--cell--Overflow: var(--pf-c-table--m-truncate--cell--Overflow);
+    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
+    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
+
+    // show overflow for thead cells
+    --pf-c-table--m-no-wrap--cell--Overflow: var(--pf-c-table--m-no-wrap--thead--cell--Overflow);
+
+    th,
+    td {
+      vertical-align: bottom;
+    }
   }
 
   // Table body cell
   // stylelint-disable
   tbody {
-    --pf-c-table-cell--PaddingTop: var(--pf-c-table-tbody-cell--PaddingTop);
-    --pf-c-table-cell--PaddingBottom: var(--pf-c-table-tbody-cell--PaddingBottom);
+    --pf-c-table--cell--PaddingTop: var(--pf-c-table--tbody--cell--PaddingTop);
+    --pf-c-table--cell--PaddingBottom: var(--pf-c-table--tbody--cell--PaddingBottom);
+
+    > tr > * {
+      overflow-wrap: break-word;
+      vertical-align: baseline;
+    }
 
     // Border treatment
     // using first child as row does not calculate height appropriately
@@ -248,16 +319,16 @@
       top: var(--pf-c-table__expandable-row--before--Top);
       bottom: var(--pf-c-table__expandable-row--before--Bottom);
       left: 0;
-      width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
 
       // add border left
       background-color: transparent;
+      border-left: var(--pf-c-table__expandable-row--before--BorderLeftWidth) solid var(--pf-c-table__expandable-row--before--BorderColor);
     }
 
     // add background color when active
-    &.pf-m-expanded > tr > :not(th):first-child::before {
-      background-color: var(--pf-c-table__expandable-row--before--BackgroundColor);
+    &.pf-m-expanded > tr > :first-child::before {
+      --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
     }
   }
   // stylelint-enable
@@ -274,32 +345,176 @@
       // explicitly reset padding rather than css variable, as the button within uses the variable
       padding: 0;
     }
+  }
 
-    .pf-c-button {
-      width: 100%;
-      padding: var(--pf-c-table-cell--PaddingTop) var(--pf-c-table-cell--PaddingRight) var(--pf-c-table-cell--PaddingBottom) var(--pf-c-table-cell--PaddingLeft);
-      font-size: inherit;
-      font-weight: inherit;
-      text-align: left;
-    }
+  // set property here to increase specificity
+  .pf-c-table__sort {
+    min-width: var(--pf-c-table__sort--MinWidth);
+  }
+
+  .pf-m-truncate {
+    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-truncate--cell--MinWidth);
+    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-truncate--cell--MaxWidth);
+    --pf-c-table--cell--Overflow: var(--pf-c-table--m-truncate--cell--Overflow);
+    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
+    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
+    --pf-c-table__text--MaxWidth: var(--pf-c-table__text--m-truncate--MaxWidth);
+  }
+
+  .pf-m-wrap {
+    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-wrap--cell--MinWidth);
+    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-wrap--cell--MaxWidth);
+    --pf-c-table--cell--Overflow: var(--pf-c-table--m-wrap--cell--Overflow);
+    --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-wrap--cell--TextOverflow);
+    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-wrap--cell--WhiteSpace);
+  }
+
+  .pf-m-no-wrap {
+    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-no-wrap--cell--MinWidth);
+    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-no-wrap--cell--MaxWidth);
+    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-no-wrap--cell--WhiteSpace);
+  }
+
+  .pf-m-fit-content {
+    --pf-c-table--cell--MinWidth: var(--pf-c-table--m-fit-content--cell--MinWidth);
+    --pf-c-table--cell--MaxWidth: var(--pf-c-table--m-fit-content--cell--MaxWidth);
+    --pf-c-table--cell--Width: var(--pf-c-table--m-fit-content--cell--Width);
+    --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-fit-content--cell--WhiteSpace);
+  }
+
+  .pf-m-break-word {
+    --pf-c-table--cell--WordBreak: break-word;
   }
 }
 
-// Toggle, check, action - minimize width and padding.
+// Text
+.pf-c-table__text {
+  // Only apply these settings if specifically modified
+  &.pf-m-truncate,
+  &.pf-m-wrap,
+  &.pf-m-no-wrap,
+  &.pf-m-fit-content,
+  &.pf-m-break-word {
+    --pf-c-table--m-truncate--cell--MinWidth: 100%;
+
+    position: relative;
+    display: block;
+    width: var(--pf-c-table--cell--Width);
+    min-width: var(--pf-c-table--cell--MinWidth);
+    max-width: var(--pf-c-table--cell--MaxWidth);
+    overflow: var(--pf-c-table--cell--Overflow);
+    text-overflow: var(--pf-c-table--cell--TextOverflow);
+    word-break: var(--pf-c-table--cell--WordBreak);
+    white-space: var(--pf-c-table--cell--WhiteSpace);
+  }
+}
+
+// Cell content
+.pf-c-table__cell-content {
+  min-width: 100%;
+  max-width: 1px;
+}
+
+// Button
+.pf-c-table__button {
+  position: static;
+  width: 100%;
+  padding: var(--pf-c-table--cell--PaddingTop) var(--pf-c-table--cell--PaddingRight) var(--pf-c-table--cell--PaddingBottom) var(--pf-c-table--cell--PaddingLeft);
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--pf-c-table__button--Color);
+  text-align: left;
+  white-space: inherit;
+  user-select: text;
+  background-color: var(--pf-c-table__button--BackgroundColor);
+  border: 0;
+
+  // Define clickable area with invisible ::before pseudo
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    cursor: pointer;
+    content: "";
+  }
+
+  // Remove outline and apply to parent td
+  &:hover,
+  &:focus,
+  &:active {
+    outline: none;
+  }
+
+  &:hover {
+    color: var(--pf-c-table__button--hover--Color);
+  }
+
+  &:focus {
+    color: var(--pf-c-table__button--focus--Color);
+  }
+
+  &:active {
+    color: var(--pf-c-table__button--active--Color);
+  }
+}
+
+// Focus styles
+.pf-c-table__sort,
+.pf-c-table__compound-expansion-toggle {
+  &:active,
+  &:focus-within {
+    outline-offset: var(--pf-c-table__button--OutlineOffset);
+
+    // stylelint-disable media-feature-name-no-vendor-prefix
+    @media (-webkit-min-device-pixel-ratio: 0) {
+      outline-style: auto;
+      outline-color: -webkit-focus-ring-color;
+    }
+    // stylelint-enable
+  }
+
+  // Pass properties to text
+  .pf-c-table__text {
+    display: block;
+    width: auto;
+    overflow: var(--pf-c-table--cell--Overflow);
+    text-overflow: var(--pf-c-table--cell--TextOverflow);
+    white-space: var(--pf-c-table--cell--WhiteSpace);
+  }
+}
+
+// Sort content
+// display grid for buttons is not supported
+.pf-c-table__button-content {
+  display: inline-grid;
+  align-items: var(--pf-c-table__button-content--AlignItems);
+  justify-content: start;
+  grid-template-columns: auto;
+  grid-auto-columns: max-content;
+}
+
+// Toggle, check, action - minimize padding.
 .pf-c-table .pf-c-table__toggle,
-.pf-c-table .pf-c-table__check,
 .pf-c-table .pf-c-table__action,
 .pf-c-table .pf-c-table__inline-edit-action {
-  --pf-c-table-cell--PaddingBottom: 0;
+  --pf-c-table--cell--PaddingBottom: 0;
+}
 
-  width: 1%;
+// Toggle, check, action - minimize width.
+.pf-c-table .pf-c-table__check,
+.pf-c-table .pf-c-table__toggle,
+.pf-c-table .pf-c-table__action,
+.pf-c-table .pf-c-table__inline-edit-action {
+  --pf-c-table--cell--MinWidth: 0;
+  --pf-c-table--cell--Width: 1%;
 }
 
 // Toggle table cell
-// ==================================================================
 .pf-c-table__toggle {
-  --pf-c-table-cell--PaddingRight: 0;
-  --pf-c-table-cell--PaddingLeft: 0;
+  --pf-c-table--cell--PaddingRight: 0;
+  --pf-c-table--cell--PaddingLeft: 0;
 
   vertical-align: top;
 
@@ -324,11 +539,10 @@
 }
 
 // Check table cell
-// ==================================================================
 .pf-c-table__check {
   vertical-align: top;
 
-  --pf-c-table-cell--FontSize: var(--pf-c-table__check--input--FontSize);
+  --pf-c-table--cell--FontSize: var(--pf-c-table__check--input--FontSize);
 
   > input {
     margin-top: var(--pf-c-table__check--input--MarginTop);
@@ -337,104 +551,119 @@
 }
 
 // Table action cell
-// ==================================================================
 .pf-c-table__action,
 .pf-c-table__inline-edit-action {
-  --pf-c-table-cell--PaddingTop: 0;
-  --pf-c-table-cell--PaddingRight: var(--pf-c-table__action--PaddingRight);
-  --pf-c-table-cell--PaddingBottom: 0;
-  --pf-c-table-cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
+  --pf-c-table--cell--PaddingTop: 0;
+  --pf-c-table--cell--PaddingRight: var(--pf-c-table__action--PaddingRight);
+  --pf-c-table--cell--PaddingBottom: 0;
+  --pf-c-table--cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
 
   padding-top: 0;
   padding-bottom: 0;
   vertical-align: middle;
 }
 
+// Inline edit
 .pf-c-table__inline-edit-action {
-  --pf-c-table-cell--PaddingLeft: 0;
-  --pf-c-table-cell--PaddingRight: 0;
+  --pf-c-table--cell--PaddingLeft: 0;
+  --pf-c-table--cell--PaddingRight: 0;
 
   text-align: right;
 }
 
-// Table toggle compount expansion
-// using this method because the button may not always be full height of the parent cell if siblings wrap
-// ==================================================================
+// Compound expansion toggle
 .pf-c-table__compound-expansion-toggle {
+  --pf-c-table__button--Color: var(--pf-c-table__compound-expansion-toggle__button--Color);
+  --pf-c-table__button--hover--Color: var(--pf-c-table__compound-expansion-toggle__button--hover--Color);
+  --pf-c-table__button--focus--Color: var(--pf-c-table__compound-expansion-toggle__button--focus--Color);
+  --pf-c-table__button--active--Color: var(--pf-c-table__compound-expansion-toggle__button--active--Color);
+
   position: relative;
 
+  // Apply borders to button to avoid conflicts with expanded states
+  .pf-c-table__button::before,
+  .pf-c-table__button::after {
+    position: absolute;
+    right: 0;
+    content: "";
+    border-style: solid;
+    border-width: 0;
+  }
+
+  .pf-c-table__button::before {
+    top: 0;
+    bottom: var(--pf-c-table__compound-expansion-toggle__button--before--Bottom);
+    left: var(--pf-c-table__compound-expansion-toggle__button--before--Left);
+    border-color: var(--pf-c-table__compound-expansion-toggle__button--before--BorderColor);
+    border-right-width: var(--pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth);
+    border-left-width: var(--pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth);
+  }
+
+  .pf-c-table__button::after {
+    // overlap previous row's border
+    top: var(--pf-c-table__compound-expansion-toggle__button--after--Top);
+    left: var(--pf-c-table__compound-expansion-toggle__button--after--Left);
+    pointer-events: none;
+    border-color: var(--pf-c-table__compound-expansion-toggle__button--after--BorderColor);
+    border-top-width: var(--pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth);
+  }
+
+  &:hover,
+  &:focus-within,
   &.pf-m-expanded {
-    border-bottom: var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderColor);
+    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
+    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
+    --pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth: var(--pf-c-table__compound-expansion-toggle__button--after--BorderWidth);
   }
 
-  &.pf-m-expanded,
-  &:hover {
-    .pf-c-button::before {
-      position: absolute;
-      top: calc(var(--pf-c-table--BorderWidth) * -1);
-      right: 0;
-      left: 0;
-      content: "";
-      border-top: var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderColor);
-    }
-
-    .pf-c-button::after {
-      bottom: calc(var(--pf-c-table--BorderWidth) * -1);
-      border-right: var(--pf-c-table__compound-expansion-toggle--BorderRight--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderRight--BorderColor);
-      border-left: var(--pf-c-table__compound-expansion-toggle--BorderLeft--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderLeft--BorderColor);
-    }
+  &:first-child {
+    --pf-c-table__compound-expansion-toggle__button--after--Left: 0;
+    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
   }
 
-  .pf-c-button {
-    --pf-c-button--BorderRadius: 0;
+  &:last-child {
+    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: 0;
+  }
 
-    // hack: firefox doesn't respect height: 100%. borders are set with ::before & ::after which are
-    // relative to the parent when setting button position: static
-    position: static;
+  &.pf-m-expanded {
+    border-bottom: var(--pf-c-table--BackgroundColor) solid var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
+  }
+
+  // set text to respond to content
+  .pf-c-table__text {
+    --pf-c-table--cell--MinWidth: 0;
+    --pf-c-table--cell--MaxWidth: none;
+    --pf-c-table--cell--Width: auto;
   }
 }
 
 // Table sort
 // ==================================================================
 .pf-c-table__sort {
-  // override pf-m-plain color
-  .pf-c-button {
-    // stylelint-disable
-    &.pf-m-plain {
-      color: var(--pf-c-table__sort--c-button--Color);
-    }
-  }
-  // stylelint-enable
-
-  &.pf-m-wrap {
-    .pf-c-button {
-      display: flex;
-      white-space: normal;
-    }
+  .pf-c-table__button:hover {
+    --pf-c-table__sort-indicator--Color: var(--pf-c-table__sort__button--hover__sort-indicator--Color);
   }
 
-  &.pf-m-selected {
-    // set button and indicator color
-    .pf-c-button,
-    .pf-c-table__sort-indicator {
-      color: var(--pf-c-table__sort--sorted--Color);
-    }
+  .pf-c-table__button:focus {
+    --pf-c-table__sort-indicator--Color: var(--pf-c-table__sort__button--focus__sort-indicator--Color);
   }
 
-  &:not(.pf-m-selected) {
-    &:hover {
-      .pf-c-table__sort-indicator {
-        color: var(--pf-c-table__sort-indicator--hover--Color);
-      }
-    }
+  .pf-c-table__button:active {
+    --pf-c-table__sort-indicator--Color: var(--pf-c-table__sort__button--active__sort-indicator--Color);
+  }
+
+  &.pf-m-selected .pf-c-table__button {
+    --pf-c-table__sort-indicator--Color: var(--pf-c-table__sort--m-selected__sort-indicator--Color);
+
+    // override state colors on text
+    color: var(--pf-c-table__sort--m-selected__button--Color);
   }
 }
 
 // Sort indicator
 .pf-c-table__sort-indicator {
-  align-self: flex-start;
+  grid-column: 2;
   margin-left: var(--pf-c-table__sort-indicator--MarginLeft);
-  line-height: var(--pf-c-table__sort-indicator--LineHeight);
   color: var(--pf-c-table__sort-indicator--Color);
   pointer-events: none;
 }
@@ -442,8 +671,8 @@
 // Expandable row
 // ==================================================================
 .pf-c-table__expandable-row {
-  --pf-c-table-cell--PaddingTop: 0;
-  --pf-c-table-cell--PaddingBottom: 0;
+  --pf-c-table--cell--PaddingTop: 0;
+  --pf-c-table--cell--PaddingBottom: 0;
 
   position: relative;
   border-bottom: 0 solid transparent;
@@ -484,19 +713,18 @@
   }
 }
 
-
 // Nested table
 // ==================================================================
 .pf-c-table .pf-c-table {
   tr > * {
     // First child padding left
     &:first-child {
-      --pf-c-table-cell--PaddingLeft: var(--pf-c-table--nested--first-last-child--PaddingLeft);
+      --pf-c-table--cell--PaddingLeft: var(--pf-c-table--nested--first-last-child--PaddingLeft);
     }
 
     // Last child padding right
     &:last-child {
-      --pf-c-table-cell--PaddingRight: var(--pf-c-table--nested--first-last-child--PaddingRight);
+      --pf-c-table--cell--PaddingRight: var(--pf-c-table--nested--first-last-child--PaddingRight);
     }
   }
 }
@@ -504,7 +732,7 @@
 // Compact table
 // ==================================================================
 .pf-c-table.pf-m-compact {
-  --pf-c-table-cell--FontSize: var(--pf-c-table--m-compact--FontSize);
+  --pf-c-table--cell--FontSize: var(--pf-c-table--m-compact--FontSize);
 
   &.pf-m-no-border-rows:not(.pf-m-expandable) {
     tbody {
@@ -514,30 +742,22 @@
   }
 
   tr {
-    --pf-c-table-cell--PaddingLeft: var(--pf-c-table--m-compact-cell--PaddingLeft);
-    --pf-c-table-cell--PaddingRight: var(--pf-c-table--m-compact-cell--PaddingRight);
+    --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact-cell--PaddingLeft);
+    --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact-cell--PaddingRight);
 
     &:not(.pf-c-table__expandable-row) {
-      --pf-c-table-cell--FontSize: var(--pf-c-table--m-compact--FontSize);
-      --pf-c-table-cell--PaddingTop: var(--pf-c-table--m-compact-cell--PaddingTop);
-      --pf-c-table-cell--PaddingBottom: var(--pf-c-table--m-compact-cell--PaddingBottom);
+      --pf-c-table--cell--FontSize: var(--pf-c-table--m-compact--FontSize);
+      --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact-cell--PaddingTop);
+      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact-cell--PaddingBottom);
 
       // stylelint-disable
       > * {
         &:first-child {
-          --pf-c-table-cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--PaddingLeft);
-
-          @media screen and (max-width: $pf-global--breakpoint--xl) {
-            --pf-c-table-cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--xl--PaddingLeft);
-          }
+          --pf-c-table--cell--PaddingLeft: var(--pf-c-table--m-compact-cell--first-last-child--PaddingLeft);
         }
 
         &:last-child {
-          --pf-c-table-cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--PaddingRight);
-
-          @media screen and (max-width: $pf-global--breakpoint--xl) {
-            --pf-c-table-cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--xl--PaddingRight);
-          }
+          --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact-cell--first-last-child--PaddingRight);
         }
       }
       // stylelint-enable
@@ -551,14 +771,14 @@
   }
 
   .pf-c-table__action {
-    --pf-c-table-cell--PaddingTop: var(--pf-c-table__action--PaddingTop);
-    --pf-c-table-cell--PaddingBottom: var(--pf-c-table__action--PaddingBottom);
-    --pf-c-table-cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
+    --pf-c-table--cell--PaddingTop: var(--pf-c-table__action--PaddingTop);
+    --pf-c-table--cell--PaddingBottom: var(--pf-c-table__action--PaddingBottom);
+    --pf-c-table--cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
   }
 
   .pf-c-table__toggle {
-    --pf-c-table-cell--PaddingTop: var(--pf-c-table--m-compact__toggle--PaddingTop);
-    --pf-c-table-cell--PaddingBottom: var(--pf-c-table--m-compact__toggle--PaddingBottom);
+    --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact__toggle--PaddingTop);
+    --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact__toggle--PaddingBottom);
   }
 
   .pf-c-table__icon {
@@ -568,11 +788,11 @@
   // nested tables
   .pf-c-table & tr > * {
     &:first-child {
-      --pf-c-table-cell--PaddingLeft: var(--pf-c-table--nested--first-last-child--PaddingLeft);
+      --pf-c-table--cell--PaddingLeft: var(--pf-c-table--nested--first-last-child--PaddingLeft);
     }
 
     &:last-child {
-      --pf-c-table-cell--PaddingRight: var(--pf-c-table--nested--first-last-child--PaddingRight);
+      --pf-c-table--cell--PaddingRight: var(--pf-c-table--nested--first-last-child--PaddingRight);
     }
   }
 
@@ -593,77 +813,60 @@
   }
 }
 
-// Modifier - fit-content
-.pf-c-table .pf-m-fit-content {
-  // limit width and padding, fit contents of cell
-  width: 1%;
-  white-space: nowrap;
-}
-
-// Modifier - Wrap
-.pf-c-table .pf-m-wrap {
-  white-space: normal;
-  vertical-align: top;
-}
-
 // Modifier - Width
 // stylelint-disable
-.pf-c-table [class*="pf-m-width-"] {
-  table-layout: fixed;
-}
-
 .pf-c-table .pf-m-width-10 {
-  width: 10%;
+  --pf-c-table--cell--Width: 10%;
 }
 
 .pf-c-table .pf-m-width-15 {
-  width: 15%;
+  --pf-c-table--cell--Width: 15%;
 }
 
 .pf-c-table .pf-m-width-20 {
-  width: 20%;
+  --pf-c-table--cell--Width: 20%;
 }
 
 .pf-c-table .pf-m-width-25 {
-  width: 25%;
+  --pf-c-table--cell--Width: 25%;
 }
 
 .pf-c-table .pf-m-width-30 {
-  width: 30%;
+  --pf-c-table--cell--Width: 30%;
 }
 
 .pf-c-table .pf-m-width-35 {
-  width: 35%;
+  --pf-c-table--cell--Width: 35%;
 }
 
 .pf-c-table .pf-m-width-40 {
-  width: 40%;
+  --pf-c-table--cell--Width: 40%;
 }
 
 .pf-c-table .pf-m-width-45 {
-  width: 45%;
+  --pf-c-table--cell--Width: 45%;
 }
 
 .pf-c-table .pf-m-width-50 {
-  width: 50%;
+  --pf-c-table--cell--Width: 50%;
 }
 
 .pf-c-table .pf-m-width-60 {
-  width: 60%;
+  --pf-c-table--cell--Width: 60%;
 }
 
 .pf-c-table .pf-m-width-70 {
-  width: 70%;
+  --pf-c-table--cell--Width: 70%;
 }
 
 .pf-c-table .pf-m-width-80 {
-  width: 80%;
+  --pf-c-table--cell--Width: 80%;
 }
 
 .pf-c-table .pf-m-width-90 {
-  width: 90%;
+  --pf-c-table--cell--Width: 90%;
 }
 
-.pf-c-table .pf-m-width-max {
-  width: 100%;
+.pf-c-table .pf-m-width-100 {
+  --pf-c-table--cell--Width: 100%;
 }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -153,15 +153,14 @@
   // Sort button
   --pf-c-table__sort__button--Color: var(--pf-global--Color--100);
   --pf-c-table__sort--m-selected__button--Color: var(--pf-global--active-color--100);
-  --pf-c-table__sort--m-selected--Color: var(--pf-global--active-color--100);
-  --pf-c-table__sort--m-selected__sort-indicator--Color: var(--pf-global--active-color--100);
 
   // Sort indicator
   --pf-c-table__sort-indicator--Color: var(--pf-global--disabled-color--200);
+  --pf-c-table__sort-indicator--MarginLeft: var(--pf-global--spacer--md);
+  --pf-c-table__sort--m-selected__sort-indicator--Color: var(--pf-global--active-color--100);
   --pf-c-table__sort__button--hover__sort-indicator--Color: var(--pf-global--Color--100);
   --pf-c-table__sort__button--active__sort-indicator--Color: var(--pf-global--Color--100);
   --pf-c-table__sort__button--focus__sort-indicator--Color: var(--pf-global--Color--100);
-  --pf-c-table__sort-indicator--MarginLeft: var(--pf-global--spacer--md);
 
   // Compound expansion toggle button
   --pf-c-table__compound-expansion-toggle__button--Color: var(--pf-global--active-color--100);
@@ -228,7 +227,7 @@
   tr > * {
     @include pf-hidden-visible(var(--pf-c-table--cell--hidden-visible--Display));
 
-    // set position relative for ::before borders
+    // set position relative for ::before/::after borders
     position: relative;
     width: var(--pf-c-table--cell--Width);
     min-width: var(--pf-c-table--cell--MinWidth);
@@ -281,7 +280,6 @@
     --pf-c-table--cell--FontSize: var(--pf-c-table--thead--cell--FontSize);
     --pf-c-table--cell--FontWeight: var(--pf-c-table--thead--cell--FontWeight);
     --pf-c-table--cell--Width: var(--pf-c-table--thead--cell--Width);
-    --pf-c-table__button-content--AlignItems: var(--pf-c-table--thead__button-content--AlignItems);
 
     // Set default th behavior to truncate
     --pf-c-table--cell--MinWidth: var(--pf-c-table--m-truncate--cell--MinWidth);
@@ -289,6 +287,9 @@
     --pf-c-table--cell--Overflow: var(--pf-c-table--m-truncate--cell--Overflow);
     --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
     --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
+
+    // Align content to bottom
+    --pf-c-table__button-content--AlignItems: var(--pf-c-table--thead__button-content--AlignItems);
 
     // show overflow for thead cells
     --pf-c-table--m-no-wrap--cell--Overflow: var(--pf-c-table--m-no-wrap--thead--cell--Overflow);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -60,7 +60,7 @@
 
   // Truncate
   --pf-c-table--m-truncate--cell--MaxWidth: 1px;
-  --pf-c-table--m-truncate--cell--MinWidth: 10ch;
+  --pf-c-table--m-truncate--cell--MinWidth: 9ch;
 
   // Hidden visible
   --pf-c-table--cell--hidden-visible--Display: table-cell;
@@ -239,7 +239,7 @@
     }
 
     &:empty {
-      width: 0;
+      width: auto;
       min-width: 0;
       padding: 0;
     }
@@ -341,10 +341,13 @@
     --pf-c-table--cell--WhiteSpace: nowrap;
   }
 
+  .pf-c-table__icon,
   .pf-m-fit-content {
     --pf-c-table--cell--MinWidth: fit-content;
     --pf-c-table--cell--MaxWidth: fit-content;
     --pf-c-table--cell--Width: 1%;
+    --pf-c-table--cell--Overflow: visible;
+    --pf-c-table--cell--TextOverflow: clip;
     --pf-c-table--cell--WhiteSpace: nowrap;
   }
 
@@ -541,6 +544,10 @@
 
   position: relative;
 
+  &.pf-m-truncate {
+    overflow: visible;
+  }
+
   // Apply borders to button to avoid conflicts with expanded states
   .pf-c-table__button::before,
   .pf-c-table__button::after {
@@ -578,16 +585,16 @@
   }
 
   &:first-child {
+    --pf-c-table__compound-expansion-toggle__button--before--Left: 0;
     --pf-c-table__compound-expansion-toggle__button--after--Left: 0;
-    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
-  }
-
-  &:last-child {
-    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: 0;
   }
 
   &.pf-m-expanded {
     border-bottom: var(--pf-c-table--BackgroundColor) solid var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
+
+    &:first-child {
+      --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
+    }
   }
 
   // set text to respond to content
@@ -597,6 +604,14 @@
     --pf-c-table--cell--Width: auto;
   }
 }
+
+// stylelint-disable selector-no-qualifying-type
+.pf-c-table tbody.pf-m-expanded,
+.pf-c-table__expandable-row.pf-m-expanded,
+.pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child {
+  --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
+}
+// stylelint-enable
 
 // Table sort
 // ==================================================================
@@ -666,10 +681,6 @@
     border-bottom-color: var(--pf-c-table__expandable-row--m-expanded--BorderBottomColor);
     border-bottom-width: var(--pf-c-table--BorderWidth);
     box-shadow: var(--pf-c-table__expandable-row--m-expanded--BoxShadow);
-
-    :first-child::before {
-      --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
-    }
   }
 
 
@@ -748,6 +759,8 @@
   }
 
   .pf-c-table__icon {
+    width: auto;
+    min-width: 0;
     text-align: center;
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -89,7 +89,7 @@
   --pf-c-table--m-compact__toggle--PaddingBottom: 0;
 
   // Check
-  --pf-c-table__check--input--MarginTop: #{pf-size-prem(3px)};
+  --pf-c-table__check--input--MarginTop: #{pf-size-prem(4px)};
   --pf-c-table__check--input--FontSize: var(--pf-global--FontSize--md);
 
   // Action
@@ -295,6 +295,14 @@
       // add border left
       background-color: transparent;
       border-left: var(--pf-c-table__expandable-row--before--BorderLeftWidth) solid var(--pf-c-table__expandable-row--before--BorderColor);
+    }
+
+    // Check table cell
+    .pf-c-table__check {
+      > input {
+        margin-top: var(--pf-c-table__check--input--MarginTop);
+        vertical-align: top;
+      }
     }
   }
   // stylelint-enable
@@ -506,14 +514,7 @@
 
 // Check table cell
 .pf-c-table__check {
-  vertical-align: top;
-
   --pf-c-table--cell--FontSize: var(--pf-c-table__check--input--FontSize);
-
-  > input {
-    margin-top: var(--pf-c-table__check--input--MarginTop);
-    vertical-align: top;
-  }
 }
 
 // Table action cell
@@ -712,6 +713,10 @@
 // ==================================================================
 .pf-c-table.pf-m-compact {
   --pf-c-table--cell--FontSize: var(--pf-c-table--m-compact--FontSize);
+  --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact--cell--PaddingTop);
+  --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact--cell--PaddingRight);
+  --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact--cell--PaddingBottom);
+  --pf-c-table--cell--PaddingRight: var(--pf-c-table--m-compact--cell--PaddingLeft);
 
   &.pf-m-no-border-rows:not(.pf-m-expandable) {
     tbody {
@@ -745,8 +750,8 @@
 
   // Thead only
   thead {
-    --pf-c-table--m-compact--cell--PaddingTop: var(--pf-c-table--m-compact-th--PaddingTop);
-    --pf-c-table--m-compact--cell--PaddingBottom: var(--pf-c-table--m-compact-th--PaddingBottom);
+    --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact-th--PaddingTop);
+    --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact-th--PaddingBottom);
   }
 
   .pf-c-table__action {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -376,12 +376,6 @@
   }
 }
 
-// Cell content
-.pf-c-table__cell-content {
-  min-width: 100%;
-  max-width: 1px;
-}
-
 // Button
 .pf-c-table__button {
   position: static;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -32,7 +32,6 @@
   --pf-c-table--thead--cell--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-table--thead--cell--FontWeight: var(--pf-global--FontWeight--bold);
   --pf-c-table--m-no-wrap--thead--cell--Overflow: visible;
-  --pf-c-table--thead__button-content--AlignItems: end;
 
   // Tbody cell
   --pf-c-table--tbody--cell--PaddingTop: var(--pf-global--spacer--lg);
@@ -288,9 +287,6 @@
     --pf-c-table--cell--TextOverflow: var(--pf-c-table--m-truncate--cell--TextOverflow);
     --pf-c-table--cell--WhiteSpace: var(--pf-c-table--m-truncate--cell--WhiteSpace);
 
-    // Align content to bottom
-    --pf-c-table__button-content--AlignItems: var(--pf-c-table--thead__button-content--AlignItems);
-
     // show overflow for thead cells
     --pf-c-table--m-no-wrap--cell--Overflow: var(--pf-c-table--m-no-wrap--thead--cell--Overflow);
 
@@ -385,6 +381,7 @@
 
   .pf-m-break-word {
     --pf-c-table--cell--WordBreak: break-word;
+    --pf-c-table--cell--WhiteSpace: normal;
   }
 }
 
@@ -490,7 +487,7 @@
 // display grid for buttons is not supported
 .pf-c-table__button-content {
   display: inline-grid;
-  align-items: var(--pf-c-table__button-content--AlignItems);
+  align-items: end;
   justify-content: start;
   grid-template-columns: auto;
   grid-auto-columns: max-content;

--- a/src/patternfly/demos/Table/table-compound-expansion-table.hbs
+++ b/src/patternfly/demos/Table/table-compound-expansion-table.hbs
@@ -11,10 +11,10 @@
         Pull requests
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"'}}
-       Work spaces
+        Work spaces
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"'}}
-       Last commit
+        Last commit
       {{/table-th}}
       {{#> table-td}}{{/table-td}}
       {{#> table-td}}{{/table-td}}
@@ -26,29 +26,23 @@
       {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          10
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code-branch" aria-hidden="true"></i>
+        {{/button-icon}}
+        10
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-2"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code" aria-hidden="true"></i>
+        {{/button-icon}}
           4
-        {{/button}}
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-3"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-cube" aria-hidden="true"></i>
+        {{/button-icon}}
+        4
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>20 minutes</span>
@@ -89,29 +83,23 @@
       {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          3
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-4"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code-branch" aria-hidden="true"></i>
+        {{/button-icon}}
+        3
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          4
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-5"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code" aria-hidden="true"></i>
+        {{/button-icon}}
+        4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          2
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-6"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-cube" aria-hidden="true"></i>
+        {{/button-icon}}
+        2
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>1 day ago</span>
@@ -149,32 +137,26 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
-       {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-th table-th--data-label="Repository name"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code-branch" aria-hidden="true"></i>
-          {{/button-icon}}
-          70
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-7"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code-branch" aria-hidden="true"></i>
+        {{/button-icon}}
+        70
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-code" aria-hidden="true"></i>
-          {{/button-icon}}
-          15
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-8"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-code" aria-hidden="true"></i>
+        {{/button-icon}}
+        15
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces"}}
-        {{#> button button--modifier="pf-m-link" button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {{/button-icon}}
-          12
-        {{/button}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Work spaces" table-td--button--attribute=(concat 'aria-expanded="false" aria-controls="' table--id '-nested-table-9"')}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-cube" aria-hidden="true"></i>
+        {{/button-icon}}
+        12
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         <span>2 days ago</span>


### PR DESCRIPTION
**Preview:** https://patternfly-pr-2965.surge.sh/documentation/core/components/table

fixes #2869 
fixes #2265 
fixes #2261
fixes #2205 
fixes #1948 

- removed `.pf-m-expanded` from compound expansion table example.

## Breaking changes
This PR fixes multiple table issues. 
* Adds dedicated table button `.pf-c-table__button`: this button relies on `::after` pseudo element to define clickable area, as previous height hacks cause cross browser bugs. `focus-ring` is disabled on this button and applied to the parent table cell.
* Hover, focus, active and selected states `.pf-c-table__sort` and `.pf-c-table__compound-expansion-toggle`: updates border discrepancies using `::before` and `::after` pseudos and negative offsets.
* Adds text wrapping control `.pf-m-truncate`, `.pf-m-wrap`, `.pf-m-no-wrap`, `.pf-m-break-word` and `.pf-m-fit-content`.
* Adds `.pf-c-table__text` wrapper for grid layout truncation/wrapping control.

// Will update when approved

The following classes have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `.`

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--`

The following variables have been renamed. Any reference to the old variable should be updated to use the new variable:
* `--pf-c-` has changed to `--pf-c-`

Some of the general CSS structure has also changed, so please reference the [file changeset](https://github.com/patternfly/patternfly/pull/2965/files).