### PR TITLE
Issue 2967

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,9 +10,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-basic"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
@@ -27,9 +29,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-sm-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-small"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-sm-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -47,9 +51,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-large"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-lg-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -81,9 +87,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-with-description-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-description"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
     A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
   {{/modal-box-description}}
@@ -117,7 +125,8 @@ A modal box is a generic rectangular container that can be used to build modals.
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. **Required** |
-| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. |
+| `.pf-c-modal-box__header` | `<div>` | Initiates a modal box header. |
+| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. The title goes in the `.pf-c-modal-box__header` element. |
 | `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title and modal body are **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}"
+  {{#if modal-box-header--attribute}}
+    {{{modal-box-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,10 +1,10 @@
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-modal-box--BorderColor: transparent;
-  --pf-c-modal-box--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--child--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--child--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--child--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box--last-child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
@@ -15,20 +15,20 @@
   --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
   // Description
-  --pf-c-modal-box__c-title--description--MarginTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box__header--description--PaddingTop: var(--pf-global--spacer--xs);
 
   // Body
-  --pf-c-modal-box--body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
-  --pf-c-modal-box__description--body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-modal-box--c-title--body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
+  --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
-  --pf-c-modal-box--c-button--Top: calc(var(--pf-c-modal-box--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
+  --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
   --pf-c-modal-box--c-button--Right: var(--pf-global--spacer--md);
   --pf-c-modal-box--c-button--sibling--MarginRight: var(--pf-global--spacer--xl);
 
   // Footer
-  --pf-c-modal-box__footer--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--lg);
 
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
@@ -44,7 +44,6 @@
   width: var(--pf-c-modal-box--Width);
   max-width: var(--pf-c-modal-box--MaxWidth);
   max-height: var(--pf-c-modal-box--MaxHeight);
-  padding: var(--pf-c-modal-box--PaddingTop) var(--pf-c-modal-box--PaddingRight) var(--pf-c-modal-box--PaddingBottom) var(--pf-c-modal-box--PaddingLeft);
   background-color: var(--pf-c-modal-box--BackgroundColor);
   border: var(--pf-c-modal-box--BorderSize) solid var(--pf-c-modal-box--BorderColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
@@ -73,32 +72,47 @@
       margin-right: var(--pf-c-modal-box--c-button--sibling--MarginRight); // Create room for the close button
     }
   }
+}
+
+.pf-c-modal-box__header,
+.pf-c-modal-box__description,
+.pf-c-modal-box__body,
+.pf-c-modal-box__footer {
+  padding-top: var(--pf-c-modal-box--child--PaddingTop);
+  padding-right: var(--pf-c-modal-box--child--PaddingRight);
+  padding-left: var(--pf-c-modal-box--child--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box--last-child--PaddingBottom);
+  }
+}
+
+.pf-c-modal-box__header {
+  flex: 0 0 auto;
+
+  + .pf-c-modal-box__description {
+    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__header--description--PaddingTop);
+  }
+
+  + .pf-c-modal-box__body {
+    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
+  }
 
   > .pf-c-title {
     @include pf-text-overflow;
-
-    flex: 0 0 auto;
-
-    + .pf-c-modal-box__description {
-      margin-top: var(--pf-c-modal-box__c-title--description--MarginTop);
-    }
-
-    + .pf-c-modal-box__body {
-      margin-top: var(--pf-c-modal-box--c-title--body--MarginTop);
-    }
   }
 }
 
 .pf-c-modal-box__description {
   + .pf-c-modal-box__body {
-    margin-top: var(--pf-c-modal-box__description--body--MarginTop);
+    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__description--body--PaddingTop);
   }
 }
 
 // Body
 .pf-c-modal-box__body {
   flex: 1 1 auto;
-  min-height: var(--pf-c-modal-box--body--MinHeight);
+  min-height: var(--pf-c-modal-box__body--MinHeight);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -108,10 +122,11 @@
 
 // Footer
 .pf-c-modal-box__footer {
+  --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__footer--PaddingTop);
+
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  margin-top: var(--pf-c-modal-box__footer--MarginTop);
 
   // Base margin left and right equal for buttons when wrapped
   > .pf-c-button:not(:last-child) {

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,10 +1,6 @@
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-modal-box--BorderColor: transparent;
-  --pf-c-modal-box--child--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--child--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--last-child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
@@ -14,13 +10,26 @@
   --pf-c-modal-box--m-lg--lg--MaxWidth: #{pf-size-prem(1120px)};
   --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
+  // Header
+  --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--last-child--PaddingBottom: var(--pf-global--spacer--lg);
+
   // Description
-  --pf-c-modal-box__header--description--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box__description--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box__description--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__description--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__description--last-child--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Body
   --pf-c-modal-box__body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
-  --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__body--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
   --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
@@ -29,6 +38,9 @@
 
   // Footer
   --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingLeft: var(--pf-global--spacer--lg);
 
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
@@ -74,28 +86,22 @@
   }
 }
 
-.pf-c-modal-box__header,
-.pf-c-modal-box__description,
-.pf-c-modal-box__body,
-.pf-c-modal-box__footer {
-  padding-top: var(--pf-c-modal-box--child--PaddingTop);
-  padding-right: var(--pf-c-modal-box--child--PaddingRight);
-  padding-left: var(--pf-c-modal-box--child--PaddingLeft);
-
-  &:last-child {
-    padding-bottom: var(--pf-c-modal-box--last-child--PaddingBottom);
-  }
-}
-
 .pf-c-modal-box__header {
   flex: 0 0 auto;
+  padding-top: var(--pf-c-modal-box__header--PaddingTop);
+  padding-right: var(--pf-c-modal-box__header--PaddingRight);
+  padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__header--last-child--PaddingBottom);
+  }
 
   + .pf-c-modal-box__description {
-    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__header--description--PaddingTop);
+    --pf-c-modal-box__description--PaddingTop: var(--pf-c-modal-box__header--description--PaddingTop);
   }
 
   + .pf-c-modal-box__body {
-    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
   }
 
   > .pf-c-title {
@@ -104,8 +110,16 @@
 }
 
 .pf-c-modal-box__description {
+  padding-top: var(--pf-c-modal-box__description--PaddingTop);
+  padding-right: var(--pf-c-modal-box__description--PaddingRight);
+  padding-left: var(--pf-c-modal-box__description--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__description--last-child--PaddingBottom);
+  }
+
   + .pf-c-modal-box__body {
-    --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__description--body--PaddingTop);
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__description--body--PaddingTop);
   }
 }
 
@@ -113,20 +127,29 @@
 .pf-c-modal-box__body {
   flex: 1 1 auto;
   min-height: var(--pf-c-modal-box__body--MinHeight);
+  padding-top: var(--pf-c-modal-box__body--PaddingTop);
+  padding-right: var(--pf-c-modal-box__body--PaddingRight);
+  padding-left: var(--pf-c-modal-box__body--PaddingLeft);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   word-break: break-word;
   -webkit-overflow-scrolling: touch;
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__body--last-child--PaddingBottom);
+  }
 }
 
 // Footer
 .pf-c-modal-box__footer {
-  --pf-c-modal-box--child--PaddingTop: var(--pf-c-modal-box__footer--PaddingTop);
-
   display: flex;
   flex: 0 0 auto;
   align-items: center;
+  padding-top: var(--pf-c-modal-box__footer--PaddingTop);
+  padding-right: var(--pf-c-modal-box__footer--PaddingRight);
+  padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
+  padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
 
   // Base margin left and right equal for buttons when wrapped
   > .pf-c-button:not(:last-child) {

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -12,9 +12,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-          Overwrite existing file?
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+            Overwrite existing file?
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
@@ -41,9 +43,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-scroll-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-scroll-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
           This is a modal description. The description will not scroll with the body contents.
         {{/modal-box-description}}
@@ -80,9 +84,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-body}}
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
           <p>Form here</p>

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -328,9 +328,11 @@ section: demos
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
-      {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-        Manage columns
-      {{/title}}
+      {{#> modal-box-header}}
+        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+          Manage columns
+        {{/title}}
+      {{/modal-box-header}}
       {{#> modal-box-description}}
         {{#> content}}
           <p>Selected categories will be displayed in the table.</p>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2967

@tlabaj I think it would be more consistent for the modal component title to be it's own element of the modal component (ie, `pf-c-modal-box__title`), instead of using the title component. It looks like the react modal title is built in the component from a `title` prop on the component. How do you feel about removing the dependency on the title component in the modal, and wrapping the title in a new element (`pf-c-modal-box__title`) instead? Would there be much (or any) impact to the consumer? If that's OK I will update this PR.

## Breaking changes
This PR moves the outer padding on the modal from the `.pf-c-modal-box` container to the modal box elements that are children of the modal. To better achieve this spacing, we now wrap the modal's title in a new element `.pf-c-modal-box__header`, so anywhere a modal title is defined, it will need to be wrapped in this new element.

The following variables have been removed. Any references to them should be removed as they are no longer used in patternfly.
* `--pf-c-modal-box--PaddingTop`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingTop`, however it's important to note that this variable changes depending on the markup present in the modal, so this variable serves multiple purpopses. And it will need to be modified for each child of the modal component that touches the top edge of the modal.
* `--pf-c-modal-box--PaddingRight`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingRight`. However it will need to be modified for each child of the modal component that touches the right edge of the modal.
* `--pf-c-modal-box--PaddingBottom`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--last-child--PaddingBottom`. However it will need to be modified for each child of the modal component that touches the bottom edge of the modal.
* `--pf-c-modal-box--PaddingLeft`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingLeft`. However it will need to be modified for each child of the modal component that touches the left edge of the modal.

The following variables have been renamed. Any reference to the old name should be updated to reference the new name.
* `--pf-c-modal-box--body--MinHeight` renamed to `--pf-c-modal-box__body--MinHeight`
* `--pf-c-modal-box__c-title--description--MarginTop` ranamed to `--pf-c-modal-box__header--description--PaddingTop`
* `--pf-c-modal-box__description--body--MarginTop` renamed to `--pf-c-modal-box__description--body--PaddingTop`
* `--pf-c-modal-box--c-title--body--MarginTop` renamed to `--pf-c-modal-box__header--body--PaddingTop`
* `--pf-c-modal-box__footer--MarginTop` renamed to `--pf-c-modal-box__footer--PaddingTop`