### PR TITLE
fix(progress): enabled static width for measure value

### DIFF
--- a/src/patternfly/components/Progress/examples/Progress.md
+++ b/src/patternfly/components/Progress/examples/Progress.md
@@ -152,7 +152,7 @@ cssPrefix: pf-c-progress
 {{#> progress
   progress__value="100"
   progress--modifier="pf-m-outside pf-m-lg"
-  progress__id="progress-outside-fixed-width-2-example"
+  progress__id="progress-outside-fixed-width-3-example"
   progress-measure--modifier="pf-m-fixed-width"
 }}
 {{/progress}}

--- a/src/patternfly/components/Progress/examples/Progress.md
+++ b/src/patternfly/components/Progress/examples/Progress.md
@@ -131,6 +131,33 @@ cssPrefix: pf-c-progress
 {{/progress}}
 ```
 
+### Outside fixed width measure
+```hbs
+{{#> progress
+  progress__value="1"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-fixed-width-example"
+  progress-measure--modifier="pf-m-fixed-width"
+}}
+{{/progress}}
+<br>
+{{#> progress
+  progress__value="50"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-fixed-width-2-example"
+  progress-measure--modifier="pf-m-fixed-width"
+}}
+{{/progress}}
+<br>
+{{#> progress
+  progress__value="100"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-fixed-width-2-example"
+  progress-measure--modifier="pf-m-fixed-width"
+}}
+{{/progress}}
+```
+
 ### On single line
 ```hbs
 {{#> progress
@@ -240,3 +267,4 @@ If this component is describing the loading progress of a particular region of a
 | `.pf-m-warning` | `.pf-c-progress` |  Changes the appearance of the progess component to indicate a warning state. |
 | `.pf-m-danger` | `.pf-c-progress` |  Changes the appearance of the progess component to indicate a danger (failure) state. |
 | `.pf-m-truncate` | `.pf-c-progress__description` | Modifies the description to display a single line and truncate any overflow text with ellipses. |
+| `.pf-m-fixed-width` | `.pf-c-progress.pf-m-outside .pf-c-progress__measure` | Modifies the measure element to be a fixed width that will hold 0-100%. Overridable by setting `--pf-c-progress__measure--m-fixed-width--Width`. |

--- a/src/patternfly/components/Progress/examples/Progress.md
+++ b/src/patternfly/components/Progress/examples/Progress.md
@@ -158,29 +158,38 @@ cssPrefix: pf-c-progress
 {{/progress}}
 <br><br>
 {{#> progress
-  progress__value="10,000"
+  progress__value="1000"
+  progress__valuetext="1,000"
+  progress__valuemax="100000"
+  progress__width="1"
   progress--modifier="pf-m-outside pf-m-lg"
   progress__id="progress-outside-static-width-4-example"
   progress-measure--modifier="pf-m-static-width"
-  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 6ch;"'
 }}
 {{/progress}}
 <br>
 {{#> progress
-  progress__value="100,000"
+  progress__value="50000"
+  progress__valuetext="50,000"
+  progress__valuemax="100000"
+  progress__width="50"
   progress--modifier="pf-m-outside pf-m-lg"
   progress__id="progress-outside-static-width-5-example"
   progress-measure--modifier="pf-m-static-width"
-  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 6ch;"'
 }}
 {{/progress}}
 <br>
 {{#> progress
-  progress__value="1,000,000"
+  progress__value="100000"
+  progress__valuetext="100,000"
+  progress__valuemax="100000"
+  progress__width="100"
   progress--modifier="pf-m-outside pf-m-lg"
   progress__id="progress-outside-static-width-6-example"
   progress-measure--modifier="pf-m-static-width"
-  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 6ch;"'
 }}
 {{/progress}}
 ```

--- a/src/patternfly/components/Progress/examples/Progress.md
+++ b/src/patternfly/components/Progress/examples/Progress.md
@@ -131,29 +131,56 @@ cssPrefix: pf-c-progress
 {{/progress}}
 ```
 
-### Outside fixed width measure
+### Outside static width measure
 ```hbs
 {{#> progress
   progress__value="1"
   progress--modifier="pf-m-outside pf-m-lg"
-  progress__id="progress-outside-fixed-width-example"
-  progress-measure--modifier="pf-m-fixed-width"
+  progress__id="progress-outside-static-width-example"
+  progress-measure--modifier="pf-m-static-width"
 }}
 {{/progress}}
 <br>
 {{#> progress
   progress__value="50"
   progress--modifier="pf-m-outside pf-m-lg"
-  progress__id="progress-outside-fixed-width-2-example"
-  progress-measure--modifier="pf-m-fixed-width"
+  progress__id="progress-outside-static-width-2-example"
+  progress-measure--modifier="pf-m-static-width"
 }}
 {{/progress}}
 <br>
 {{#> progress
   progress__value="100"
   progress--modifier="pf-m-outside pf-m-lg"
-  progress__id="progress-outside-fixed-width-3-example"
-  progress-measure--modifier="pf-m-fixed-width"
+  progress__id="progress-outside-static-width-3-example"
+  progress-measure--modifier="pf-m-static-width"
+}}
+{{/progress}}
+<br><br>
+{{#> progress
+  progress__value="10,000"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-static-width-4-example"
+  progress-measure--modifier="pf-m-static-width"
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
+}}
+{{/progress}}
+<br>
+{{#> progress
+  progress__value="100,000"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-static-width-5-example"
+  progress-measure--modifier="pf-m-static-width"
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
+}}
+{{/progress}}
+<br>
+{{#> progress
+  progress__value="1,000,000"
+  progress--modifier="pf-m-outside pf-m-lg"
+  progress__id="progress-outside-static-width-6-example"
+  progress-measure--modifier="pf-m-static-width"
+  progress--attribute='style="--pf-c-progress__measure--m-static-width--MinWidth: 10ch;"'
 }}
 {{/progress}}
 ```
@@ -267,4 +294,4 @@ If this component is describing the loading progress of a particular region of a
 | `.pf-m-warning` | `.pf-c-progress` |  Changes the appearance of the progess component to indicate a warning state. |
 | `.pf-m-danger` | `.pf-c-progress` |  Changes the appearance of the progess component to indicate a danger (failure) state. |
 | `.pf-m-truncate` | `.pf-c-progress__description` | Modifies the description to display a single line and truncate any overflow text with ellipses. |
-| `.pf-m-fixed-width` | `.pf-c-progress.pf-m-outside .pf-c-progress__measure` | Modifies the measure element to be a fixed width that will hold 0-100%. Overridable by setting `--pf-c-progress__measure--m-fixed-width--Width`. |
+| `.pf-m-static-width` | `.pf-c-progress.pf-m-outside .pf-c-progress__measure` | Modifies the measure element to have a static `min-width` that will hold 0-100%. Overridable by setting `--pf-c-progress__measure--m-static-width--MinWidth`. |

--- a/src/patternfly/components/Progress/progress-measure.hbs
+++ b/src/patternfly/components/Progress/progress-measure.hbs
@@ -1,8 +1,12 @@
-{{!-- This provides the measure with a % --}}
 {{#if progress__value}}
-  {{~#if progress--dynamic}}
-    <span class="pf-c-progress__measure">{{progress__valuetext}}</span>
-  {{else}}
-    <span class="pf-c-progress__measure">{{progress__value}}%</span>
-  {{/if}}
+  <span class="pf-c-progress__measure{{#if progress-measure--modifier}} {{progress-measure--modifier}}{{/if}}"
+    {{#if progress-measure--attribute}}
+      {{{progress-measure--attribute}}}
+    {{/if}}>
+    {{~#if progress--dynamic}}
+      {{progress__valuetext}}
+    {{else}}
+      {{progress__value}}%
+    {{/if}}
+  </span>
 {{/if}}

--- a/src/patternfly/components/Progress/progress-measure.hbs
+++ b/src/patternfly/components/Progress/progress-measure.hbs
@@ -5,6 +5,8 @@
     {{/if}}>
     {{~#if progress--dynamic}}
       {{progress__valuetext}}
+    {{else if progress__valuetext}}
+      {{progress__valuetext}}
     {{else}}
       {{progress__value}}%
     {{/if}}

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -90,6 +90,7 @@
 
       &.pf-m-fixed-width {
         width: var(--pf-c-progress__measure--m-fixed-width--Width);
+        text-align: left;
       }
     }
 

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -6,7 +6,7 @@
   --pf-c-progress__bar--before--BackgroundColor: var(--pf-global--primary-color--100);
   --pf-c-progress__bar--Height: var(--pf-global--spacer--md);
   --pf-c-progress__bar--BackgroundColor: var(--pf-global--BackgroundColor--light-100); // the bar always needs white under it so that the semi-transparent color shows correctly
-  --pf-c-progress__measure--m-fixed-width--Width: 4.5ch; // 4.5 because the % character is wider than a 0
+  --pf-c-progress__measure--m-static-width--MinWidth: 4.5ch; // 4.5 because the % character is wider than a 0
   --pf-c-progress__status-icon--Color: var(--pf-global--Color--100); // the status icon default color is the default text color
   --pf-c-progress__status-icon--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-progress__bar--before--Opacity: .2; // one-off change in opacity to allow progress bar to automatically coordinate with the indicator color
@@ -88,8 +88,8 @@
       display: inline-block;
       font-size: var(--pf-c-progress--m-outside__measure--FontSize);
 
-      &.pf-m-fixed-width {
-        width: var(--pf-c-progress__measure--m-fixed-width--Width);
+      &.pf-m-static-width {
+        min-width: var(--pf-c-progress__measure--m-static-width--MinWidth);
         text-align: left;
       }
     }

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -6,6 +6,7 @@
   --pf-c-progress__bar--before--BackgroundColor: var(--pf-global--primary-color--100);
   --pf-c-progress__bar--Height: var(--pf-global--spacer--md);
   --pf-c-progress__bar--BackgroundColor: var(--pf-global--BackgroundColor--light-100); // the bar always needs white under it so that the semi-transparent color shows correctly
+  --pf-c-progress__measure--m-fixed-width--Width: 4.5ch; // 4.5 because the % character is wider than a 0
   --pf-c-progress__status-icon--Color: var(--pf-global--Color--100); // the status icon default color is the default text color
   --pf-c-progress__status-icon--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-progress__bar--before--Opacity: .2; // one-off change in opacity to allow progress bar to automatically coordinate with the indicator color
@@ -84,7 +85,12 @@
     }
 
     .pf-c-progress__measure {
+      display: inline-block;
       font-size: var(--pf-c-progress--m-outside__measure--FontSize);
+
+      &.pf-m-fixed-width {
+        width: var(--pf-c-progress__measure--m-fixed-width--Width);
+      }
     }
 
     .pf-c-progress__bar,


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3529

@kmcfaul adding you to see if the variation works with what you'd expect in the react component. Adds `pf-m-fixed-width` to the `__measure` element that fits any `0-100%` value. And that width is overridable if someone is using a non-percentage value for the measure and wants a custom width by setting `pf-m-fixed-width` and defining `--pf-c-progress__measure--m-fixed-width--Width: 25%` (where 25% is any size unit).