### PR TITLE
fix(datalist): fix shadows on selected rows

### DIFF
--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -11,37 +11,37 @@
 
   // Item
   --pf-c-data-list__item--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-data-list__item--m-selected--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-selectable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-data-list__item--m-selectable--hover--ZIndex: calc(var(--pf-c-data-list__item--m-selected--ZIndex) + 1);
   --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-selectable--focus--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-selectable--active--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
-  --pf-c-data-list__item--item--BorderBottomColor: var(--pf-global--BorderColor--300);
-  --pf-c-data-list__item--item--BorderBottomWidth: #{pf-size-prem(8px)};
-  --pf-c-data-list__item--m-selectable--hover__item--BorderTopColor: var(--pf-c-data-list__item--item--BorderBottomColor);
-  --pf-c-data-list__item--m-selectable--hover__item--BorderTopWidth: var(--pf-c-data-list__item--item--BorderBottomWidth);
-  --pf-c-data-list__item--item--sm--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-data-list__item--item--sm--BorderBottomColor: var(--pf-global--BorderColor--100);
+  --pf-c-data-list__item--BorderBottomColor: var(--pf-global--BorderColor--300);
+  --pf-c-data-list__item--BorderBottomWidth: #{pf-size-prem(8px)};
+  --pf-c-data-list__item--m-selectable--hover--item--BorderTopColor: var(--pf-c-data-list__item--BorderBottomColor);
+  --pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth: var(--pf-c-data-list__item--BorderBottomWidth);
+  --pf-c-data-list__item--sm--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-data-list__item--sm--BorderBottomColor: var(--pf-global--BorderColor--100);
 
   @media screen and (min-width: $pf-global--breakpoint--sm) {
-    --pf-c-data-list__item--item--BorderBottomWidth: var(--pf-c-data-list__item--item--sm--BorderBottomWidth);
-    --pf-c-data-list__item--item--BorderBottomColor: var(--pf-c-data-list__item--item--sm--BorderBottomColor);
+    --pf-c-data-list__item--BorderBottomWidth: var(--pf-c-data-list__item--sm--BorderBottomWidth);
+    --pf-c-data-list__item--BorderBottomColor: var(--pf-c-data-list__item--sm--BorderBottomColor);
   }
 
   // List item border left
-  --pf-c-data-list__item-row--before--BackgroundColor: transparent;
-  --pf-c-data-list__item-row--before--Width: var(--pf-global--BorderWidth--lg);
-  --pf-c-data-list__item-row--before--Transition: var(--pf-global--Transition);
-  --pf-c-data-list__item-row--before--ZIndex: var(--pf-global--ZIndex--xl);
-  --pf-c-data-list__item-row--before--Top: 0;
-  --pf-c-data-list__item--item--before--Top: calc(var(--pf-c-data-list__item--item--BorderBottomWidth) * -1);
+  --pf-c-data-list__item--before--BackgroundColor: transparent;
+  --pf-c-data-list__item--before--Width: var(--pf-global--BorderWidth--lg);
+  --pf-c-data-list__item--before--Transition: var(--pf-global--Transition);
+  --pf-c-data-list__item--before--Top: 0;
+  --pf-c-data-list__item--before--sm--Top: calc(var(--pf-c-data-list__item--BorderBottomWidth) * -1);
 
   @media (min-width: $pf-global--breakpoint--sm) {
-    --pf-c-data-list__item-row--before--Top: var(--pf-c-data-list__item--item--before--Top);
+    --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item--before--sm--Top);
   }
 
   // Data list item row
@@ -105,17 +105,11 @@
 
   // Expandable content
   --pf-c-data-list__expandable-content--BorderTopWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-data-list__expandable-content--BorderRightWidth: 0;
-  --pf-c-data-list__expandable-content--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-data-list__expandable-content--BorderLeftWidth: 0;
   --pf-c-data-list__expandable-content--BorderTopColor: var(--pf-global--BorderColor--100);
-  --pf-c-data-list__expandable-content--BorderRightColor: transparent;
-  --pf-c-data-list__expandable-content--BorderBottomColor: var(--pf-global--BorderColor--100);
-  --pf-c-data-list__expandable-content--BorderLeftColor: transparent;
   --pf-c-data-list__expandable-content--MarginRight: calc(var(--pf-c-data-list__expandable-content-body--PaddingRight) * -1);
   --pf-c-data-list__expandable-content--MarginLeft: calc(var(--pf-c-data-list__expandable-content-body--PaddingLeft) * -1);
   --pf-c-data-list__expandable-content--MaxHeight: #{pf-size-prem(600px)};
-  --pf-c-data-list__expandable-content--before--Top: calc(var(--pf-c-data-list__item--item--BorderBottomWidth) * -1);
+  --pf-c-data-list__expandable-content--before--Top: calc(var(--pf-c-data-list__item--BorderBottomWidth) * -1);
   --pf-c-data-list__expandable-content-body--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-data-list__expandable-content-body--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-data-list__expandable-content-body--PaddingBottom: var(--pf-global--spacer--md);
@@ -185,21 +179,21 @@
 
 // li
 .pf-c-data-list__item {
+  position: relative;
   display: flex;
   flex-direction: column;
   background-color: var(--pf-c-data-list__item--BackgroundColor);
+  border-bottom: var(--pf-c-data-list__item--BorderBottomWidth) solid var(--pf-c-data-list__item--BorderBottomColor);
 
-  // add border bottom to subsequent li's
-  &:not(.pf-m-expanded) {
-    border-bottom: var(--pf-c-data-list__item--item--BorderBottomWidth) solid var(--pf-c-data-list__item--item--BorderBottomColor);
-
-    &:not(.pf-m-selected):not(:last-child).pf-m-selectable:hover {
-      --pf-c-data-list__item--item--BorderBottomWidth: 0;
-
-      + .pf-c-data-list__item {
-        border-top: var(--pf-c-data-list__item--m-selectable--hover__item--BorderTopWidth) solid var(--pf-c-data-list__item--m-selectable--hover__item--BorderTopColor);
-      }
-    }
+  &::before {
+    position: absolute;
+    top: var(--pf-c-data-list__item--before--Top);
+    bottom: 0;
+    left: 0;
+    width: var(--pf-c-data-list__item--before--Width);
+    content: "";
+    background-color: var(--pf-c-data-list__item--before--BackgroundColor);
+    transition: var(--pf-c-data-list__item--before--Transition);
   }
 
   &.pf-m-selectable {
@@ -210,6 +204,16 @@
     &:focus {
       position: relative;
       z-index: var(--pf-c-data-list__item--m-selectable--hover--ZIndex);
+
+      &:not(.pf-m-selected):not(:last-child) {
+        --pf-c-data-list__item--BorderBottomWidth: 0;
+
+        // stylelint-disable
+        + .pf-c-data-list__item {
+          border-top: var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth) solid var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopColor);
+        }
+        // stylelint-enable
+      }
     }
 
     &:hover {
@@ -226,37 +230,19 @@
   }
 
   &.pf-m-selected {
-    --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
+    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
 
     position: relative;
+    z-index: var(--pf-c-data-list__item--m-selected--ZIndex);
     box-shadow: var(--pf-c-data-list__item--m-selected--BoxShadow);
   }
 
   &.pf-m-expanded {
-    --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
+    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
 
     &.pf-m-selectable:not(.pf-m-selected) {
-      --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
+      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
     }
-  }
-}
-
-
-.pf-c-data-list__item-row,
-.pf-c-data-list__expandable-content {
-  position: relative;
-
-  // Border treatment for expanded/selected rows
-  // Needs to exist here instead of on __item, since __item needs static positioning to maintain the proper stacking context for shadows to work
-  &::before {
-    position: absolute;
-    top: var(--pf-c-data-list__item-row--before--Top);
-    bottom: 0;
-    left: 0;
-    width: var(--pf-c-data-list__item-row--before--Width);
-    content: "";
-    background-color: var(--pf-c-data-list__item-row--before--BackgroundColor);
-    transition: var(--pf-c-data-list__item-row--before--Transition);
   }
 }
 
@@ -385,9 +371,7 @@
 .pf-c-data-list__expandable-content {
   max-height: var(--pf-c-data-list__expandable-content--MaxHeight);
   overflow-y: auto;
-  border-color: var(--pf-c-data-list__expandable-content--BorderTopColor) var(--pf-c-data-list__expandable-content--BorderRightColor) var(--pf-c-data-list__expandable-content--BorderBottomColor) var(--pf-c-data-list__expandable-content--BorderLeftColor);
-  border-style: solid;
-  border-width: var(--pf-c-data-list__expandable-content--BorderTopWidth) var(--pf-c-data-list__expandable-content--BorderRightWidth) var(--pf-c-data-list__expandable-content--BorderBottomWidth) var(--pf-c-data-list__expandable-content--BorderLeftWidth);
+  border-top: var(--pf-c-data-list__expandable-content--BorderTopWidth) solid var(--pf-c-data-list__expandable-content--BorderTopColor);
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     max-height: initial;

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -33,15 +33,15 @@
   }
 
   // List item border left
-  --pf-c-data-list__item--before--BackgroundColor: transparent;
-  --pf-c-data-list__item--before--Width: var(--pf-global--BorderWidth--lg);
-  --pf-c-data-list__item--before--Transition: var(--pf-global--Transition);
-  --pf-c-data-list__item--before--ZIndex: var(--pf-global--ZIndex--xl);
-  --pf-c-data-list__item--before--Top: 0;
+  --pf-c-data-list__item-row--before--BackgroundColor: transparent;
+  --pf-c-data-list__item-row--before--Width: var(--pf-global--BorderWidth--lg);
+  --pf-c-data-list__item-row--before--Transition: var(--pf-global--Transition);
+  --pf-c-data-list__item-row--before--ZIndex: var(--pf-global--ZIndex--xl);
+  --pf-c-data-list__item-row--before--Top: 0;
   --pf-c-data-list__item--item--before--Top: calc(var(--pf-c-data-list__item--item--BorderBottomWidth) * -1);
 
   @media (min-width: $pf-global--breakpoint--sm) {
-    --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item--item--before--Top);
+    --pf-c-data-list__item-row--before--Top: var(--pf-c-data-list__item--item--before--Top);
   }
 
   // Data list item row
@@ -185,21 +185,9 @@
 
 // li
 .pf-c-data-list__item {
-  position: relative;
   display: flex;
   flex-direction: column;
   background-color: var(--pf-c-data-list__item--BackgroundColor);
-
-  &::before {
-    position: absolute;
-    top: var(--pf-c-data-list__item--before--Top);
-    bottom: 0;
-    left: 0;
-    width: var(--pf-c-data-list__item--before--Width);
-    content: "";
-    background-color: var(--pf-c-data-list__item--before--BackgroundColor);
-    transition: var(--pf-c-data-list__item--before--Transition);
-  }
 
   // add border bottom to subsequent li's
   &:not(.pf-m-expanded) {
@@ -238,18 +226,37 @@
   }
 
   &.pf-m-selected {
-    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
+    --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
 
     position: relative;
     box-shadow: var(--pf-c-data-list__item--m-selected--BoxShadow);
   }
 
   &.pf-m-expanded {
-    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
+    --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
 
     &.pf-m-selectable:not(.pf-m-selected) {
-      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
+      --pf-c-data-list__item-row--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
     }
+  }
+}
+
+
+.pf-c-data-list__item-row,
+.pf-c-data-list__expandable-content {
+  position: relative;
+
+  // Border treatment for expanded/selected rows
+  // Needs to exist here instead of on __item, since __item needs static positioning to maintain the proper stacking context for shadows to work
+  &::before {
+    position: absolute;
+    top: var(--pf-c-data-list__item-row--before--Top);
+    bottom: 0;
+    left: 0;
+    width: var(--pf-c-data-list__item-row--before--Width);
+    content: "";
+    background-color: var(--pf-c-data-list__item-row--before--BackgroundColor);
+    transition: var(--pf-c-data-list__item-row--before--Transition);
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3063

The way shadows should work is the selected row has a top/bottom shadow by default, and if you hover/focus over a selectable row, that row should also have a top/bottom shadow, and if you hover/focus over a selectable row that is adjacent to a selected row, the hover shadow should take precedence over the selected row's shadow.

## Breaking changes

TBD