### PR TITLE
fix(package): downgrade engines

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,9 +3,9 @@ id: Release notes
 section: get-started
 releaseNoteTOC: true
 ---
-## 2020.12 release notes (2020-09-16)
+## 2020.12 release notes (2020-09-17)
 Packages released:
-- [@patternfly/patternfly@v4.41.1](https://www.npmjs.com/package/@patternfly/patternfly/v/4.41.1)
+- [@patternfly/patternfly@v4.42.2](https://www.npmjs.com/package/@patternfly/patternfly/v/4.42.2)
 
 ### Components
 - **Button:**
@@ -37,7 +37,10 @@ Packages released:
 - **Docs:**
   - Updated form demo id to match component id ([#3428](https://github.com/patternfly/patternfly/pull/3428))
   - Added section for hover styles ([#3432](https://github.com/patternfly/patternfly/pull/3432))
-- **Build:** Bump stylelint ([#3427](https://github.com/patternfly/patternfly/pull/3427))
+- **Build:**
+  - Bumped stylelint ([#3427](https://github.com/patternfly/patternfly/pull/3427))
+  - Upgraded workspace to use new patternfly.org theme ([#3486](https://github.com/patternfly/patternfly/pull/3486))
+  - Removed required "engines" section from package.json ([#3490](https://github.com/patternfly/patternfly/pull/3490))
 - **Icons:**
   - Removed transforms from pficons, added namespaces ([#3398](https://github.com/patternfly/patternfly/pull/3398))
   - Updated pficon data to fix svg rendering issues ([#3469](https://github.com/patternfly/patternfly/pull/3469))

--- a/package.json
+++ b/package.json
@@ -92,10 +92,6 @@
     "unified": "^9.2.0",
     "webpack": "^4.43.0"
   },
-  "engines": {
-    "node": ">=12.0.0",
-    "npm": ">=6.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/patternfly/patternfly.git"


### PR DESCRIPTION
While node>=12 is required to build and develop the workspace, the `"engines"` section limits what versions of node consumers must use to consume the `dist` folder. It's best to let consumers use whatever versions they want and instead rely on the version listed in the README for development (which is currently Node 12).