### PR TITLE
fix(button): allowed inline link text to wrap and use with span element

### DIFF
--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -1,5 +1,5 @@
-<button class="pf-c-button{{#if button--IsExpanded}} pf-m-expanded{{/if}}{{#if button--modifier}} {{button--modifier}}{{/if}}"
-  {{#if button--IsSubmit}} 
+<{{#if button--IsInlineLinkSpan}}span{{else}}button{{/if}} class="pf-c-button{{#if button--IsExpanded}} pf-m-expanded{{/if}}{{#if button--modifier}} {{button--modifier}}{{/if}}"
+  {{#if button--IsSubmit}}
     type="submit"
   {{else if button--IsReset}}
     type="reset"
@@ -9,8 +9,11 @@
   {{#if button--IsExpanded}}
     aria-expanded="true"
   {{/if}}
+  {{#if button--IsInlineLinkSpan}}
+    role="button"
+  {{/if}}
   {{#if button--attribute}}
     {{{button--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</button>
+</{{#if button--IsInlineLinkSpan}}span{{else}}button{{/if}}>

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -329,6 +329,9 @@
 
       display: inline;
       padding: 0;
+      text-align: left;
+      white-space: normal;
+      cursor: pointer;
 
       &:hover {
         --pf-c-button--m-link--Color: var(--pf-c-button--m-link--m-inline--hover--Color);

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -187,6 +187,15 @@ import './Button.css'
 {{/button-link}}
 ```
 
+### Inline link as span
+```hbs
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+{{#> button button--IsInlineLinkSpan="true" button--attribute='tabindex="0"' button--modifier="pf-m-link pf-m-inline"}}
+  This is long button text that needs to be a span so that it will wrap inline with the text around it.
+{{/button}}
+Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum velit elementum non.
+```
+
 ### Block level
 ```hbs
 {{#> button button--modifier="pf-m-primary pf-m-block"}}
@@ -250,12 +259,13 @@ Semantic buttons and links are important for usability as well as accessibility.
 | -- | -- | -- |
 | `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
 | `aria-label="[button label text]"` | `.pf-m-plain` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
-| `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. |
+| `aria-label="[descriptive text]"` | `a.pf-c-button`, `span.pf-c-button.pf-m-link.pf-m-inline` | The button component's text should adequately describe its purpose. If it does not, `aria-label` can provide more detailed interaction information. |
 | `disabled` | `button.pf-c-button` | When a button element is used, indicates that it is unavailable and removes it from keyboard focus. **Required when button is disabled** |
 | `aria-disabled="true"` | `button.pf-c-button` | When a button element is used, indicates that it is unavailable but does not prevent keyboard or hover interactions. Used when a disabled button provides interactive elements like a tooltip. |
-| `aria-disabled="true"` | `a.pf-c-button` | When a link element is used, indicates that it is unavailable. **Required when link is disabled** |
+| `aria-disabled="true"` | `a.pf-c-button.pf-m-disabled`, `span.pf-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, indicates that it is unavailable. **Required when element is disabled** |
 | `aria-expanded="true"` | `.pf-c-button.pf-m-expanded` | Indicates that the expanded content element is visible. **Required** |
-| `tabindex="-1"` | `a.pf-c-button` | When a link element is used, removes it from keyboard focus. **Required when link is disabled** |
+| `tabindex="-1"` | `a.pf-c-button.pf-m-disabled`, `span.pf-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, removes it from keyboard focus. **Required when element is disabled** |
+| `tabindex="0"` | `span.pf-c-button.pf-m-link.pf-m-inline` | Inserts the span into the tab order of the page so that it is focusable. **Required when the element is a span** |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -268,7 +278,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-danger` | `.pf-c-button` | Modifies for danger styles. |
 | `.pf-m-link` | `.pf-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
-| `.pf-m-inline` | `.pf-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link, has no padding, and is displayed inline with other inline content. |
+| `.pf-m-inline` | `.pf-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-c-button` | Creates a block level button. |
 | `.pf-m-control` | `.pf-c-button` | Modifies for control styles. **Note:** This modifier should only be used when using buttons in the Input Group or Clipboard Copy components. |
 | `.pf-m-expanded` | `.pf-c-button.pf-m-control` | Modifies a control button for the expanded state. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3313
