### PR TITLE
fix(notificationdrawer): fixed last item's color line position

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -258,6 +258,7 @@
 
   .pf-c-notification-drawer__list-item:last-child {
     --pf-c-notification-drawer__list-item--BorderBottomWidth: 0;
+    --pf-c-notification-drawer__list-item--before--Bottom: 0;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3148

This was a problem any time the last item in a group was unread. The problem is with this `calc()`:

https://github.com/patternfly/patternfly/blob/555bd56d753317b9ee72e7d944d0289548c161d5/src/patternfly/components/NotificationDrawer/notification-drawer.scss#L30

`--pf-c-notification-drawer__list-item--BorderBottomWidth` is normally a negative value, but reset on the item `.pf-c-notification-drawer__list-item:last-child` to be `0` here:

https://github.com/patternfly/patternfly/blob/555bd56d753317b9ee72e7d944d0289548c161d5/src/patternfly/components/NotificationDrawer/notification-drawer.scss#L259-L262

The calc fails with `calc(0 * -1)` though, so the declaration doesn't do anything, leaving the negative `bottom` position.

Another way to fix it could be to change `-1` in the calc to a unit (like `-1px`) but that wouldn't work as expected if `--pf-c-notification-drawer__list-item--BorderBottomWidth` may not always be represented as the same unit.