### PR TITLE
fix(docs): updated upgrade guide RedHatDisplay text

### DIFF
--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -22,7 +22,7 @@ We've made shield styles optional by default [(#2872)](https://github.com/patter
 ### Default font
 We've updated the default font from `Overpass` to `RedHatText` and `RedHatDisplay` [(#2955)](https://github.com/patternfly/patternfly/pull/2955). To continue to use `Overpass`, add the class `pf-m-overpass-font` on an element that wraps your application (for example, `<body>`).
 
-You don’t have to do anything further to use this font. However, with the change from  `Overpass`  to  `RedHatText` , we encourage you to review your application’s typography styles to ensure they are correct.
+You don’t have to do anything further to use this font. However, with the change from  `Overpass`  to  `RedHatText` and `RedHatDisplay`, we encourage you to review your application’s typography styles to ensure they are correct.
 
 ### Directory structure
 We've cleaned up our root directory a little in [(#2960)](https://github.com/patternfly/patternfly/pull/2960). If you're compiling or importing more internal parts of PatternFly, you'll likely need to update your imports:

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -22,9 +22,13 @@ We've made shield styles optional by default [(#2872)](https://github.com/patter
 ### Default font
 We've updated the default font to be `RedHatText` instead of `Overpass` [(#2955)](https://github.com/patternfly/patternfly/pull/2955). To use the old font, add the class `pf-m-overpass-font` on an element that wraps your application (for example, `<body>`).
 
-PatternFly has chosen to adopt a single font (`RedHatText`) across the library [(#3023)](https://github.com/patternfly/patternfly/pull/3023). Previously, when having opted in to the Red Hat font via `.pf-m-redhat-font`, PatternFly used 2 fonts - `RedHatText` (RHT) defined as `--pf-global--FontFamily--sans-serif`, and `RedHatDisplay` (RHD) defined as `--pf-global--FontFamily--heading--sans-serif`. `--pf-global--FontFamily--heading--sans-serif` has been removed and components have been updated to use `--pf-global--FontFamily--sans-serif` instead.
+You don’t have to do anything further to use this font. However, with the change from  `Overpass`  to  `RedHatText` , we encourage you to review your application’s typography styles to ensure they are correct.
 
-You don't have to do anything further to use this font. However, with the change from `Overpass` to `RedHatText` and with the removal of `RedHatDisplay`, we encourage you to review your application's typography styles to ensure they are correct.
+  **NOTE:** RedHatDisplay font, originally removed as part of this release, has been added back to PatternFly as of release 2020.08 [(#3188)](https://github.com/patternfly/patternfly/pull/3188). The notes above are updated to reflect this change, and the original release notes are included below for transparency.
+
+>PatternFly has chosen to adopt a single font (`RedHatText`) across the library [(#3023)](https://github.com/patternfly/patternfly/pull/3023). Previously, when having opted in to the Red Hat font via `.pf-m-redhat-font`, PatternFly used 2 fonts - `RedHatText` (RHT) defined as `--pf-global--FontFamily--sans-serif`, and `RedHatDisplay` (RHD) defined as `--pf-global--FontFamily--heading--sans-serif`. `--pf-global--FontFamily--heading--sans-serif` has been removed and components have been updated to use `--pf-global--FontFamily--sans-serif` instead.
+
+>You don't have to do anything further to use this font. However, with the change from `Overpass` to `RedHatText` and with the removal of `RedHatDisplay`, we encourage you to review your application's typography styles to ensure they are correct.
 
 ### Directory structure
 We've cleaned up our root directory a little in [(#2960)](https://github.com/patternfly/patternfly/pull/2960). If you're compiling or importing more internal parts of PatternFly, you'll likely need to update your imports:

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -20,7 +20,7 @@ We've changed the hidden breakpoint for the vertical nav to be `$pf-global--brea
 We've made shield styles optional by default [(#2872)](https://github.com/patternfly/patternfly/pull/2872). The "shield" styles were intended to help resolve styling issues when using PF3 and PF4 together, and when having opted out of the global reset CSS, but they have proven to be problematic and not necessary for most users. With this change, we encourage applications to adopt PatternFly's reset CSS, if they have specifically opted out of it previously. The shield styles can be re-enabled if needed, either by setting `$pf-global--enable-shield: true;` and compiling PatternFly's SCSS, or by manually importing `base/patternfly-shield-inheritable.css` and `base/patternfly-shield-non-inheritable`. See [(#2872)](https://github.com/patternfly/patternfly/pull/2872) for more details.
 
 ### Default font
-We've updated the default font to be `RedHatText` instead of `Overpass` [(#2955)](https://github.com/patternfly/patternfly/pull/2955). To use the old font, add the class `pf-m-overpass-font` on an element that wraps your application (for example, `<body>`).
+We've updated the default font from `Overpass` to `RedHatText` and `RedHatDisplay` [(#2955)](https://github.com/patternfly/patternfly/pull/2955). To continue to use `Overpass`, add the class `pf-m-overpass-font` on an element that wraps your application (for example, `<body>`).
 
 You don’t have to do anything further to use this font. However, with the change from  `Overpass`  to  `RedHatText` , we encourage you to review your application’s typography styles to ensure they are correct.
 

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -24,12 +24,6 @@ We've updated the default font to be `RedHatText` instead of `Overpass` [(#2955)
 
 You don’t have to do anything further to use this font. However, with the change from  `Overpass`  to  `RedHatText` , we encourage you to review your application’s typography styles to ensure they are correct.
 
-  **NOTE:** RedHatDisplay font, originally removed as part of this release, has been added back to PatternFly as of release 2020.08 [(#3188)](https://github.com/patternfly/patternfly/pull/3188). The notes above are updated to reflect this change, and the original release notes are included below for transparency.
-
->PatternFly has chosen to adopt a single font (`RedHatText`) across the library [(#3023)](https://github.com/patternfly/patternfly/pull/3023). Previously, when having opted in to the Red Hat font via `.pf-m-redhat-font`, PatternFly used 2 fonts - `RedHatText` (RHT) defined as `--pf-global--FontFamily--sans-serif`, and `RedHatDisplay` (RHD) defined as `--pf-global--FontFamily--heading--sans-serif`. `--pf-global--FontFamily--heading--sans-serif` has been removed and components have been updated to use `--pf-global--FontFamily--sans-serif` instead.
-
->You don't have to do anything further to use this font. However, with the change from `Overpass` to `RedHatText` and with the removal of `RedHatDisplay`, we encourage you to review your application's typography styles to ensure they are correct.
-
 ### Directory structure
 We've cleaned up our root directory a little in [(#2960)](https://github.com/patternfly/patternfly/pull/2960). If you're compiling or importing more internal parts of PatternFly, you'll likely need to update your imports:
 - `patternfly-common.css` to `base/patternfly-common.css`


### PR DESCRIPTION
Closes #3194 

This PR updates the Upgrade Guide to reflect RedHatDisplay font removal being reverted in https://github.com/patternfly/patternfly/pull/3188