### PR TITLE
fix(optionsmenu): clean up vars

### DIFF
--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -1,6 +1,6 @@
 .pf-c-options-menu {
   // Toggle
-  --pf-c-options-menu__toggle--Background: transparent;
+  --pf-c-options-menu__toggle--BackgroundColor: transparent;
   --pf-c-options-menu__toggle--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-options-menu__toggle--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-options-menu__toggle--PaddingBottom: var(--pf-global--spacer--form-element);
@@ -31,7 +31,7 @@
   --pf-c-options-menu--m-top--m-expanded__toggle-icon--Transform: rotate(180deg);
 
   // Text toggle button
-  --pf-c-options-menu__toggle-button--Background: transparent;
+  --pf-c-options-menu__toggle-button--BackgroundColor: transparent;
   --pf-c-options-menu__toggle-button--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-options-menu__toggle-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-options-menu__toggle-button--PaddingBottom: var(--pf-global--spacer--form-element);
@@ -48,7 +48,7 @@
   --pf-c-options-menu--m-top__menu--Transform: translateY(calc(-100% - var(--pf-global--spacer--xs))); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu item
-  --pf-c-options-menu__menu-item--Background: transparent;
+  --pf-c-options-menu__menu-item--BackgroundColor: transparent;
   --pf-c-options-menu__menu-item--Color: var(--pf-global--Color--100);
   --pf-c-options-menu__menu-item--FontSize: var(--pf-global--FontSize--md);
   --pf-c-options-menu__menu-item--PaddingTop: var(--pf-global--spacer--sm);
@@ -139,7 +139,7 @@
   padding-left: var(--pf-c-options-menu__toggle--PaddingLeft);
   line-height: var(--pf-c-options-menu__toggle--LineHeight);
   color: var(--pf-c-options-menu__toggle--Color);
-  background: var(--pf-c-options-menu__toggle--Background);
+  background-color: var(--pf-c-options-menu__toggle--BackgroundColor);
   border: none;
 
   &:not(.pf-m-text) {
@@ -185,7 +185,7 @@
 
     &:not(.pf-m-plain),
     &.pf-m-text {
-      --pf-c-options-menu__toggle--Background: var(--pf-c-options-menu__toggle--disabled--BackgroundColor);
+      --pf-c-options-menu__toggle--BackgroundColor: var(--pf-c-options-menu__toggle--disabled--BackgroundColor);
     }
 
     &::before {
@@ -200,7 +200,7 @@
 
 .pf-c-options-menu__toggle-button {
   padding: var(--pf-c-options-menu__toggle-button--PaddingTop) var(--pf-c-options-menu__toggle-button--PaddingRight) var(--pf-c-options-menu__toggle-button--PaddingBottom) var(--pf-c-options-menu__toggle-button--PaddingLeft);
-  background: var(--pf-c-options-menu__toggle-button--Background);
+  background-color: var(--pf-c-options-menu__toggle-button--BackgroundColor);
   border: 0;
 }
 
@@ -247,7 +247,7 @@
   font-size: var(--pf-c-options-menu__menu-item--FontSize);
   color: var(--pf-c-options-menu__menu-item--Color);
   white-space: nowrap;
-  background: var(--pf-c-options-menu__menu-item--Background);
+  background-color: var(--pf-c-options-menu__menu-item--BackgroundColor);
   border: none;
 
   &:hover,


### PR DESCRIPTION
closes #1971

## Breaking Changes

* Renames the following variables:

* `--pf-c-options-menu__toggle--Background` to `--pf-c-options-menu__toggle--BackgroundColor`
* `--pf-c-options-menu__toggle-button--Background` to `--pf-c-options-menu__toggle-button--BackgroundColor`
* `--pf-c-options-menu__menu-item--Background` to `--pf-c-options-menu__menu-item--BackgroundColor`