### PR TITLE
Fix tab focus 2

### DIFF
--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -130,17 +130,17 @@ cssPrefix: pf-c-tabs
 | `.pf-m-fill`  | `.pf-c-tabs` | Modifies the tabs to fill the available space. **Required** |
 
 ```hbs title=Using-the-nav-element
-{{#> tabs tabs--id="default-scroll-nav-example" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Local"' tabs-link--type="a"}}
+{{#> tabs tabs--id="default-scroll-nav-example" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Local"' tabs-link--isLink="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 ```
 
 ```hbs title=Sub-nav-using-the-nav-element
-{{#> tabs tabs--id="primary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local"' tabs-link--type="a"}}
+{{#> tabs tabs--id="primary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local"' tabs-link--isLink="true"}}
   {{> __tabs-list}}
 {{/tabs}}
 
-{{#> tabs tabs--id="secondary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local secondary"' tabs-link--type="a" tabs--modifier="pf-m-secondary"}}
+{{#> tabs tabs--id="secondary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Local secondary"' tabs-link--isLink="true" tabs--modifier="pf-m-secondary"}}
   {{> __tabs-list-secondary}}
 {{/tabs}}
 ```

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -164,14 +164,14 @@ Whenever a list of tabs is unique on the current page, it can be used in a `<nav
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-tabs` | `<nav>`, `<div>` | Initiates the tabs component. **Required** |
-| `.pf-c-tabs__list` | `<div>` | Initiates a tabs component list. **Required** |
-| `.pf-c-tabs__item` | `<div>` | Initiates a tabs component item. **Required** |
+| `.pf-c-tabs__list` | `<ul>` | Initiates a tabs component list. **Required** |
+| `.pf-c-tabs__item` | `<li>` | Initiates a tabs component item. **Required** |
 | `.pf-c-tabs__item-text` | `<span>` | Initiates a tabs component item icon. **Required** |
 | `.pf-c-tabs__item-icon` | `<span>` | Initiates a tabs component item text. **Required** |
 | `.pf-c-tabs__link` | `<button>`, `<a>` | Initiates a tabs component link. **Required** |
 | `.pf-c-tabs__scroll-button` | `<button>` | Initiates a tabs component scroll button. |
 | `.pf-m-secondary` | `.pf-c-tabs` | Applies secondary styling to the tab component. |
-| `.pf-m-no-border` | `.pf-c-tabs` | Removes bottom border from a tab component. |
+| `.pf-m-no-bottom-border` | `.pf-c-tabs` | Removes bottom border from a tab component. |
 | `.pf-m-box` | `.pf-c-tabs` | Applies box styling to the tab component. |
 | `.pf-m-vertical` | `.pf-c-tabs` | Applies vertical styling to the tab component. |
 | `.pf-m-fill` | `.pf-c-tabs` | Modifies the tabs to fill the available space. |

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -171,7 +171,7 @@ Whenever a list of tabs is unique on the current page, it can be used in a `<nav
 | `.pf-c-tabs__link` | `<button>`, `<a>` | Initiates a tabs component link. **Required** |
 | `.pf-c-tabs__scroll-button` | `<button>` | Initiates a tabs component scroll button. |
 | `.pf-m-secondary` | `.pf-c-tabs` | Applies secondary styling to the tab component. |
-| `.pf-m-no-bottom-border` | `.pf-c-tabs` | Removes bottom border from a tab component. |
+| `.pf-m-no-border-bottom` | `.pf-c-tabs` | Removes bottom border from a tab component. |
 | `.pf-m-box` | `.pf-c-tabs` | Applies box styling to the tab component. |
 | `.pf-m-vertical` | `.pf-c-tabs` | Applies vertical styling to the tab component. |
 | `.pf-m-fill` | `.pf-c-tabs` | Modifies the tabs to fill the available space. |

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -1,6 +1,9 @@
-<{{#if tabs-link--type}}{{tabs-link--type}}{{else}}button{{/if}} class="pf-c-tabs__link{{#if tabs-link--modifier}} {{tabs-link--modifier}}{{/if}}"
+<{{#if tabs-link--isLink}}a{{else}}button{{/if}} class="pf-c-tabs__link{{#if tabs-link--modifier}} {{tabs-link--modifier}}{{/if}}"
+  {{#if tabs-link--isLink}}
+    href="#"
+  {{/if}}
   {{#if tabs-link--attribute}}
     {{{tabs-link--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</{{#if tabs-link--type}}{{tabs-link--type}}{{else}}button{{/if}}>
+</{{#if tabs-link--isLink}}a{{else}}button{{/if}}>

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -141,7 +141,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   &.pf-m-secondary,
-  &.pf-m-no-bottom-border {
+  &.pf-m-no-border-bottom {
     --pf-c-tabs--before--BorderBottomWidth: 0;
   }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -9,20 +9,16 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--before--BorderRightWidth: 0;
   --pf-c-tabs--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs--before--BorderLeftWidth: 0;
-  --pf-c-tabs--Transition: padding .125s;
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg);
 
   // Vertical
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg);
   --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
 
   // Box
-  --pf-c-tabs--m-box--inset: 0;
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
   --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--xl--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
-
-  // Vertical box
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
 
   // Tab link
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);
@@ -92,7 +88,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   padding-right: var(--pf-c-tabs--inset);
   padding-left: var(--pf-c-tabs--inset);
   overflow: hidden;
-  transition: var(--pf-c-tabs--Transition);
 
   &::before {
     position: absolute;
@@ -157,7 +152,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
     --pf-c-tabs__link--after--Top: 0;
     --pf-c-tabs__link--after--Bottom: auto;
-    --pf-c-tabs--inset: var(--pf-c-tabs--m-box--inset);
 
     // Set hover on top border
     .pf-c-tabs__link {
@@ -457,6 +451,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       @each $spacer, $spacer-value in $pf-c-tabs--spacer-map {
         &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
           --pf-c-tabs--inset: #{$spacer-value};
+          --pf-c-tabs--m-vertical--inset: #{$spacer-value};
+          --pf-c-tabs--m-vertical--m-box--inset: #{$spacer-value};
 
           @if $spacer == none {
             --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -130,11 +130,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       margin-left: 0;
       transform: translateX(0);
     }
+  }
 
-    &.pf-m-secondary,
-    &.pf-m-no-border {
-      --pf-c-tabs--before--border-width--base: 0;
-    }
+  &.pf-m-secondary,
+  &.pf-m-no-border {
+    --pf-c-tabs--before--BorderBottomWidth: 0;
   }
 
   // Remove bottom border for variants

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -183,7 +183,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
     }
 
-    // Collapse left border into scroll button when expanded
+    // Collapse left border into list when expanded
     &.pf-m-scrollable .pf-c-tabs__scroll-button:nth-of-type(2)::before {
       left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
     }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -2,17 +2,27 @@ $pf-c-tabs--breakpoint-map: build-breakpoint-map("base", "md", "lg", "xl", "2xl"
 $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-tabs {
-  --pf-c-tabs--Inset: 0;
-  --pf-c-tabs--before--BorderStyle: solid;
+  --pf-c-tabs--inset: 0;
   --pf-c-tabs--before--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-tabs--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-tabs--before--border-width--base: var(--pf-global--BorderWidth--sm);
   --pf-c-tabs--before--BorderTopWidth: 0;
   --pf-c-tabs--before--BorderRightWidth: 0;
-  --pf-c-tabs--before--BorderBottomWidth: var(--pf-c-tabs--before--BorderWidth);
+  --pf-c-tabs--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs--before--BorderLeftWidth: 0;
-  --pf-c-tabs--m-vertical--Inset: var(--pf-global--spacer--lg);
+  --pf-c-tabs--Transition: padding .125s;
+
+  // Vertical
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg);
   --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
-  --pf-c-tabs--m-vertical--m-box--Inset: var(--pf-global--spacer--xl);
+
+  // Box
+  --pf-c-tabs--m-box--inset: 0;
+  --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+  --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+  --pf-c-tabs--m-box__item--m-current--first-child__link--before--xl--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
+
+  // Vertical box
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
 
   // Tab link
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);
@@ -22,40 +32,41 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-tabs__link--Transition: left .125s, border-width .125s;
   --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
-  --pf-c-tabs__item--m-current__link--Background: var(--pf-global--BackgroundColor--100);
+  --pf-c-tabs__item--m-current__link--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-tabs--m-vertical__link--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-tabs--m-vertical__link--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-tabs--m-box__link--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   // Link before
-  --pf-c-tabs__link--before--BorderStyle: solid;
-  --pf-c-tabs__link--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
-  --pf-c-tabs__link--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-tabs__link--before--border-color--base: var(--pf-global--BorderColor--100);
+  --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--border-color--base);
+  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
+  --pf-c-tabs__link--before--border-width--base: var(--pf-global--BorderWidth--sm);
   --pf-c-tabs__link--before--BorderTopWidth: 0;
   --pf-c-tabs__link--before--BorderRightWidth: 0;
   --pf-c-tabs__link--before--BorderBottomWidth: 0;
   --pf-c-tabs__link--before--BorderLeftWidth: 0;
-  --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--BorderColor);
-  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--BorderColor);
-  --pf-c-tabs__link--before--Left: calc(var(--pf-c-tabs__link--before--BorderWidth) * -1);
-  --pf-c-tabs__item--m-current__link--after--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-tabs__link--before--Left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
 
   // Link after
-  --pf-c-tabs__link--after--BorderStyle: solid;
+  --pf-c-tabs__link--after--Top: auto;
+  --pf-c-tabs__link--after--Right: 0;
+  --pf-c-tabs__link--after--Bottom: 0;
   --pf-c-tabs__link--after--BorderColor: var(--pf-global--BorderColor--light-100);
   --pf-c-tabs__link--after--BorderWidth: 0;
   --pf-c-tabs__link--after--BorderTopWidth: 0;
   --pf-c-tabs__link--after--BorderRightWidth: 0;
   --pf-c-tabs__link--after--BorderLeftWidth: 0;
   --pf-c-tabs__link--hover--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-tabs__link--child--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-tabs__link--focus--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-tabs__link--active--after--BorderWidth: var(--pf-global--BorderWidth--lg);
   --pf-c-tabs__item--m-current__link--after--BorderColor: var(--pf-global--active-color--100);
   --pf-c-tabs__item--m-current__link--after--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-tabs--m-vertical--m-box__link--after--Top: 0;
+  --pf-c-tabs__link--child--MarginRight: var(--pf-global--spacer--md);
 
   // Scroll buttons
-  --pf-c-tabs__scroll-button--BorderStyle: solid;
   --pf-c-tabs__scroll-button--Color: var(--pf-global--Color--100);
   --pf-c-tabs__scroll-button--hover--Color: var(--pf-global--active-color--100);
   --pf-c-tabs__scroll-button--disabled--Color: var(--pf-global--disabled-color--200);
@@ -67,9 +78,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Scroll buttons before
   --pf-c-tabs__scroll-button--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
-  --pf-c-tabs__scroll-button--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-tabs__scroll-button--before--border-width--base: var(--pf-global--BorderWidth--sm);
   --pf-c-tabs__scroll-button--before--BorderRightWidth: 0;
-  --pf-c-tabs__scroll-button--before--BorderBottomWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
+  --pf-c-tabs__scroll-button--before--BorderBottomWidth: var(--pf-c-tabs__scroll-button--before--border-width--base);
   --pf-c-tabs__scroll-button--before--BorderLeftWidth: 0;
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
@@ -78,13 +89,17 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   position: relative;
   display: flex;
-  padding-right: var(--pf-c-tabs--Inset);
-  padding-left: var(--pf-c-tabs--Inset);
+  padding-right: var(--pf-c-tabs--inset);
+  padding-left: var(--pf-c-tabs--inset);
   overflow: hidden;
+  transition: var(--pf-c-tabs--Transition);
 
   &::before {
-    border-color: var(--pf-c-tabs--before--BorderColor);
-    border-style: var(--pf-c-tabs--before--BorderStyle);
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: solid var(--pf-c-tabs--before--BorderColor);
     border-width: var(--pf-c-tabs--before--BorderTopWidth) var(--pf-c-tabs--before--BorderRightWidth) var(--pf-c-tabs--before--BorderBottomWidth) var(--pf-c-tabs--before--BorderLeftWidth);
   }
 
@@ -123,7 +138,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     &.pf-m-secondary,
     &.pf-m-no-border {
-      --pf-c-tabs--before--BorderWidth: 0;
+      --pf-c-tabs--before--border-width--base: 0;
     }
   }
 
@@ -138,8 +153,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // Box
   &.pf-m-box {
     --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor);
-    --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--BorderWidth);
-    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
+    --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+    --pf-c-tabs__link--after--Top: 0;
+    --pf-c-tabs__link--after--Bottom: auto;
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-box--inset);
 
     // Set hover on top border
     .pf-c-tabs__link {
@@ -152,15 +170,31 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     }
 
     .pf-c-tabs__item.pf-m-current {
-      --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__item--m-current__link--Background);
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
+      --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
       --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--BackgroundColor);
     }
 
+    // stylelint-disable
     // Add border to first-child
-    .pf-c-tabs__item.pf-m-current:first-child {
-      --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--BorderWidth);
+    .pf-c-tabs__item.pf-m-current:first-child .pf-c-tabs__link::before {
+      border-left-width: var(--pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth);
     }
+
+    // Add border to last-child
+    .pf-c-tabs__item.pf-m-current:last-child .pf-c-tabs__link::before {
+      border-right-width: var(--pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth);
+    }
+
+    // Collapse left border into scroll button when expanded
+    &.pf-m-scrollable .pf-c-tabs__item.pf-m-current:first-child .pf-c-tabs__link::before {
+      left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+    }
+
+    // Collapse left border into scroll button when expanded
+    &.pf-m-scrollable .pf-c-tabs__scroll-button:nth-of-type(2)::before {
+      left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+    }
+    // stylelint-enable
 
     // stylelint-disable selector-max-class
     // Remove offset from current adjacent item
@@ -172,21 +206,25 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Vertical
   &.pf-m-vertical {
-    --pf-c-tabs--Inset: var(--pf-c-tabs--m-vertical--Inset);
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset);
     --pf-c-tabs--before--BorderBottomWidth: 0;
-    --pf-c-tabs--before--BorderLeftWidth: var(--pf-c-tabs--before--BorderWidth);
-    --pf-c-tabs__link--before--Left: 0;
+    --pf-c-tabs--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
     --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
+    --pf-c-tabs__link--before--Left: 0;
+    --pf-c-tabs__link--after--Top: 0;
+    --pf-c-tabs__link--after--Bottom: 0;
+    --pf-c-tabs__link--after--Right: auto;
 
     display: inline-flex;
     flex-direction: column;
+    height: 100%; // If not a flex child, set height
+    padding: 0; // Because vertical variant has no scroll buttons, reset padding
 
-    // If not a flex child, set height
-    height: 100%;
-
-    // Because vertical variant has no scroll buttons, reset padding
-    padding: 0;
+    &::before {
+      top: 0;
+      right: auto;
+    }
 
     .pf-c-tabs__list {
       flex-direction: column;
@@ -195,11 +233,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
     .pf-c-tabs__item:first-child {
-      margin-top: var(--pf-c-tabs--Inset);
+      margin-top: var(--pf-c-tabs--inset);
     }
 
     .pf-c-tabs__item:last-child {
-      margin-bottom: var(--pf-c-tabs--Inset);
+      margin-bottom: var(--pf-c-tabs--inset);
     }
 
     // Set hover on left border
@@ -219,32 +257,41 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Box, vertical
   &.pf-m-box.pf-m-vertical {
-    --pf-c-tabs--Inset: var(--pf-c-tabs--m-vertical--m-box--Inset);
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
     --pf-c-tabs--before--BorderLeftWidth: 0;
-    --pf-c-tabs--before--BorderRightWidth: var(--pf-c-tabs--before--BorderWidth);
+    --pf-c-tabs--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+
+    &::before {
+      right: 0;
+      left: auto;
+    }
 
     // stylelint-disable selector-max-class
     // Remove border from last-child
     .pf-c-tabs__item:last-child {
       --pf-c-tabs__link--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--BorderWidth);
+      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
     }
 
     // Add border right color and weight
     .pf-c-tabs__item.pf-m-current {
-      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--Background);
-      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--BorderColor);
-      --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--BorderWidth);
+      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
+      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
+      --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+
+      &:first-child {
+        --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
     }
 
     // Add border right color and weight
     .pf-c-tabs__item:first-child.pf-m-current {
-      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--BorderWidth);
+      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
     }
 
     // Offset vertical border to overlap horizontal border
     .pf-c-tabs__link::after {
-      top: calc(var(--pf-c-tabs__link--before--BorderWidth) * -1);
+      top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
     }
 
     // Undo offset to .pf-m-current adjacent item
@@ -264,6 +311,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   display: flex;
   max-width: 100%;
   overflow-x: auto;
+  scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -290,47 +338,61 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 .pf-c-tabs__link::after,
 .pf-c-tabs__scroll-button::before {
   position: absolute;
-  top: 0;
   right: 0;
   bottom: 0;
   left: 0;
   content: "";
+  border-style: solid;
+}
+
+.pf-c-tabs__link::before,
+.pf-c-tabs__link::after,
+.pf-c-tabs__scroll-button::before {
+  top: 0;
 }
 
 // Tab link
 .pf-c-tabs__link {
-  // Set default border target
-  --pf-c-tabs__link--after--BorderBottomWidth: var(--pf-c-tabs__link--after--BorderWidth);
+  --pf-c-tabs__link--after--BorderBottomWidth: var(--pf-c-tabs__link--after--BorderWidth); // Set default border target
 
   position: relative;
   display: flex;
   flex: 1;
   padding: var(--pf-c-tabs__link--PaddingTop) var(--pf-c-tabs__link--PaddingRight) var(--pf-c-tabs__link--PaddingBottom) var(--pf-c-tabs__link--PaddingLeft);
   color: var(--pf-c-tabs__link--Color);
-  user-select: none;
+  text-decoration: none;
   background-color: var(--pf-c-tabs__link--BackgroundColor);
   outline-offset: var(--pf-c-tabs__link--OutlineOffset);
 
   &::before {
-    border-color: var(--pf-c-tabs__link--before--BorderColor);
-    border-style: var(--pf-c-tabs__link--before--BorderStyle);
+    pointer-events: none;
+    border-color: var(--pf-c-tabs__link--before--border-color--base);
     border-width: var(--pf-c-tabs__link--before--BorderTopWidth) var(--pf-c-tabs__link--before--BorderRightWidth) var(--pf-c-tabs__link--before--BorderBottomWidth) var(--pf-c-tabs__link--before--BorderLeftWidth);
     border-right-color: var(--pf-c-tabs__link--before--BorderRightColor);
     border-bottom-color: var(--pf-c-tabs__link--before--BorderBottomColor);
+    transition: var(--pf-c-tabs__link--Transition);
   }
 
   &::after {
-    left: var(--pf-c-tabs__link--before--Left);
+    top: var(--pf-c-tabs__link--after--Top);
+    right: var(--pf-c-tabs__link--after--Right);
+    bottom: var(--pf-c-tabs__link--after--Bottom);
+    left: var(--pf-c-tabs__link--before--Left); // use the ::before Left value to offset the top border / overlap left border
     border-color: var(--pf-c-tabs__link--after--BorderColor);
-    border-style: var(--pf-c-tabs__link--after--BorderStyle);
     border-width: var(--pf-c-tabs__link--after--BorderTopWidth) var(--pf-c-tabs__link--after--BorderRightWidth) var(--pf-c-tabs__link--after--BorderBottomWidth) var(--pf-c-tabs__link--after--BorderLeftWidth);
   }
 
   // Tab item hover state
   &:hover {
     --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--hover--after--BorderWidth);
+  }
 
-    text-decoration: none;
+  &:focus {
+    --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--focus--after--BorderWidth);
+  }
+
+  &:active {
+    --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--active--after--BorderWidth);
   }
 
   .pf-c-tabs__item-icon,
@@ -362,19 +424,18 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   &::before {
     border-color: var(--pf-c-tabs__scroll-button--before--BorderColor);
-    border-style: var(--pf-c-tabs__scroll-button--BorderStyle);
     border-width: 0 var(--pf-c-tabs__scroll-button--before--BorderRightWidth) var(--pf-c-tabs__scroll-button--before--BorderBottomWidth) var(--pf-c-tabs__scroll-button--before--BorderLeftWidth);
   }
 
   &:nth-of-type(1) {
-    --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
+    --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--border-width--base);
 
     margin-right: calc(var(--pf-c-tabs__scroll-button--Width) * -1);
     transform: translateX(-100%);
   }
 
   &:nth-of-type(2) {
-    --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--BorderWidth);
+    --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--border-width--base);
 
     margin-left: calc(var(--pf-c-tabs__scroll-button--Width) * -1);
     transform: translateX(100%);
@@ -395,7 +456,15 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     @include pf-apply-breakpoint($breakpoint, $pf-c-tabs--breakpoint-map) {
       @each $spacer, $spacer-value in $pf-c-tabs--spacer-map {
         &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
-          --pf-c-tabs--Inset: #{$spacer-value};
+          --pf-c-tabs--inset: #{$spacer-value};
+
+          @if $spacer == none {
+            --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+          }
+
+          @else {
+            --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
+          }
         }
       }
     }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -16,7 +16,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
 
   // Box
-  --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+  --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
   --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
 
   // Tab link
@@ -105,6 +105,14 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     .pf-c-tabs__item {
       flex-grow: 1;
+
+      &:first-child {
+        --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+      }
+
+      &:last-child {
+        --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: 0;
+      }
     }
 
     .pf-c-tabs__link {
@@ -452,14 +460,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
           --pf-c-tabs--inset: #{$spacer-value};
           --pf-c-tabs--m-vertical--inset: #{$spacer-value};
           --pf-c-tabs--m-vertical--m-box--inset: #{$spacer-value};
-
-          @if $spacer == none {
-            --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
-          }
-
-          @else {
-            --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
-          }
         }
       }
     }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -18,7 +18,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
   --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
-  --pf-c-tabs--m-box__item--m-current--first-child__link--before--xl--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
 
   // Tab link
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -27,7 +27,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-tabs__link--Transition: left .125s, border-width .125s;
   --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
   --pf-c-tabs__item--m-current__link--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-tabs--m-vertical__link--PaddingTop: var(--pf-global--spacer--md);
@@ -69,7 +68,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__scroll-button--Width: var(--pf-global--spacer--2xl);
   --pf-c-tabs__scroll-button--xl--Width: var(--pf-global--spacer--3xl);
   --pf-c-tabs__scroll-button--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-tabs__scroll-button--Transition: margin .125s, transform .125s, opacity .125s;
+  --pf-c-tabs__scroll-button--TransitionDuration--margin: .125s;
+  --pf-c-tabs__scroll-button--TransitionDuration--transform: .125s;
+  --pf-c-tabs__scroll-button--TransitionDuration--opacity: .125s;
 
   // Scroll buttons before
   --pf-c-tabs__scroll-button--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
@@ -140,7 +141,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   &.pf-m-secondary,
-  &.pf-m-no-border {
+  &.pf-m-no-bottom-border {
     --pf-c-tabs--before--BorderBottomWidth: 0;
   }
 
@@ -371,7 +372,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     border-width: var(--pf-c-tabs__link--before--BorderTopWidth) var(--pf-c-tabs__link--before--BorderRightWidth) var(--pf-c-tabs__link--before--BorderBottomWidth) var(--pf-c-tabs__link--before--BorderLeftWidth);
     border-right-color: var(--pf-c-tabs__link--before--BorderRightColor);
     border-bottom-color: var(--pf-c-tabs__link--before--BorderBottomColor);
-    transition: var(--pf-c-tabs__link--Transition);
   }
 
   &::after {
@@ -415,7 +415,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   background-color: var(--pf-c-tabs__scroll-button--BackgroundColor);
   outline-offset: var(--pf-c-tabs__scroll-button--OutlineOffset);
   opacity: 0;
-  transition: var(--pf-c-tabs__scroll-button--Transition);
+  transition: margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin), transform var(--pf-c-tabs__scroll-button--TransitionDuration--transform), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity);
 
   &:hover,
   &:active,


### PR DESCRIPTION
closes #2920 
relates to #2893 

## Breaking changes
This PR updates tab `:focus` and `:active` states to reflect hover state. It also resizes the tab `::after` pseudo element to not consume the entirety of the button. 

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--pf-c-tabs--before--BorderStyle`
* `--pf-c-tabs__link--before--BorderStyle`
* `--pf-c-tabs__link--after--BorderStyle`
* `--pf-c-tabs__scroll-button--BorderStyle`
* `--pf-c-tabs__link--child--MarginRight`
* `--pf-c-tabs--m-vertical--m-box__link--after--Top`