### PR TITLE
fix(notification-badge): added hover/focus styles for unread/attention

### DIFF
--- a/src/patternfly/components/NotificationBadge/notification-badge.scss
+++ b/src/patternfly/components/NotificationBadge/notification-badge.scss
@@ -35,10 +35,12 @@
   // Unread
   --pf-c-notification-badge--m-unread--Color: var(--pf-global--Color--light-100);
   --pf-c-notification-badge--m-unread--after--BackgroundColor: var(--pf-global--active-color--100);
+  --pf-c-notification-badge--m-unread--hover--after--BackgroundColor: var(--pf-global--primary-color--200);
 
   // Attention
   --pf-c-notification-badge--m-attention--Color: var(--pf-global--Color--light-100);
   --pf-c-notification-badge--m-attention--after--BackgroundColor: var(--pf-global--danger-color--100);
+  --pf-c-notification-badge--m-attention--hover--after--BackgroundColor: var(--pf-global--danger-color--200);
   --pf-c-notification-badge__count--MarginLeft: var(--pf-global--spacer--xs);
 
   // Attention icon
@@ -94,12 +96,20 @@
     --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-notification-badge--m-unread--after--BackgroundColor);
 
     color: var(--pf-c-notification-badge--m-unread--Color);
+
+    &:hover {
+      --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-notification-badge--m-unread--hover--after--BackgroundColor);
+    }
   }
 
   &.pf-m-attention {
     --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-notification-badge--m-attention--after--BackgroundColor);
 
     color: var(--pf-c-notification-badge--m-attention--Color);
+
+    &:hover {
+      --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-notification-badge--m-attention--hover--after--BackgroundColor);
+    }
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -52,6 +52,10 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 
   // Header tools notification badge
   --pf-c-page__header-tools-item--c-notification-badge--hover--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  --pf-c-page__header-tools--c-button--notification-badge--m-unread--after--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-page__header-tools--c-button--notification-badge--m-attention--after--BackgroundColor: var(--pf-global--danger-color--200);
+  --pf-c-page__header-tools--c-button--m-selected--notification-badge--m-unread--after--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-page__header-tools--c-button--m-selected--notification-badge--m-attention--after--BackgroundColor: var(--pf-global--danger-color--200);
 
   // Header tools group button
   --pf-c-page__header-tools--c-button--m-selected--before--Width: auto;
@@ -293,12 +297,30 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
       // stylelint-disable
       .pf-c-notification-badge {
         &.pf-m-unread {
+          --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-page__header-tools--c-button--m-selected--notification-badge--m-unread--after--BackgroundColor);
+
           &::after {
             border-color: var(--pf-c-page__header-tools--c-button--m-selected--c-notification-badge--m-unread--after--BorderColor);
           }
         }
+
+        &.pf-m-attention {
+          --pf-c-notification-badge--after--BackgroundColor: var(--pf-global--danger-color--200);
+        }
       }
       // stylelint-enable
+    }
+  }
+
+  .pf-c-button:focus {
+    .pf-c-notification-badge {
+      &.pf-m-unread {
+        --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-page__header-tools--c-button--notification-badge--m-unread--after--BackgroundColor);
+      }
+
+      &.pf-m-attention {
+        --pf-c-notification-badge--after--BackgroundColor: var(--pf-c-page__header-tools--c-button--notification-badge--m-attention--after--BackgroundColor);
+      }
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3450

@mcarrano @mceledonia this works, and the color changes applies to the notification badge in a dark area (masthead) and light area (the example page). Though I'll note that we've traditionally made things lighter on hover/focus in dark theme, and this makes them darker. Just want to make sure I got that right?