### PR TITLE
fix(tabs-box-border-top): fixed box vertical border top

### DIFF
--- a/src/patternfly/components/Tabs/examples/Tabs.css
+++ b/src/patternfly/components/Tabs/examples/Tabs.css
@@ -1,5 +1,0 @@
-#ws-core-c-tabs-vertical .ws-preview-html,
-#ws-core-c-tabs-box-vertical .ws-preview-html {
-  display: flex;
-  align-items: stretch;
-}

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -4,8 +4,6 @@ section: components
 cssPrefix: pf-c-tabs
 ---
 
-import './Tabs.css'
-
 ## Examples
 
 ```hbs title=Default

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -179,16 +179,21 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
     --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
 
-    max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
+    display: inline-flex;
+    flex-direction: column;
+
+    // If not a flex child, set height
+    height: 100%;
 
     // Because vertical variant has no scroll buttons, reset padding
     padding: 0;
 
     .pf-c-tabs__list {
       flex-direction: column;
+      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
     }
 
-    // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent odd scrolling behavior
+    // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
     .pf-c-tabs__item:first-child {
       margin-top: var(--pf-c-tabs--Inset);
     }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -231,6 +231,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--BorderWidth);
     }
 
+    // Add border right color and weight
+    .pf-c-tabs__item:first-child.pf-m-current {
+      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--BorderWidth);
+    }
+
     // Offset vertical border to overlap horizontal border
     .pf-c-tabs__link::after {
       top: calc(var(--pf-c-tabs__link--before--BorderWidth) * -1);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -179,12 +179,13 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
     --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
 
+    max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
+
     // Because vertical variant has no scroll buttons, reset padding
     padding: 0;
 
     .pf-c-tabs__list {
       flex-direction: column;
-      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
     }
 
     // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent odd scrolling behavior


### PR DESCRIPTION
Fixes `.pf-c-tabs.pf-m-box.pf-m-vertical .pf-c-tabs__item:first-child.pf-m-current` border top
<img width="449" alt="Screen Shot 2020-04-29 at 7 34 17 PM" src="https://user-images.githubusercontent.com/5385435/80657291-38506b80-8a51-11ea-8cbf-013352c5ba82.png">
and `.pf-c-tabs.pf-m-vertical` right border position
<img width="672" alt="Screen Shot 2020-04-29 at 7 34 21 PM" src="https://user-images.githubusercontent.com/5385435/80657300-3e464c80-8a51-11ea-9e72-bd82f3b06269.png">
