### PR TITLE
fix(emptystate): split single padding var to top/right/bottom/left

### DIFF
--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,5 +1,8 @@
 .pf-c-empty-state {
-  --pf-c-empty-state--Padding: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-empty-state__content--MaxWidth: none;
   --pf-c-empty-state__icon--MarginBottom: var(--pf-global--spacer--lg);
   --pf-c-empty-state__icon--FontSize: var(--pf-global--icon--FontSize--xl);
@@ -25,7 +28,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--pf-c-empty-state--Padding);
+  padding: var(--pf-c-empty-state--PaddingTop) var(--pf-c-empty-state--PaddingRight) var(--pf-c-empty-state--PaddingBottom) var(--pf-c-empty-state--PaddingLeft);
   text-align: center;
 
   &.pf-m-sm {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3085

## Breaking changes
This PR removes `--pf-c-empty-state--Padding`. Any reference to that variable should be removed as it is no longer used.

To change the empty state outer padding, use `--pf-c-empty-state--PaddingTop`, `--pf-c-empty-state--PaddingRight`, `--pf-c-empty-state--PaddingBottom`, and `--pf-c-empty-state--PaddingLeft` instead.