### PR TITLE
fix(pagination): removed options menu per page text styling

### DIFF
--- a/src/patternfly/components/Pagination/examples/Pagination.md
+++ b/src/patternfly/components/Pagination/examples/Pagination.md
@@ -156,6 +156,5 @@ Note: `<button>` or `<a>` elements can be used in `.pf-c-pagination__nav-page-se
 | `.pf-c-pagination__total-items` | `<div>` | Initiates element to replace the options menu on mobile. |
 | `.pf-c-pagination__nav` | `<nav>` |  Initiates pagination nav. |
 | `.pf-c-pagination__nav-page-select` | `<div>` |  Initiates pagination nav page select. |
-| `.pf-c-pagination__menu-text` | `<span>` | Indicates text in menu dropdown. |
 | `.pf-m-footer` | `.pf-c-pagination` | Modifies for bottom/footer pagination component styles. |
 | `.pf-m-compact` | `.pf-c-pagination` | Modifies for compact pagination component styles. |

--- a/src/patternfly/components/Pagination/pagination-options-menu.hbs
+++ b/src/patternfly/components/Pagination/pagination-options-menu.hbs
@@ -7,13 +7,13 @@
   {{/options-menu-toggle}}
   {{#> options-menu-menu}}
     {{#> options-menu-menu-item}}
-      5 <span class="pf-c-pagination__menu-text">per page</span>
+      5 per page
     {{/options-menu-menu-item}}
     {{#> options-menu-menu-item options-menu-menu-item--IsSelected="true"}}
-      10 <span class="pf-c-pagination__menu-text">per page</span>
+      10 per page
     {{/options-menu-menu-item}}
     {{#> options-menu-menu-item}}
-      20 <span class="pf-c-pagination__menu-text">per page</span>
+      20 per page
     {{/options-menu-menu-item}}
   {{/options-menu-menu}}
 {{/options-menu}}

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -5,9 +5,6 @@
 
   // Dropdown
   --pf-c-pagination--c-options-menu__toggle--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-pagination__menu-text--PaddingLeft: var(--pf-global--spacer--xs);
-  --pf-c-pagination__menu-text--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-pagination__menu-text--Color: var(--pf-global--Color--200);
 
   // Nav
   --pf-c-pagination__nav--c-button--PaddingLeft: var(--pf-global--spacer--sm);
@@ -114,11 +111,4 @@
     display: none;
     visibility: hidden;
   }
-}
-
-// Dropdown elements
-.pf-c-pagination__menu-text {
-  padding-left: var(--pf-c-pagination__menu-text--PaddingLeft);
-  font-size: var(--pf-c-pagination__menu-text--FontSize);
-  color: var(--pf-c-pagination__menu-text--Color);
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3010

## Breaking changes
This PR removes the `.pf-c-pagination__menu-text` element from the pagination options menu items. The options menu item text should just be normal text.

Any use of the class `.pf-c-pagination__menu-text` or the vars `--pf-c-pagination__menu-text--PaddingLeft`, `--pf-c-pagination__menu-text--FontSize` and `--pf-c-pagination__menu-text--Color` should be removed as they are no longer used in patternfly.