### PR TITLE
fix(charts): Adjust chart tooltip padding

### DIFF
--- a/src/patternfly/base/_chart-globals.scss
+++ b/src/patternfly/base/_chart-globals.scss
@@ -268,7 +268,7 @@ $pf-chart-tooltip--flyoutStyle--PointerEvents: "none";
 $pf-chart-tooltip--flyoutStyle--stroke--Color: $pf-chart-global--Fill--Color--900;
 $pf-chart-tooltip--flyoutStyle--Fill: $pf-chart-global--Fill--Color--900;
 $pf-chart-tooltip--pointer--Width: 20;
-$pf-chart-tooltip--Padding: 16;
+$pf-chart-tooltip--Padding: 8;
 $pf-chart-tooltip--PointerEvents: "none";
 
 // Voronoi Chart


### PR DESCRIPTION
Victory changed the way padding is applied to chart tooltips. With the latest Victory packages, the tooltip appears too large.

Fixes https://github.com/patternfly/patternfly/issues/3346

**Before**
<img width="699" alt="Screen Shot 2020-07-29 at 8 26 50 PM" src="https://user-images.githubusercontent.com/17481322/88868795-206abe00-d1df-11ea-853c-c701b6eda64b.png">

**After**
<img width="714" alt="Screen Shot 2020-07-29 at 8 27 21 PM" src="https://user-images.githubusercontent.com/17481322/88869503-f9ad8700-d1e0-11ea-997b-3ab77007c4f9.png">
