### PR TITLE
fix(modal-box): added __header element

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -104,17 +104,40 @@ cssPrefix: pf-c-modal-box
 {{/modal-box}}
 ```
 
+```hbs title=Custom-title
+{{#> modal-box modal-box--attribute='aria-labelledby="modal-custom-title" aria-describedby="modal-custom-description"'}}
+  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+   <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+  {{#> modal-box-header}}
+    {{#> title title--modifier="pf-m-4xl" title--attribute='id="modal-custom-title"'}}Custom title{{/title}}
+  {{/modal-box-header}}
+  {{#> modal-box-body modal-box-body--attribute='id="modal-custom-description"'}}
+    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
+  {{/modal-box-body}}
+  {{#> modal-box-footer}}
+    Modal footer
+  {{/modal-box-footer}}
+{{/modal-box}}
+```
+
+```hbs title=Modal-box-as-generic-container
+{{#> modal-box modal-box--attribute='aria-label="Generic modal box container"'}}
+  The modal box children elements can be removed, and the modal serves as a generic modal container. One use case of this is when creating a wizard in a modal.
+{{/modal-box}}
+```
+
 ## Documentation
 ### Overview
-A modal box is a generic rectangular container that can be used to build modals. A modal box can have four sections: title, description, body, and footer. Title or body is required. Alternatively, no sections can be used, and the modal will just serve as a box with no padding for custom modal content. If no `.pf-c-modal-box__title` is used, `aria-label="[title of modal]"` must be provided for `.pf-c-modal-box`.
+A modal box is a generic rectangular container that can be used to build modals. A modal box can have the following sections: header, title, description, body, and footer. With normal use of the modal, a title or body is required. Alternatively, no child elements can be used, and the `.pf-c-modal-box` container will  serve as a generic container with no padding for custom modal content. If no `.pf-c-modal-box__title` is used, `aria-label="[title of modal]"` must be provided for `.pf-c-modal-box`.
 
 
 ### Accessibility
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**|
-| `aria-labelledby="[id value of .pf-c-title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-title is present** |
-| `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when `.pf-c-title` is _not_ present** |
+| `aria-labelledby="[id value of .pf-c-modal-box__title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-title is present** |
+| `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when `.pf-c-modal-box__title` is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
 | `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
@@ -125,7 +148,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. |
-| `.pf-c-modal-box__header` | `<header>` | Initiates a modal box header. |
+| `.pf-c-modal-box__header` | `<header>` | Initiates a modal box header. **Required** if using a `.pf-c-modal-box__title`. |
 | `.pf-c-modal-box__title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`, `<div>` | Initiates a modal box title. |
 | `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title is **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,9 +10,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
-    Modal title
-  {{/modal-box-title}}
+  {{#> modal-box-header}}
+    {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
+      Modal title
+    {{/modal-box-title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
@@ -27,9 +29,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-title modal-box-title--attribute='id="modal-sm-title"'}}
-    Modal title
-  {{/modal-box-title}}
+  {{#> modal-box-header}}
+    {{#> modal-box-title modal-box-title--attribute='id="modal-sm-title"'}}
+      Modal title
+    {{/modal-box-title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-sm-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -47,9 +51,11 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
-    Modal title
-  {{/modal-box-title}}
+  {{#> modal-box-header}}
+    {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
+      Modal title
+    {{/modal-box-title}}
+  {{/modal-box-header}}
   {{#> modal-box-body modal-box-body--attribute='id="modal-lg-description"'}}
     Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -81,12 +87,14 @@ cssPrefix: pf-c-modal-box
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
    <i class="fas fa-times" aria-hidden="true"></i>
   {{/button}}
-  {{#> modal-box-title modal-box-title--attribute='id="modal-with-description-title"'}}
-    Modal title
-  {{/modal-box-title}}
-  {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
-    A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
-  {{/modal-box-description}}
+  {{#> modal-box-header}}
+    {{#> modal-box-title modal-box-title--attribute='id="modal-with-description-title"'}}
+      Modal title
+    {{/modal-box-title}}
+    {{#> modal-box-description modal-box-description--attribute='id="modal-with-description-description"'}}
+      A description is used when you want to provide more info about the modal than the title is able to describe. The content in the description is static and will not scroll with the rest of the modal body.
+    {{/modal-box-description}}
+  {{/modal-box-header}}
   {{#> modal-box-body}}
     To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
@@ -116,9 +124,10 @@ A modal box is a generic rectangular container that can be used to build modals.
 | Class | Applied | Outcome |
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
-| `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. **Required** |
+| `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. |
+| `.pf-c-modal-box__header` | `<header>` | Initiates a modal box header. |
 | `.pf-c-modal-box__title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`, `<div>` | Initiates a modal box title. |
-| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title and modal body are **required** if using a modal description. |
+| `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title is **required** if using a modal description. |
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -151,7 +151,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__header` | `<header>` | Initiates a modal box header. **Required** if using a `.pf-c-modal-box__title`. |
 | `.pf-c-modal-box__title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`, `<div>` | Initiates a modal box title. |
 | `.pf-c-modal-box__description` | `<div>` | Initiates a modal box description. A modal title is **required** if using a modal description. |
-| `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. A modal box body is **required** if there is no modal box title. |
+| `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |
 | `.pf-m-lg` | `.pf-c-modal-box` | Modifies for a large modal box width. |

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -122,8 +122,8 @@ cssPrefix: pf-c-modal-box
 ```
 
 ```hbs title=Modal-box-as-generic-container
-{{#> modal-box modal-box--attribute='aria-label="Generic modal box container"'}}
-  The modal box children elements can be removed, and the modal serves as a generic modal container. One use case of this is when creating a wizard in a modal.
+{{#> modal-box modal-box--attribute='aria-labelledby="modal-generic-container-description"'}}
+  <p id="modal-generic-container-description">The modal box children elements can be removed, and the modal serves as a generic modal container. One use case of this is when creating a wizard in a modal.</p>
 {{/modal-box}}
 ```
 

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -136,7 +136,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**|
-| `aria-labelledby="[id value of .pf-c-modal-box__title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-title is present** |
+| `aria-labelledby="[id value of .pf-c-modal-box__title or custom modal title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-title is present** |
 | `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when `.pf-c-modal-box__title` is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,0 +1,6 @@
+<header class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}"
+  {{#if modal-box-header--attribute}}
+    {{{modal-box-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</header>

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -9,19 +9,18 @@
   --pf-c-modal-box--MaxHeight: calc(100% - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
   // Header
+  --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-modal-box__header--last-child--PaddingBottom: var(--pf-global--spacer--lg);
+
+  // Title
   --pf-c-modal-box__title--LineHeight: var(--pf-global--LineHeight--sm);
   --pf-c-modal-box__title--FontSize: var(--pf-global--FontSize--2xl);
   --pf-c-modal-box__title--FontWeight: var(--pf-global--FontWeight--bold);
-  --pf-c-modal-box__title--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__title--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__title--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__title--last-child--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Description
   --pf-c-modal-box__description--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-modal-box__description--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__description--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__description--last-child--PaddingBottom: var(--pf-global--spacer--lg);
 
   // Body
   --pf-c-modal-box__body--MinHeight: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md)); // Allow for at least 1 line of content in the body
@@ -29,8 +28,7 @@
   --pf-c-modal-box__body--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-modal-box__body--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-modal-box__body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-c-modal-box__title--body--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-modal-box__description--body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
   --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
@@ -83,38 +81,31 @@
   }
 }
 
+.pf-c-modal-box__header {
+  padding-top: var(--pf-c-modal-box__header--PaddingTop);
+  padding-right: var(--pf-c-modal-box__header--PaddingRight);
+  padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+
+  &:last-child {
+    padding-bottom: var(--pf-c-modal-box__header--last-child--PaddingBottom);
+  }
+
+  + .pf-c-modal-box__body {
+    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__header--body--PaddingTop);
+  }
+}
+
 .pf-c-modal-box__title {
   @include pf-text-overflow;
 
   flex: 0 0 auto;
-  padding-top: var(--pf-c-modal-box__title--PaddingTop);
-  padding-right: var(--pf-c-modal-box__title--PaddingRight);
-  padding-left: var(--pf-c-modal-box__title--PaddingLeft);
   font-size: var(--pf-c-modal-box__title--FontSize);
   font-weight: var(--pf-c-modal-box__title--FontWeight);
   line-height: var(--pf-c-modal-box__title--LineHeight);
-
-  &:last-child {
-    padding-bottom: var(--pf-c-modal-box__title--last-child--PaddingBottom);
-  }
-
-  + .pf-c-modal-box__body {
-    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__title--body--PaddingTop);
-  }
 }
 
 .pf-c-modal-box__description {
   padding-top: var(--pf-c-modal-box__description--PaddingTop);
-  padding-right: var(--pf-c-modal-box__description--PaddingRight);
-  padding-left: var(--pf-c-modal-box__description--PaddingLeft);
-
-  &:last-child {
-    padding-bottom: var(--pf-c-modal-box__description--last-child--PaddingBottom);
-  }
-
-  + .pf-c-modal-box__body {
-    --pf-c-modal-box__body--PaddingTop: var(--pf-c-modal-box__description--body--PaddingTop);
-  }
 }
 
 // Body


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3081

## Breaking changes

This PR adds a new element `header.pf-c-modal-box__header` that wraps the `.pf-c-modal-box__title` and `.pf-c-modal-box__description` elements. All instances of `.pf-c-modal-box__title` and `.pf-c-modal-box__description` should be wrapped in `.pf-c-modal-box__header`

The following variables were renamed. Any reference to the old name should be updated to reference the new name.
  * `--pf-c-modal-box__title--PaddingTop` renamed to `--pf-c-modal-box__header--PaddingTop`
  * `--pf-c-modal-box__title--PaddingRight` renamed to `--pf-c-modal-box__header--PaddingRight`
  * `--pf-c-modal-box__title--PaddingLeft` renamed to `--pf-c-modal-box__header--PaddingLeft`
  * `--pf-c-modal-box__title--last-child--PaddingBottom` renamed to `--pf-c-modal-box__header--last-child--PaddingBottom`
  * `--pf-c-modal-box__title--body--PaddingTop` renamed to `--pf-c-modal-box__header--body--PaddingTop`

The following variables were removed. Any reference to them should be removed as they are no longer used in patternfly.
  * `--pf-c-modal-box__description--PaddingRight`
  * `--pf-c-modal-box__description--PaddingLeft`
  * `--pf-c-modal-box__description--last-child--PaddingBottom`
  * `--pf-c-modal-box__description--body--PaddingTop`