### PR TITLE
fix(table): removed compound expansion active border

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -682,7 +682,6 @@
     }
   }
 
-  &:active,
   &:focus-within {
     outline-offset: var(--pf-c-table__button--OutlineOffset);
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3119

@christiemolloy I'm not seeing that, but I am seeing an `:active` border that doesn't seem to match any other interactive styles we have on elements like this. WDYT?