### PR TITLE
feat(page): added ability to limit width of content in page section

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -169,7 +169,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-c-page__main-nav` | `<section>` |   Creates a container to nest the navigation component in the main page area. |
 | `.pf-c-page__main-breadcrumb` | `<section>` |   Creates a container to nest the breadcrumb component in the main page area. |
 | `.pf-c-page__main-section` | `<section>` |  Creates a section container in the main page area. **Note: The last/only `.pf-c-page__main-section` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
-| `.pf-c-page__main-section-body` | `<div>` | Creates the body section for a page section. **Required when using `.pf-m-limit-width` on `.pf-c-page__main-section`** |
+| `.pf-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required when using `.pf-m-limit-width` on `.pf-c-page__main-section`** |
 | `.pf-c-page__drawer` | `<div>` |  Creates a container for the drawer component when placing the main page element in the drawer body. |
 | `.pf-m-selected` | `.pf-c-page__header-tools-item` | Modifies a header tools item to indicate that the button inside is in the selected state. |
 | `.pf-m-expanded` | `.pf-c-page__sidebar` |  Modifies the sidebar for the expanded state. |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -169,6 +169,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-c-page__main-nav` | `<section>` |   Creates a container to nest the navigation component in the main page area. |
 | `.pf-c-page__main-breadcrumb` | `<section>` |   Creates a container to nest the breadcrumb component in the main page area. |
 | `.pf-c-page__main-section` | `<section>` |  Creates a section container in the main page area. **Note: The last/only `.pf-c-page__main-section` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
+| `.pf-c-page__main-section-body` | `<div>` | Creates the body section for a page section. **Required when using `.pf-m-limit-width` on `.pf-c-page__main-section`** |
 | `.pf-c-page__drawer` | `<div>` |  Creates a container for the drawer component when placing the main page element in the drawer body. |
 | `.pf-m-selected` | `.pf-c-page__header-tools-item` | Modifies a header tools item to indicate that the button inside is in the selected state. |
 | `.pf-m-expanded` | `.pf-c-page__sidebar` |  Modifies the sidebar for the expanded state. |
@@ -183,3 +184,4 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-m-no-fill` | `.pf-c-page__main-section` | Modifies a main page section to not grow to fill the available vertical space. |
 | `.pf-m-hidden{-on-[breakpoint]}` | `.pf-c-page__header-tools-group`, `.pf-c-page__header-tools-item` | Hides a header tools group or item at a specified breakpoint, or hides it at all breakpoints with `.pf-m-hidden`. |
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-page__header-tools-group`, `.pf-c-page__header-tools-item` | Shows a header tools group or item at a specified breakpoint. |
+| `.pf-m-limit-width` | `.pf-c-page__main-section` | Modifies a page section to limit the `max-width` of the content inside. |

--- a/src/patternfly/components/Page/page-main-body.hbs
+++ b/src/patternfly/components/Page/page-main-body.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-page__main-body{{#if page-main-body--modifier}} {{page-main-body--modifier}}{{/if}}"
+  {{#if page-main-body--attribute}}
+    {{{page-main-body--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Page/page-main-breadcrumb.hbs
+++ b/src/patternfly/components/Page/page-main-breadcrumb.hbs
@@ -1,6 +1,12 @@
-<section class="pf-c-page__main-breadcrumb{{#if page-main-breadcrumb--modifier}} {{page-main-breadcrumb--modifier}}{{/if}}"
+<section class="pf-c-page__main-breadcrumb{{#if page-main-breadcrumb--IsLimitWidth}} pf-m-limit-width{{/if}}{{#if page-main-breadcrumb--modifier}} {{page-main-breadcrumb--modifier}}{{/if}}"
   {{#if page-main-breadcrumb--attribute}}
     {{{page-main-breadcrumb--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if page-main-breadcrumb--IsLimitWidth}}
+    {{#> page-main-body}}
+      {{> @partial-block}}
+    {{/page-main-body}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
 </section>

--- a/src/patternfly/components/Page/page-main-nav.hbs
+++ b/src/patternfly/components/Page/page-main-nav.hbs
@@ -1,6 +1,12 @@
-<section class="pf-c-page__main-nav{{#if page-main-nav--modifier}} {{page-main-nav--modifier}}{{/if}}"
+<section class="pf-c-page__main-nav{{#if page-main-nav--IsLimitWidth}} pf-m-limit-width{{/if}}{{#if page-main-nav--modifier}} {{page-main-nav--modifier}}{{/if}}"
   {{#if page-main-nav--attribute}}
     {{{page-main-nav--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if page-main-nav--IsLimitWidth}}
+    {{#> page-main-body}}
+      {{> @partial-block}}
+    {{/page-main-body}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
 </section>

--- a/src/patternfly/components/Page/page-main-section-body.hbs
+++ b/src/patternfly/components/Page/page-main-section-body.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-page__main-section-body{{#if page-main-section-body--modifier}} {{page-main-section-body--modifier}}{{/if}}"
+  {{#if page-main-section-body--attribute}}
+    {{{page-main-section-body--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Page/page-main-section-body.hbs
+++ b/src/patternfly/components/Page/page-main-section-body.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-page__main-section-body{{#if page-main-section-body--modifier}} {{page-main-section-body--modifier}}{{/if}}"
-  {{#if page-main-section-body--attribute}}
-    {{{page-main-section-body--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Page/page-main-section.hbs
+++ b/src/patternfly/components/Page/page-main-section.hbs
@@ -3,9 +3,9 @@
     {{{page-main-section--attribute}}}
   {{/if}}>
   {{#if page-main-section--IsLimitWidth}}
-    {{#> page-main-section-body}}
+    {{#> page-main-body}}
       {{> @partial-block}}
-    {{/page-main-section-body}}
+    {{/page-main-body}}
   {{else}}
     {{> @partial-block}}
   {{/if}}

--- a/src/patternfly/components/Page/page-main-section.hbs
+++ b/src/patternfly/components/Page/page-main-section.hbs
@@ -1,6 +1,12 @@
-<section class="pf-c-page__main-section{{#if page-main-section--modifier}} {{page-main-section--modifier}}{{/if}}"
+<section class="pf-c-page__main-section{{#if page-main-section--IsLimitWidth}} pf-m-limit-width{{/if}}{{#if page-main-section--modifier}} {{page-main-section--modifier}}{{/if}}"
   {{#if page-main-section--attribute}}
     {{{page-main-section--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if page-main-section--IsLimitWidth}}
+    {{#> page-main-section-body}}
+      {{> @partial-block}}
+    {{/page-main-section-body}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
 </section>

--- a/src/patternfly/components/Page/page-main-wizard.hbs
+++ b/src/patternfly/components/Page/page-main-wizard.hbs
@@ -1,6 +1,12 @@
-<section class="pf-c-page__main-wizard{{#if page-main-wizard--modifier}} {{page-main-wizard--modifier}}{{/if}}"
+<section class="pf-c-page__main-wizard{{#if page-main-wizard--IsLimitWidth}} pf-m-limit-width{{/if}}{{#if page-main-wizard--modifier}} {{page-main-wizard--modifier}}{{/if}}"
   {{#if page-main-wizard--attribute}}
     {{{page-main-wizard--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if page-main-wizard--IsLimitWidth}}
+    {{#> page-main-body}}
+      {{> @partial-block}}
+    {{/page-main-body}}
+  {{else}}
+    {{> @partial-block}}
+  {{/if}}
 </section>

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -94,7 +94,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-breadcrumb--main-section--PaddingTop: var(--pf-global--spacer--md);
 
   // Main section body
-  --pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth: calc(#{pf-size-prem(1710px)} - var(--pf-c-page__sidebar--Width));
+  --pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--pf-c-page__sidebar--Width));
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--xl--PaddingTop);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -431,13 +431,11 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 .pf-c-page__main-section,
 .pf-c-page__main-wizard {
   &.pf-m-limit-width {
-    display: flex;
-    flex-direction: column;
     padding: 0;
 
     .pf-c-page__main-body {
-      flex: 1;
       max-width: var(--pf-c-page--section--m-limit-width--MaxWidth);
+      height: 100%;
     }
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -93,8 +93,8 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-page__main-breadcrumb--main-section--PaddingTop: var(--pf-global--spacer--md);
 
-  // Main section body
-  --pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--pf-c-page__sidebar--Width));
+  // Limit width
+  --pf-c-page--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--pf-c-page__sidebar--Width));
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--xl--PaddingTop);
@@ -136,6 +136,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main-section--m-dark-200--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
 
   // Wizard main section
+  --pf-c-page__main-wizard--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__main-wizard--BorderTopColor: var(--pf-global--BorderColor--100);
   --pf-c-page__main-wizard--BorderTopWidth: var(--pf-global--BorderWidth--sm);
 
@@ -417,23 +418,44 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
       }
     }
   }
+}
 
+.pf-c-page__main-wizard {
+  flex: 1 0 0;
+  background-color: var(--pf-c-page__main-wizard--BackgroundColor);
+  border-top: var(--pf-c-page__main-wizard--BorderTopWidth) solid var(--pf-c-page__main-wizard--BorderTopColor);
+}
+
+.pf-c-page__main-nav,
+.pf-c-page__main-breadcrumb,
+.pf-c-page__main-section,
+.pf-c-page__main-wizard {
   &.pf-m-limit-width {
     display: flex;
     flex-direction: column;
     padding: 0;
 
-    .pf-c-page__main-section-body {
+    .pf-c-page__main-body {
       flex: 1;
-      max-width: var(--pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth);
-      padding: var(--pf-c-page__main-section--PaddingTop) var(--pf-c-page__main-section--PaddingRight) var(--pf-c-page__main-section--PaddingBottom) var(--pf-c-page__main-section--PaddingLeft);
+      max-width: var(--pf-c-page--section--m-limit-width--MaxWidth);
     }
   }
 }
 
-.pf-c-page__main-wizard {
-  flex: 1 0 0;
-  border-top: var(--pf-c-page__main-wizard--BorderTopWidth) solid var(--pf-c-page__main-wizard--BorderTopColor);
+.pf-c-page__main-body {
+  .pf-c-page__main-nav & {
+    padding-top: var(--pf-c-page__main-nav--PaddingTop);
+    padding-right: var(--pf-c-page__main-nav--PaddingRight);
+    padding-left: var(--pf-c-page__main-nav--PaddingLeft);
+  }
+
+  .pf-c-page__main-breadcrumb & {
+    padding: var(--pf-c-page__main-breadcrumb--PaddingTop) var(--pf-c-page__main-breadcrumb--PaddingRight) var(--pf-c-page__main-breadcrumb--PaddingBottom) var(--pf-c-page__main-breadcrumb--PaddingLeft);
+  }
+
+  .pf-c-page__main-section & {
+    padding: var(--pf-c-page__main-section--PaddingTop) var(--pf-c-page__main-section--PaddingRight) var(--pf-c-page__main-section--PaddingBottom) var(--pf-c-page__main-section--PaddingLeft);
+  }
 }
 
 .pf-c-page__drawer {

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -93,6 +93,9 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   --pf-c-page__main--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-page__main-breadcrumb--main-section--PaddingTop: var(--pf-global--spacer--md);
 
+  // Main section body
+  --pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth: calc(#{pf-size-prem(1710px)} - var(--pf-c-page__sidebar--Width));
+
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-section--xl--PaddingTop);
     --pf-c-page__main-section--PaddingRight: var(--pf-c-page__main-section--xl--PaddingRight);
@@ -407,8 +410,23 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
       }
 
       &.pf-m-no-padding#{$breakpoint-name} {
-        padding: 0;
+        --pf-c-page__main-section--PaddingTop: 0;
+        --pf-c-page__main-section--PaddingRight: 0;
+        --pf-c-page__main-section--PaddingBottom: 0;
+        --pf-c-page__main-section--PaddingLeft: 0;
       }
+    }
+  }
+
+  &.pf-m-limit-width {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+
+    .pf-c-page__main-section-body {
+      flex: 1;
+      max-width: var(--pf-c-page__main-section--m-limit-width__main-section-body--MaxWidth);
+      padding: var(--pf-c-page__main-section--PaddingTop) var(--pf-c-page__main-section--PaddingRight) var(--pf-c-page__main-section--PaddingBottom) var(--pf-c-page__main-section--PaddingLeft);
     }
   }
 }

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -178,7 +178,7 @@ wrapperTag: div
     {{/nav}}
   {{/page-sidebar}}
   {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
-    {{#> page-main-nav}}
+    {{#> page-main-nav page-main-nav--IsLimitWidth="true"}}
       {{#> nav nav--IsHorizontal="true" nav--IsTertiary="true" nav--IsScrollable="true" nav--attribute='aria-label="Local"'}}
         {{#> nav-list}}
           {{#> nav-item}}

--- a/src/patternfly/demos/Page/page-template-breadcrumb.hbs
+++ b/src/patternfly/demos/Page/page-template-breadcrumb.hbs
@@ -1,4 +1,4 @@
-{{#> page-main-breadcrumb}}
+{{#> page-main-breadcrumb page-main-breadcrumb--IsLimitWidth="true"}}
   {{#> breadcrumb}}
     {{#> breadcrumb-list}}
       {{#> breadcrumb-item}}

--- a/src/patternfly/demos/Page/page-template-gallery.hbs
+++ b/src/patternfly/demos/Page/page-template-gallery.hbs
@@ -1,4 +1,4 @@
-{{#> page-main-section}}
+{{#> page-main-section page-main-section--IsLimitWidth="true"}}
   {{#> gallery gallery--modifier="pf-m-gutter"}}
     {{#> gallery-item}}
       {{#> card}}

--- a/src/patternfly/demos/Page/page-template-title.hbs
+++ b/src/patternfly/demos/Page/page-template-title.hbs
@@ -1,4 +1,4 @@
-{{#> page-main-section page-main-section--modifier="pf-m-light"}}
+{{#> page-main-section page-main-section--modifier="pf-m-light" page-main-section--IsLimitWidth="true"}}
   {{#> content}}
     <h1>Main title</h1>
     <p>This is a demo of the Page component.</p>

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -21,14 +21,16 @@ wrapperTag: div
     {{#> page-main-nav}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    {{#> page-main-section page-main-section--modifier="pf-m-light"}}
-      {{> table-main-section-content}}
+    {{#> page-main-section page-main-section--modifier="pf-m-light" page-main-section--IsLimitWidth="true"}}
+      {{#> content}}
+        <h1>Table demos</h1>
+        <p>Below is an example of a Table.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum suscipit venenatis enim, ut ultrices metus ornare at. Curabitur vel nibh id leo finibus suscipit. Curabitur eu tellus lectus. Vivamus lacus leo, lobortis ac convallis ac, dapibus vel ligula. Suspendisse vitae felis at augue blandit sollicitudin. Sed erat metus, pellentesque vel accumsan vitae, tincidunt id erat. Mauris et pharetra felis. Duis at nisi leo. Nam blandit dui dui, in euismod est dapibus sed. Vivamus sed dolor ullamcorper, euismod orci efficitur, ornare leo. Sed sit amet sollicitudin nulla. Nunc tristique sem ut est laoreet efficitur. Cras tristique finibus risus, eget fringilla tellus porta vitae. Duis id nunc ultricies, ultrices nibh vel, sollicitudin tellus.</p>
+      {{/content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
-      {{#> card}}
-        {{> table-simple-table}}
-        {{> table-pagination-footer}}
-      {{/card}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md pf-m-light" page-main-section--IsLimitWidth="true"}}
+      {{> table-simple-table}}
+      {{> table-pagination-footer}}
     {{/page-main-section}}
   {{/page-main}}
 {{/page}}
@@ -269,15 +271,17 @@ wrapperTag: div
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
-      {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
-        Manage columns
-      {{/modal-box-title}}
-      {{#> modal-box-description}}
-        {{#> content}}
-          <p>Selected categories will be displayed in the table.</p>
-          {{#> button button--modifier="pf-m-link pf-m-inline"}}Select all{{/button}}
-        {{/content}}
-      {{/modal-box-description}}
+      {{#> modal-box-header}}
+        {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
+          Manage columns
+        {{/modal-box-title}}
+        {{#> modal-box-description}}
+          {{#> content}}
+            <p>Selected categories will be displayed in the table.</p>
+            {{#> button button--modifier="pf-m-link pf-m-inline"}}Select all{{/button}}
+          {{/content}}
+        {{/modal-box-description}}
+      {{/modal-box-header}}
       {{#> modal-box-body modal-box-body--attribute='id="modal-description"'}}
         {{#> data-list data-list--id="table-column-management" data-list--attribute='aria-label="Table column management"' data-list--modifier="pf-m-compact"}}
           {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -18,7 +18,7 @@ wrapperTag: div
     {{> table-page-nav}}
   {{/page-sidebar}}
   {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
-    {{#> page-main-nav}}
+    {{#> page-main-nav page-main-nav--IsLimitWidth="true"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
     {{#> page-main-section page-main-section--modifier="pf-m-light" page-main-section--IsLimitWidth="true"}}

--- a/src/patternfly/demos/Wizard/examples/Wizard.md
+++ b/src/patternfly/demos/Wizard/examples/Wizard.md
@@ -250,7 +250,7 @@ wrapperTag: div
     {{/page-template-breadcrumb}}
     {{#> page-template-title}}
     {{/page-template-title}}
-    {{#> page-main-wizard}}
+    {{#> page-main-wizard page-main-wizard--IsLimitWidth="true"}}
       {{#> wizard}}
         {{#> wizard-toggle}}
           {{#> wizard-toggle-list}}
@@ -389,7 +389,7 @@ wrapperTag: div
     {{/page-template-breadcrumb}}
     {{#> page-template-title}}
     {{/page-template-title}}
-    {{#> page-main-wizard}}
+    {{#> page-main-wizard page-main-wizard--IsLimitWidth="true"}}
       {{#> wizard wizard--IsExpanded="true"}}
         {{#> wizard-toggle}}
           {{#> wizard-toggle-list}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/2910

@mcarrano @mceledonia you can see the enhancement in:

* The breadcrumb, tertiary nav, title/content and gallery sections on the page demos - https://patternfly-pr-3340.surge.sh/documentation/core/demos/page
* The basic table demo - https://patternfly-pr-3340.surge.sh/documentation/core/demos/table/basic
  * In this demo, I changed the table page section to `.pf-m-light` (gives it a white background instead of grey), and removed the card that the table was in.
* The in-page wizard demos
  * https://patternfly-pr-3340.surge.sh/documentation/core/demos/wizard/in-page-nav-expanded-mobile
  * https://patternfly-pr-3340.surge.sh/documentation/core/demos/wizard/in-page
  * I updated the default background color of the wizard container to be white. It was previously transparent, but never visible because the wizard would cover it.