### PR TITLE
fix(table-grid): move borders to ::after

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -627,18 +627,18 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr table-tr--expanded="true"}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--modifier="pf-m-expanded" table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;10
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
         <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
         234
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-3"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-3"')}}
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         4
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-th table-th--data-label="Workspaces"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -677,19 +677,19 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-4"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-4"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
         2
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-5"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-5"')}}
         <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
         82
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-6"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-6"')}}
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         1
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-th table-th--data-label="Workspaces"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}
@@ -728,19 +728,19 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-7"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-7"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
         4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-8"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-8"')}}
         <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
         4
       {{/table-td}}
-      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Workspaces" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-9"')}}
+      {{#> table-td table-td--compound-expansion-toggle="true" table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-9"')}}
         <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
         1
       {{/table-td}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-th table-th--data-label="Workspaces"}}
         <a href="#">siemur/test-space</a>
       {{/table-th}}
       {{#> table-td table-td--data-label="Last commit"}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -414,7 +414,7 @@ When header cells are empty or they contain interactive elements, `<th>` should 
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="{{table--id}}-check-all" aria-label="Select all rows">
       {{/table-td}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--modifier="pf-m-width-30" table-th--selected="true" table-th--desc="true"}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--modifier="pf-m-width-30" table-th--selected="true" table-th--asc="true"}}
         Repositories
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -319,7 +319,7 @@
       }
     }
 
-    > tr > :first-child:not(.pf-c-table__check)::before {
+    > tr > :first-child:not(.pf-c-table__check)::after {
       --pf-c-table__expandable-row--before--BorderLeftWidth: 0;
 
       position: static;
@@ -354,10 +354,9 @@
       border-top-color: var(--pf-c-table--BorderColor);
     }
 
-    td:first-child:not(.pf-c-table__check)::before {
-      // Border treatment
-      display: none;
-      visibility: hidden;
+    > :first-child::after {
+      // Remove border treatment
+      content: none;
     }
 
     td {

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -50,7 +50,7 @@
 
   // Row
   --pf-c-table-tr--responsive--border-width--base: var(--pf-global--spacer--sm);
-  --pf-c-table-tr--responsive--last-child--BorderBottomWidth: var(--pf-c-table-tr--responsive--border-width--base);
+  --pf-c-table-tr--responsive--last-child--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-table-tr--responsive--GridColumnGap: var(--pf-global--spacer--md);
   --pf-c-table-tr--responsive--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-table-tr--responsive--PaddingTop: var(--pf-global--spacer--md);
@@ -354,8 +354,8 @@
       border-top-color: var(--pf-c-table--BorderColor);
     }
 
-    > :first-child::after {
-      // Remove border treatment
+    > :first-child:not(.pf-c-table__check)::after {
+      // Border treatment
       content: none;
     }
 
@@ -393,6 +393,10 @@
     grid-column: -1;
     justify-self: end;
     padding-right: 0;
+
+    &::after {
+      content: none;
+    }
   }
 
   .pf-c-table__button {

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -43,14 +43,14 @@
   // Body
   --pf-c-table-tbody--responsive--MarginTop: var(--pf-global--spacer--xs);
   --pf-c-table-tbody--m-expanded--before--Top: var(--pf-global--spacer--sm);
-  --pf-c-table-tbody--responsive--BorderWidth: var(--pf-global--spacer--sm);
-  --pf-c-table--tbody--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table-tbody--responsive--border-width--base: var(--pf-global--spacer--sm);
+  --pf-c-table--tbody--after--border-width--base: var(--pf-global--BorderWidth--lg);
   --pf-c-table--tbody--after--BorderLeftWidth: 0;
   --pf-c-table--tbody--after--BorderColor: var(--pf-global--active-color--100);
 
   // Row
-  --pf-c-table-tr--responsive--BorderWidth: var(--pf-global--spacer--sm);
-  --pf-c-table-tr--responsive--last-child--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table-tr--responsive--border-width--base: var(--pf-global--spacer--sm);
+  --pf-c-table-tr--responsive--last-child--BorderBottomWidth: var(--pf-c-table-tr--responsive--border-width--base);
   --pf-c-table-tr--responsive--GridColumnGap: var(--pf-global--spacer--md);
   --pf-c-table-tr--responsive--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-table-tr--responsive--PaddingTop: var(--pf-global--spacer--md);
@@ -162,7 +162,7 @@
     display: block;
 
     &:first-of-type {
-      border-top: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
+      border-top: var(--pf-c-table-tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 
@@ -173,24 +173,24 @@
 
   // Table row
   tr:not(.pf-c-table__expandable-row) {
-    border-bottom: var(--pf-c-table-tr--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
+    border-bottom: var(--pf-c-table-tr--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
   }
 
   // The last tr should always have a border width of 1px
   tr:last-child,
   tbody:last-of-type:not(:only-of-type) > tr {
-    border-bottom-width: var(--pf-c-table-tr--responsive--last-child--BorderWidth);
+    border-bottom-width: var(--pf-c-table-tr--responsive--last-child--BorderBottomWidth);
   }
 
   tbody.pf-m-expanded {
-    border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
+    border-bottom: var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor);
 
     tr:not(.pf-c-table__expandable-row) {
       border-bottom: 0;
     }
 
     &:not(:last-of-type) {
-      border-bottom: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
+      border-bottom: var(--pf-c-table-tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 
@@ -312,7 +312,7 @@
     }
 
     &.pf-m-expanded {
-      --pf-c-table--tbody--after--BorderLeftWidth: var(--pf-c-table--tbody--after--BorderWidth);
+      --pf-c-table--tbody--after--BorderLeftWidth: var(--pf-c-table--tbody--after--border-width--base);
 
       & tbody {
         --pf-c-table--tbody--after--BorderLeftWidth: 0;

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -210,6 +210,7 @@
     & > * {
       padding: var(--pf-c-table--cell--responsive--PaddingTop) var(--pf-c-table--cell--responsive--PaddingRight) var(--pf-c-table--cell--responsive--PaddingBottom) var(--pf-c-table--cell--responsive--PaddingLeft);
 
+      // remove padding from first child to align with kebab
       &:first-child {
         --pf-c-table--cell--responsive--PaddingTop: var(--pf-c-table--cell--first-child--responsive--PaddingTop);
       }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -41,9 +41,7 @@
   --pf-c-table--responsive--BorderColor: var(--pf-global--BorderColor--300);
 
   // Body
-  --pf-c-table-tbody--responsive--MarginTop: var(--pf-global--spacer--xs);
-  --pf-c-table-tbody--m-expanded--before--Top: var(--pf-global--spacer--sm);
-  --pf-c-table-tbody--responsive--border-width--base: var(--pf-global--spacer--sm);
+  --pf-c-table--tbody--responsive--border-width--base: var(--pf-global--spacer--sm);
   --pf-c-table--tbody--after--border-width--base: var(--pf-global--BorderWidth--lg);
   --pf-c-table--tbody--after--BorderLeftWidth: 0;
   --pf-c-table--tbody--after--BorderColor: var(--pf-global--active-color--100);
@@ -83,7 +81,7 @@
   --pf-c-table-td--responsive--GridColumnGap: var(--pf-global--spacer--md);
   --pf-c-table--cell--responsive--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-table--cell--responsive--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-table-cell-th--responsive--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-table--cell--first-child--responsive--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-table--cell--responsive--PaddingRight: 0;
   --pf-c-table--cell--responsive--PaddingLeft: 0;
 
@@ -162,7 +160,7 @@
     display: block;
 
     &:first-of-type {
-      border-top: var(--pf-c-table-tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
+      border-top: var(--pf-c-table--tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 
@@ -190,7 +188,7 @@
     }
 
     &:not(:last-of-type) {
-      border-bottom: var(--pf-c-table-tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
+      border-bottom: var(--pf-c-table--tbody--responsive--border-width--base) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 
@@ -211,11 +209,10 @@
     // Reset td padding
     & > * {
       padding: var(--pf-c-table--cell--responsive--PaddingTop) var(--pf-c-table--cell--responsive--PaddingRight) var(--pf-c-table--cell--responsive--PaddingBottom) var(--pf-c-table--cell--responsive--PaddingLeft);
-    }
 
-    // remove padding from first th to align with kebab
-    th {
-      padding-top: var(--pf-c-table-cell-th--responsive--PaddingTop);
+      &:first-child {
+        --pf-c-table--cell--responsive--PaddingTop: var(--pf-c-table--cell--first-child--responsive--PaddingTop);
+      }
     }
   }
 
@@ -320,7 +317,7 @@
     }
 
     > tr > :first-child:not(.pf-c-table__check)::after {
-      --pf-c-table__expandable-row--before--BorderLeftWidth: 0;
+      --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
 
       position: static;
       width: auto;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -505,10 +505,6 @@
         transform: rotate(var(--pf-c-table__toggle--c-button--m-expanded__toggle-icon--Rotate));
       }
     }
-
-    &::after {
-      content: none;
-    }
   }
 
   .pf-c-table__toggle-icon {
@@ -672,7 +668,7 @@
   // stylelint-disable
   td {
     &.pf-m-no-padding {
-      padding: 0 0 0 var(--pf-c-table__expandable-row--after--BorderWidth); // set padding-left to adjust for left border.
+      padding: 0 0 0 var(--pf-c-table__expandable-row--after--border-width--base); // set padding-left to adjust for left border.
 
       .pf-c-table__expandable-row-content {
         padding: 0;
@@ -704,7 +700,7 @@
 .pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child,
 .pf-c-table__expandable-row.pf-m-expanded > :first-child,
 .pf-c-table tbody.pf-m-expanded > tr > :not(.pf-c-table__compound-expansion-toggle) {
-  --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--BorderWidth);
+  --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
 }
 // stylelint-enable
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -113,12 +113,11 @@
   --pf-c-table__expandable-row-content--PaddingBottom: var(--pf-global--spacer--lg);
 
   // ::before border
-  --pf-c-table__expandable-row--before--Top: calc(var(--pf-c-table--BorderWidth) * -1);
-  --pf-c-table__expandable-row--before--Bottom: calc(var(--pf-c-table--BorderWidth) * -1);
-  --pf-c-table__expandable-row--before--BorderWidth: var(--pf-global--BorderWidth--lg);
-  --pf-c-table__expandable-row--before--BorderRightWidth: 0;
-  --pf-c-table__expandable-row--before--BorderLeftWidth: 0;
-  --pf-c-table__expandable-row--before--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-table__expandable-row--after--Top: calc(var(--pf-c-table--BorderWidth) * -1);
+  --pf-c-table__expandable-row--after--Bottom: calc(var(--pf-c-table--BorderWidth) * -1);
+  --pf-c-table__expandable-row--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
+  --pf-c-table__expandable-row--after--BorderColor: var(--pf-global--active-color--100);
 
   // Icon inline
   --pf-c-table__icon-inline--MarginRight: var(--pf-global--spacer--sm);
@@ -279,18 +278,18 @@
 
     // Border treatment
     // using first child as row does not calculate height appropriately
-    > tr > :first-child::before {
+    > tr > :first-child::after {
       position: absolute;
 
       // offset top to extend above tr border
-      top: var(--pf-c-table__expandable-row--before--Top);
-      bottom: var(--pf-c-table__expandable-row--before--Bottom);
+      top: var(--pf-c-table__expandable-row--after--Top);
+      bottom: var(--pf-c-table__expandable-row--after--Bottom);
       left: 0;
       content: "";
 
       // add border left
       background-color: transparent;
-      border-left: var(--pf-c-table__expandable-row--before--BorderLeftWidth) solid var(--pf-c-table__expandable-row--before--BorderColor);
+      border-left: var(--pf-c-table__expandable-row--after--BorderLeftWidth) solid var(--pf-c-table__expandable-row--after--BorderColor);
     }
 
     // Check table cell
@@ -506,6 +505,10 @@
         transform: rotate(var(--pf-c-table__toggle--c-button--m-expanded__toggle-icon--Rotate));
       }
     }
+
+    &::after {
+      content: none;
+    }
   }
 
   .pf-c-table__toggle-icon {
@@ -662,14 +665,14 @@
   box-shadow: 0 0 0 0 transparent;
 
   &,
-  td:first-child::before {
+  td:first-child::after {
     transition: var(--pf-c-table__expandable-row--Transition);
   }
 
   // stylelint-disable
   td {
     &.pf-m-no-padding {
-      padding: 0 0 0 var(--pf-c-table__expandable-row--before--BorderWidth); // set padding-left to adjust for left border.
+      padding: 0 0 0 var(--pf-c-table__expandable-row--after--BorderWidth); // set padding-left to adjust for left border.
 
       .pf-c-table__expandable-row-content {
         padding: 0;
@@ -701,7 +704,7 @@
 .pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child,
 .pf-c-table__expandable-row.pf-m-expanded > :first-child,
 .pf-c-table tbody.pf-m-expanded > tr > :not(.pf-c-table__compound-expansion-toggle) {
-  --pf-c-table__expandable-row--before--BorderLeftWidth: var(--pf-c-table__expandable-row--before--BorderWidth);
+  --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--BorderWidth);
 }
 // stylelint-enable
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -11,7 +11,7 @@
   // Base
   --pf-c-table--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-table--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-table--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table--border-width--base: var(--pf-global--BorderWidth--sm);
 
   // Caption
   --pf-c-table-caption--FontSize: var(--pf-global--FontSize--sm);
@@ -113,9 +113,9 @@
   --pf-c-table__expandable-row-content--PaddingBottom: var(--pf-global--spacer--lg);
 
   // ::before border
-  --pf-c-table__expandable-row--after--Top: calc(var(--pf-c-table--BorderWidth) * -1);
-  --pf-c-table__expandable-row--after--Bottom: calc(var(--pf-c-table--BorderWidth) * -1);
-  --pf-c-table__expandable-row--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table__expandable-row--after--Top: calc(var(--pf-c-table--border-width--base) * -1);
+  --pf-c-table__expandable-row--after--Bottom: calc(var(--pf-c-table--border-width--base) * -1);
+  --pf-c-table__expandable-row--after--border-width--base: var(--pf-global--BorderWidth--lg);
   --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
   --pf-c-table__expandable-row--after--BorderColor: var(--pf-global--active-color--100);
 
@@ -144,19 +144,19 @@
   --pf-c-table__compound-expansion-toggle__button--active--Color: var(--pf-global--link--Color--hover);
 
   // ::before border treatment
-  --pf-c-table__compound-expansion-toggle__button--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__compound-expansion-toggle__button--before--border-width--base: var(--pf-global--BorderWidth--sm);
   --pf-c-table__compound-expansion-toggle__button--before--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: 0;
   --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
-  --pf-c-table__compound-expansion-toggle__button--before--Bottom: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
-  --pf-c-table__compound-expansion-toggle__button--before--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+  --pf-c-table__compound-expansion-toggle__button--before--Bottom: calc(var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base) * -1);
+  --pf-c-table__compound-expansion-toggle__button--before--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base) * -1);
 
   // ::before border treatment
-  --pf-c-table__compound-expansion-toggle__button--after--BorderWidth: var(--pf-global--BorderWidth--lg);
+  --pf-c-table__compound-expansion-toggle__button--after--border-width--base: var(--pf-global--BorderWidth--lg);
   --pf-c-table__compound-expansion-toggle__button--after--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth: 0;
-  --pf-c-table__compound-expansion-toggle__button--after--Top: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
-  --pf-c-table__compound-expansion-toggle__button--after--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth) * -1);
+  --pf-c-table__compound-expansion-toggle__button--after--Top: calc(var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base) * -1);
+  --pf-c-table__compound-expansion-toggle__button--after--Left: calc(var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base) * -1);
 
   // Compact table
   --pf-c-table--m-compact-th--PaddingTop: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--xs));
@@ -202,7 +202,7 @@
   // Standard table row (non-expandable)
   // exclude expandable rows
   tr:not(.pf-c-table__expandable-row) {
-    border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
+    border-bottom: var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor);
   }
 
   // Table cell
@@ -597,9 +597,9 @@
   &:hover,
   &:focus-within,
   &.pf-m-expanded {
-    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
-    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
-    --pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth: var(--pf-c-table__compound-expansion-toggle__button--after--BorderWidth);
+    --pf-c-table__compound-expansion-toggle__button--before--BorderRightWidth: var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base);
+    --pf-c-table__compound-expansion-toggle__button--before--BorderLeftWidth: var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base);
+    --pf-c-table__compound-expansion-toggle__button--after--BorderTopWidth: var(--pf-c-table__compound-expansion-toggle__button--after--border-width--base);
   }
 
   &:first-child {
@@ -609,7 +609,7 @@
 
   &.pf-m-expanded {
     .pf-c-table__button::before {
-      border-bottom: var(--pf-c-table--BackgroundColor) solid var(--pf-c-table__compound-expansion-toggle__button--before--BorderWidth);
+      border-bottom: var(--pf-c-table--BackgroundColor) solid var(--pf-c-table__compound-expansion-toggle__button--before--border-width--base);
     }
 
     &:first-child {
@@ -689,7 +689,7 @@
   // Modifier - Expanded tr
   &.pf-m-expanded {
     border-bottom-color: var(--pf-c-table__expandable-row--m-expanded--BorderBottomColor);
-    border-bottom-width: var(--pf-c-table--BorderWidth);
+    border-bottom-width: var(--pf-c-table--border-width--base);
     box-shadow: var(--pf-c-table__expandable-row--m-expanded--BoxShadow);
   }
 
@@ -735,7 +735,7 @@
 
   &.pf-m-no-border-rows:not(.pf-m-expandable) {
     tbody {
-      --pf-c-table--BorderWidth: 0;
+      --pf-c-table--border-width--base: 0;
       --pf-c-table--BorderColor: transparent;
     }
   }


### PR DESCRIPTION
This PR moves `::before` borders to `::after` borders to prevent the following hidden label (`[data-label]::before`)

![Screen Shot 2020-05-14 at 11 03 46 AM](https://user-images.githubusercontent.com/5385435/81950983-9b560c80-95d2-11ea-9317-4175d3876cdc.png)

![Screen Shot 2020-05-14 at 11 08 30 AM](https://user-images.githubusercontent.com/5385435/81951540-45ce2f80-95d3-11ea-90e5-0868e512bf71.png)

## Breaking changes
This PR updates `.pf-c-table` borders to use `::after` pseudos to draw borders, rather than `::before` pseudos. 

The following variables have been removed. Any reference to them should be removed as they are no longer used in patternfly:
* `--pf-c-table__expandable-row--before--BorderRightWidth`
* `--pf-c-table-cell-th--responsive--PaddingTop`

The following variables have been renamed. Any reference to the old variable should be updated to use the new variable:
* `--pf-c-table-tbody--responsive—BorderWidth` has changed to `--pf-c-table-tbody--responsive--border-width—base`
* `--pf-c-table--tbody--after—BorderWidth` has changed to `--pf-c-table--tbody--after--border-width—base`
* `--pf-c-table-tr--responsive—BorderWidth` has changed to `--pf-c-table-tr--responsive--border-width—base`
* `--pf-c-table-tr--responsive--last-child—BorderWidth` has changed to `--pf-c-table-tr--responsive--last-child—BorderBottomWidth`
* `--pf-c-table-tbody--responsive—BorderWidth` has changed to `--pf-c-table-tbody--responsive--border-width--base`
* `--pf-c-table-tr--responsive—BorderWidth` has changed to `--pf-c-table-tr--responsive--border-width--base`
* `--pf-c-table--BorderWidth` has changed to `--pf-c-table--border-width--base`
* `--pf-c-table__expandable-row--before--Top` has changed to `--pf-c-table__expandable-row--after--Top`
* `--pf-c-table__expandable-row--before--Bottom` has changed to `--pf-c-table__expandable-row--after--Bottom`
* `--pf-c-table__expandable-row--before--BorderWidth` has changed to `--pf-c-table__expandable-row--after--border-width--base`
* `--pf-c-table__expandable-row--before--BorderLeftWidth` has changed to `--pf-c-table__expandable-row--after--BorderLeftWidth`
* `--pf-c-table__expandable-row--before--BorderColor` has changed to `--pf-c-table__expandable-row--after--BorderColor`
* `--pf-c-table__compound-expansion-toggle__button--before--BorderWidth` has changed to `--pf-c-table__compound-expansion-toggle__button--before--border-width--base`
* `--pf-c-table__compound-expansion-toggle__button--after--BorderWidth` has changed to `--pf-c-table__compound-expansion-toggle__button--after--border-width--base`
