### PR TITLE
fix(form-control): updated placeholder block so the color change applies

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -191,7 +191,7 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   // stylelint-enable
 
   &::placeholder {
-    --pf-c-form-control--Color: var(--pf-c-form-control--placeholder--Color);
+    color: var(--pf-c-form-control--placeholder--Color);
   }
 
   &:not(textarea) {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3578

@mcarrano @mceledonia the css we had in place to change the placeholder text to black-600 wasn't working. This PR fixes that so the color is now black-600.