### PR TITLE
WIP refactor(nav-structure): removed __list-tertiary, added -m-tertiary

### DIFF
--- a/src/patternfly/components/Nav/examples/Nav.css
+++ b/src/patternfly/components/Nav/examples/Nav.css
@@ -1,9 +1,12 @@
+#ws-core-c-nav-default,
 #ws-core-c-nav-basic,
 #ws-core-c-nav-grouped,
 #ws-core-c-nav-default,
 #ws-core-c-nav-expanded,
 #ws-core-c-nav-expanded-with-subnav-titles,
-#ws-core-c-nav-mixed {
+#ws-core-c-nav-mixed,
+#ws-core-c-nav-horizontal,
+#ws-core-c-nav-horizontal-overflow {
   background-color: var(--pf-global--BackgroundColor--dark-300);
 }
 
@@ -28,9 +31,4 @@
 #ws-core-c-nav-horizontal-in-masthead .pf-c-page__header-nav,
 #ws-core-c-nav-horizontal-in-masthead-overflow .pf-c-page__header-nav {
   grid-row: 1;
-}
-
-#ws-core-c-nav-tertiary,
-#ws-core-c-nav-tertiary-overflow {
-  padding-top: 0;
 }

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -265,32 +265,58 @@ import './Nav.css'
 {{/nav}}
 ```
 
-```hbs title=Horizontal-in-masthead
-{{#> page}}
-  {{#> page-header}}
-    {{#> page-header-nav}}
-      {{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Global"'}}
-        {{#> nav-list nav-list--type="horizontal"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Item 3
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-header-nav}}
-  {{/page-header}}
-{{/page}}
+```hbs title=Horizontal
+{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Global"'}}
+  {{#> nav-list nav-list--type="horizontal"}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Item 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Item 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Item 3
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
+```
+
+```hbs title=Horizontal-overflow
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Global"'}}
+  {{#> nav-list nav-list--type="horizontal"}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 3
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 4
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Horizontal nav item 5
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
 ```
 
 ```hbs title=Horizontal-in-masthead-overflow
@@ -332,72 +358,60 @@ import './Nav.css'
 ```
 
 ```hbs title=Tertiary
-{{#> page}}
-  {{#> page-main}}
-    {{#> page-main-nav}}
-      {{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"'}}
-        {{#> nav-list nav-list--type="tertiary"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Item 3
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-main-nav}}
-  {{/page-main}}
-{{/page}}
+{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
+  {{#> nav-list nav-list--type="horizontal"}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Item 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Item 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Item 3
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
 ```
 
 ```hbs title=Tertiary-overflow
-{{#> page}}
-  {{#> page-main}}
-    {{#> page-main-nav}}
-      {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
-        {{#> nav-list nav-list--type="tertiary"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Tertiary nav item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Tertiary nav item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Tertiary nav item 3
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Tertiary nav item 4
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Tertiary nav item 5
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-main-nav}}
-  {{/page-main}}
-{{/page}}
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
+  {{#> nav-list nav-list--type="horizontal"}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Tertiary nav item 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Tertiary nav item 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Tertiary nav item 3
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Tertiary nav item 4
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Tertiary nav item 5
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
 ```
 
-```hbs title=Default-light-mode
+```hbs title=Default-in-light-mode
 {{#> nav nav--attribute='aria-label="Global"' nav--modifier="pf-m-light"}}
   {{#> nav-list}}
     {{#> nav-item}}
@@ -494,6 +508,39 @@ import './Nav.css'
 {{/nav}}
 ```
 
+```hbs title=Horizontal-in-light-mode
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Global"' nav--modifier="pf-m-light"}}
+  {{#> nav-list nav-list--type="horizontal"}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 1
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 2
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 3
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#"}}
+        Horizontal nav item 4
+      {{/nav-link}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+        Horizontal nav item 5
+      {{/nav-link}}
+    {{/nav-item}}
+  {{/nav-list}}
+{{/nav}}
+```
+
+
 ## Documentation
 ### Overview
 The navigation system relies on several different sub-components:
@@ -501,7 +548,6 @@ The navigation system relies on several different sub-components:
 * `.pf-c-nav__list` - default navigation list. It is the basis for both default and expandable, vertical navigation.
 * `.pf-c-nav__simple-list` - nav list simple is used within `.pf-c-nav__subnav` in expandable navigation.
 * `.pf-c-nav__horizontal-list` - nav list horizontal is a shareable component that can be used within the page header, as primary navigation, or as tertiary navigation, when expandable, vertical navigation is implemented.
-* `.pf-c-nav__tertiary-list` - nav list tertiary is a component that can be used within `<main>`, as third level navigation (tertiary navigation), when expandable, vertical navigation is implemented.
 
 ### Accessibility
 | Attribute | Applied to | Outcome |
@@ -528,8 +574,9 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__section-title` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>` | Initiates a nav section title. |
 | `.pf-c-nav__toggle` | `<span>` | Initiates a chevron indicating expandability of a `pf-c-nav__list-link`. |
 | `.pf-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon wrapper. |
+| `.pf-m-horizontal` | `.pf-c-nav` | Modifies nav for the horizontal variation. |
+| `.pf-m-light` | `.pf-c-nav` | Modifies nav for the light variation. **Note: for use with vertical nav, `.pf-m-light` is required on the page component's sidebar element (`.pf-c-page__sidebar`)**. |
 | `.pf-m-scrollable` | `.pf-c-nav` | Modifies nav for the scrollable state. |
-| `.pf-m-light` | `.pf-c-nav` | Modifies nav for the light variation. **Note: only for use with vertical navs, and requires `.pf-m-light` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |
 | `.pf-m-expandable` | `.pf-c-nav__item` | Modifies for the expandable state. |
 | `.pf-m-expanded` | `.pf-c-nav__item` | Modifies for the expanded state. |
 | `.pf-m-current` | `.pf-c-nav__link` | Modifies for the current state. |

--- a/src/patternfly/components/Nav/examples/Nav.md
+++ b/src/patternfly/components/Nav/examples/Nav.md
@@ -319,44 +319,6 @@ import './Nav.css'
 {{/nav}}
 ```
 
-```hbs title=Horizontal-in-masthead-overflow
-{{#> page}}
-  {{#> page-header}}
-    {{#> page-header-nav}}
-      {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Global"'}}
-        {{#> nav-list nav-list--type="horizontal"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Horizontal nav item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Horizontal nav item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Horizontal nav item 3
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Horizontal nav item 4
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Horizontal nav item 5
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-header-nav}}
-  {{/page-header}}
-{{/page}}
-```
-
 ```hbs title=Tertiary
 {{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
   {{#> nav-list nav-list--type="horizontal"}}

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -24,6 +24,92 @@
   --pf-c-nav--m-light__subnav__link--active--after--BorderColor: var(--pf-global--BorderColor--dark-100);
   --pf-c-nav--m-light--c-divider--BackgroundColor: var(--pf-global--BorderColor--300);
 
+  // Light scroll buttons
+  --pf-c-nav--m-light__scroll-button--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav--m-light__scroll-button--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-light__scroll-button--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-light__scroll-button--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-light__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
+
+  // Scroll buttons before
+  --pf-c-nav--m-light__scroll-button--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav--m-light__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
+
+  // Horizontal list
+  --pf-c-nav--m-horizontal__link--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-nav--m-horizontal__link--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-nav--m-horizontal__link--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav--m-horizontal__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav--m-horizontal__link--lg--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-nav--m-horizontal__link--lg--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-nav--m-horizontal__link--Color: var(--pf-global--Color--light-300);
+  --pf-c-nav--m-horizontal__link--hover--Color: var(--pf-global--active-color--400);
+  --pf-c-nav--m-horizontal__link--focus--Color: var(--pf-global--active-color--400);
+  --pf-c-nav--m-horizontal__link--active--Color: var(--pf-global--active-color--400);
+  --pf-c-nav--m-horizontal__link--m-current--Color: var(--pf-global--active-color--400);
+  --pf-c-nav--m-horizontal__link--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal__link--hover--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal__link--focus--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal__link--active--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal__link--m-current--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal__link--before--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-nav--m-horizontal__link--before--BorderWidth: 0;
+  --pf-c-nav--m-horizontal__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+
+  // Horizontal light
+  --pf-c-nav--m-horizontal--m-light__link--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav--m-horizontal--m-light__link--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-horizontal--m-light__link--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-horizontal--m-light__link--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-horizontal--m-light__link--m-current--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-horizontal--m-light__link--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal--m-light__link--hover--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal--m-light__link--focus--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal--m-light__link--active--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal--m-light__link--m-current--BackgroundColor: transparent;
+  --pf-c-nav--m-horizontal--m-light__link--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav--m-horizontal--m-light__link--before--BorderWidth: 0;
+  --pf-c-nav--m-horizontal--m-light__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal--m-light__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal--m-light__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-horizontal--m-light__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+
+  // Tertiary list
+  --pf-c-nav--m-tertiary__link--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-nav--m-tertiary__link--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-nav--m-tertiary__link--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-nav--m-tertiary__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-nav--m-tertiary__link--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav--m-tertiary__link--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__link--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__link--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__link--m-current--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__link--BackgroundColor: transparent;
+  --pf-c-nav--m-tertiary__link--hover--BackgroundColor: transparent;
+  --pf-c-nav--m-tertiary__link--focus--BackgroundColor: transparent;
+  --pf-c-nav--m-tertiary__link--active--BackgroundColor: transparent;
+  --pf-c-nav--m-tertiary__link--m-current--BackgroundColor: transparent;
+  --pf-c-nav--m-tertiary__link--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__link--before--BorderWidth: 0;
+  --pf-c-nav--m-tertiary__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-tertiary__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-tertiary__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-nav--m-tertiary__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
+
+  // Light scroll buttons
+  --pf-c-nav--m-tertiary__scroll-button--Color: var(--pf-global--Color--dark-100);
+  --pf-c-nav--m-tertiary__scroll-button--hover--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__scroll-button--focus--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__scroll-button--active--Color: var(--pf-global--active-color--100);
+  --pf-c-nav--m-tertiary__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
+
+  // Scroll buttons before
+  --pf-c-nav--m-tertiary__scroll-button--before--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-nav--m-tertiary__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
+
   // Item
   --pf-c-nav__item--m-expanded__toggle--Transform: rotate(90deg);
   --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
@@ -77,52 +163,6 @@
   --pf-c-nav__simple-list__link--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-nav__simple-list__link--Color: var(--pf-global--Color--dark-100);
   --pf-c-nav__simple-list__link--m-current--after--BorderWidth: var(--pf-global--BorderWidth--xl);
-
-  // Horizontal list
-  --pf-c-nav__horizontal-list__link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list__link--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__horizontal-list__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list__link--lg--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-nav__horizontal-list__link--lg--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-nav__horizontal-list__link--Color: var(--pf-global--Color--light-300);
-  --pf-c-nav__horizontal-list__link--hover--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--focus--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--active--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--m-current--Color: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--hover--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--focus--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--active--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--m-current--BackgroundColor: transparent;
-  --pf-c-nav__horizontal-list__link--before--BorderColor: var(--pf-global--active-color--400);
-  --pf-c-nav__horizontal-list__link--before--BorderWidth: 0;
-  --pf-c-nav__horizontal-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__horizontal-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__horizontal-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__horizontal-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-
-  // Tertiary list
-  --pf-c-nav__tertiary-list__link--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__tertiary-list__link--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-nav__tertiary-list__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-nav__tertiary-list__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-nav__tertiary-list__link--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__tertiary-list__link--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--focus--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--active--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--m-current--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--hover--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--focus--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--active--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--m-current--BackgroundColor: transparent;
-  --pf-c-nav__tertiary-list__link--before--BorderColor: var(--pf-global--active-color--100);
-  --pf-c-nav__tertiary-list__link--before--BorderWidth: 0;
-  --pf-c-nav__tertiary-list__link--hover--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__tertiary-list__link--focus--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__tertiary-list__link--active--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-nav__tertiary-list__link--m-current--before--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Sub nav
   --pf-c-nav__subnav--PaddingBottom: var(--pf-global--spacer--md);
@@ -202,43 +242,41 @@
     --pf-c-nav__subnav--PaddingLeft: var(--pf-c-nav__subnav--xl--PaddingLeft);
   }
 
-  &.pf-m-light {
-    --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-light__item--before--BorderColor);
-    --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-c-nav--m-light__item--m-current--not--m-expanded__link--BackgroundColor);
-    --pf-c-nav__link--Color: var(--pf-c-nav--m-light__link--Color);
-    --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-light__link--hover--Color);
-    --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-light__link--focus--Color);
-    --pf-c-nav__link--active--Color: var(--pf-c-nav--m-light__link--active--Color);
-    --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-light__link--m-current--Color);
-    --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-light__link--hover--BackgroundColor);
-    --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-light__link--focus--BackgroundColor);
-    --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-light__link--active--BackgroundColor);
-    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-light__link--m-current--BackgroundColor);
-    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-light__link--before--BorderColor);
-    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav--m-light__link--after--BorderColor);
-    --pf-c-nav__subnav__link--hover--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--hover--after--BorderColor);
-    --pf-c-nav__subnav__link--focus--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--focus--after--BorderColor);
-    --pf-c-nav__subnav__link--active--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--active--after--BorderColor);
-    --pf-c-nav__subnav__link--m-current--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--m-current--after--BorderColor);
-    --pf-c-nav__section-title--Color: var(--pf-c-nav--m-light__section-title--Color);
-    --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-light__section-title--BorderBottomColor);
-
-    .pf-c-divider {
-      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-light--c-divider--BackgroundColor);
-    }
-  }
-
-  // Divider
-  .pf-c-divider {
-    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--c-divider--BackgroundColor);
-
-    padding-right: var(--pf-c-nav--c-divider--PaddingRight);
-    padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
-    margin-top: var(--pf-c-nav--c-divider--MarginTop);
-    margin-bottom: var(--pf-c-nav--c-divider--MarginBottom);
-  }
-
+  // Horizontal list, masthead
   &.pf-m-horizontal {
+    --pf-c-nav__link--PaddingTop: var(--pf-c-nav--m-horizontal__link--PaddingTop);
+    --pf-c-nav__link--PaddingRight: var(--pf-c-nav--m-horizontal__link--PaddingRight);
+    --pf-c-nav__link--PaddingBottom: var(--pf-c-nav--m-horizontal__link--PaddingBottom);
+    --pf-c-nav__link--PaddingLeft: var(--pf-c-nav--m-horizontal__link--PaddingLeft);
+    --pf-c-nav__link--Color: var(--pf-c-nav--m-horizontal__link--Color);
+    --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-horizontal__link--hover--Color);
+    --pf-c-nav__link--active--Color: var(--pf-c-nav--m-horizontal__link--active--Color);
+    --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-horizontal__link--focus--Color);
+    --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-horizontal__link--m-current--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-horizontal__link--BackgroundColor);
+    --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-horizontal__link--hover--BackgroundColor);
+    --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-horizontal__link--focus--BackgroundColor);
+    --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-horizontal__link--active--BackgroundColor);
+    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-horizontal__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-horizontal__link--before--BorderColor);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-horizontal__link--before--BorderWidth);
+
+    .pf-c-nav__link:hover {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-horizontal__link--hover--before--BorderWidth);
+    }
+
+    .pf-c-nav__link:focus {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-horizontal__link--focus--before--BorderWidth);
+    }
+
+    .pf-c-nav__link:active {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-horizontal__link--active--before--BorderWidth);
+    }
+
+    .pf-c-nav__link.pf-m-current {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-horizontal__link--m-current--before--BorderWidth);
+    }
+
     position: relative;
     display: flex;
     flex-wrap: wrap;
@@ -260,6 +298,125 @@
         content: none;
       }
     }
+
+    &.pf-m-light {
+      // Horizontal light
+      --pf-c-nav__link--Color: var(--pf-c-nav--m-horizontal--m-light__link--Color);
+      --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-horizontal--m-light__link--hover--Color);
+      --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-horizontal--m-light__link--focus--Color);
+      --pf-c-nav__link--active--Color: var(--pf-c-nav--m-horizontal--m-light__link--active--Color);
+      --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-horizontal--m-light__link--m-current--Color);
+      --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-horizontal--m-light__link--BackgroundColor);
+      --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-horizontal--m-light__link--hover--BackgroundColor);
+      --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-horizontal--m-light__link--focus--BackgroundColor);
+      --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-horizontal--m-light__link--active--BackgroundColor);
+      --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-horizontal--m-light__link--m-current--BackgroundColor);
+      --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-horizontal--m-light__link--before--BorderColor);
+      --pf-c-nav__link--before--BorderWidth: var(--pf-c-nav--m-horizontal--m-light__link--before--BorderWidth);
+      --pf-c-nav__link--hover--before--BorderWidth: var(--pf-c-nav--m-horizontal--m-light__link--hover--before--BorderWidth);
+      --pf-c-nav__link--focus--before--BorderWidth: var(--pf-c-nav--m-horizontal--m-light__link--focus--before--BorderWidth);
+      --pf-c-nav__link--active--before--BorderWidth: var(--pf-c-nav--m-horizontal--m-light__link--active--before--BorderWidth);
+      --pf-c-nav__link--m-current--before--BorderWidth: var(--pf-c-nav--m-horizontal--m-light__link--m-current--before--BorderWidth);
+    }
+  }
+
+  // Tertiary list
+  &.pf-m-tertiary {
+    --pf-c-nav__link--PaddingTop: var(--pf-c-nav--m-tertiary__link--PaddingTop);
+    --pf-c-nav__link--PaddingRight: var(--pf-c-nav--m-tertiary__link--PaddingRight);
+    --pf-c-nav__link--PaddingBottom: var(--pf-c-nav--m-tertiary__link--PaddingBottom);
+    --pf-c-nav__link--PaddingLeft: var(--pf-c-nav--m-tertiary__link--PaddingLeft);
+    --pf-c-nav__link--Color: var(--pf-c-nav--m-tertiary__link--Color);
+    --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-tertiary__link--hover--Color);
+    --pf-c-nav__link--active--Color: var(--pf-c-nav--m-tertiary__link--active--Color);
+    --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-tertiary__link--focus--Color);
+    --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-tertiary__link--m-current--Color);
+    --pf-c-nav__link--BackgroundColor: var(--pf-c-nav--m-tertiary__link--BackgroundColor);
+    --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-tertiary__link--hover--BackgroundColor);
+    --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-tertiary__link--focus--BackgroundColor);
+    --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-tertiary__link--active--BackgroundColor);
+    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-tertiary__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-tertiary__link--before--BorderColor);
+    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-tertiary__link--before--BorderWidth);
+
+    .pf-c-nav__link:hover {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-tertiary__link--hover--before--BorderWidth);
+    }
+
+    .pf-c-nav__link:focus {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-tertiary__link--focus--before--BorderWidth);
+    }
+
+    .pf-c-nav__link:active {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-tertiary__link--active--before--BorderWidth);
+    }
+
+    .pf-c-nav__link.pf-m-current {
+      --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav--m-tertiary__link--m-current--before--BorderWidth);
+    }
+
+    // Light scroll buttons
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav--m-tertiary__scroll-button--Color);
+    --pf-c-nav__scroll-button--hover--Color: var(--pf-c-nav--m-tertiary__scroll-button--hover--Color);
+    --pf-c-nav__scroll-button--focus--Color: var(--pf-c-nav--m-tertiary__scroll-button--focus--Color);
+    --pf-c-nav__scroll-button--active--Color: var(--pf-c-nav--m-tertiary__scroll-button--active--Color);
+    --pf-c-nav__scroll-button--disabled--Color: var(--pf-c-nav--m-tertiary__scroll-button--disabled--Color);
+
+    // Scroll buttons before
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav--m-tertiary__scroll-button--before--BorderColor);
+    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-nav--m-tertiary__scroll-button--disabled--before--BorderColor);
+
+    .pf-c-divider {
+      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-tertiary--c-divider--BackgroundColor);
+    }
+  }
+
+  &.pf-m-light {
+    --pf-c-nav__item--before--BorderColor: var(--pf-c-nav--m-light__item--before--BorderColor);
+    --pf-c-nav__item--m-current--not--m-expanded__link--BackgroundColor: var(--pf-c-nav--m-light__item--m-current--not--m-expanded__link--BackgroundColor);
+    --pf-c-nav__link--Color: var(--pf-c-nav--m-light__link--Color);
+    --pf-c-nav__link--hover--Color: var(--pf-c-nav--m-light__link--hover--Color);
+    --pf-c-nav__link--focus--Color: var(--pf-c-nav--m-light__link--focus--Color);
+    --pf-c-nav__link--active--Color: var(--pf-c-nav--m-light__link--active--Color);
+    --pf-c-nav__link--m-current--Color: var(--pf-c-nav--m-light__link--m-current--Color);
+    --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav--m-light__link--hover--BackgroundColor);
+    --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav--m-light__link--focus--BackgroundColor);
+    --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav--m-light__link--active--BackgroundColor);
+    --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav--m-light__link--m-current--BackgroundColor);
+    --pf-c-nav__link--before--BorderColor: var(--pf-c-nav--m-light__link--before--BorderColor);
+    --pf-c-nav__link--after--BorderColor: var(--pf-c-nav--m-light__link--after--BorderColor);
+    --pf-c-nav__subnav__link--hover--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--hover--after--BorderColor);
+    --pf-c-nav__subnav__link--focus--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--focus--after--BorderColor);
+    --pf-c-nav__subnav__link--active--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--active--after--BorderColor);
+    --pf-c-nav__subnav__link--m-current--after--BorderColor: var(--pf-c-nav--m-light__subnav__link--m-current--after--BorderColor);
+    --pf-c-nav__section-title--Color: var(--pf-c-nav--m-light__section-title--Color);
+    --pf-c-nav__section-title--BorderBottomColor: var(--pf-c-nav--m-light__section-title--BorderBottomColor);
+
+    // Light scroll buttons
+    --pf-c-nav__scroll-button--Color: var(--pf-c-nav--m-light__scroll-button--Color);
+    --pf-c-nav__scroll-button--hover--Color: var(--pf-c-nav--m-light__scroll-button--hover--Color);
+    --pf-c-nav__scroll-button--focus--Color: var(--pf-c-nav--m-light__scroll-button--focus--Color);
+    --pf-c-nav__scroll-button--active--Color: var(--pf-c-nav--m-light__scroll-button--active--Color);
+    --pf-c-nav__scroll-button--disabled--Color: var(--pf-c-nav--m-light__scroll-button--disabled--Color);
+
+    // Scroll buttons before
+    --pf-c-nav__scroll-button--before--BorderColor: var(--pf-c-nav--m-light__scroll-button--before--BorderColor);
+    --pf-c-nav__scroll-button--disabled--before--BorderColor: var(--pf-c-nav--m-light__scroll-button--disabled--before--BorderColor);
+
+    .pf-c-divider {
+      --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--m-light--c-divider--BackgroundColor);
+    }
+  }
+
+
+  // Divider
+  .pf-c-divider {
+    --pf-c-divider--after--BackgroundColor: var(--pf-c-nav--c-divider--BackgroundColor);
+
+    padding-right: var(--pf-c-nav--c-divider--PaddingRight);
+    padding-left: var(--pf-c-nav--c-divider--PaddingLeft);
+    margin-top: var(--pf-c-nav--c-divider--MarginTop);
+    margin-bottom: var(--pf-c-nav--c-divider--MarginBottom);
   }
 
   &.pf-m-scrollable {
@@ -395,8 +552,7 @@
 }
 
 // Horizontal and tertiary list
-.pf-c-nav__horizontal-list,
-.pf-c-nav__tertiary-list {
+.pf-c-nav__horizontal-list {
   --pf-c-nav__link--Right: var(--pf-c-nav__link--PaddingRight);
   --pf-c-nav__link--Left: var(--pf-c-nav__link--PaddingLeft);
 
@@ -429,78 +585,6 @@
 
   .pf-c-nav__link::after {
     content: none;
-  }
-}
-
-// Horizontal list, masthead
-.pf-c-nav__horizontal-list {
-  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__horizontal-list__link--PaddingTop);
-  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__horizontal-list__link--PaddingRight);
-  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__horizontal-list__link--PaddingBottom);
-  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__horizontal-list__link--PaddingLeft);
-  --pf-c-nav__link--Color: var(--pf-c-nav__horizontal-list__link--Color);
-  --pf-c-nav__link--hover--Color: var(--pf-c-nav__horizontal-list__link--hover--Color);
-  --pf-c-nav__link--active--Color: var(--pf-c-nav__horizontal-list__link--active--Color);
-  --pf-c-nav__link--focus--Color: var(--pf-c-nav__horizontal-list__link--focus--Color);
-  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__horizontal-list__link--m-current--Color);
-  --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__horizontal-list__link--BackgroundColor);
-  --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__horizontal-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__horizontal-list__link--focus--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__horizontal-list__link--active--BackgroundColor);
-  --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__horizontal-list__link--m-current--BackgroundColor);
-  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__horizontal-list__link--before--BorderColor);
-  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--before--BorderWidth);
-
-  .pf-c-nav__link:hover {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--hover--before--BorderWidth);
-  }
-
-  .pf-c-nav__link:focus {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--focus--before--BorderWidth);
-  }
-
-  .pf-c-nav__link:active {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--active--before--BorderWidth);
-  }
-
-  .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__horizontal-list__link--m-current--before--BorderWidth);
-  }
-}
-
-// Tertiary list
-.pf-c-nav__tertiary-list {
-  --pf-c-nav__link--PaddingTop: var(--pf-c-nav__tertiary-list__link--PaddingTop);
-  --pf-c-nav__link--PaddingRight: var(--pf-c-nav__tertiary-list__link--PaddingRight);
-  --pf-c-nav__link--PaddingBottom: var(--pf-c-nav__tertiary-list__link--PaddingBottom);
-  --pf-c-nav__link--PaddingLeft: var(--pf-c-nav__tertiary-list__link--PaddingLeft);
-  --pf-c-nav__link--Color: var(--pf-c-nav__tertiary-list__link--Color);
-  --pf-c-nav__link--hover--Color: var(--pf-c-nav__tertiary-list__link--hover--Color);
-  --pf-c-nav__link--active--Color: var(--pf-c-nav__tertiary-list__link--active--Color);
-  --pf-c-nav__link--focus--Color: var(--pf-c-nav__tertiary-list__link--focus--Color);
-  --pf-c-nav__link--m-current--Color: var(--pf-c-nav__tertiary-list__link--m-current--Color);
-  --pf-c-nav__link--BackgroundColor: var(--pf-c-nav__tertiary-list__link--BackgroundColor);
-  --pf-c-nav__link--hover--BackgroundColor: var(--pf-c-nav__tertiary-list__link--hover--BackgroundColor);
-  --pf-c-nav__link--focus--BackgroundColor: var(--pf-c-nav__tertiary-list__link--focus--BackgroundColor);
-  --pf-c-nav__link--active--BackgroundColor: var(--pf-c-nav__tertiary-list__link--active--BackgroundColor);
-  --pf-c-nav__link--m-current--BackgroundColor: var(--pf-c-nav__tertiary-list__link--m-current--BackgroundColor);
-  --pf-c-nav__link--before--BorderColor: var(--pf-c-nav__tertiary-list__link--before--BorderColor);
-  --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--before--BorderWidth);
-
-  .pf-c-nav__link:hover {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--hover--before--BorderWidth);
-  }
-
-  .pf-c-nav__link:focus {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--focus--before--BorderWidth);
-  }
-
-  .pf-c-nav__link:active {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--active--before--BorderWidth);
-  }
-
-  .pf-c-nav__link.pf-m-current {
-    --pf-c-nav__link--before--BorderBottomWidth: var(--pf-c-nav__tertiary-list__link--m-current--before--BorderWidth);
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -115,17 +115,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
     --pf-c-page__main-nav--PaddingLeft: var(--pf-c-page__main-nav--xl--PaddingLeft);
   }
 
-  // Light scroll buttons
-  --pf-c-nav__main-nav--c-nav__scroll-button--Color: var(--pf-global--Color--dark-100);
-  --pf-c-nav__main-nav--c-nav__scroll-button--hover--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__main-nav--c-nav__scroll-button--focus--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__main-nav--c-nav__scroll-button--active--Color: var(--pf-global--active-color--100);
-  --pf-c-nav__main-nav--c-nav__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
-
-  // Scroll buttons before
-  --pf-c-nav__main-nav--c-nav__scroll-button--before--BorderColor: var(--pf-global--BorderColor--300);
-  --pf-c-nav__main-nav--c-nav__scroll-button--disabled--before--BorderColor: var(--pf-global--disabled-color--300);
-
   // Main section breadcrumb
   --pf-c-page__main-breadcrumb--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__main-breadcrumb--PaddingTop: var(--pf-global--spacer--md);

--- a/src/patternfly/demos/DataList/data-list-main-section-nav.hbs
+++ b/src/patternfly/demos/DataList/data-list-main-section-nav.hbs
@@ -1,5 +1,5 @@
-{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"'}}
-  {{#> nav-list nav-list--type="tertiary"}}
+{{#> nav nav--IsHorizontal="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
+  {{#> nav-list nav-list--type="horizontal"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
         Nav item 1

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -174,8 +174,8 @@ section: demos
   {{/page-sidebar}}
   {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav}}
-      {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
-        {{#> nav-list nav-list--type="tertiary"}}
+      {{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
+        {{#> nav-list nav-list--type="horizontal"}}
           {{#> nav-item}}
             {{#> nav-link nav-link--href="#" nav-link--current="true"}}
               Tertiary nav item 1

--- a/src/patternfly/demos/Table/table-main-section-nav.hbs
+++ b/src/patternfly/demos/Table/table-main-section-nav.hbs
@@ -1,5 +1,5 @@
-{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
-  {{#> nav-list nav-list--type="tertiary"}}
+{{#> nav nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"' nav--modifier="pf-m-tertiary"}}
+  {{#> nav-list nav-list--type="horizontal"}}
     {{#> nav-item}}
       {{#> nav-link nav-link--href="#" nav-link--current="true"}}
         Nav Item 1


### PR DESCRIPTION
closes #3024 

## Breaking changes
summary

The following classes have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `.pf-c-`

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--`

The following variables have been renamed. Any reference to the old variable should be updated to use the new variable:
* `--pf-c-` has changed to `--pf-c-`

Some of the general CSS structure has also changed, so please reference the [file changeset](https://github.com/patternfly/patternfly/pull/-/files).