### PR TITLE
chore(page): added main section element examples

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -136,6 +136,42 @@ wrapperTag: div
 {{/page}}
 ```
 
+### Main section variations
+```hbs
+{{#> page}}
+  {{#> page-header}}
+    {{#> page-header-brand}}
+      {{#> page-header-brand-toggle}}
+        toggle
+      {{/page-header-brand-toggle}}
+      {{#> page-header-brand-link}}
+        Logo
+      {{/page-header-brand-link}}
+    {{/page-header-brand}}
+    {{#> page-header-tools}}
+      header-tools
+    {{/page-header-tools}}
+  {{/page-header}}
+  {{#> page-sidebar}}
+    pf-c-nav
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-main-nav}}
+      `.pf-c-page__main-nav` for tertiary navigation
+    {{/page-main-nav}}
+    {{#> page-main-breadcrumb}}
+      `.pf-c-page__main-breadcrumb` for breadcrumbs
+    {{/page-main-breadcrumb}}
+    {{#> page-main-section}}
+      `.pf-c-page__main-section` for main sections
+    {{/page-main-section}}
+    {{#> page-main-wizard}}
+      `.pf-c-page__main-wizard` for wizards
+    {{/page-main-wizard}}
+  {{/page-main}}
+{{/page}}
+```
+
 ## Documentation
 ### Overview
 This component provides the basic chrome for a page, including sidebar, header, and main areas.
@@ -169,6 +205,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-c-page__main-nav` | `<section>` |   Creates a container to nest the navigation component in the main page area. |
 | `.pf-c-page__main-breadcrumb` | `<section>` |   Creates a container to nest the breadcrumb component in the main page area. |
 | `.pf-c-page__main-section` | `<section>` |  Creates a section container in the main page area. **Note: The last/only `.pf-c-page__main-section` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
+| `.pf-c-page__main-wizard` | `<section>` | Creates a container to nest the wizard component in the mian page area. |
 | `.pf-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required when using `.pf-m-limit-width` on `.pf-c-page__main-section`** |
 | `.pf-c-page__drawer` | `<div>` |  Creates a container for the drawer component when placing the main page element in the drawer body. |
 | `.pf-m-selected` | `.pf-c-page__header-tools-item` | Modifies a header tools item to indicate that the button inside is in the selected state. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/1997

We already have a demo at https://www.patternfly.org/v4/documentation/core/demos/page/tertiary-nav

Opened a react issue to create a demo at https://github.com/patternfly/patternfly-react/issues/4676, and will create a react issue to add the section examples to https://www.patternfly.org/v4/documentation/react/components/page once this PR is merged.