### PR TITLE
fix(modal): refactored the top aligned variation so it works better

### DIFF
--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -10,9 +10,9 @@
   --pf-c-modal-box--MaxHeight: calc(100% - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
   --pf-c-modal-box--m-align-top--spacer: var(--pf-global--spacer--sm);
   --pf-c-modal-box--m-align-top--xl--spacer: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--m-align-top--MarginTop: var(--pf-c-modal-box--m-align-top--spacer);
-  --pf-c-modal-box--m-align-top--MaxHeight: calc(100% - var(--pf-c-modal-box--m-align-top--spacer) * 2);
-  --pf-c-modal-box--m-align-top--MaxWidth: calc(100% - var(--pf-c-modal-box--m-align-top--spacer) * 2);
+  --pf-c-modal-box--m-align-top--Top: var(--pf-c-modal-box--m-align-top--spacer);
+  --pf-c-modal-box--m-align-top--MaxHeight: calc(100% - min(var(--pf-c-modal-box--m-align-top--spacer), var(--pf-global--spacer--2xl)) - var(--pf-c-modal-box--m-align-top--spacer));
+  --pf-c-modal-box--m-align-top--MaxWidth: calc(100% - min(var(--pf-c-modal-box--m-align-top--spacer) * 2, var(--pf-global--spacer--xl)));
 
   @media (min-width: $pf-global--breakpoint--xl) {
     --pf-c-modal-box--m-align-top--spacer: var(--pf-c-modal-box--m-align-top--xl--spacer);
@@ -78,10 +78,10 @@
   }
 
   &.pf-m-align-top {
+    top: var(--pf-c-modal-box--m-align-top--Top);
     align-self: flex-start;
     max-width: var(--pf-c-modal-box--m-align-top--MaxWidth);
     max-height: var(--pf-c-modal-box--m-align-top--MaxHeight);
-    margin-top: var(--pf-c-modal-box--m-align-top--MarginTop);
   }
 
   // Close button

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -10,7 +10,7 @@
   --pf-c-modal-box--MaxHeight: calc(100% - var(--pf-global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
   --pf-c-modal-box--m-align-top--spacer: var(--pf-global--spacer--sm);
   --pf-c-modal-box--m-align-top--xl--spacer: var(--pf-global--spacer--xl);
-  --pf-c-modal-box--m-align-top--Top: var(--pf-c-modal-box--m-align-top--spacer);
+  --pf-c-modal-box--m-align-top--MarginTop: var(--pf-c-modal-box--m-align-top--spacer); // Rename to --Top at breaking change
   --pf-c-modal-box--m-align-top--MaxHeight: calc(100% - min(var(--pf-c-modal-box--m-align-top--spacer), var(--pf-global--spacer--2xl)) - var(--pf-c-modal-box--m-align-top--spacer));
   --pf-c-modal-box--m-align-top--MaxWidth: calc(100% - min(var(--pf-c-modal-box--m-align-top--spacer) * 2, var(--pf-global--spacer--xl)));
 
@@ -78,7 +78,7 @@
   }
 
   &.pf-m-align-top {
-    top: var(--pf-c-modal-box--m-align-top--Top);
+    top: var(--pf-c-modal-box--m-align-top--MarginTop);
     align-self: flex-start;
     max-width: var(--pf-c-modal-box--m-align-top--MaxWidth);
     max-height: var(--pf-c-modal-box--m-align-top--MaxHeight);


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/3480

yay `min()` and `max()`! 

refactored this a bit to
* use `top` instead of `margin-top` since percentage based values for `margin-top` will not work as intended.
* set smart values for min/max-width so that, if the top-aligned spacer is < the default left/right/bottom gutter for a modal, the gutters will match the spacer, creating equal space around the modal. But if the spacer is > the default gutter sizes, the default gutters are applied.