### PR TITLE
chore(build): don't upload artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ jobs:
         name: Upload a11y report
         command: node .circleci/upload-preview.js coverage/dist
         when: always
-    - store_artifacts:
-        path: coverage/
     - persist_to_workspace:
         root: ~/project
         paths:


### PR DESCRIPTION
Speeds up builds ~1m20s. We upload them to surge and no longer need to upload them in CI since they're rather large now.