### PR TITLE
fix(chipgroup): update removable action icon

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group-close.hbs
+++ b/src/patternfly/components/ChipGroup/chip-group-close.hbs
@@ -3,6 +3,6 @@
     {{{chip-group-close--attribute}}}
   {{/if}}>
   {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-button ' chip-group--id '-label" aria-label="Close chip group" id="' chip-group--id '-button"')}}
-    <i class="fas fa-times" aria-hidden="true"></i>
+    <i class="fas fa-times-circle" aria-hidden="true"></i>
   {{/button}}
 </div>

--- a/src/patternfly/components/ChipGroup/examples/ChipGroup.md
+++ b/src/patternfly/components/ChipGroup/examples/ChipGroup.md
@@ -316,6 +316,7 @@ If you want to create sub-groupings of chips to represent multiple values applie
 The chip group requires the [chip component](/documentation/core/components/chip).
 
 ### Accessibility
+
 **All single chip accessibility and usage requirements apply.**
 
 | Attributes for closable chip group button | Applied to | Outcome |


### PR DESCRIPTION
closes #3247 

@maryshak1996 @mceledonia I noticed the removable action doesn't have the same spacing as in the design kit. Do you know the actual px for the padding ?

<img width="458" alt="Screen Shot 2020-07-06 at 11 40 03 AM" src="https://user-images.githubusercontent.com/20118816/86612167-b3685d80-bf7d-11ea-84a4-365de8119785.png">
