### PR TITLE
fix(build): copy UPGRADE-GUIDE.md

### DIFF
--- a/build/gulp/copy.js
+++ b/build/gulp/copy.js
@@ -29,7 +29,7 @@ function copySource(sassFiles) {
     src('src/icons/definitions/*').pipe(dest('dist/icons/')),
     src('src/icons/PfIcons/*').pipe(dest('dist/icons/PfIcons/')),
     // For NPM
-    src('README.md').pipe(dest('dist')),
+    src('*.md').pipe(dest('dist')),
     src('package.json').pipe(dest('dist'))
   ]);
 }


### PR DESCRIPTION
This is how patternfly-org consumes the UPGRADE-GUIDE.md.

I'll just copy it over manually for now.