### PR TITLE
fix(inputgroup): fix double line in invalid

### DIFF
--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -17,7 +17,7 @@
 
   // Form control
   --pf-c-input-group--c-form-control--invalid--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-input-group--c-form-control--MarginRight: 1px;
+  --pf-c-input-group--c-form-control--MarginRight: 0;
 
   // This component always needs to be light
   @include pf-t-light;


### PR DESCRIPTION
closes #2732 

@mcoker can this be positioned as a bug so that I can remove the block and variable ?