### PR TITLE
fix(notificationdrawer): wrapped long item description, group title

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -233,6 +233,7 @@
 .pf-c-notification-drawer__list-item-description {
   grid-row: 2 / 3;
   margin-bottom: var(--pf-c-notification-drawer__list-item-description--MarginBottom);
+  word-break: break-word;
 }
 
 .pf-c-notification-drawer__list-item-timestamp {
@@ -288,6 +289,7 @@
 
   margin-right: var(--pf-c-notification-drawer__group-toggle-title--MarginRight);
   text-align: left;
+  word-break: break-word;
 }
 
 .pf-c-notification-drawer__group-toggle-count {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3285