### PR TITLE
chore(global): dark theme poc

### DIFF
--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -1,7 +1,5 @@
 // Set common reset styles for patternfly components
 [class*="pf-c-"] {
-  color: var(--pf-global--Color--100);
-
   &,
   &::before,
   &::after {

--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -1,5 +1,7 @@
 // Set common reset styles for patternfly components
 [class*="pf-c-"] {
+  color: var(--pf-global--Color--100);
+
   &,
   &::before,
   &::after {

--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -277,6 +277,21 @@
 
 /* stylelint-disable */
 .ws-preview-html {
+  .pf-c-page {
+    --pf-c-page__sidebar--BackgroundColor: var(--pf-global--palette--black-700);
+    --pf-c-page__header--BackgroundColor: var(--pf-global--palette--black-900);
+  }
+
+  .pf-c-form-control {
+    --pf-c-form-control--BackgroundColor: var(--pf-global--palette--black-600);
+    --pf-c-form-control--BorderTopColor: transparent;
+    --pf-c-form-control--BorderRightColor: transparent;
+    --pf-c-form-control--BorderBottomColor: transparent;
+    --pf-c-form-control--BorderLeftColor: transparent;
+  }
+}
+
+[class*="pf-c-"] {
   // palette
   --pf-global--palette--black-50: #e7ebeb;
   --pf-global--palette--black-100: #d3d6d7;
@@ -311,18 +326,7 @@
   --pf-global--Color--light-100: #fff;
   --pf-global--Color--200: var(--pf-global--palette--black-200);
 
-  .pf-c-page {
-    --pf-c-page__sidebar--BackgroundColor: var(--pf-global--palette--black-700);
-    --pf-c-page__header--BackgroundColor: var(--pf-global--palette--black-900);
-  }
-
-  .pf-c-form-control {
-    --pf-c-form-control--BackgroundColor: var(--pf-global--palette--black-600);
-    --pf-c-form-control--BorderTopColor: transparent;
-    --pf-c-form-control--BorderRightColor: transparent;
-    --pf-c-form-control--BorderBottomColor: transparent;
-    --pf-c-form-control--BorderLeftColor: transparent;
-  }
+  color: var(--pf-global--Color--100);
 }
 
 // RedHat Font overrides

--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -271,6 +271,58 @@
   // A11y
   --pf-global--target-size--MinWidth: #{$pf-global--target-size--MinWidth};
   --pf-global--target-size--MinHeight: #{$pf-global--target-size--MinHeight};
+
+  // Dark theme
+}
+
+/* stylelint-disable */
+.ws-preview-html {
+  // palette
+  --pf-global--palette--black-50: #e7ebeb;
+  --pf-global--palette--black-100: #d3d6d7;
+  --pf-global--palette--black-200: #a9adaf;
+  --pf-global--palette--black-300: #808487;
+  --pf-global--palette--black-400: #565b5f;
+  --pf-global--palette--black-500: #42474b;
+  --pf-global--palette--black-600: #292d32;
+  --pf-global--palette--black-700: #1b1e24;
+  --pf-global--palette--black-800: #12141a;
+  --pf-global--palette--black-900: #05050c;
+  --pf-global--palette--red-9999: #f64747;
+
+  // bg
+  --pf-global--BackgroundColor--100: var(--pf-global--palette--black-700);
+  --pf-global--BackgroundColor--light-100: var(--pf-global--palette--black-700);
+  --pf-global--BackgroundColor--200: var(--pf-global--palette--black-800);
+  --pf-global--BackgroundColor--light-300: var(--pf-global--palette--black-800);
+
+  // border
+  --pf-global--BorderColor--100: var(--pf-global--palette--black-600);
+
+  // state colors
+  --pf-global--primary-color--100: var(--pf-global--palette--blue-300);
+  --pf-global--active-color--100: var(--pf-global--palette--blue-300);
+  --pf-global--success-color--100: var(--pf-global--palette--green-400);
+  --pf-global--warning-color--100: var(--pf-global--palette--gold-300);
+  --pf-global--danger-color--100: var(--pf-global--palette--red-9999);
+
+  // text
+  --pf-global--Color--100: #fff;
+  --pf-global--Color--light-100: #fff;
+  --pf-global--Color--200: var(--pf-global--palette--black-200);
+
+  .pf-c-page {
+    --pf-c-page__sidebar--BackgroundColor: var(--pf-global--palette--black-700);
+    --pf-c-page__header--BackgroundColor: var(--pf-global--palette--black-900);
+  }
+
+  .pf-c-form-control {
+    --pf-c-form-control--BackgroundColor: var(--pf-global--palette--black-600);
+    --pf-c-form-control--BorderTopColor: transparent;
+    --pf-c-form-control--BorderRightColor: transparent;
+    --pf-c-form-control--BorderBottomColor: transparent;
+    --pf-c-form-control--BorderLeftColor: transparent;
+  }
 }
 
 // RedHat Font overrides
@@ -281,3 +333,9 @@
   --pf-global--FontWeight--semi-bold: var(--pf-global--FontWeight--overpass--semi-bold);
   --pf-global--FontWeight--bold: var(--pf-global--FontWeight--overpass--bold);
 }
+
+.ws-example,
+.ws-lite-example {
+  background: var(--pf-global--palette--black-900) !important;
+}
+/* stylelint-enable */


### PR DESCRIPTION
POC - do not merge.

fixes https://github.com/patternfly/patternfly/issues/3297

Everything was able to be updated via global vars except for

* sidebar background color
  * no global var change for `--pf-c-page__sidebar--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);`
* masthead background color
  * no global var change for `--pf-c-page__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);`
* form control border
  * we're removing the borders in dark theme, which doesn't go with the change of `--pf-global--BorderColor--100` to `pf-global--palette--black-600`. Technically we don't have to change/remove the border colors though since the borders are now `black-600` which matches the custom background color for form control elements, though if these elements should not have a border in dark theme, we should remove them.
* form control background-color
  * doesn't go with the change of `--pf-global--BackgroundColor--100` to `--pf-global--palette--black-700`