### PR TITLE
fix(alertgroup): removed misformed metastring

### DIFF
--- a/src/patternfly/components/AlertGroup/examples/AlertGroup.md
+++ b/src/patternfly/components/AlertGroup/examples/AlertGroup.md
@@ -55,7 +55,7 @@ cssPrefix: pf-c-alert-group
 | `.pf-c-alert-group__item` | `<li>` | Creates an alert group item. **Required** |
 
 ### Toast alert group
-```hbs isFullscreen=true
+```hbs isFullscreen
 {{#> alert-group alert-group--modifier="pf-m-toast"}}
   {{#> alert-item}}
     {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success toast alert"'}}


### PR DESCRIPTION
For the underway org redesign, metastrings should now be [valid JSX attributes.](https://www.reactenlightenment.com/react-nodes/4.4.html)

Examples:
- `prop="string value"`
- `prop={jsExpression}`
- `prop` (which is equivalent to `prop={true}`)