### PR TITLE
fix(button): updated control variation disabled state

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -108,10 +108,6 @@
   --pf-c-button--m-control--after--BorderBottomColor: var(--pf-global--BorderColor--200);
   --pf-c-button--m-control--after--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
-  --pf-c-button--m-control--disabled--after--BorderTopColor: transparent;
-  --pf-c-button--m-control--disabled--after--BorderRightColor: transparent;
-  --pf-c-button--m-control--disabled--after--BorderBottomColor: var(--pf-global--BorderColor--200);
-  --pf-c-button--m-control--disabled--after--BorderLeftColor: transparent;
   --pf-c-button--m-control--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-button--m-control--hover--Color: var(--pf-global--Color--100);
   --pf-c-button--m-control--hover--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
@@ -343,7 +339,6 @@
   &.pf-m-control {
     --pf-c-button--BorderRadius: var(--pf-c-button--m-control--BorderRadius);
     --pf-c-button--disabled--BackgroundColor: var(--pf-c-button--m-control--disabled--BackgroundColor);
-    --pf-c-button--disabled--BorderColor: var(--pf-c-button--m-control--disabled--after--BorderTopColor) var(--pf-c-button--m-control--disabled--after--BorderRightColor) var(--pf-c-button--m-control--disabled--after--BorderBottomColor) var(--pf-c-button--m-control--disabled--after--BorderLeftColor);
 
     color: var(--pf-c-button--m-control--Color);
     background-color: var(--pf-c-button--m-control--BackgroundColor);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -101,11 +101,17 @@
   // Control Button
   --pf-c-button--m-control--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-button--m-control--Color: var(--pf-global--Color--100);
+  --pf-c-button--m-control--BorderRadius: 0;
   --pf-c-button--m-control--after--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-button--m-control--after--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-button--m-control--after--BorderRightColor: var(--pf-global--BorderColor--300);
   --pf-c-button--m-control--after--BorderBottomColor: var(--pf-global--BorderColor--200);
   --pf-c-button--m-control--after--BorderLeftColor: var(--pf-global--BorderColor--300);
+  --pf-c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
+  --pf-c-button--m-control--disabled--after--BorderTopColor: transparent;
+  --pf-c-button--m-control--disabled--after--BorderRightColor: transparent;
+  --pf-c-button--m-control--disabled--after--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-button--m-control--disabled--after--BorderLeftColor: transparent;
   --pf-c-button--m-control--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-button--m-control--hover--Color: var(--pf-global--Color--100);
   --pf-c-button--m-control--hover--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
@@ -122,11 +128,6 @@
   --pf-c-button--m-control--m-expanded--Color: var(--pf-global--Color--100);
   --pf-c-button--m-control--m-expanded--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-button--m-control--m-expanded--after--BorderBottomColor: var(--pf-global--active-color--100);
-  --pf-c-button--m-control--disabled--after--BorderTopColor: transparent;
-  --pf-c-button--m-control--disabled--after--BorderRightColor: transparent;
-  --pf-c-button--m-control--disabled--after--BorderBottomColor: transparent;
-  --pf-c-button--m-control--disabled--after--BorderLeftColor: transparent;
-  --pf-c-button--m-control--disabled--BackgroundColor: transparent;
 
   // Styles for an icon in button
   --pf-c-button__icon--m-start--MarginRight: var(--pf-global--spacer--xs);
@@ -340,7 +341,9 @@
   }
 
   &.pf-m-control {
+    --pf-c-button--BorderRadius: var(--pf-c-button--m-control--BorderRadius);
     --pf-c-button--disabled--BackgroundColor: var(--pf-c-button--m-control--disabled--BackgroundColor);
+    --pf-c-button--disabled--BorderColor: var(--pf-c-button--m-control--disabled--after--BorderTopColor) var(--pf-c-button--m-control--disabled--after--BorderRightColor) var(--pf-c-button--m-control--disabled--after--BorderBottomColor) var(--pf-c-button--m-control--disabled--after--BorderLeftColor);
 
     color: var(--pf-c-button--m-control--Color);
     background-color: var(--pf-c-button--m-control--BackgroundColor);
@@ -348,8 +351,6 @@
     &::after {
       --pf-c-button--BorderWidth: var(--pf-c-button--m-control--after--BorderWidth);
       --pf-c-button--BorderColor: var(--pf-c-button--m-control--after--BorderTopColor) var(--pf-c-button--m-control--after--BorderRightColor) var(--pf-c-button--m-control--after--BorderBottomColor) var(--pf-c-button--m-control--after--BorderLeftColor);
-
-      border-radius: initial;
     }
 
     &:hover {
@@ -394,16 +395,6 @@
         --pf-c-button--m-control--after--BorderBottomColor: var(--pf-c-button--m-control--m-expanded--after--BorderBottomColor);
 
         border-bottom-width: var(--pf-c-button--m-control--m-expanded--after--BorderBottomWidth);
-      }
-    }
-
-    &:disabled,
-    &.pf-m-disabled {
-      &::after {
-        --pf-c-button--m-control--after--BorderTopColor: var(--pf-c-button--m-control--disabled--after--BorderTopColor);
-        --pf-c-button--m-control--after--BorderRightColor: var(--pf-c-button--m-control--disabled--after--BorderRightColor);
-        --pf-c-button--m-control--after--BorderBottomColor: var(--pf-c-button--m-control--disabled--after--BorderBottomColor);
-        --pf-c-button--m-control--after--BorderLeftColor: var(--pf-c-button--m-control--disabled--after--BorderLeftColor);
       }
     }
   }

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -39,15 +39,15 @@ import './Button.css'
   {{/button-icon}}
 {{/button}}
 
-{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
-  <i class="fas fa-times" aria-hidden="true"></i>
-{{/button}}
-
 {{#> button button--modifier="pf-m-inline pf-m-link"}}
   Inline link
 {{/button}}
 <br>
 <br>
+{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+  <i class="fas fa-times" aria-hidden="true"></i>
+{{/button}}
+<br><br>
 {{#> button button--modifier="pf-m-control"}}
   Control
 {{/button}}
@@ -84,6 +84,10 @@ import './Button.css'
 <br>
 {{#> button button--modifier="pf-m-link pf-m-inline" button--attribute="disabled"}}
   Inline link disabled
+{{/button}}
+<br><br>
+{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove" disabled'}}
+  <i class="fas fa-times" aria-hidden="true"></i>
 {{/button}}
 <br>
 <br>

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -16,12 +16,6 @@
   --pf-c-file-upload__file-details__c-form-control--MinHeight: calc(var(--pf-global--spacer--3xl) * 2);
 
   // Button overrides
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderTopColor: var(--pf-global--BorderColor--300);
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderBottomColor: var(--pf-global--BorderColor--200);
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderLeftColor: var(--pf-global--BorderColor--300);
-  --pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-file-upload__file-select__c-button--m-control--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
 
   position: relative;
@@ -72,18 +66,6 @@
 .pf-c-file-upload__file-select {
   .pf-c-button.pf-m-control {
     outline-offset: var(--pf-c-file-upload__file-select__c-button--m-control--OutlineOffset);
-
-    &:disabled {
-      color: initial;
-      background-color: var(--pf-c-file-upload__file-select__c-button--m-control--disabled--BackgroundColor);
-
-      &::after {
-        content: "";
-        border: var(--pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderWidth) solid;
-        border-color: var(--pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderTopColor) var(--pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderRightColor) var(--pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderBottomColor) var(--pf-c-file-upload__file-select__c-button--m-control--disabled--after--BorderLeftColor);
-        border-radius: initial;
-      }
-    }
   }
 }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -126,7 +126,7 @@ $pf-c-form-control--m-search--Coordinates: "M505 442.7L405.3 343c-4.5-4.5-10.6-7
         --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--readonly--hover--BorderBottomColor);
       }
 
-      &:focus:not(.pf-m-success):not([aria-invalid="true"]) {
+      &:focus {
         --pf-c-form-control--focus--PaddingBottom: var(--pf-c-form-control--readonly--focus--PaddingBottom);
         --pf-c-form-control--focus--BorderBottomWidth: var(--pf-c-form-control--readonly--focus--BorderBottomWidth);
         --pf-c-form-control--focus--BorderBottomColor: var(--pf-c-form-control--readonly--focus--BorderBottomColor);

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -50,10 +50,11 @@ $pf-c-form-control--m-search--Coordinates: "M505 442.7L405.3 343c-4.5-4.5-10.6-7
   --pf-c-form-control--disabled--BorderColor: transparent;
 
   // input readonly style
-  --pf-c-form-control--readonly--focus--BackgroundColor: var(--pf-global--disabled-color--300);
-  --pf-c-form-control--readonly--focus--PaddingBottom: var(--pf-c-form-control--PaddingBottom);
+  --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--disabled-color--300);
+  --pf-c-form-control--readonly--hover--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-form-control--readonly--focus--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm));
   --pf-c-form-control--readonly--focus--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-form-control--readonly--focus--BorderBottomColor: var(--pf-global--disabled-color--100);
+  --pf-c-form-control--readonly--focus--BorderBottomColor: var(--pf-global--BorderColor--200);
 
   // Input m-invalid
   --pf-c-form-control--invalid--BorderBottomWidth: var(--pf-global--BorderWidth--md);
@@ -118,14 +119,18 @@ $pf-c-form-control--m-search--Coordinates: "M505 442.7L405.3 343c-4.5-4.5-10.6-7
   }
 
   &[readonly] {
-    &,
-    &:hover:not(.pf-m-success):not([aria-invalid="true"]),
-    &:focus:not(.pf-m-success):not([aria-invalid="true"]) {
-      --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--readonly--focus--BorderBottomColor);
+    background-color: var(--pf-c-form-control--readonly--BackgroundColor);
 
-      padding-bottom: var(--pf-c-form-control--readonly--focus--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-      background-color: var(--pf-c-form-control--readonly--focus--BackgroundColor);
-      border-bottom-width: var(--pf-c-form-control--readonly--focus--BorderBottomWidth);
+    &:not(.pf-m-success):not([aria-invalid="true"]) {
+      &:hover {
+        --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--readonly--hover--BorderBottomColor);
+      }
+
+      &:focus:not(.pf-m-success):not([aria-invalid="true"]) {
+        --pf-c-form-control--focus--PaddingBottom: var(--pf-c-form-control--readonly--focus--PaddingBottom);
+        --pf-c-form-control--focus--BorderBottomWidth: var(--pf-c-form-control--readonly--focus--BorderBottomWidth);
+        --pf-c-form-control--focus--BorderBottomColor: var(--pf-c-form-control--readonly--focus--BorderBottomColor);
+      }
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2701

## Breaking changes

#### Button

This PR updates the visuals of the control button disabled state.

* The following variables were removed. All references to them should be removed as they are no longer used in patternfly.
  * `--pf-c-button--m-control--disabled--after--BorderTopColor`
  * `--pf-c-button--m-control--disabled--after--BorderRightColor`
  * `--pf-c-button--m-control--disabled--after--BorderBottomColor`
  * `--pf-c-button--m-control--disabled--after--BorderLeftColor`

#### Form Control

* `--pf-c-form-control--readonly--focus--BackgroundColor` was renamed to `--pf-c-form-control--readonly--BackgroundColor`. All references to the old variable name should be updated to reference the new variable name instead.
* `--pf-c-form-control--readonly--focus--PaddingBottom` was removed. Any reference to it should be removed as it is no longer used in patternfly. 