### PR TITLE
fix(dev-lite): parse new h3 example titles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
             if [[ -n $CIRCLE_PULL_REQUEST ]];
             then
                 git fetch --tags
-                node scripts/sizeReport/sizeReport origin/master --comment
+                node scripts/sizeReport/sizeReport --comment
             fi;
           when: always
       - store_artifacts:

--- a/scripts/gulp/codeTransformer.js
+++ b/scripts/gulp/codeTransformer.js
@@ -19,22 +19,32 @@ function getWrapperDiv(section, title, exampleName, toWrap, classNames) {
 
 // https://github.com/unifiedjs/unified#plugin
 function codeTransformer(config) {
-  function visitor(node) {
-    const match = node.meta.match(/title=(\S*)/);
-    if (match) {
-      const id = getId(match[1]);
-      if (config.examples[id]) {
-        node.type = 'html';
-        node.value = getWrapperDiv(
-          config.section,
-          config.title,
-          id.toLowerCase(),
-          config.examples[id].code,
-          'ws-lite-example'
-        );
-        delete node.meta;
-        delete node.language;
+  function visitor(node, _index, parent) {
+    let id = 'no-id';
+    let startLooking = false;
+    for (let i = parent.children.length - 1; i >= 0; i--) {
+      const child = parent.children[i];
+      if (child === node) {
+        startLooking = true;
+      } else if (startLooking) {
+        if (child.type === 'heading' && child.depth === 3 && child.children && child.children[0].value) {
+          id = getId(child.children[0].value);
+          parent.children.splice(i, 1);
+          break;
+        }
       }
+    }
+    if (config.examples[id]) {
+      node.type = 'html';
+      node.value = getWrapperDiv(
+        config.section,
+        config.title,
+        id.toLowerCase(),
+        config.examples[id].code,
+        'ws-lite-example'
+      );
+      delete node.meta;
+      delete node.language;
     }
   }
 

--- a/scripts/sizeReport/sizeReport.js
+++ b/scripts/sizeReport/sizeReport.js
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .version('1.0.0')
   .description("Generates a report comparing a folder's size to another commit's using NPM.")
-  .arguments('<pattern>')
+  .arguments('[pattern]')
   .option('-c, --comment', 'Whether to leave a github comment on CIRCLE_PR_NUMBER', false)
   .option('-d, --dir <dir>', 'Directory to compare', 'dist')
   .action(compare);
@@ -18,12 +18,19 @@ async function compare(pattern, options) {
   let compareDir;
   try {
     // Install from NPM
-    const sha = execSync(`git show-ref -s ${pattern}`);
-    const shaTag = execSync(`git show-ref --tags | grep ${sha}`)
-      .toString()
-      .split(' ')[1]
-      .replace('refs/tags/', '')
-      .replace('prerelease-v', '');
+    let shaTag;
+    if (pattern) {
+      const sha = execSync(`git show-ref -s ${pattern}`);
+      shaTag = execSync(`git show-ref --tags | grep ${sha}`)
+        .toString()
+        .split(' ')[1]
+        .replace('refs/tags/', '')
+        .replace('prerelease-v', '');
+    } else {
+      shaTag = execSync(`git describe --abbrev=0 --tags`)
+        .toString()
+        .replace('prerelease-v', '');
+    }
 
     // eslint-disable-next-line
     const packageName = require(path.join(process.cwd(), 'package.json')).name;


### PR DESCRIPTION
Fixes:
```sh
➜  patternfly npm run dev:lite

> @patternfly/patternfly@0.0.0-development dev:lite /home/redallen/src/patternfly
> gulp develop

[15:41:47] Using gulpfile ~/src/patternfly/gulpfile.js
[15:41:47] Starting 'develop'...
[15:41:47] Starting 'compileSrcSASS'...
[15:41:47] Starting 'copyWorkspaceAssets'...
[15:41:47] Starting 'compileSrcHBS'...
Browserslist: caniuse-lite is outdated. Please run next command `npm update`
[15:41:56] Finished 'compileSrcSASS' after 8.56 s
[15:41:57] Finished 'copyWorkspaceAssets' after 9.81 s
[15:41:57] Finished 'compileSrcHBS' after 9.85 s
[15:41:57] Starting 'compileSrcMD'...
[15:41:58] 'compileSrcMD' errored after 743 ms
[15:41:58] TypeError: Cannot read property 'match' of null
    at visitor (/home/redallen/src/patternfly/scripts/gulp/codeTransformer.js:23:29)
    at overload (/home/redallen/src/patternfly/node_modules/unist-util-visit/index.js:27:12)
    at one (/home/redallen/src/patternfly/node_modules/unist-util-visit/node_modules/unist-util-visit-parents/index.js:34:25)
    at all (/home/redallen/src/patternfly/node_modules/unist-util-visit/node_modules/unist-util-visit-parents/index.js:57:16)
    at one (/home/redallen/src/patternfly/node_modules/unist-util-visit/node_modules/unist-util-visit-parents/index.js:42:28)
    at visitParents (/home/redallen/src/patternfly/node_modules/unist-util-visit/node_modules/unist-util-visit-parents/index.js:26:3)
    at visit (/home/redallen/src/patternfly/node_modules/unist-util-visit/index.js:22:3)
    at transformer (/home/redallen/src/patternfly/scripts/gulp/codeTransformer.js:42:5)
    at wrapped (/home/redallen/src/patternfly/node_modules/trough/wrap.js:25:19)
    at next (/home/redallen/src/patternfly/node_modules/trough/index.js:57:24)
    at Object.run (/home/redallen/src/patternfly/node_modules/trough/index.js:31:10)
    at executor (/home/redallen/src/patternfly/node_modules/unified/index.js:295:20)
    at Function.run (/home/redallen/src/patternfly/node_modules/unified/index.js:292:5)
    at pipelineRun (/home/redallen/src/patternfly/node_modules/unified/index.js:26:5)
    at wrapped (/home/redallen/src/patternfly/node_modules/trough/wrap.js:25:19)
    at next (/home/redallen/src/patternfly/node_modules/trough/index.js:57:24)
[15:41:58] 'develop' errored after 11 s
```

Bonus: also fixes the CSS size lint!