### PR TITLE
fix(backdrop): removed blur, renamed var

### DIFF
--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -1,7 +1,6 @@
 .pf-c-backdrop {
   --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--lg);
-  --pf-c-backdrop--Color: var(--pf-global--BackgroundColor--dark-transparent-100);
-  --pf-c-backdrop--BackdropFilter: blur(10px);
+  --pf-c-backdrop--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-100);
 
   position: fixed;
   top: 0;
@@ -9,10 +8,7 @@
   z-index: var(--pf-c-backdrop--ZIndex);
   width: 100%;
   height: 100%;
-  background-color: var(--pf-c-backdrop--Color);
-  // stylelint-disable-next-line
-  -webkit-backdrop-filter: var(--pf-c-backdrop--BackdropFilter); // Vendor prefix needed for Safari, but it is not getting added in the autoprefixer right now
-  backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
+  background-color: var(--pf-c-backdrop--BackgroundColor);
 }
 
 .pf-c-backdrop__open {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3003

## Breaking changes
This PR removes the blur from the backdrop component. This is a visual change only and no further updates are needed to consume this change.

The variable `--pf-c-backdrop--BackdropFilter` was removed. Any reference to it should be removed as it is no longer used in patternfly.

The variable `--pf-c-backdrop--Color` was renamed to `--pf-c-backdrop--BackgroundColor`. Any reference to the old variable name should be updated to reference the new variable name.