### PR TITLE
fix(drawer-full-page): scoped drawer__body >  page__main

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -242,7 +242,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 }
 
 // Page level drawer
-.pf-c-drawer .pf-c-page__main {
+.pf-c-drawer__body > .pf-c-page__main {
   min-height: 100%;
 }
 


### PR DESCRIPTION
hotfix 
closes #3267 