### PR TITLE
fix(modal): added medium, adjusted maxwidths for better responsiveness

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -46,6 +46,28 @@ cssPrefix: pf-c-modal-box
 {{/modal-box}}
 ```
 
+```hbs title=Medium
+{{#> modal-box modal-box--modifier="pf-m-md" modal-box--attribute='aria-labelledby="modal-md-title" aria-describedby="modal-md-description"'}}
+  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+  {{#> modal-box-header}}
+    {{#> modal-box-title modal-box-title--attribute='id="modal-md-title"'}}
+      Modal title
+    {{/modal-box-title}}
+  {{/modal-box-header}}
+  {{#> modal-box-body modal-box-body--attribute='id="modal-md-description"'}}
+    Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat.
+  {{/modal-box-body}}
+  {{#> modal-box-footer}}
+    Modal footer
+  {{/modal-box-footer}}
+{{/modal-box}}
+```
+
 ```hbs title=Large
 {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
@@ -154,4 +176,5 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__body` | `<div>` | Initiates a modal box body. |
 | `.pf-c-modal-box__footer` | `<footer>` | Initiates a modal box footer. |
 | `.pf-m-sm` | `.pf-c-modal-box` | Modifies for a small modal box width. |
+| `.pf-m-md` | `.pf-c-modal-box` | Modifies for a medium modal box width. |
 | `.pf-m-lg` | `.pf-c-modal-box` | Modifies for a large modal box width. |

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -5,6 +5,7 @@
   --pf-c-modal-box--Width: 100%;
   --pf-c-modal-box--MaxWidth: calc(100% - var(--pf-global--spacer--xl)); // Ensure modal has gutters at full width
   --pf-c-modal-box--m-sm--sm--MaxWidth: #{pf-size-prem(560px)}; // MaxWidth is based on optimal line length for reading
+  --pf-c-modal-box--m-md--Width: #{pf-size-prem(840px)};
   --pf-c-modal-box--m-lg--lg--MaxWidth: #{pf-size-prem(1120px)};
   --pf-c-modal-box--MaxHeight: calc(100% - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
 
@@ -55,18 +56,16 @@
   background-color: var(--pf-c-modal-box--BackgroundColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
-  // At breakpoint--sm, set max width to variable value and ignore margins
   &.pf-m-sm {
-    @media screen and (min-width: $pf-global--breakpoint--sm) {
-      --pf-c-modal-box--MaxWidth: var(--pf-c-modal-box--m-sm--sm--MaxWidth);
-    }
+    --pf-c-modal-box--Width: var(--pf-c-modal-box--m-sm--sm--MaxWidth);
   }
 
-  // At breakpoint--xl, set max width to variable value and ignore margins
+  &.pf-m-md {
+    --pf-c-modal-box--Width: var(--pf-c-modal-box--m-md--Width);
+  }
+
   &.pf-m-lg {
-    @media screen and (min-width: $pf-global--breakpoint--xl) {
-      --pf-c-modal-box--MaxWidth: var(--pf-c-modal-box--m-lg--lg--MaxWidth);
-    }
+    --pf-c-modal-box--Width: var(--pf-c-modal-box--m-lg--lg--MaxWidth);
   }
 
   // Close button

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -12,9 +12,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
-          Overwrite existing file?
-        {{/modal-box-title}}
+        {{#> modal-box-header}}
+          {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
+            Overwrite existing file?
+          {{/modal-box-title}}
+        {{/modal-box-header}}
         {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
@@ -41,12 +43,14 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-title  modal-box-title--attribute='id="modal-scroll-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/modal-box-title}}
-        {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
-          This is a modal description. The description will not scroll with the body contents.
-        {{/modal-box-description}}
+        {{#> modal-box-header}}
+          {{#> modal-box-title  modal-box-title--attribute='id="modal-scroll-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/modal-box-title}}
+          {{#> modal-box-description modal-box-description--attribute='id="modal-scroll-description"'}}
+            This is a modal description. The description will not scroll with the body contents.
+          {{/modal-box-description}}
+        {{/modal-box-header}}
         {{#> modal-box-body}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
@@ -72,6 +76,37 @@ section: demos
 {{/modal}}
 ```
 
+```hbs title=Medium isFullscreen
+{{#> modal}}
+  {{#> backdrop}}
+    {{#> bullseye}}
+      {{#> modal-box modal-box--modifier="pf-m-md" modal-box--attribute='aria-labelledby="modal-md-title" aria-describedby="modal-md-description"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
+          <i class="fas fa-times" aria-hidden="true"></i>
+        {{/button}}
+        {{#> modal-box-header}}
+          {{#> modal-box-title modal-box-title--attribute='id="modal-md-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/modal-box-title}}
+        {{/modal-box-header}}
+        {{#> modal-box-body}}
+          <p id="modal-md-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
+          <p>Form here</p>
+        {{/modal-box-body}}
+        {{#> modal-box-footer}}
+          {{#> button button--modifier="pf-m-primary"}}
+            Save
+          {{/button}}
+          {{#> button button--modifier="pf-m-link"}}
+            Cancel
+          {{/button}}
+        {{/modal-box-footer}}
+      {{/modal-box}}
+    {{/bullseye}}
+  {{/backdrop}}
+{{/modal}}
+```
+
 ```hbs title=Large isFullscreen
 {{#> modal}}
   {{#> backdrop}}
@@ -80,9 +115,11 @@ section: demos
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
           <i class="fas fa-times" aria-hidden="true"></i>
         {{/button}}
-        {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
-          This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
-        {{/modal-box-title}}
+        {{#> modal-box-header}}
+          {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
+            This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
+          {{/modal-box-title}}
+        {{/modal-box-header}}
         {{#> modal-box-body}}
           <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
           <p>Form here</p>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2979

Noticed the modal demos were broken, so went ahead and added this, too.

@mattnolting @christiemolloy wdyt about this change? Since the size modifiers were applied at breakpoints before, the point at which the size modifier applies needs to be 32px below whatever the breakpoint is in order for the modal to resize smoothly between the size modifier and adjusting with the width of the browser. So the existing small and large modifiers jerk a little right at the point where the modifier is applied. That also meant this medium modifier would need to apply at 736px to not jerk when the modifier is applied, and design wanted that width to be 840px.

The changes I made don't break the variable name API, and the react component's `width` prop will still work as expected. In a breaking change release, I'd propose we change `--pf-c-modal-box--m-sm--sm--MaxWidth` to `--pf-c-modal-box--m-sm--Width` and `--pf-c-modal-box--m-lg--lg--MaxWidth` to `--pf-c-modal-box--m-lg--MaxWidth`.