### PR TITLE
fix(notificationdrawer/alert): improved title wrapping

### DIFF
--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -19,6 +19,7 @@
   // Title
   --pf-c-alert__title--FontWeight: var(--pf-global--FontWeight--bold);
   --pf-c-alert__title--Color: var(--pf-global--default-color--300);
+  --pf-c-alert__title--max-lines: 1;
 
   // Action
   --pf-c-alert__action--MarginTop: calc(var(--pf-global--spacer--form-element) * 2 * -1);
@@ -80,8 +81,8 @@
   grid-template-columns: var(--pf-c-alert--GridTemplateColumns);
   grid-template-areas:
     "icon title action"
-    "icon description description"
-    "icon actiongroup actiongroup";
+    ". description description"
+    ". actiongroup actiongroup";
 
   &.pf-m-success {
     --pf-c-alert--BorderTopColor: var(--pf-c-alert--m-success--BorderTopColor);
@@ -131,6 +132,10 @@
   font-weight: var(--pf-c-alert__title--FontWeight);
   color: var(--pf-c-alert__title--Color);
   word-break: break-word;
+
+  &.pf-m-truncate {
+    @include pf-line-clamp("var(--pf-c-alert__title--max-lines)");
+  }
 }
 
 .pf-c-alert__description {

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -130,6 +130,7 @@
   grid-area: title;
   font-weight: var(--pf-c-alert__title--FontWeight);
   color: var(--pf-c-alert__title--Color);
+  word-break: break-word;
 }
 
 .pf-c-alert__description {

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -14,7 +14,7 @@ cssPrefix: pf-c-alert
     Default alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information alert"'}}
   {{#> alert-icon alert-icon--type="info-circle"}}
   {{/alert-icon}}
@@ -23,7 +23,7 @@ cssPrefix: pf-c-alert
     Info alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -32,7 +32,7 @@ cssPrefix: pf-c-alert
     Success alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-warning" alert--attribute='aria-label="Warning alert"'}}
   {{#> alert-icon alert-icon--type="exclamation-triangle"}}
   {{/alert-icon}}
@@ -41,7 +41,7 @@ cssPrefix: pf-c-alert
     Warning alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger alert"'}}
   {{#> alert-icon alert-icon--type="exclamation-circle"}}
   {{/alert-icon}}
@@ -77,7 +77,7 @@ cssPrefix: pf-c-alert
     {{/button}}
   {{/alert-action-group}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -94,7 +94,7 @@ cssPrefix: pf-c-alert
     Success alert description. This should tell the user more information about the alert. <a href="#">This is a link.</a>
   {{/alert-description}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -116,7 +116,7 @@ cssPrefix: pf-c-alert
     {{/button}}
   {{/alert-action-group}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -130,7 +130,7 @@ cssPrefix: pf-c-alert
     {{/button}}
   {{/alert-action}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -138,6 +138,30 @@ cssPrefix: pf-c-alert
     {{#> screen-reader}}Success alert:{{/screen-reader}}
       Success alert title
   {{/alert-title}}
+{{/alert}}
+<br>
+{{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert with title truncation"'}}
+  {{#> alert-icon alert-icon--type="check-circle"}}
+  {{/alert-icon}}
+  {{#> alert-title alert-title--modifier="pf-m-truncate"}}
+    {{#> screen-reader}}Success alert:{{/screen-reader}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pellentesque neque cursus enim fringilla tincidunt. Proin lobortis aliquam dictum. Nam vel ullamcorper nulla, nec blandit dolor. Vivamus pellentesque neque justo, nec accumsan nulla rhoncus id. Suspendisse mollis, tortor quis faucibus volutpat, sem leo fringilla turpis, ac lacinia augue metus in nulla. Cras vestibulum lacinia orci. Pellentesque sodales consequat interdum. Sed porttitor tincidunt metus nec iaculis. Pellentesque non commodo justo. Morbi feugiat rhoncus neque, vitae facilisis diam aliquam nec. Sed dapibus vitae quam at tristique. Nunc vel commodo mi. Mauris et rhoncus leo.
+  {{/alert-title}}
+  {{#> alert-description}}
+    This example uses ".pf-m-truncate" to limit the title to a single line and truncate any overflow text with ellipses.
+  {{/alert-description}}
+{{/alert}}
+<br>
+{{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert with title truncation at 2 lines"'}}
+  {{#> alert-icon alert-icon--type="check-circle"}}
+  {{/alert-icon}}
+  {{#> alert-title alert-title--modifier="pf-m-truncate" alert-title--attribute='style="--pf-c-alert__title--max-lines: 2"'}}
+    {{#> screen-reader}}Success alert:{{/screen-reader}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pellentesque neque cursus enim fringilla tincidunt. Proin lobortis aliquam dictum. Nam vel ullamcorper nulla, nec blandit dolor. Vivamus pellentesque neque justo, nec accumsan nulla rhoncus id. Suspendisse mollis, tortor quis faucibus volutpat, sem leo fringilla turpis, ac lacinia augue metus in nulla. Cras vestibulum lacinia orci. Pellentesque sodales consequat interdum. Sed porttitor tincidunt metus nec iaculis. Pellentesque non commodo justo. Morbi feugiat rhoncus neque, vitae facilisis diam aliquam nec. Sed dapibus vitae quam at tristique. Nunc vel commodo mi. Mauris et rhoncus leo.
+  {{/alert-title}}
+  {{#> alert-description}}
+    This example uses ".pf-m-truncate" and sets "--pf-c-alert__title--max-lines: 2" to limit title to two lines and truncate any overflow text with ellipses.
+  {{/alert-description}}
 {{/alert}}
 ```
 
@@ -150,7 +174,7 @@ cssPrefix: pf-c-alert
     Default inline alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-info pf-m-inline" alert--attribute='aria-label="Inline information alert"'}}
   {{#> alert-icon alert-icon--type="info-circle"}}
   {{/alert-icon}}
@@ -159,7 +183,7 @@ cssPrefix: pf-c-alert
     Info inline alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success pf-m-inline" alert--attribute='aria-label="Inline success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -168,7 +192,7 @@ cssPrefix: pf-c-alert
     Success inline alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-warning pf-m-inline" alert--attribute='aria-label="Inline warning alert"'}}
   {{#> alert-icon alert-icon--type="exclamation-triangle"}}
   {{/alert-icon}}
@@ -177,7 +201,7 @@ cssPrefix: pf-c-alert
     Warning inline alert title
   {{/alert-title}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-danger pf-m-inline" alert--attribute='aria-label="Inline danger alert"'}}
   {{#> alert-icon alert-icon--type="exclamation-circle"}}
   {{/alert-icon}}
@@ -213,7 +237,7 @@ cssPrefix: pf-c-alert
     {{/button}}
   {{/alert-action-group}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success pf-m-inline" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -230,7 +254,7 @@ cssPrefix: pf-c-alert
     Success alert description. This should tell the user more information about the alert. <a href="#">This is a link.</a>
   {{/alert-description}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success pf-m-inline" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -252,7 +276,7 @@ cssPrefix: pf-c-alert
     {{/button}}
   {{/alert-action-group}}
 {{/alert}}
-<br />
+<br>
 {{#> alert alert--modifier="pf-m-success pf-m-inline" alert--attribute='aria-label="Success alert"'}}
   {{#> alert-icon alert-icon--type="check-circle"}}
   {{/alert-icon}}
@@ -262,6 +286,7 @@ cssPrefix: pf-c-alert
   {{/alert-title}}
 {{/alert}}
 ```
+
 ## Documentation
 ### Overview
 Add a modifier class to the default alert to change the color: `.pf-m-success`, `.pf-m-danger`, `.pf-m-warning`, or `.pf-m-info`.
@@ -295,3 +320,4 @@ Add a modifier class to the default alert to change the color: `.pf-m-success`, 
 | `.pf-m-warning` | `.pf-c-alert` |  Applies warning styling. |
 | `.pf-m-info` | `.pf-c-alert` |  Applies info styling. |
 | `.pf-m-inline` | `.pf-c-alert` |  Applies inline styling. |
+| `.pf-m-truncate` | `.pf-c-alert__title` |  Modifies the title to display a single line and truncate any overflow text with ellipses. **Note:** you can specify the max number of lines to show by setting the `--pf-c-alert__title--max-lines` (the default value is `1`). |

--- a/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -140,3 +140,4 @@ cssPrefix: pf-c-notification-drawer
 | `.pf-m-read` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the read state. |
 | `.pf-m-hoverable` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item hover states to inidicate it is clickable. |
 | `.pf-m-expanded` | `.pf-c-notification-drawer__group` | Modifies a notification group for the expanded state. |
+| `.pf-m-truncate` | `.pf-c-notification-drawer__list-item-header-title` |  Modifies the title to display a single line and truncate any overflow text with ellipses. **Note:** you can specify the max number of lines to show by setting the `--pf-c-notification-drawer__list-item-header-title--max-lines` (the default value is `1`). |

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -67,4 +67,38 @@
       30 minutes ago
     {{/notification-drawer-list-item-timestamp}}
   {{/notification-drawer-list-item}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--modifier="pf-m-hoverable" notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title notification-drawer-list-item-header-title--modifier="pf-m-truncate"}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quis odio risus. Ut dictum vitae sapien at posuere. Nullam suscipit massa quis lacus pellentesque scelerisque. Donec non maximus neque, quis ornare nunc. Vivamus in nibh sed libero feugiat feugiat. Nulla lacinia rutrum est, a commodo odio vestibulum suscipit. Nullam id quam et quam porttitor interdum quis nec tellus. Vestibulum arcu dui, pulvinar eu tellus in, semper mattis diam. Sed commodo tincidunt lacus non pulvinar. Curabitur tempor molestie vestibulum. Vivamus vel mi dignissim, efficitur neque eget, efficitur massa. Mauris vitae nunc augue. Donec augue lorem, malesuada et quam vitae, volutpat mattis nisi. Nullam nec venenatis ex, quis lobortis purus. Sed nisl dolor, mattis sit amet tincidunt quis, mollis sed massa.
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action4") dropdown--modifier="pf-m-top" dropdown-menu--modifier="pf-m-align-right" dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This example uses ".pf-m-truncate" to limit the title to a single line and truncate any overflow text with ellipses.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      40 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--modifier="pf-m-hoverable" notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title  notification-drawer-list-item-header-title--modifier="pf-m-truncate"  notification-drawer-list-item-header-title--attribute='style="--pf-c-notification-drawer__list-item-header-title--max-lines: 2"'}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quis odio risus. Ut dictum vitae sapien at posuere. Nullam suscipit massa quis lacus pellentesque scelerisque. Donec non maximus neque, quis ornare nunc. Vivamus in nibh sed libero feugiat feugiat. Nulla lacinia rutrum est, a commodo odio vestibulum suscipit. Nullam id quam et quam porttitor interdum quis nec tellus. Vestibulum arcu dui, pulvinar eu tellus in, semper mattis diam. Sed commodo tincidunt lacus non pulvinar. Curabitur tempor molestie vestibulum. Vivamus vel mi dignissim, efficitur neque eget, efficitur massa. Mauris vitae nunc augue. Donec augue lorem, malesuada et quam vitae, volutpat mattis nisi. Nullam nec venenatis ex, quis lobortis purus. Sed nisl dolor, mattis sit amet tincidunt quis, mollis sed massa.
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action4") dropdown--modifier="pf-m-top" dropdown-menu--modifier="pf-m-align-right" dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This example uses ".pf-m-truncate" and sets "--pf-c-notification-drawer__list-item-header-title--max-lines: 2" to limit title to two lines and truncate any overflow text with ellipses.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      50 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
 {{/notification-drawer-list}}

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -57,6 +57,7 @@
 
   // List item header title
   --pf-c-notification-drawer__list-item-header-title--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-notification-drawer__list-item-header-title--max-lines: 1;
   --pf-c-notification-drawer__list-item--m-read__list-item-header-title--FontWeight: var(--pf-global--FontWeight--normal);
 
   // List item description
@@ -83,6 +84,7 @@
 
   // Group toggle title
   --pf-c-notification-drawer__group-toggle-title--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle-title--max-lines: 1;
 
   // Group toggle count
   --pf-c-notification-drawer__group-toggle-count--MarginRight: var(--pf-global--spacer--md);
@@ -217,6 +219,10 @@
 .pf-c-notification-drawer__list-item-header-title {
   font-weight: var(--pf-c-notification-drawer__list-item-header-title--FontWeight);
   word-break: break-word;
+
+  &.pf-m-truncate {
+    @include pf-line-clamp("var(--pf-c-notification-drawer__list-item-header-title--max-lines)");
+  }
 }
 
 .pf-c-notification-drawer__list-item-action {
@@ -277,9 +283,10 @@
 }
 
 .pf-c-notification-drawer__group-toggle-title {
-  @include pf-text-overflow();
+  @include pf-line-clamp("var(--pf-c-notification-drawer__group-toggle-title--max-lines)");
 
   margin-right: var(--pf-c-notification-drawer__group-toggle-title--MarginRight);
+  text-align: left;
 }
 
 .pf-c-notification-drawer__group-toggle-count {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -81,6 +81,9 @@
   --pf-c-notification-drawer__group-toggle--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-notification-drawer__group-toggle--OutlineOffset: #{pf-size-prem(-4px)};
 
+  // Group toggle title
+  --pf-c-notification-drawer__group-toggle-title--MarginRight: var(--pf-global--spacer--md);
+
   // Group toggle count
   --pf-c-notification-drawer__group-toggle-count--MarginRight: var(--pf-global--spacer--md);
 
@@ -213,6 +216,7 @@
 
 .pf-c-notification-drawer__list-item-header-title {
   font-weight: var(--pf-c-notification-drawer__list-item-header-title--FontWeight);
+  word-break: break-word;
 }
 
 .pf-c-notification-drawer__list-item-action {
@@ -270,6 +274,12 @@
   border: solid var(--pf-c-notification-drawer__group-toggle--BorderColor);
   border-width: 0 0 var(--pf-c-notification-drawer__group-toggle--BorderBottomWidth) 0;
   outline-offset: var(--pf-c-notification-drawer__group-toggle--OutlineOffset);
+}
+
+.pf-c-notification-drawer__group-toggle-title {
+  @include pf-text-overflow();
+
+  margin-right: var(--pf-c-notification-drawer__group-toggle-title--MarginRight);
 }
 
 .pf-c-notification-drawer__group-toggle-count {

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -150,6 +150,15 @@
   white-space: nowrap;
 }
 
+@mixin pf-line-clamp($line-clamp-val: 1) {
+  // stylelint-disable
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: #{$line-clamp-val};
+  // stylelint-enable
+  overflow: hidden;
+}
+
 @mixin pf-overflow-hide-scroll {
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3144

This PR enables long strings when used as title of a notification in the notification drawer to wrap:
<img width="591" alt="Screen Shot 2020-05-29 at 4 50 23 PM" src="https://user-images.githubusercontent.com/35148959/83308697-f5f38900-a1cc-11ea-9212-b135cf33f688.png">

----

It also enables the same behavior in the alert component for consistency:
<img width="575" alt="Screen Shot 2020-05-29 at 4 54 29 PM" src="https://user-images.githubusercontent.com/35148959/83308804-3e12ab80-a1cd-11ea-834a-14fdf08ebcb9.png">

----

And the way notification drawer group/section title/toggle wraps currently isn't ideal, so I updated it to truncate when the title text exceeds the width of the toggle (to be consistent with the accordion) - @mcarrano wdyt of this?
<img width="591" alt="Screen Shot 2020-05-29 at 4 49 26 PM" src="https://user-images.githubusercontent.com/35148959/83308695-f55af280-a1cc-11ea-89b5-17270263ba22.png">

----

Alternatively, we could allow that text to wrap - it would look like this.

<img width="564" alt="Screen Shot 2020-05-29 at 4 48 23 PM" src="https://user-images.githubusercontent.com/35148959/83308694-f4c25c00-a1cc-11ea-8f84-34ea4751807c.png">

