### PR TITLE
feat(date-picker): added date-picker, flatpickr styles

### DIFF
--- a/src/patternfly/components/DatePicker/date-picker-calendar.hbs
+++ b/src/patternfly/components/DatePicker/date-picker-calendar.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-date-picker__calendar{{#if date-picker-calendar--modifier}} {{date-picker-calendar--modifier}}{{/if}}"
+  {{#if date-picker-calendar--attribute}}
+    {{date-picker-calendar--attribute}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/DatePicker/date-picker-helper-text.hbs
+++ b/src/patternfly/components/DatePicker/date-picker-helper-text.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-date-picker__helper-text{{#if date-picker-helper-text--IsError}} pf-m-error{{/if}}{{#if date-picker-helper-text--modifier}} {{date-picker-helper-text--modifier}}{{/if}}"
+  {{#if date-picker-helper-text--attribute}}
+    {{date-picker-helper-text--attribute}}
+  {{/if}}>
+  {{date-picker-helper-text--text}}
+</div>

--- a/src/patternfly/components/DatePicker/date-picker-input.hbs
+++ b/src/patternfly/components/DatePicker/date-picker-input.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-date-picker__input{{#if date-picker-input--modifier}} {{date-picker-input--modifier}}{{/if}}"
+  {{#if date-picker-input--attribute}}
+    {{date-picker-input--attribute}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/DatePicker/date-picker.hbs
+++ b/src/patternfly/components/DatePicker/date-picker.hbs
@@ -6,4 +6,9 @@
   {{#if date-picker-helper-text--text}}
     {{> date-picker-helper-text}}
   {{/if}}
+  {{#if date-picker--IsExpanded}}
+    {{#> date-picker-calendar}}
+      Calendar
+    {{/date-picker-calendar}}
+  {{/if}}
 </div>

--- a/src/patternfly/components/DatePicker/date-picker.hbs
+++ b/src/patternfly/components/DatePicker/date-picker.hbs
@@ -1,0 +1,9 @@
+<div class="pf-c-date-picker{{#if date-picker--modifier}} {{date-picker--modifier}}{{/if}}"
+  {{#if date-picker--attribute}}
+    {{date-picker--attribute}}
+  {{/if}}>
+  {{> date-picker-input}}
+  {{#if date-picker-helper-text--text}}
+    {{> date-picker-helper-text}}
+  {{/if}}
+</div>

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,8 +1,20 @@
 .pf-c-date-picker {
+  --pf-c-date-picker--m-top__calendar--Top: 0;
+  --pf-c-date-picker--m-top__calendar--TranslateY: calc(-100% - var(--pf-global--spacer--xs));
   --pf-c-date-picker__helper-text--MarginTop: var(--pf-global--spacer--xs);
   --pf-c-date-picker__helper-text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-date-picker__helper-text--Color: var(--pf-global--Color--100);
   --pf-c-date-picker__helper-text--m-error--Color: var(--pf-global--danger-color--100);
+  --pf-c-date-picker__calendar--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__calendar--BoxShadow: var(--pf-global--BoxShadow--md);
+  --pf-c-date-picker__calendar--ZIndex: var(--pf-global--ZIndex--sm);
+  --pf-c-date-picker__calendar--Top: calc(100% + var(--pf-global--spacer--xs));
+  --pf-c-date-picker__calendar--Right: auto;
+  --pf-c-date-picker__calendar--Left: 0;
+  --pf-c-date-picker__calendar--m-align-right--Right: 0;
+  --pf-c-date-picker__calendar--m-align-right--Left: auto;
+
+  position: relative;
 }
 
 .pf-c-date-picker__helper-text {
@@ -12,5 +24,26 @@
 
   &.pf-m-error {
     --pf-c-date-picker__helper-text--Color: var(--pf-c-date-picker__helper-text--m-error--Color);
+  }
+}
+
+.pf-c-date-picker__calendar {
+  position: absolute;
+  top: var(--pf-c-date-picker__calendar--Top);
+  right: var(--pf-c-date-picker__calendar--Right);
+  left: var(--pf-c-date-picker__calendar--Left);
+  z-index: var(--pf-c-date-picker__calendar--ZIndex);
+  background-color: var(--pf-c-date-picker__calendar--BackgroundColor);
+  box-shadow: var(--pf-c-date-picker__calendar--BoxShadow);
+
+  &.pf-m-align-right {
+    --pf-c-date-picker__calendar--Right: var(--pf-c-date-picker__calendar--m-align-right--Right);
+    --pf-c-date-picker__calendar--Left: var(--pf-c-date-picker__calendar--m-align-right--Left);
+  }
+
+  .pf-c-date-picker.pf-m-top & {
+    --pf-c-date-picker__calendar--Top: var(--pf-c-date-picker--m-top__calendar--Top);
+
+    transform: translateY(var(--pf-c-date-picker--m-top__calendar--TranslateY));
   }
 }

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,0 +1,16 @@
+.pf-c-date-picker {
+  --pf-c-date-picker__helper-text--MarginTop: var(--pf-global--spacer--xs);
+  --pf-c-date-picker__helper-text--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-date-picker__helper-text--Color: var(--pf-global--Color--100);
+  --pf-c-date-picker__helper-text--m-error--Color: var(--pf-global--danger-color--100);
+}
+
+.pf-c-date-picker__helper-text {
+  margin-top: var(--pf-c-date-picker__helper-text--MarginTop);
+  font-size: var(--pf-c-date-picker__helper-text--FontSize);
+  color: var(--pf-c-date-picker__helper-text--Color);
+
+  &.pf-m-error {
+    --pf-c-date-picker__helper-text--Color: var(--pf-c-date-picker__helper-text--m-error--Color);
+  }
+}

--- a/src/patternfly/components/DatePicker/examples/DatePicker.css
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.css
@@ -1,0 +1,3 @@
+#ws-core-c-date-picker-expanded {
+  height: 100px;
+}

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -5,6 +5,8 @@ section: components
 cssPrefix: pf-c-date-picker
 ---
 
+import './DatePicker.css'
+
 ## Examples
 
 ### Basic
@@ -23,20 +25,19 @@ cssPrefix: pf-c-date-picker
 
 ### Invalid
 ```hbs
-{{#> date-picker date-picker--id="Invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
+{{#> date-picker date-picker--id="invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
   {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'aria-invalid="true" type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
 {{/date-picker}}
 ```
 
+### Expanded
+```hbs
+{{#> date-picker date-picker--id="expanded" date-picker--IsExpanded="true"}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar pf-m-expanded" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Expanded date picker example"')}}
+{{/date-picker}}
+```
+
 ## Documentation
-
-
-### Accessibility
-
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `title` | `.pf-c-description-list` | Provides an accessible title for the description list. **Required** |
-
 ### Usage
 
 | Class | Applied to | Outcome |
@@ -44,4 +45,7 @@ cssPrefix: pf-c-date-picker
 | `.pf-c-date-picker` | `<div>` | Initiates the date picker component. **Required** |
 | `.pf-c-date-picker__input` | `<div>` | Initiates the date picker input container. **Required** |
 | `.pf-c-date-picker__helper-text` | `<div>` | Initiates the date picker helper text. |
+| `.pf-c-date-picker__calendar` | `<div>` | Initiates an optional date picker calendar container. **Note:** Required in the react date picker component. |
+| `.pf-m-top` | `.pf-c-date-picker` | Modifies to display the calendar above the date picker. |
 | `.pf-m-error` | `.pf-c-date-picker__helper-text` | Modifies the helper text for the invalid/error state. |
+| `.pf-m-align-right` | `.pf-c-date-picker__calendar` | Modifies the calendar to align the calendar to the right edge of the date picker. |

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -1,0 +1,47 @@
+---
+id: 'Date picker'
+beta: true
+section: components
+cssPrefix: pf-c-date-picker
+---
+
+## Examples
+
+### Basic
+```hbs
+{{#> date-picker date-picker--id="basic"}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+{{/date-picker}}
+```
+
+### Helper text
+```hbs
+{{#> date-picker date-picker--id="helper-text" date-picker-helper-text--text="Select a date."}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+{{/date-picker}}
+```
+
+### Invalid
+```hbs
+{{#> date-picker date-picker--id="Invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'aria-invalid="true" type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+{{/date-picker}}
+```
+
+## Documentation
+
+
+### Accessibility
+
+| Attribute | Applied to | Outcome |
+| -- | -- | -- |
+| `title` | `.pf-c-description-list` | Provides an accessible title for the description list. **Required** |
+
+### Usage
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-date-picker` | `<div>` | Initiates the date picker component. **Required** |
+| `.pf-c-date-picker__input` | `<div>` | Initiates the date picker input container. **Required** |
+| `.pf-c-date-picker__helper-text` | `<div>` | Initiates the date picker helper text. |
+| `.pf-m-error` | `.pf-c-date-picker__helper-text` | Modifies the helper text for the invalid/error state. |

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -21,6 +21,8 @@ import './FormControl.css'
 <br><br>
 {{> form-control controlType="input" input="true" form-control--attribute='disabled type="text" value="Disabled" id="input-disabled" aria-label="Disabled input example"'}}
 <br><br>
+{{> form-control controlType="input" input="true" form-control--IsExpanded="true" form-control--attribute='type="text" value="Expanded" id="input-expanded" aria-label="Expanded input example"'}}
+<br><br>
 {{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute='type="search" value="Search" id="input-search" name="search-input" aria-label="Search input example"'}}
 <br><br>
 {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute='type="text" value="Calendar" id="input-calendar" name="input-calendar" aria-label="Calendar input example"'}}
@@ -130,6 +132,7 @@ Resizes horizontally
 | `id` | `.pf-c-form-control` | Provides an `id` value that can be used with the `for` attribute on an associated `<label>` element to provide an accessible label for the form control element.
 | `aria-invalid="true"` | `.pf-c-form-control` | Indicates that the form control is in the error state and applies error state styling. |
 | `aria-label="descriptive text"` | `.pf-c-form-control` | Provides an accessible label for assistive technology. |
+| `aria-expanded="true"` | `.pf-c-form-control.pf-m-expanded` | Indicates that clicking in the form control has toggled something else to be expanded. |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -143,3 +146,4 @@ Resizes horizontally
 | `.pf-m-icon` | `input.pf-c-form-control` | Modifies a form control text input to be able to specify a custom SVG background via `--pf-c-form-control--m-icon--BackgroundUrl`, and other optional vars for other background properties.
 | `.pf-m-calendar` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the calendar icon. |
 | `.pf-m-clock` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the clock icon. |
+| `.pf-m-expanded` | `input.pf-c-form-control` | Modifies a form control for the expanded state. This is used when clicking in the text input toggles something open/closed. |

--- a/src/patternfly/components/FormControl/form-control.hbs
+++ b/src/patternfly/components/FormControl/form-control.hbs
@@ -1,4 +1,7 @@
-<{{controlType}} class="pf-c-form-control{{#if form-control--modifier}} {{form-control--modifier}}{{/if}}"
+<{{controlType}} class="pf-c-form-control{{#if form-control--IsExpanded}} pf-m-expanded{{/if}}{{#if form-control--modifier}} {{form-control--modifier}}{{/if}}"
+  {{#if form-control--IsExpanded}}
+    aria-expanded="true"
+  {{/if}}
   {{#if form-control--attribute}}
     {{{form-control--attribute}}}
 	{{/if}}

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -53,6 +53,11 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   --pf-c-form-control--focus--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--focus--BorderBottomWidth));
   --pf-c-form-control--focus--BorderBottomColor: var(--pf-global--primary-color--100);
 
+  // focus
+  --pf-c-form-control--m-expanded--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-form-control--m-expanded--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--focus--BorderBottomWidth));
+  --pf-c-form-control--m-expanded--BorderBottomColor: var(--pf-global--primary-color--100);
+
   // input placeholder style
   --pf-c-form-control--placeholder--Color: var(--pf-global--Color--dark-200);
 
@@ -221,6 +226,13 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
 
     padding-bottom: var(--pf-c-form-control--focus--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
     border-bottom-width: var(--pf-c-form-control--focus--BorderBottomWidth);
+  }
+
+  &.pf-m-expanded {
+    --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--m-expanded--BorderBottomColor);
+
+    padding-bottom: var(--pf-c-form-control--m-expanded--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
+    border-bottom-width: var(--pf-c-form-control--m-expanded--BorderBottomWidth);
   }
 
   &:disabled {

--- a/src/patternfly/components/_all.scss
+++ b/src/patternfly/components/_all.scss
@@ -24,6 +24,7 @@
 
 // @import "./DescriptionList/description-list-order.scss";
 @import "./Toolbar/toolbar.scss";
+@import "./DatePicker/date-picker.scss";
 @import "./Divider/divider.scss";
 @import "./Drawer/drawer.scss";
 @import "./Dropdown/dropdown.scss";

--- a/src/patternfly/patternfly-date-picker.scss
+++ b/src/patternfly/patternfly-date-picker.scss
@@ -4,6 +4,7 @@
     // calendar
     --pf-c-date-picker__flatpickr__calendar--Background: var(--pf-global--BackgroundColor--light-100);
     --pf-c-date-picker__flatpickr__calendar--Padding: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__calendar--open--ZIndex: var(--pf-global--ZIndex--sm);
 
     // month/year section
     --pf-c-date-picker__flatpickr__months--PaddingBottom: var(--pf-global--spacer--md);
@@ -38,6 +39,10 @@
     // flatpickr container
     background: var(--pf-c-date-picker__flatpickr__calendar--Background);
     padding: var(--pf-c-date-picker__flatpickr__calendar--Padding);
+
+    &.open {
+      z-index: var(--pf-c-date-picker__flatpickr__calendar--open--ZIndex);
+    }
   }
 
   .flatpickr-innerContainer {

--- a/src/patternfly/patternfly-date-picker.scss
+++ b/src/patternfly/patternfly-date-picker.scss
@@ -1,143 +1,145 @@
 // stylelint-disable
-.flatpickr-calendar {
-  // calendar
-  --pf-c-date-picker__flatpickr__calendar--Background: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-date-picker__flatpickr__calendar--Padding: var(--pf-global--spacer--md);
+.pf-c-date-picker__calendar {
+  &.flatpickr-calendar {
+    // calendar
+    --pf-c-date-picker__flatpickr__calendar--Background: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__calendar--Padding: var(--pf-global--spacer--md);
 
-  // month/year section
-  --pf-c-date-picker__flatpickr__months--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-date-picker__flatpickr__month--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-date-picker__flatpickr__month-select--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-date-picker__flatpickr__month-select--year--MarginLeft: var(--pf-global--spacer--sm);
-  --pf-c-date-picker__flatpickr__month-arrow--Color: var(--pf-global--Color--dark-200);
-  --pf-c-date-picker__flatpickr__month-arrow--hover--Color: var(--pf-global--Color--dark-100);
-  --pf-c-date-picker__flatpickr__year--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    // month/year section
+    --pf-c-date-picker__flatpickr__months--PaddingBottom: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__month--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__month-select--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__month-select--year--MarginLeft: var(--pf-global--spacer--sm);
+    --pf-c-date-picker__flatpickr__month-arrow--Color: var(--pf-global--Color--dark-200);
+    --pf-c-date-picker__flatpickr__month-arrow--hover--Color: var(--pf-global--Color--dark-100);
+    --pf-c-date-picker__flatpickr__year--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+
+    // Weekdays section
+    --pf-c-date-picker__flatpickr__weekdays--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__weekdays--PaddingBottom: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__weekdays--MarginBottom: var(--pf-global--spacer--sm);
+    --pf-c-date-picker__flatpickr__weekdays--BorderBottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    --pf-c-date-picker__flatpickr__weekday--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+
+    // Calendar days
+    --pf-c-date-picker__flatpickr__calendar__day--Color: var(--pf-global--Color--dark-100);
+    --pf-c-date-picker__flatpickr__calendar__day--disabled--Color: var(--pf-global--disabled-color--200);
+    --pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor: var(--pf-global--BackgroundColor--light-300);
+    --pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+    --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--primary-color--100);
+    --pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background: var(--pf-global--primary-color--100);
+    --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--Color--light-100);
+    --pf-c-date-picker__flatpickr__calendar__day--today--BorderColor: var(--pf-global--primary-color--100);
+    --pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor: var(--pf-global--primary-color--100);
+    --pf-c-date-picker__flatpickr__calendar__day--today--hover--Background: var(--pf-global--primary-color--100);
+    --pf-c-date-picker__flatpickr__calendar__day--today--hover--Color: var(--pf-global--Color--light-100);
+
+    // flatpickr container
+    background: var(--pf-c-date-picker__flatpickr__calendar--Background);
+    padding: var(--pf-c-date-picker__flatpickr__calendar--Padding);
+  }
+
+  .flatpickr-innerContainer {
+    border: 0;
+  }
+
+  // Month/year section
+  .flatpickr-months .flatpickr-month {
+    background: var(--pf-c-date-picker__flatpickr__month--BackgroundColor);
+  }
+
+  .flatpickr-current-month .flatpickr-monthDropdown-months {
+    background: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
+  }
+
+  .flatpickr-current-month .flatpickr-monthDropdown-months:hover {
+    background: var(--pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor);
+  }
+
+  .numInputWrapper:hover {
+    background: var(--pf-c-date-picker__flatpickr__year--hover--BackgroundColor);
+  }
+
+  .flatpickr-months .flatpickr-next-month,
+  .flatpickr-months .flatpickr-prev-month {
+    color: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
+    fill: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
+  }
+
+  .flatpickr-months .flatpickr-next-month:hover,
+  .flatpickr-months .flatpickr-prev-month:hover,
+  .flatpickr-months .flatpickr-next-month:hover svg,
+  .flatpickr-months .flatpickr-prev-month:hover svg {
+    color: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
+    fill: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
+  }
+
+  .flatpickr-months {
+    position: relative;
+    padding-bottom: var(--pf-c-date-picker__flatpickr__months--PaddingBottom);
+  }
+
+  .flatpickr-monthDropdown-months + .numInputWrapper {
+    margin-left: var(--pf-c-date-picker__flatpickr__month-select--year--MarginLeft);
+  }
 
   // Weekdays section
-  --pf-c-date-picker__flatpickr__weekdays--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-date-picker__flatpickr__weekdays--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-date-picker__flatpickr__weekdays--MarginBottom: var(--pf-global--spacer--sm);
-  --pf-c-date-picker__flatpickr__weekdays--BorderBottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-  --pf-c-date-picker__flatpickr__weekday--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  .flatpickr-weekdays {
+    background: var(--pf-c-date-picker__flatpickr__weekdays--BackgroundColor);
+  }
+
+  span.flatpickr-weekday {
+    background: var(--pf-c-date-picker__flatpickr__weekday--BackgroundColor);
+  }
+
+  .flatpickr-weekdays {
+    padding-bottom: var(--pf-c-date-picker__flatpickr__weekdays--PaddingBottom);
+    margin-bottom: var(--pf-c-date-picker__flatpickr__weekdays--MarginBottom);
+    border-bottom: var(--pf-c-date-picker__flatpickr__weekdays--BorderBottom);
+  }
 
   // Calendar days
-  --pf-c-date-picker__flatpickr__calendar__day--Color: var(--pf-global--Color--dark-100);
-  --pf-c-date-picker__flatpickr__calendar__day--disabled--Color: var(--pf-global--disabled-color--200);
-  --pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
-  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background: var(--pf-global--primary-color--100);
-  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--Color--light-100);
-  --pf-c-date-picker__flatpickr__calendar__day--today--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor: var(--pf-global--primary-color--100);
-  --pf-c-date-picker__flatpickr__calendar__day--today--hover--Background: var(--pf-global--primary-color--100);
-  --pf-c-date-picker__flatpickr__calendar__day--today--hover--Color: var(--pf-global--Color--light-100);
+  .flatpickr-days {
+    border: 0;
+  }
 
-  // flatpickr container
-  background: var(--pf-c-date-picker__flatpickr__calendar--Background);
-  padding: var(--pf-c-date-picker__flatpickr__calendar--Padding);
-}
+  .flatpickr-day:focus,
+  .flatpickr-day:hover {
+    border-color: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor);
+    background: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor);
+  }
 
-.flatpickr-innerContainer {
-  border: 0;
-}
+  .flatpickr-day.selected,
+  .flatpickr-day.selected:focus,
+  .flatpickr-day.selected:hover {
+    border-color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
+    background: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background);
+    color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
+  }
 
-// Month/year section
-.flatpickr-months .flatpickr-month {
-  background: var(--pf-c-date-picker__flatpickr__month--BackgroundColor);
-}
+  .flatpickr-day.flatpickr-disabled,
+  .flatpickr-day.flatpickr-disabled:hover,
+  .flatpickr-day.nextMonthDay,
+  .flatpickr-day.notAllowed,
+  .flatpickr-day.notAllowed.nextMonthDay,
+  .flatpickr-day.notAllowed.prevMonthDay,
+  .flatpickr-day.prevMonthDay {
+    color: var(--pf-c-date-picker__flatpickr__calendar__day--disabled--Color);
+  }
 
-.flatpickr-current-month .flatpickr-monthDropdown-months {
-  background: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
-}
+  .flatpickr-day {
+    color: var(--pf-c-date-picker__flatpickr__calendar__day--Color);
+  }
 
-.flatpickr-current-month .flatpickr-monthDropdown-months:hover {
-  background: var(--pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor);
-}
+  .flatpickr-day.today {
+    border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--BorderColor);
+  }
 
-.numInputWrapper:hover {
-  background: var(--pf-c-date-picker__flatpickr__year--hover--BackgroundColor);
-}
-
-.flatpickr-months .flatpickr-next-month,
-.flatpickr-months .flatpickr-prev-month {
-  color: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
-  fill: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
-}
-
-.flatpickr-months .flatpickr-next-month:hover,
-.flatpickr-months .flatpickr-prev-month:hover,
-.flatpickr-months .flatpickr-next-month:hover svg,
-.flatpickr-months .flatpickr-prev-month:hover svg {
-  color: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
-  fill: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
-}
-
-.flatpickr-months {
-  position: relative;
-  padding-bottom: var(--pf-c-date-picker__flatpickr__months--PaddingBottom);
-}
-
-.flatpickr-monthDropdown-months + .numInputWrapper {
-  margin-left: var(--pf-c-date-picker__flatpickr__month-select--year--MarginLeft);
-}
-
-// Weekdays section
-.flatpickr-weekdays {
-  background: var(--pf-c-date-picker__flatpickr__weekdays--BackgroundColor);
-}
-
-span.flatpickr-weekday {
-  background: var(--pf-c-date-picker__flatpickr__weekday--BackgroundColor);
-}
-
-.flatpickr-weekdays {
-  padding-bottom: var(--pf-c-date-picker__flatpickr__weekdays--PaddingBottom);
-  margin-bottom: var(--pf-c-date-picker__flatpickr__weekdays--MarginBottom);
-  border-bottom: var(--pf-c-date-picker__flatpickr__weekdays--BorderBottom);
-}
-
-// Calendar days
-.flatpickr-days {
-  border: 0;
-}
-
-.flatpickr-day:focus,
-.flatpickr-day:hover {
-  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor);
-  background: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor);
-}
-
-.flatpickr-day.selected,
-.flatpickr-day.selected:focus,
-.flatpickr-day.selected:hover {
-  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
-  background: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background);
-  color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
-}
-
-.flatpickr-day.flatpickr-disabled,
-.flatpickr-day.flatpickr-disabled:hover,
-.flatpickr-day.nextMonthDay,
-.flatpickr-day.notAllowed,
-.flatpickr-day.notAllowed.nextMonthDay,
-.flatpickr-day.notAllowed.prevMonthDay,
-.flatpickr-day.prevMonthDay {
-  color: var(--pf-c-date-picker__flatpickr__calendar__day--disabled--Color);
-}
-
-.flatpickr-day {
-  color: var(--pf-c-date-picker__flatpickr__calendar__day--Color);
-}
-
-.flatpickr-day.today {
-  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--BorderColor);
-}
-
-.flatpickr-day.today:focus,
-.flatpickr-day.today:hover {
-  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor);
-  background: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Background);
-  color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Color);
+  .flatpickr-day.today:focus,
+  .flatpickr-day.today:hover {
+    border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor);
+    background: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Background);
+    color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Color);
+  }
 }

--- a/src/patternfly/patternfly-date-picker.scss
+++ b/src/patternfly/patternfly-date-picker.scss
@@ -2,8 +2,10 @@
 .pf-c-date-picker__calendar {
   &.flatpickr-calendar {
     // calendar
-    --pf-c-date-picker__flatpickr__calendar--Background: var(--pf-global--BackgroundColor--light-100);
-    --pf-c-date-picker__flatpickr__calendar--Padding: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__calendar--PaddingTop: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__calendar--PaddingRight: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__calendar--PaddingBottom: var(--pf-global--spacer--md);
+    --pf-c-date-picker__flatpickr__calendar--PaddingLeft: var(--pf-global--spacer--md);
     --pf-c-date-picker__flatpickr__calendar--open--ZIndex: var(--pf-global--ZIndex--sm);
 
     // month/year section
@@ -29,7 +31,8 @@
     --pf-c-date-picker__flatpickr__weekdays--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
     --pf-c-date-picker__flatpickr__weekdays--PaddingBottom: var(--pf-global--spacer--md);
     --pf-c-date-picker__flatpickr__weekdays--MarginBottom: var(--pf-global--spacer--sm);
-    --pf-c-date-picker__flatpickr__weekdays--BorderBottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    --pf-c-date-picker__flatpickr__weekdays--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+    --pf-c-date-picker__flatpickr__weekdays--BorderBottomColor: var(--pf-global--BorderColor--100);
     --pf-c-date-picker__flatpickr__weekday--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
 
     // Calendar days
@@ -46,8 +49,7 @@
     --pf-c-date-picker__flatpickr__calendar__day--today--hover--Color: var(--pf-global--Color--light-100);
 
     // flatpickr container
-    background: var(--pf-c-date-picker__flatpickr__calendar--Background);
-    padding: var(--pf-c-date-picker__flatpickr__calendar--Padding);
+    padding: var(--pf-c-date-picker__flatpickr__calendar--PaddingTop) var(--pf-c-date-picker__flatpickr__calendar--PaddingRight) var(--pf-c-date-picker__flatpickr__calendar--PaddingBottom) var(--pf-c-date-picker__flatpickr__calendar--PaddingLeft);
 
     &.open {
       z-index: var(--pf-c-date-picker__flatpickr__calendar--open--ZIndex);
@@ -128,7 +130,7 @@
   .flatpickr-weekdays {
     padding-bottom: var(--pf-c-date-picker__flatpickr__weekdays--PaddingBottom);
     margin-bottom: var(--pf-c-date-picker__flatpickr__weekdays--MarginBottom);
-    border-bottom: var(--pf-c-date-picker__flatpickr__weekdays--BorderBottom);
+    border-bottom: var(--pf-c-date-picker__flatpickr__weekdays--BorderBottomWidth) solid var(--pf-c-date-picker__flatpickr__weekdays--BorderBottomColor);
   }
 
   // Calendar days

--- a/src/patternfly/patternfly-date-picker.scss
+++ b/src/patternfly/patternfly-date-picker.scss
@@ -9,12 +9,21 @@
     // month/year section
     --pf-c-date-picker__flatpickr__months--PaddingBottom: var(--pf-global--spacer--md);
     --pf-c-date-picker__flatpickr__month--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__month--PaddingTop: 10px;
+    --pf-c-date-picker__flatpickr__month--FontSize: var(--pf-global--FontSize--md);
+    --pf-c-date-picker__flatpickr__month-select--PaddingRight: var(--pf-global--spacer--lg);
+    --pf-c-date-picker__flatpickr__month-select--FontWeight: var(--pf-global--FontWeight--normal);
+    --pf-c-date-picker__flatpickr__month-select--BackgroundUrl: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='%23urrentColor' d='M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z'/%3E%3C/svg%3E");;
+    --pf-c-date-picker__flatpickr__month-select--BackgroundSize: .625em;
+    --pf-c-date-picker__flatpickr__month-select--BackgroundPosition: calc(100% - var(--pf-global--spacer--sm)) center;
     --pf-c-date-picker__flatpickr__month-select--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-    --pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
     --pf-c-date-picker__flatpickr__month-select--year--MarginLeft: var(--pf-global--spacer--sm);
+    --pf-c-date-picker__flatpickr__month-arrow--Width: 7px;
     --pf-c-date-picker__flatpickr__month-arrow--Color: var(--pf-global--Color--dark-200);
     --pf-c-date-picker__flatpickr__month-arrow--hover--Color: var(--pf-global--Color--dark-100);
     --pf-c-date-picker__flatpickr__year--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+    --pf-c-date-picker__flatpickr__year--FontWeight: var(--pf-global--FontWeight--normal);
 
     // Weekdays section
     --pf-c-date-picker__flatpickr__weekdays--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
@@ -50,16 +59,34 @@
   }
 
   // Month/year section
+  .flatpickr-months {
+    position: relative;
+    padding-bottom: var(--pf-c-date-picker__flatpickr__months--PaddingBottom);
+  }
+
   .flatpickr-months .flatpickr-month {
     background: var(--pf-c-date-picker__flatpickr__month--BackgroundColor);
   }
 
+  .flatpickr-current-month {
+    padding-top: var(--pf-c-date-picker__flatpickr__month--PaddingTop);
+    font-size: var(--pf-c-date-picker__flatpickr__month--FontSize);
+  }
+
   .flatpickr-current-month .flatpickr-monthDropdown-months {
-    background: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background-image: var(--pf-c-date-picker__flatpickr__month-select--BackgroundUrl);
+    background-position: var(--pf-c-date-picker__flatpickr__month-select--BackgroundPosition);
+    background-size: var(--pf-c-date-picker__flatpickr__month-select--BackgroundSize);
+    background-repeat: no-repeat;
+    background-color: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
+    font-weight: var(--pf-c-date-picker__flatpickr__month-select--FontWeight);
+    padding-right: var(--pf-c-date-picker__flatpickr__month-select--PaddingRight);
   }
 
   .flatpickr-current-month .flatpickr-monthDropdown-months:hover {
-    background: var(--pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor);
+    --pf-c-date-picker__flatpickr__month-select--BackgroundColor: var(--pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor);
   }
 
   .numInputWrapper:hover {
@@ -70,6 +97,7 @@
   .flatpickr-months .flatpickr-prev-month {
     color: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
     fill: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
+    width: var(--pf-c-date-picker__flatpickr__month-arrow--Width);
   }
 
   .flatpickr-months .flatpickr-next-month:hover,
@@ -80,13 +108,12 @@
     fill: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
   }
 
-  .flatpickr-months {
-    position: relative;
-    padding-bottom: var(--pf-c-date-picker__flatpickr__months--PaddingBottom);
-  }
-
   .flatpickr-monthDropdown-months + .numInputWrapper {
     margin-left: var(--pf-c-date-picker__flatpickr__month-select--year--MarginLeft);
+  }
+
+  .flatpickr-current-month input.cur-year {
+    font-weight: var(--pf-c-date-picker__flatpickr__year--FontWeight);
   }
 
   // Weekdays section

--- a/src/patternfly/patternfly-date-picker.scss
+++ b/src/patternfly/patternfly-date-picker.scss
@@ -1,0 +1,143 @@
+// stylelint-disable
+.flatpickr-calendar {
+  // calendar
+  --pf-c-date-picker__flatpickr__calendar--Background: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__flatpickr__calendar--Padding: var(--pf-global--spacer--md);
+
+  // month/year section
+  --pf-c-date-picker__flatpickr__months--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-date-picker__flatpickr__month--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__flatpickr__month-select--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__flatpickr__month-select--year--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-date-picker__flatpickr__month-arrow--Color: var(--pf-global--Color--dark-200);
+  --pf-c-date-picker__flatpickr__month-arrow--hover--Color: var(--pf-global--Color--dark-100);
+  --pf-c-date-picker__flatpickr__year--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+
+  // Weekdays section
+  --pf-c-date-picker__flatpickr__weekdays--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-date-picker__flatpickr__weekdays--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-date-picker__flatpickr__weekdays--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-date-picker__flatpickr__weekdays--BorderBottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  --pf-c-date-picker__flatpickr__weekday--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+
+  // Calendar days
+  --pf-c-date-picker__flatpickr__calendar__day--Color: var(--pf-global--Color--dark-100);
+  --pf-c-date-picker__flatpickr__calendar__day--disabled--Color: var(--pf-global--disabled-color--200);
+  --pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background: var(--pf-global--primary-color--100);
+  --pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor: var(--pf-global--Color--light-100);
+  --pf-c-date-picker__flatpickr__calendar__day--today--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-date-picker__flatpickr__calendar__day--today--hover--Background: var(--pf-global--primary-color--100);
+  --pf-c-date-picker__flatpickr__calendar__day--today--hover--Color: var(--pf-global--Color--light-100);
+
+  // flatpickr container
+  background: var(--pf-c-date-picker__flatpickr__calendar--Background);
+  padding: var(--pf-c-date-picker__flatpickr__calendar--Padding);
+}
+
+.flatpickr-innerContainer {
+  border: 0;
+}
+
+// Month/year section
+.flatpickr-months .flatpickr-month {
+  background: var(--pf-c-date-picker__flatpickr__month--BackgroundColor);
+}
+
+.flatpickr-current-month .flatpickr-monthDropdown-months {
+  background: var(--pf-c-date-picker__flatpickr__month-select--BackgroundColor);
+}
+
+.flatpickr-current-month .flatpickr-monthDropdown-months:hover {
+  background: var(--pf-c-date-picker__flatpickr__month-select--hover--BackgroundColor);
+}
+
+.numInputWrapper:hover {
+  background: var(--pf-c-date-picker__flatpickr__year--hover--BackgroundColor);
+}
+
+.flatpickr-months .flatpickr-next-month,
+.flatpickr-months .flatpickr-prev-month {
+  color: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
+  fill: var(--pf-c-date-picker__flatpickr__month-arrow--Color);
+}
+
+.flatpickr-months .flatpickr-next-month:hover,
+.flatpickr-months .flatpickr-prev-month:hover,
+.flatpickr-months .flatpickr-next-month:hover svg,
+.flatpickr-months .flatpickr-prev-month:hover svg {
+  color: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
+  fill: var(--pf-c-date-picker__flatpickr__month-arrow--hover--Color);
+}
+
+.flatpickr-months {
+  position: relative;
+  padding-bottom: var(--pf-c-date-picker__flatpickr__months--PaddingBottom);
+}
+
+.flatpickr-monthDropdown-months + .numInputWrapper {
+  margin-left: var(--pf-c-date-picker__flatpickr__month-select--year--MarginLeft);
+}
+
+// Weekdays section
+.flatpickr-weekdays {
+  background: var(--pf-c-date-picker__flatpickr__weekdays--BackgroundColor);
+}
+
+span.flatpickr-weekday {
+  background: var(--pf-c-date-picker__flatpickr__weekday--BackgroundColor);
+}
+
+.flatpickr-weekdays {
+  padding-bottom: var(--pf-c-date-picker__flatpickr__weekdays--PaddingBottom);
+  margin-bottom: var(--pf-c-date-picker__flatpickr__weekdays--MarginBottom);
+  border-bottom: var(--pf-c-date-picker__flatpickr__weekdays--BorderBottom);
+}
+
+// Calendar days
+.flatpickr-days {
+  border: 0;
+}
+
+.flatpickr-day:focus,
+.flatpickr-day:hover {
+  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BorderColor);
+  background: var(--pf-c-date-picker__flatpickr__calendar__day--hover--BackgroundColor);
+}
+
+.flatpickr-day.selected,
+.flatpickr-day.selected:focus,
+.flatpickr-day.selected:hover {
+  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
+  background: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--Background);
+  color: var(--pf-c-date-picker__flatpickr__calendar__day--selected--hover--BorderColor);
+}
+
+.flatpickr-day.flatpickr-disabled,
+.flatpickr-day.flatpickr-disabled:hover,
+.flatpickr-day.nextMonthDay,
+.flatpickr-day.notAllowed,
+.flatpickr-day.notAllowed.nextMonthDay,
+.flatpickr-day.notAllowed.prevMonthDay,
+.flatpickr-day.prevMonthDay {
+  color: var(--pf-c-date-picker__flatpickr__calendar__day--disabled--Color);
+}
+
+.flatpickr-day {
+  color: var(--pf-c-date-picker__flatpickr__calendar__day--Color);
+}
+
+.flatpickr-day.today {
+  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--BorderColor);
+}
+
+.flatpickr-day.today:focus,
+.flatpickr-day.today:hover {
+  border-color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--BorderColor);
+  background: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Background);
+  color: var(--pf-c-date-picker__flatpickr__calendar__day--today--hover--Color);
+}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/180

to test the flatpickr styles, you can import the compiled `patternfly-date-picker.css` in the root into this POC page http://datepicker-in-progress.surge.sh/documentation/react/components/datepicker

@nicolethoen right now I'm just styling the flatpickr classes directly. We'll want to scope these styles so that we only style our date picker instance of flatpickr, in case someone uses flatpickr on their site for some other purpose. Can we add a class to the `.flatpickr-calendar` element, or wrap it in a container so I can target the styles to the class we add?