### PR TITLE
fix(drawer-focus): added tab focus fix

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -21,7 +21,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__panel--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-drawer__panel--TransitionDuration: var(--pf-global--TransitionDuration);
   --pf-c-drawer__panel--TransitionProperty: margin, transform, box-shadow;
-  --pf-c-drawer__panel--AnimationDelay: var(--pf-global--TransitionDuration);
 
   // Child padding
   --pf-c-drawer--child--PaddingTop: var(--pf-global--spacer--md);
@@ -170,7 +169,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 }
 
 // Remove tab focus
-@include pf-animate-remove-tab-focus(".pf-c-drawer__panel", var(--pf-c-drawer__panel--AnimationDelay));
+@include pf-animate-remove-tab-focus(".pf-c-drawer__panel", var(--pf-c-drawer__panel--TransitionDuration));
 
 // Panel head
 .pf-c-drawer__head {

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -11,7 +11,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__content--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-drawer__content--ZIndex: var(--pf-global--ZIndex--xs);
 
-
   // Panel
   --pf-c-drawer__panel--FlexBasis: 100%;
   --pf-c-drawer__panel--md--FlexBasis: 50%;
@@ -20,8 +19,9 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__panel--xl--FlexBasis: #{pf-size-prem(450px)};
   --pf-c-drawer__panel--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-drawer__panel--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-drawer__panel--TransitionDuration: .25s;
+  --pf-c-drawer__panel--TransitionDuration: var(--pf-global--TransitionDuration);
   --pf-c-drawer__panel--TransitionProperty: margin, transform, box-shadow;
+  --pf-c-drawer__panel--AnimationDelay: var(--pf-global--TransitionDuration);
 
   // Child padding
   --pf-c-drawer--child--PaddingTop: var(--pf-global--spacer--md);
@@ -75,7 +75,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   // Actions
-  // --pf-c-drawer__actions--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-drawer__actions--MarginTop: calc(#{pf-size-prem(6px)} * -1);
   --pf-c-drawer__actions--MarginRight: calc(#{pf-size-prem(6px)} * -1);
 
@@ -169,6 +168,9 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     --pf-c-drawer__content--BackgroundColor: transparent;
   }
 }
+
+// Remove tab focus
+@include pf-animate-remove-tab-focus(".pf-c-drawer__panel", var(--pf-c-drawer__panel--AnimationDelay));
 
 // Panel head
 .pf-c-drawer__head {

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -204,14 +204,14 @@
 
 // Animate tab focus removal
 @mixin pf-animate-remove-tab-focus($element, $delay: $pf-global--TransitionDuration) {
-  @keyframes visibility-hidden {
+  @keyframes pf-remove-tab-focus {
     to {
       visibility: hidden;
     }
   }
 
   #{$element}[hidden] {
-    animation-name: visibility-hidden;
+    animation-name: pf-remove-tab-focus;
     animation-delay: #{$delay};
     animation-fill-mode: forwards;
   }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -212,7 +212,7 @@
 
   #{$element}[hidden] {
     animation-name: visibility-hidden;
-    animation-delay: 2s;
+    animation-delay: #{$delay};
     animation-fill-mode: forwards;
   }
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -201,3 +201,18 @@
     #{$value}: #{$prop};
   }
 }
+
+// Animate tab focus removal
+@mixin pf-animate-remove-tab-focus($element, $delay: $pf-global--TransitionDuration) {
+  @keyframes visibility-hidden {
+    to {
+      visibility: hidden;
+    }
+  }
+
+  #{$element}[hidden] {
+    animation-name: visibility-hidden;
+    animation-delay: 2s;
+    animation-fill-mode: forwards;
+  }
+}


### PR DESCRIPTION
fixes #3129 
closes #2779 

Added `pf-animate-remove-tab-focus` which sets a delay on css properties to hide element from tab focus. 