### PR TITLE
fix(global-var): updated success-200 to be a shade lighter

### DIFF
--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -76,7 +76,7 @@ $pf-global--default-color--100:         $pf-color-cyan-200 !default;
 $pf-global--default-color--200:         $pf-color-cyan-300 !default;
 $pf-global--default-color--300:         $pf-color-cyan-500 !default;
 $pf-global--success-color--100:         $pf-color-green-500 !default;
-$pf-global--success-color--200:         $pf-color-green-700 !default;
+$pf-global--success-color--200:         $pf-color-green-600 !default;
 $pf-global--info-color--100:            $pf-color-blue-300 !default;
 $pf-global--info-color--200:            $pf-color-blue-600 !default;
 $pf-global--warning-color--100:         $pf-color-gold-400 !default;


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/3314

The places success-200 is used

```
components/Form/form.scss:  --pf-c-form__helper-text--m-success--Color: var(--pf-global--success-color--200);
components/Alert/alert.scss:  --pf-c-alert--m-success__title--Color: var(--pf-global--success-color--200);
components/Label/label.scss:  --pf-c-label--m-green__content--Color: var(--pf-global--success-color--200);
```