### PR TITLE
fix(select): added pf-m-focus support for favorite __menu-items

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -44,8 +44,6 @@
   --pf-c-app-launcher__menu-item--disabled--Color: var(--pf-global--Color--dark-200);
   --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-app-launcher__menu-item--m-link--PaddingRight: 0;
-  --pf-c-app-launcher__menu-item--m-link--hover--BackgroundColor: transparent;
-  --pf-c-app-launcher__menu-item--m-action--hover--BackgroundColor: transparent;
   --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
   --pf-c-app-launcher__menu-item--m-action--Width: auto;
   --pf-c-app-launcher__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
@@ -177,12 +175,11 @@
     text-decoration: none;
   }
 
-  @at-root .pf-c-app-launcher__menu-wrapper,
-  & {
-    &:hover,
-    &:focus {
-      background-color: var(--pf-c-app-launcher__menu-item--hover--BackgroundColor);
-    }
+  @at-root .pf-c-app-launcher__menu-wrapper:hover,
+  .pf-c-app-launcher__menu-wrapper:focus-within,
+  &:hover,
+  &:focus {
+    background-color: var(--pf-c-app-launcher__menu-item--hover--BackgroundColor);
   }
 
   &:disabled,
@@ -215,11 +212,9 @@
 
   &.pf-m-link {
     --pf-c-app-launcher__menu-item--PaddingRight: var(--pf-c-app-launcher__menu-item--m-link--PaddingRight);
-    --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-c-app-launcher__menu-item--m-link--hover--BackgroundColor);
   }
 
   &.pf-m-action {
-    --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-c-app-launcher__menu-item--m-action--hover--BackgroundColor);
     --pf-c-app-launcher__menu-item--Color: var(--pf-c-app-launcher__menu-item--m-action--Color);
     --pf-c-app-launcher__menu-item--Width: var(--pf-c-app-launcher__menu-item--m-action--Width);
 

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -44,9 +44,11 @@
   --pf-c-app-launcher__menu-item--disabled--Color: var(--pf-global--Color--dark-200);
   --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-app-launcher__menu-item--m-link--PaddingRight: 0;
+  --pf-c-app-launcher__menu-item--m-link--hover--BackgroundColor: transparent;
   --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
   --pf-c-app-launcher__menu-item--m-action--Width: auto;
   --pf-c-app-launcher__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-app-launcher__menu-item--m-action--hover--BackgroundColor: transparent;
   --pf-c-app-launcher__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200);
   --pf-c-app-launcher__menu-item--m-action--hover--Color: var(--pf-global--Color--100);
   --pf-c-app-launcher__menu-item--m-favorite__menu-item--m-action--Color: var(--pf-global--palette--gold-400);
@@ -177,6 +179,7 @@
 
   @at-root .pf-c-app-launcher__menu-wrapper:hover,
   .pf-c-app-launcher__menu-wrapper:focus-within,
+  .pf-c-app-launcher__menu-wrapper.pf-m-focus,
   &:hover,
   &:focus {
     background-color: var(--pf-c-app-launcher__menu-item--hover--BackgroundColor);
@@ -212,11 +215,13 @@
 
   &.pf-m-link {
     --pf-c-app-launcher__menu-item--PaddingRight: var(--pf-c-app-launcher__menu-item--m-link--PaddingRight);
+    --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-c-app-launcher__menu-item--m-link--hover--BackgroundColor);
   }
 
   &.pf-m-action {
     --pf-c-app-launcher__menu-item--Color: var(--pf-c-app-launcher__menu-item--m-action--Color);
     --pf-c-app-launcher__menu-item--Width: var(--pf-c-app-launcher__menu-item--m-action--Width);
+    --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-c-app-launcher__menu-item--m-action--hover--BackgroundColor);
 
     font-size: var(--pf-c-app-launcher__menu-item--m-action--FontSize);
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -94,9 +94,6 @@
   --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-select__menu-item--disabled--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-link--Width: auto;
-  --pf-c-select__menu-item--m-link--hover--BackgroundColor: transparent;
-  --pf-c-select__menu-item--m-link--focus--BackgroundColor: transparent;
-  --pf-c-select__menu-item--m-action--hover--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
   --pf-c-select__menu-item--m-action--Width: auto;
   --pf-c-select__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
@@ -428,14 +425,11 @@
     --pf-c-select__menu-item-main--PaddingRight: 0;
     --pf-c-select__menu-item-description--PaddingRight: 0;
     --pf-c-select__menu-item--Width: var(--pf-c-select__menu-item--m-link--Width);
-    --pf-c-select__menu-item--hover--BackgroundColor: var(--pf-c-select__menu-item--m-link--hover--BackgroundColor);
-    --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-c-select__menu-item--m-link--focus--BackgroundColor);
 
     flex-grow: 1;
   }
 
   &.pf-m-action {
-    --pf-c-select__menu-item--hover--BackgroundColor: var(--pf-c-select__menu-item--m-action--hover--BackgroundColor);
     --pf-c-select__menu-item--Color: var(--pf-c-select__menu-item--m-action--Color);
     --pf-c-select__menu-item--Width: var(--pf-c-select__menu-item--m-action--Width);
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -94,9 +94,13 @@
   --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-select__menu-item--disabled--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-link--Width: auto;
+  --pf-c-select__menu-item--m-link--hover--BackgroundColor: transparent;
+  --pf-c-select__menu-item--m-link--focus--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
   --pf-c-select__menu-item--m-action--Width: auto;
   --pf-c-select__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-select__menu-item--m-action--hover--BackgroundColor: transparent;
+  --pf-c-select__menu-item--m-action--focus--BackgroundColor: transparent;
   --pf-c-select__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200);
   --pf-c-select__menu-item--m-action--hover--Color: var(--pf-global--Color--100);
   --pf-c-select__menu-item--m-action--focus--Color: var(--pf-global--Color--100);
@@ -414,6 +418,7 @@
   }
 
   @at-root .pf-c-select__menu-wrapper:focus-within,
+  .pf-c-select__menu-wrapper.pf-m-focus,
   &:focus,
   &.pf-m-focus {
     position: relative;
@@ -425,6 +430,8 @@
     --pf-c-select__menu-item-main--PaddingRight: 0;
     --pf-c-select__menu-item-description--PaddingRight: 0;
     --pf-c-select__menu-item--Width: var(--pf-c-select__menu-item--m-link--Width);
+    --pf-c-select__menu-item--hover--BackgroundColor: var(--pf-c-select__menu-item--m-link--hover--BackgroundColor);
+    --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-c-select__menu-item--m-link--focus--BackgroundColor);
 
     flex-grow: 1;
   }
@@ -432,6 +439,8 @@
   &.pf-m-action {
     --pf-c-select__menu-item--Color: var(--pf-c-select__menu-item--m-action--Color);
     --pf-c-select__menu-item--Width: var(--pf-c-select__menu-item--m-action--Width);
+    --pf-c-select__menu-item--hover--BackgroundColor: var(--pf-c-select__menu-item--m-action--hover--BackgroundColor);
+    --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-c-select__menu-item--m-action--focus--BackgroundColor);
 
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3429

This also adds `:focus-within` support in the app launcher to match the select, so that when you focus on an element in a favorite menu item, the whole item's background changes. This will change the current keyboard navigation style in the app launcher from:
![before](https://user-images.githubusercontent.com/35148959/91230243-c8957900-e6f0-11ea-8086-4b77b2dc3c84.gif)



to:
![after](https://user-images.githubusercontent.com/35148959/91230251-cc290000-e6f0-11ea-91aa-63c9697fb91b.gif)


This makes the app launcher match the select, and the general style of navigating any of these types of menus by keyboard.