### PR TITLE
fix(alert): fix heading order

### DIFF
--- a/src/patternfly/components/Alert/alert-title.hbs
+++ b/src/patternfly/components/Alert/alert-title.hbs
@@ -1,6 +1,8 @@
-<span class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
-  {{#if alert-title--attribute}}
-    {{{alert-title--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>
+<p>
+  <strong class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
+    {{#if alert-title--attribute}}
+      {{{alert-title--attribute}}}
+    {{/if}}>
+    {{> @partial-block}}
+  </strong>
+</p>

--- a/src/patternfly/components/Alert/alert-title.hbs
+++ b/src/patternfly/components/Alert/alert-title.hbs
@@ -1,6 +1,6 @@
-<h4 class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
+<span class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
   {{#if alert-title--attribute}}
     {{{alert-title--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</h4>
+</span>

--- a/src/patternfly/components/Alert/alert-title.hbs
+++ b/src/patternfly/components/Alert/alert-title.hbs
@@ -1,8 +1,8 @@
-<p>
-  <strong class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
-    {{#if alert-title--attribute}}
-      {{{alert-title--attribute}}}
-    {{/if}}>
+<p class="pf-c-alert__title{{#if alert-title--modifier}} {{alert-title--modifier}}{{/if}}"
+  {{#if alert-title--attribute}}
+    {{{alert-title--attribute}}}
+  {{/if}}>
+  <strong>
     {{> @partial-block}}
   </strong>
 </p>

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -311,7 +311,7 @@ Add a modifier class to the default alert to change the color: `.pf-m-success`, 
 | -- | -- | -- |
 | `.pf-c-alert` | `<div>` |  Applies default alert styling. Always use with a modifier class. ** Required**|
 | `.pf-c-alert__icon` | `<div>` |  	Defines the alert icon. ** Required **|
-| `.pf-c-alert__title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Defines the alert title. ** Required **|
+| `.pf-c-alert__title` | `<span>` |  Defines the alert title. ** Required **|
 | `.pf-c-alert__description` | `<div>` |  Defines the alert description area. |
 | `.pf-c-alert__action` | `<div>` |  Defines the action button wrapper. Should contain `.pf-c-button.pf-m-plain` for close action or `.pf-c-button.pf-m-link` for link text. It should only include one action. |
 | `.pf-c-alert__action-group` | `<div>` |  Defines the action button group. Should contain `.pf-c-button.pf-m-link.pf-m-inline` for inline link text. **Note: ** only inline link buttons are supported in the alert action group. |

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -311,7 +311,7 @@ Add a modifier class to the default alert to change the color: `.pf-m-success`, 
 | -- | -- | -- |
 | `.pf-c-alert` | `<div>` |  Applies default alert styling. Always use with a modifier class. ** Required**|
 | `.pf-c-alert__icon` | `<div>` |  	Defines the alert icon. ** Required **|
-| `.pf-c-alert__title` | `<span>` |  Defines the alert title. ** Required **|
+| `.pf-c-alert__title` | `<p>, <h1-h6>` |  Defines the alert title. ** Required **|
 | `.pf-c-alert__description` | `<div>` |  Defines the alert description area. |
 | `.pf-c-alert__action` | `<div>` |  Defines the action button wrapper. Should contain `.pf-c-button.pf-m-plain` for close action or `.pf-c-button.pf-m-link` for link text. It should only include one action. |
 | `.pf-c-alert__action-group` | `<div>` |  Defines the action button group. Should contain `.pf-c-button.pf-m-link.pf-m-inline` for inline link text. **Note: ** only inline link buttons are supported in the alert action group. |

--- a/src/patternfly/demos/Page/page-template-title.hbs
+++ b/src/patternfly/demos/Page/page-template-title.hbs
@@ -1,8 +1,6 @@
 {{#> page-main-section page-main-section--modifier="pf-m-light"}}
   {{#> content}}
     <h1>Main title</h1>
-    <h2>Secondary title</h2>
-    <h3>Tertiary title</h3>
     <p>This is a demo of the Page component.</p>
   {{/content}}
 {{/page-main-section}}

--- a/src/patternfly/demos/Page/page-template-title.hbs
+++ b/src/patternfly/demos/Page/page-template-title.hbs
@@ -1,6 +1,8 @@
 {{#> page-main-section page-main-section--modifier="pf-m-light"}}
   {{#> content}}
     <h1>Main title</h1>
+    <h2>Secondary title</h2>
+    <h3>Tertiary title</h3>
     <p>This is a demo of the Page component.</p>
   {{/content}}
 {{/page-main-section}}


### PR DESCRIPTION
Closes #3199

Alerts can appear in many contexts, so a `<span>` instead of `<h4>` makes more sense.