### PR TITLE
fix(page): move masthead selected button mod to header-tools-item

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -165,7 +165,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-c-page__main-breadcrumb` | `<section>` |   Creates a container to nest the breadcrumb component in the main page area. |
 | `.pf-c-page__main-section` | `<section>` |  Creates a section container in the main page area. **Note: The last/only `.pf-c-page__main-section` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
 | `.pf-c-page__drawer` | `<div>` |  Creates a container for the drawer component when placing the main page element in the drawer body. |
-| `.pf-m-selected` | `.pf-c-page__header-tools .pf-c-button` | Modifies the button in the masthead for the selected state. |
+| `.pf-m-selected` | `.pf-c-page__header-tools-item` | Modifies a header tools item to indicate that the button inside is in the selected state. |
 | `.pf-m-expanded` | `.pf-c-page__sidebar` |  Modifies the sidebar for the expanded state. |
 | `.pf-m-collapsed` | `.pf-c-page__sidebar` |  Modifies the sidebar for the collapsed state. |
 | `.pf-m-light` | `.pf-c-page__sidebar` |  Modifies the sidebar the light variation. **Note: for use with a light themed nav component** |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -236,8 +236,36 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   margin-right: var(--pf-c-page__header-tools--MarginRight);
   margin-left: auto; // to push it to the right
 
+  .pf-c-avatar {
+    margin-left: var(--pf-c-page__header-tools--c-avatar--MarginLeft);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    grid-column: 3 / 4;
+  }
+}
+
+.pf-c-page__header-tools-group {
+  @include pf-hidden-visible(var(--pf-c-page__header-tools-group--Display));
+
+  align-items: center;
+
+  & + & {
+    margin-left: var(--pf-c-page__header-tools-group--MarginLeft);
+  }
+}
+
+.pf-c-page__header-tools-item {
+  @include pf-hidden-visible(var(--pf-c-page__header-tools-item--Display));
+
   .pf-c-button {
-    &.pf-m-selected {
+    > * {
+      position: relative;
+    }
+  }
+
+  &.pf-m-selected {
+    .pf-c-button {
       &::before {
         position: absolute;
         top: 0;
@@ -260,33 +288,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
       }
       // stylelint-enable
     }
-
-    > * {
-      position: relative;
-    }
   }
-
-  .pf-c-avatar {
-    margin-left: var(--pf-c-page__header-tools--c-avatar--MarginLeft);
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    grid-column: 3 / 4;
-  }
-}
-
-.pf-c-page__header-tools-group {
-  @include pf-hidden-visible(var(--pf-c-page__header-tools-group--Display));
-
-  align-items: center;
-
-  & + & {
-    margin-left: var(--pf-c-page__header-tools-group--MarginLeft);
-  }
-}
-
-.pf-c-page__header-tools-item {
-  @include pf-hidden-visible(var(--pf-c-page__header-tools-item--Display));
 }
 
 // Sidebar

--- a/src/patternfly/demos/Page/page-template-header-tools-elements.hbs
+++ b/src/patternfly/demos/Page/page-template-header-tools-elements.hbs
@@ -13,21 +13,23 @@
   {{/page-header-tools-group}}
   {{#> page-header-tools-group}}
     {{#if page-header-tools--IsNotification}}
-      {{#> page-header-tools-item}}
-        {{#if page-header-tools--IsNotificationSelected}}
-          {{#> button button--modifier="pf-m-plain pf-m-selected" button--attribute='aria-label="Unread notifications" aria-expanded="true"'}}
+      {{#if page-header-tools--IsNotificationSelected}}
+        {{#> page-header-tools-item page-header-tools-item--modifier="pf-m-selected"}}
+          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Unread notifications" aria-expanded="true"'}}
             {{#> notification-badge notification-badge--modifier="pf-m-unread"}}
               <i class="fas fa-bell" aria-hidden="true"></i>
             {{/notification-badge}}
           {{/button}}
-        {{else}}
+        {{/page-header-tools-item}}
+      {{else}}
+        {{#> page-header-tools-item}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Unread notifications" aria-expanded="false"'}}
             {{#> notification-badge notification-badge--modifier="pf-m-unread"}}
               <i class="fas fa-bell" aria-hidden="true"></i>
             {{/notification-badge}}
           {{/button}}
-        {{/if}}
-      {{/page-header-tools-item}}
+        {{/page-header-tools-item}}
+      {{/if}}
     {{/if}}
     {{#> page-header-tools-item page-header-tools-item--modifier="pf-m-hidden-on-lg"}}
       {{#> dropdown id=(concat page--id '-dropdown-kebab-right-aligned-1') dropdown--IsActionMenu="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3108

## Breaking changes

This PR moves the `.pf-m-selected` class in the masthead toolbar from the `.pf-c-button` component to the `.pf-c-page__header-tools-item` element. Any instance of `.pf-m-selected` on a `.pf-c-button` in the masthead should be moved to its containing `.pf-c-page__header-tools-item` element.