### PR TITLE
fix(breadcrumb): always use divider and hide first

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -84,3 +84,10 @@
     font-weight: var(--pf-global--FontWeight--semi-bold);
   }
 }
+
+// Hide divider of first child - required for react since dividers are included in each item
+// Consider revisiting this in a breaking change release
+.pf-c-breadcrumb__list > :first-child .pf-c-breadcrumb__item-divider {
+  display: none;
+  visibility: hidden;
+}

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -9,6 +9,7 @@ cssPrefix: pf-c-breadcrumb
 {{#> breadcrumb}}
   {{#> breadcrumb-list}}
     {{#> breadcrumb-item}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section home
       {{/breadcrumb-link}}
@@ -39,6 +40,7 @@ cssPrefix: pf-c-breadcrumb
 {{#> breadcrumb}}
   {{#> breadcrumb-list}}
     {{#> breadcrumb-item}}
+      {{> breadcrumb-item-divider}}
         Section home
     {{/breadcrumb-item}}
     {{#> breadcrumb-item}}
@@ -79,6 +81,7 @@ cssPrefix: pf-c-breadcrumb
 {{#> breadcrumb}}
   {{#> breadcrumb-list}}
     {{#> breadcrumb-item}}
+      {{> breadcrumb-item-divider}}
       {{#> breadcrumb-link}}
         Section home
       {{/breadcrumb-link}}


### PR DESCRIPTION
Towards patternfly/patternfly-react#4422