### PR TITLE
fix(card): moved __header to __title, __head to __header

### DIFF
--- a/src/patternfly/components/Card/card-head-main.hbs
+++ b/src/patternfly/components/Card/card-head-main.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-card__head-main{{#if card-head-main--modifier}} {{card-head-main--modifier}}{{/if}}"
-  {{#if card-head-main--attribute}}
-    {{{card-head-main--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Card/card-head.hbs
+++ b/src/patternfly/components/Card/card-head.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-card__head{{#if card-head--modifier}} {{card-head--modifier}}{{/if}}"
-  {{#if card-head--attribute}}
-    {{{card-head--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Card/card-header-main.hbs
+++ b/src/patternfly/components/Card/card-header-main.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-card__header-main{{#if card-header-main--modifier}} {{card-header-main--modifier}}{{/if}}"
+  {{#if card-header-main--attribute}}
+    {{{card-header-main--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Card/card-header.hbs
+++ b/src/patternfly/components/Card/card-header.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-card__header pf-c-title pf-m-md{{#if card-header--modifier}} {{card-header--modifier}}{{/if}}"
+<div class="pf-c-card__header{{#if card-header--modifier}} {{card-header--modifier}}{{/if}}"
   {{#if card-header--attribute}}
     {{{card-header--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -15,16 +15,16 @@
   --pf-c-card--m-compact--child--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-card--m-compact__header--not--last-child--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-card--m-compact__title--not--last-child--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-card--m-flat--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-card--m-flat--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-card--first-child--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-card__header--FontFamily: var(--pf-global--FontFamily--sans-serif);
-  --pf-c-card__header--FontWeight: var(--pf-global--FontWeight--bold);
-  --pf-c-card__header--not--last-child--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-card__title--not--last-child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card__body--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__footer--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
@@ -79,7 +79,7 @@
     --pf-c-card--child--PaddingRight: var(--pf-c-card--m-compact--child--PaddingRight);
     --pf-c-card--child--PaddingBottom: var(--pf-c-card--m-compact--child--PaddingBottom);
     --pf-c-card--child--PaddingLeft: var(--pf-c-card--m-compact--child--PaddingLeft);
-    --pf-c-card__header--not--last-child--PaddingBottom: var(--pf-c-card--m-compact__header--not--last-child--PaddingBottom);
+    --pf-c-card__title--not--last-child--PaddingBottom: var(--pf-c-card--m-compact__title--not--last-child--PaddingBottom);
   }
 
   &.pf-m-flat {
@@ -89,15 +89,15 @@
   }
 }
 
-.pf-c-card__head {
+.pf-c-card__header {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
-.pf-c-card__header.pf-c-title.pf-m-md {
-  font-family: var(--pf-c-card__header--FontFamily);
-  font-weight: var(--pf-c-card__header--FontWeight);
+.pf-c-card__title {
+  font-family: var(--pf-c-card__title--FontFamily);
+  font-weight: var(--pf-c-card__title--FontWeight);
 }
 
 .pf-c-card__actions {
@@ -112,15 +112,15 @@
     margin-left: var(--pf-c-card__actions--child--MarginLeft);
   }
 
-  + .pf-c-card__header,
+  + .pf-c-card__title,
   + .pf-c-card__body,
   + .pf-c-card__footer {
     padding: 0;
   }
 }
 
-.pf-c-card__head,
 .pf-c-card__header,
+.pf-c-card__title,
 .pf-c-card__body,
 .pf-c-card__footer {
   padding-right: var(--pf-c-card--child--PaddingRight);
@@ -132,10 +132,10 @@
   }
 }
 
-.pf-c-card__head,
-.pf-c-card__header {
+.pf-c-card__header,
+.pf-c-card__title {
   &:not(:last-child) {
-    padding-bottom: var(--pf-c-card__header--not--last-child--PaddingBottom);
+    padding-bottom: var(--pf-c-card__title--not--last-child--PaddingBottom);
   }
 }
 
@@ -153,7 +153,7 @@
 
 // RedHat Font overrides
 @include pf-m-overpass-font {
-  .pf-c-card .pf-c-card__header {
+  .pf-c-card .pf-c-card__title {
     font-weight: var(--pf-global--FontWeight--normal);
   }
 }

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -253,9 +253,9 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__title` | `<div>` | Creates the title of a card. |
 | `.pf-c-card__body` | `<div>` | Creates the body of a card. By default, the body element fills the available space in the card. You can use multiple `.pf-c-card__body` elements. |
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
-| `.pf-c-card__header` | `<div>` | Creates the head of the card where images or actions can go. |
-| `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
-| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
+| `.pf-c-card__header` | `<div>` | Creates the header of the card where images, actions, and/or the card title can go. |
+| `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card header. |
+| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card header when using an image, logo, or text. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -7,9 +7,9 @@ cssPrefix: pf-c-card
 ## Examples
 ```hbs title=Basic
 {{#> card}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -21,18 +21,39 @@ cssPrefix: pf-c-card
 
 ```hbs title=With-image-and-action
 {{#> card card--id="card-action-example-1"}}
-  {{#> card-head}}
-    {{#> card-head-main}}
+  {{#> card-header}}
+    {{#> card-header-main}}
       <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-head-main}}
+    {{/card-header-main}}
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
       <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
     {{/card-actions}}
-  {{/card-head}}
-  {{#> card-header card-header--attribute=(concat 'id="' card--id '-check-label"')}}
-    Header
+  {{/card-header}}
+  {{#> card-title card-title--attribute=(concat 'id="' card--id '-check-label"')}}
+    Title
+  {{/card-title}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+```
+
+```hbs title=With-title-in-head
+{{#> card card--id="card-action-example-2"}}
+  {{#> card-header}}
+    {{#> card-actions}}
+      {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+      {{/dropdown}}
+      <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+    {{/card-actions}}
+    {{#> card-title card-title--attribute=(concat 'id="' card--id '-check-label"')}}
+      This is a really really really really really really really really really really long title
+    {{/card-title}}
   {{/card-header}}
   {{#> card-body}}
     Body
@@ -43,36 +64,15 @@ cssPrefix: pf-c-card
 {{/card}}
 ```
 
-```hbs title=With-header-in-head
-{{#> card card--id="card-action-example-2"}}
-  {{#> card-head}}
-    {{#> card-actions}}
-      {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
-      {{/dropdown}}
-      <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
-    {{/card-actions}}
-    {{#> card-header card-header--attribute=(concat 'id="' card--id '-check-label"')}}
-      This is a really really really really really really really really really really long header
-    {{/card-header}}
-  {{/card-head}}
-  {{#> card-body}}
-    Body
-  {{/card-body}}
-  {{#> card-footer}}
-    Footer
-  {{/card-footer}}
-{{/card}}
-```
-
-```hbs title=With-only-actions-in-head-(no-header/footer)
+```hbs title=With-only-actions-in-head-(no-title/footer)
 {{#> card card--id="card-action-example-3"}}
-  {{#> card-head}}
+  {{#> card-header}}
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
       <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
     {{/card-actions}}
-  {{/card-head}}
+  {{/card-header}}
   {{#> card-body card-body--attribute=(concat 'id="' card--id '-check-label"')}}
     This is the card body, there are only actions in the card head.
   {{/card-body}}
@@ -80,14 +80,14 @@ cssPrefix: pf-c-card
 ```
 ```hbs title=With-only-image-in-head
 {{#> card}}
-  {{#> card-head}}
-    {{#> card-head-main}}
-      <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-head-main}}
-  {{/card-head}}
   {{#> card-header}}
-    Header
+    {{#> card-header-main}}
+      <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
+    {{/card-header-main}}
   {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -99,19 +99,19 @@ cssPrefix: pf-c-card
 
 ```hbs title=With-no-footer
 {{#> card}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     This card has no footer
   {{/card-body}}
 {{/card}}
 ```
 
-```hbs title=With-no-header
+```hbs title=With-no-title
 {{#> card}}
   {{#> card-body}}
-    This card has no header
+    This card has no title
   {{/card-body}}
   {{#> card-footer}}
     Footer
@@ -129,9 +129,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=With-multiple-body-sections
 {{#> card}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -149,9 +149,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=With-only-one-body-that-fills
 {{#> card}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body card-body--modifier="pf-m-no-fill"}}
     Body pf-m-no-fill
   {{/card-body}}
@@ -169,9 +169,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=Compact
 {{#> card card--modifier="pf-m-compact"}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -183,9 +183,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=Hover
 {{#> card card--modifier="pf-m-hoverable"}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -197,9 +197,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=Selectable
 {{#> card card--modifier="pf-m-selectable" card--attribute='tabindex="0"'}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -211,9 +211,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=Selected
 {{#> card card--modifier="pf-m-selectable pf-m-selected" card--attribute='tabindex="0"'}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -225,9 +225,9 @@ cssPrefix: pf-c-card
 
 ```hbs title=Flat
 {{#> card card--modifier="pf-m-flat"}}
-  {{#> card-header}}
-    Header
-  {{/card-header}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
   {{#> card-body}}
     Body
   {{/card-body}}
@@ -250,12 +250,12 @@ A card is a generic rectangular container that can be used to build other compon
 | Class | Applied | Outcome |
 | ---- | ---- | ---- |
 | `.pf-c-card` | `<div>` | Creates a card component.  **Required** |
-| `.pf-c-card__header` | `<div>` | Creates the header of a card. |
+| `.pf-c-card__title` | `<div>` | Creates the title of a card. |
 | `.pf-c-card__body` | `<div>` | Creates the body of a card. By default, the body element fills the available space in the card. You can use multiple `.pf-c-card__body` elements. |
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
-| `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
+| `.pf-c-card__header` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
-| `.pf-c-card__head-main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
+| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |

--- a/src/patternfly/demos/CardView/card-view-demo-template-gallery.hbs
+++ b/src/patternfly/demos/CardView/card-view-demo-template-gallery.hbs
@@ -1,191 +1,191 @@
 {{#> gallery gallery--modifier="pf-m-gutter"}}
     {{#> card card--id="card-1" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">Patternfly</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
           PatternFly is a community project that promotes design commonality and improves user experience.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-2" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">ActiveMQ</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         The ActiveMQ component allows messages to be sent to a JMS Queue or Topic; or messages to be consumed from a JMS Queue or Topic using Apache ActiveMQ.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-3" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">Apache Spark</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         This documentation page covers the Apache Spark component for the Apache Camel.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-4" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">Avro</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         This component provides a dataformat for avro, which allows serialization and deserialization of messages using Apache Avro’s binary dataformat. Moreover, it provides support for Apache Avro’s rpc, by providing producers and consumers endpoint for using avro over netty or http.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-5" card--modifier="pf-m-hoverable pf-m-compact"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Azure Services</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
       The Camel Components for Windows Azure Services provide connectivity to Azure services from Camel.
     {{/card-body}}
     {{/card}}
     {{#> card card--id="card-6" card--modifier="pf-m-hoverable pf-m-compact"}}
-    {{#> card-head}}
+    {{#> card-header}}
         <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">Crypto</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
       For providing flexible endpoints to sign and verify exchanges using the Signature Service of the Java Cryptographic Extension.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-7" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/camel-dropbox_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">DropBox</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         The dropbox: component allows you to treat Dropbox remote folders as a producer or consumer of messages.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-8" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/camel-infinispan_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">JBoss Data Grid</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         Read or write to a fully-supported distributed cache and data grid for faster integration services.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-9" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/FuseConnector_Icons_REST.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">REST</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         The rest component allows to define REST endpoints (consumer) using the Rest DSL and plugin to other Camel components as the REST transport.
         From Camel 2.18 onwards the rest component can also be used as a client (producer) to call REST services.
       {{/card-body}}
     {{/card}}
     {{#> card card--id="card-10" card--modifier="pf-m-hoverable pf-m-compact"}}
-      {{#> card-head}}
+      {{#> card-header}}
         <img src="/assets/images/camel-swagger-java_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
           {{/dropdown}}
           <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
         {{/card-actions}}
-      {{/card-head}}
-      {{#> card-header}}
+      {{/card-header}}
+      {{#> card-title}}
         <p id="{{card--id}}-check-label">SWAGGER</p>
         {{#> content}}
           <small>Provided by Red Hat</small>
         {{/content}}
-      {{/card-header}}
+      {{/card-title}}
       {{#> card-body}}
         Expose REST services and their APIs using Swagger specification.
       {{/card-body}}

--- a/src/patternfly/demos/MasterDetail/master-detail-card-view.hbs
+++ b/src/patternfly/demos/MasterDetail/master-detail-card-view.hbs
@@ -1,190 +1,190 @@
 {{#> gallery gallery--modifier="pf-m-gutter"}}
   {{#> card card--id=(concat master-detail-template--id '-card-1') card--modifier="pf-m-selectable pf-m-selected"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Patternfly</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
         PatternFly is a community project that promotes design commonality and improves user experience.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-2') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">ActiveMQ</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
       The ActiveMQ component allows messages to be sent to a JMS Queue or Topic; or messages to be consumed from a JMS Queue or Topic using Apache ActiveMQ.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-3') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Apache Spark</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
       This documentation page covers the Apache Spark component for the Apache Camel.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-4') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Avro</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
       This component provides a dataformat for avro, which allows serialization and deserialization of messages using Apache Avro’s binary dataformat. Moreover, it provides support for Apache Avro’s rpc, by providing producers and consumers endpoint for using avro over netty or http.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-5') card--modifier="pf-m-selectable"}}
-  {{#> card-head}}
+  {{#> card-header}}
     <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
       <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
     {{/card-actions}}
-  {{/card-head}}
-  {{#> card-header}}
+  {{/card-header}}
+  {{#> card-title}}
     <p id="{{card--id}}-check-label">Azure Services</p>
     {{#> content}}
       <small>Provided by Red Hat</small>
     {{/content}}
-  {{/card-header}}
+  {{/card-title}}
   {{#> card-body}}
     The Camel Components for Windows Azure Services provide connectivity to Azure services from Camel.
   {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-6') card--modifier="pf-m-selectable"}}
-  {{#> card-head}}
+  {{#> card-header}}
       <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Crypto</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
     For providing flexible endpoints to sign and verify exchanges using the Signature Service of the Java Cryptographic Extension.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-7') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Patternfly</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
         PatternFly is a community project that promotes design commonality and improves user experience.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-8') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Patternfly</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
         PatternFly is a community project that promotes design commonality and improves user experience.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-9') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Patternfly</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
         PatternFly is a community project that promotes design commonality and improves user experience.
     {{/card-body}}
   {{/card}}
   {{#> card card--id=(concat master-detail-template--id '-card-10') card--modifier="pf-m-selectable"}}
-    {{#> card-head}}
+    {{#> card-header}}
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
         {{/dropdown}}
         <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
       {{/card-actions}}
-    {{/card-head}}
-    {{#> card-header}}
+    {{/card-header}}
+    {{#> card-title}}
       <p id="{{card--id}}-check-label">Patternfly</p>
       {{#> content}}
         <small>Provided by Red Hat</small>
       {{/content}}
-    {{/card-header}}
+    {{/card-title}}
     {{#> card-body}}
         PatternFly is a community project that promotes design commonality and improves user experience.
     {{/card-body}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3034

## Breaking changes

This PR renames the `.pf-c-card__header` element to `.pf-c-card__title`, and removes the dependency of `.pf-c-title` from `.pf-c-card__title`. And that allows us to rename `.pf-c-card__head` to `.pf-c-card__header`.

The following elements' classes have changed. Any reference to the old class should be updated to reference the new class instead.

* `.pf-c-card__header` has been renamed to `.pf-c-card__title`.  Also `.pf-c-title` and the title size modifiers should be removed from `.pf-c-card__title`.
* `.pf-c-card__head` has been renamed to `.pf-c-card__header`. 
* `.pf-c-card__head-main` has been renamed to `.pf-c-card__header-main`.

The following variables were renamed. Any reference to the old variable name should be updated to reference the new name instead.

* `--pf-c-card--m-compact__header--not--last-child--PaddingBottom` was renamed to `--pf-c-card--m-compact__title--not--last-child--PaddingBottom`
* `--pf-c-card__header--FontFamily` was renamed to `--pf-c-card__title--FontFamily`
* `--pf-c-card__header--FontWeight` was renamed to `--pf-c-card__title--FontWeight`
* `--pf-c-card__header--not--last-child--PaddingBottom` was renamed to `--pf-c-card__title--not--last-child--PaddingBottom`
* `--pf-c-card__header--not--last-child--PaddingBottom` was renamed to `--pf-c-card__title--not--last-child--PaddingBottom`
