### PR TITLE
chore(npm): publish v3 branch to v3 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "tag": "latest"
+    "tag": "v3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Now that we've committed to v4 this will prevent v3 from publishing directly to `latest`.