### PR TITLE
fix(chipgroup): fix cut off chip text

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -49,9 +49,9 @@
 }
 
 .pf-c-chip-group__list-item {
+  display: inline-flex;
   margin-right: var(--pf-c-chip-group__list-item--MarginRight);
   margin-bottom: var(--pf-c-chip-group__list-item--MarginBottom);
-  line-height: 1;
 }
 
 .pf-c-chip-group__label {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3083

This stems from `line-height: 1` on the chip-group__list-item elements, which was needed so that those elements are the same height in Firefox and other browsers (they're 0.5px taller in FF for some reason). I tried to figure out the root cause of that and couldn't track it down, though it seems to have something to do with font rendering. Changing the font family to `sans-serif` fixes that 0.5px discrepancy.

Making the list items a flex parent also solves it, which is better than setting the `line-height`,  so I did that and removed the `line-height`.