### PR TITLE
fix(applauncher): clean up variables

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -65,9 +65,7 @@
   --pf-c-app-launcher__menu-item-external-icon--FontSize: var(--pf-global--icon--FontSize--sm);
 
   // Groups
-  --pf-c-app-launcher__group--PaddingTop: 0; // remove at breaking change
   --pf-c-app-launcher__group--group--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-app-launcher__group--first-child--PaddingTop: 0; // remove at breaking change
   --pf-c-app-launcher__group-title--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-app-launcher__group-title--PaddingRight: var(--pf-c-app-launcher__menu-item--PaddingRight);
   --pf-c-app-launcher__group-title--PaddingBottom: var(--pf-c-app-launcher__menu-item--PaddingBottom);
@@ -253,18 +251,12 @@
   font-size: var(--pf-c-app-launcher__menu-item-external-icon--FontSize);
   color: var(--pf-c-app-launcher__menu-item-external-icon--Color);
   opacity: 0;
-  transform: var(--pf-c-app-launcher__menu-item-external-icon--Transform); // move icon a bit to appear more visually centered
+  transform: var(--pf-c-app-launcher__menu-item-external-icon--Transform); // move icon by 1px to appear more visually centered
 }
 
 .pf-c-app-launcher__group {
-  padding-top: var(--pf-c-app-launcher__group--PaddingTop); // remove at breaking change
-
-  &:first-child {
-    --pf-c-app-launcher__group--PaddingTop: var(--pf-c-app-launcher__group--first-child--PaddingTop); // remove at breaking change
-  }
-
   & + & {
-    --pf-c-app-launcher__group--PaddingTop: var(--pf-c-app-launcher__group--group--PaddingTop);
+    padding-top: var(--pf-c-app-launcher__group--group--PaddingTop);
   }
 }
 


### PR DESCRIPTION
closes #2617 

## Breaking Changes

* Removes the following variables. All instances of them should be removed from your application:
* `--pf-c-app-launcher__group--PaddingTop`
* `--pf-c-app-launcher__group--first-child--PaddingTop`