### PR TITLE
fix(modal): added header, moved padding from container to elements

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -127,7 +127,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. **Required** |
 | `.pf-c-modal-box__header` | `<div>` | Initiates a modal box header. |
 | `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. The title goes in the `.pf-c-modal-box__header` element. |
-| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title and modal body are **required** if using a modal description. |
+| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal header, title and modal body are **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,11 +10,9 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-header}}
-    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-basic"'}}
-      Modal header
-    {{/title}}
-  {{/modal-box-header}}
+  {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
+    Modal title
+  {{/modal-box-title}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
@@ -29,11 +27,9 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-header}}
-    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-small"'}}
-      Modal header
-    {{/title}}
-  {{/modal-box-header}}
+  {{#> modal-box-title modal-box-title--attribute='id="modal-sm-title"'}}
+    Modal title
+  {{/modal-box-title}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-sm-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -51,11 +47,9 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-header}}
-    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-large"'}}
-      Modal header
-    {{/title}}
-  {{/modal-box-header}}
+  {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
+    Modal title
+  {{/modal-box-title}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-lg-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -68,13 +62,13 @@ cssPrefix: pf-c-modal-box
 {{/modal-box}}
 ```
 
-```hbs title=Without-header
-{{#> modal-box modal-box--attribute='aria-label="Example of a modal without a header" aria-describedby="modal-no-header-description"'}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+```hbs title=Without-title
+{{#> modal-box modal-box--attribute='aria-label="Example of a modal without a title" aria-describedby="modal-no-title-description"'}}
+  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
   {{#> modal-box-body}}
-    <span id="modal-no-header-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    <span id="modal-no-title-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   {{/modal-box-body}}
   {{#> modal-box-footer}}
     Modal footer
@@ -87,11 +81,9 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-header}}
-    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-description"'}}
-      Modal header
-    {{/title}}
-  {{/modal-box-header}}
+  {{#> modal-box-title modal-box-title--attribute='id="modal-with-description-title"'}}
+    Modal title
+  {{/modal-box-title}}
   {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
     A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
   {{/modal-box-description}}
@@ -106,7 +98,7 @@ cssPrefix: pf-c-modal-box
 
 ## Documentation
 ### Overview
-A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required. If no `.pf-c-title` is used, `aria-label="[title of modal]"` must be provided for `.pf-c-modal-box`.
+A modal box is a generic rectangular container that can be used to build modals. A modal box can have four sections: title, description, body, and footer. Title or body is required. Alternatively, no sections can be used, and the modal will just serve as a box with no padding for custom modal content. If no `.pf-c-modal-box__title` is used, `aria-label="[title of modal]"` must be provided for `.pf-c-modal-box`.
 
 
 ### Accessibility
@@ -125,9 +117,8 @@ A modal box is a generic rectangular container that can be used to build modals.
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. **Required** |
-| `.pf-c-modal-box__header` | `<div>` | Initiates a modal box header. |
-| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. The title goes in the `.pf-c-modal-box__header` element. |
-| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal header, title and modal body are **required** if using a modal description. |
+| `.pf-c-modal-box__title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`, `<div>` | Initiates a modal box title. |
+| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title and modal body are **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,9 +10,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-basic"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
@@ -27,9 +29,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-sm-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-small"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-sm-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -47,9 +51,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-large"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-lg-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -81,9 +87,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-with-description-title"'}}
-    Modal header
-  {{/title}}
+  {{#> modal-box-header}}
+    {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title-description"'}}
+      Modal header
+    {{/title}}
+  {{/modal-box-header}}
   {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
     A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
   {{/modal-box-description}}
@@ -117,7 +125,8 @@ A modal box is a generic rectangular container that can be used to build modals.
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. **Required** |
-| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. |
+| `.pf-c-modal-box__header` | `<div>` | Initiates a modal box header. |
+| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. The title goes in the `.pf-c-modal-box__header` element. |
 | `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title and modal body are **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}"
+  {{#if modal-box-header--attribute}}
+    {{{modal-box-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}"
-  {{#if modal-box-header--attribute}}
-    {{{modal-box-header--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/ModalBox/modal-box-title.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-title.hbs
@@ -1,0 +1,6 @@
+<{{#if modal-box-title--type}}{{modal-box-title--type}}{{else}}h1{{/if}} class="pf-c-modal-box__title{{#if modal-box-title--modifier}} {{modal-box-title--modifier}}{{/if}}"
+  {{#if modal-box-title--attribute}}
+    {{{modal-box-title--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{#if modal-box-title--type}}{{modal-box-title--type}}{{else}}h1{{/if}}>

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -93,10 +93,6 @@
     padding-bottom: var(--pf-c-modal-box__header--last-child--PaddingBottom);
   }
 
-  + .pf-c-modal-box__description {
-    --pf-c-modal-box__description--PaddingTop: var(--pf-c-modal-box__header--description--PaddingTop);
-  }
-
   + .pf-c-modal-box__body {
     --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
   }

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -9,10 +9,12 @@
   --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
   // Header
-  --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__header--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__header--last-child--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__title--LineHeight: var(--pf-global--LineHeight--sm);
+  --pf-c-modal-box__title--FontSize: var(--pf-global--FontSize--2xl);
+  --pf-c-modal-box__title--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__title--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__title--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__title--last-child--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Description
   --pf-c-modal-box__description--PaddingTop: var(--pf-global--spacer--xs);
@@ -26,7 +28,7 @@
   --pf-c-modal-box__body--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-modal-box__body--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-modal-box__body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__title--body--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
@@ -83,22 +85,23 @@
   }
 }
 
-.pf-c-modal-box__header {
+.pf-c-modal-box__title {
+  @include pf-text-overflow;
+
   flex: 0 0 auto;
-  padding-top: var(--pf-c-modal-box__header--PaddingTop);
-  padding-right: var(--pf-c-modal-box__header--PaddingRight);
-  padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+  padding-top: var(--pf-c-modal-box__title--PaddingTop);
+  padding-right: var(--pf-c-modal-box__title--PaddingRight);
+  padding-left: var(--pf-c-modal-box__title--PaddingLeft);
+  font-family: var(--pf-global--FontFamily--heading--sans-serif);
+  font-size: var(--pf-c-modal-box__title--FontSize);
+  line-height: var(--pf-c-modal-box__title--LineHeight);
 
   &:last-child {
-    padding-bottom: var(--pf-c-modal-box__header--last-child--PaddingBottom);
+    padding-bottom: var(--pf-c-modal-box__title--last-child--PaddingBottom);
   }
 
   + .pf-c-modal-box__body {
-    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
-  }
-
-  > .pf-c-title {
-    @include pf-text-overflow;
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__title--body--PaddingTop);
   }
 }
 

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,9 +1,5 @@
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-modal-box--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--xl);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-modal-box--Width: 100%;
@@ -12,21 +8,37 @@
   --pf-c-modal-box--m-lg--lg--MaxWidth: #{pf-size-prem(1120px)};
   --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
+  // Header
+  --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--last-child--PaddingBottom: var(--pf-global--spacer--lg);
+
   // Description
-  --pf-c-modal-box__c-title--description--MarginTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box__description--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-modal-box__description--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__description--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__description--last-child--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Body
-  --pf-c-modal-box--body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
-  --pf-c-modal-box__description--body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-modal-box--c-title--body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
+  --pf-c-modal-box__body--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
-  --pf-c-modal-box--c-button--Top: calc(var(--pf-c-modal-box--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
+  --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
   --pf-c-modal-box--c-button--Right: var(--pf-global--spacer--md);
   --pf-c-modal-box--c-button--sibling--MarginRight: var(--pf-global--spacer--xl);
 
   // Footer
-  --pf-c-modal-box__footer--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__footer--PaddingLeft: var(--pf-global--spacer--lg);
 
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
@@ -42,7 +54,6 @@
   width: var(--pf-c-modal-box--Width);
   max-width: var(--pf-c-modal-box--MaxWidth);
   max-height: var(--pf-c-modal-box--MaxHeight);
-  padding: var(--pf-c-modal-box--PaddingTop) var(--pf-c-modal-box--PaddingRight) var(--pf-c-modal-box--PaddingBottom) var(--pf-c-modal-box--PaddingLeft);
   background-color: var(--pf-c-modal-box--BackgroundColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
@@ -70,37 +81,61 @@
       margin-right: var(--pf-c-modal-box--c-button--sibling--MarginRight); // Create room for the close button
     }
   }
+}
+
+.pf-c-modal-box__header {
+  flex: 0 0 auto;
+  padding-top: var(--pf-c-modal-box__header--PaddingTop);
+  padding-right: var(--pf-c-modal-box__header--PaddingRight);
+  padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__header--last-child--PaddingBottom);
+  }
+
+  + .pf-c-modal-box__description {
+    --pf-c-modal-box__description--PaddingTop: var(--pf-c-modal-box__header--description--PaddingTop);
+  }
+
+  + .pf-c-modal-box__body {
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
+  }
 
   > .pf-c-title {
     @include pf-text-overflow;
-
-    flex: 0 0 auto;
-
-    + .pf-c-modal-box__description {
-      margin-top: var(--pf-c-modal-box__c-title--description--MarginTop);
-    }
-
-    + .pf-c-modal-box__body {
-      margin-top: var(--pf-c-modal-box--c-title--body--MarginTop);
-    }
   }
 }
 
 .pf-c-modal-box__description {
+  padding-top: var(--pf-c-modal-box__description--PaddingTop);
+  padding-right: var(--pf-c-modal-box__description--PaddingRight);
+  padding-left: var(--pf-c-modal-box__description--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__description--last-child--PaddingBottom);
+  }
+
   + .pf-c-modal-box__body {
-    margin-top: var(--pf-c-modal-box__description--body--MarginTop);
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__description--body--PaddingTop);
   }
 }
 
 // Body
 .pf-c-modal-box__body {
   flex: 1 1 auto;
-  min-height: var(--pf-c-modal-box--body--MinHeight);
+  min-height: var(--pf-c-modal-box__body--MinHeight);
+  padding-top: var(--pf-c-modal-box__body--PaddingTop);
+  padding-right: var(--pf-c-modal-box__body--PaddingRight);
+  padding-left: var(--pf-c-modal-box__body--PaddingLeft);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   word-break: break-word;
   -webkit-overflow-scrolling: touch;
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__body--last-child--PaddingBottom);
+  }
 }
 
 // Footer
@@ -108,7 +143,10 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  margin-top: var(--pf-c-modal-box__footer--MarginTop);
+  padding-top: var(--pf-c-modal-box__footer--PaddingTop);
+  padding-right: var(--pf-c-modal-box__footer--PaddingRight);
+  padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
+  padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
 
   // Base margin left and right equal for buttons when wrapped
   > .pf-c-button:not(:last-child) {

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -45,9 +45,6 @@
   // Footer buttons
   --pf-c-modal-box__footer--c-button--MarginRight: var(--pf-global--spacer--md); // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
   --pf-c-modal-box__footer--c-button--sm--MarginRight: calc(var(--pf-c-modal-box__footer--c-button--MarginRight) / 2);
-  --pf-c-modal-box__footer__c-button--first-of-type--MarginLeft: auto;
-
-  @include pf-t-light; // This component always needs to be light
 
   position: relative;
   z-index: var(--pf-c-modal-box--ZIndex);

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -12,9 +12,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-          Overwrite existing file?
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+            Overwrite existing file?
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
@@ -41,9 +43,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-scroll-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-scroll-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
           This is a modal description. The description will not scroll with the body contents.
         {{/modal-box-description}}
@@ -80,9 +84,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/title}}
+        {{#> modal-box-header}}
+          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/title}}
+        {{/modal-box-header}}
         {{#> modal-box-body}}
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
           <p>Form here</p>

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -12,10 +12,8 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header}}
-          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-            Overwrite existing file?
-          {{/title}}
+        {{#> modal-box-header modal-box-header--attribute='id="modal-title"'}}
+          Overwrite existing file?
         {{/modal-box-header}}
         {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
@@ -43,10 +41,8 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header}}
-          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-scroll-title"'}}
-            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-          {{/title}}
+        {{#> modal-box-header  modal-box-header--attribute='id="modal-scroll-title"'}}
+          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
         {{/modal-box-header}}
         {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
           This is a modal description. The description will not scroll with the body contents.
@@ -84,10 +80,8 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-header}}
-          {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-lg-title"'}}
-            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-          {{/title}}
+        {{#> modal-box-header modal-box-header--attribute='id="modal-lg-title"'}}
+          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
         {{/modal-box-header}}
         {{#> modal-box-body}}
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -328,9 +328,11 @@ section: demos
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
-      {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-        Manage columns
-      {{/title}}
+      {{#> modal-box-header}}
+        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
+          Manage columns
+        {{/title}}
+      {{/modal-box-header}}
       {{#> modal-box-description}}
         {{#> content}}
           <p>Selected categories will be displayed in the table.</p>

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -328,10 +328,8 @@ section: demos
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
-      {{#> modal-box-header}}
-        {{#> title titleType="h1" title--modifier="pf-m-2xl" title--attribute='id="modal-title"'}}
-          Manage columns
-        {{/title}}
+      {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
+        Manage columns
       {{/modal-box-header}}
       {{#> modal-box-description}}
         {{#> content}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2967

@tlabaj I think it would be more consistent for the modal component title to be it's own element of the modal component (ie, `pf-c-modal-box__title`), instead of using the title component. It looks like the react modal title is built in the component from a `title` prop on the component. How do you feel about removing the dependency on the title component in the modal, and wrapping the title in a new element (`pf-c-modal-box__title`) instead? Would there be much (or any) impact to the consumer? If that's OK I will update this PR.

## Breaking changes
This PR moves the outer padding on the modal from the `.pf-c-modal-box` container to the modal box elements that are children of the modal. To better achieve this spacing, we have dropped the use of the title component to serve as the modal title, and this is now an element of the modal component called `.pf-c-modal-box__title`. Any instance of `.pf-c-title` in the modal that serves as the modal title should be replaced with `.pf-c-modal-box__title`.

The following variables have been removed. Any references to them should be removed as they are no longer used in patternfly.
* `--pf-c-modal-box--PaddingTop`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingTop`, however it's important to note that this variable changes depending on the markup present in the modal, so this variable serves multiple purpopses. And it will need to be modified for each child of the modal component that touches the top edge of the modal.
* `--pf-c-modal-box--PaddingRight`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingRight`. However it will need to be modified for each child of the modal component that touches the right edge of the modal.
* `--pf-c-modal-box--PaddingBottom`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--last-child--PaddingBottom`. However it will need to be modified for each child of the modal component that touches the bottom edge of the modal.
* `--pf-c-modal-box--PaddingLeft`
  * This can now be achieved using `--pf-c-modal-box__[modal element]--PaddingLeft`. However it will need to be modified for each child of the modal component that touches the left edge of the modal.

The following variables have been renamed. Any reference to the old name should be updated to reference the new name.
* `--pf-c-modal-box--body--MinHeight` renamed to `--pf-c-modal-box__body--MinHeight`
* `--pf-c-modal-box__c-title--description--MarginTop` ranamed to `--pf-c-modal-box__title--description--PaddingTop`
* `--pf-c-modal-box__description--body--MarginTop` renamed to `--pf-c-modal-box__description--body--PaddingTop`
* `--pf-c-modal-box--c-title--body--MarginTop` renamed to `--pf-c-modal-box__title--body--PaddingTop`
* `--pf-c-modal-box__footer--MarginTop` renamed to `--pf-c-modal-box__footer--PaddingTop`