### PR TITLE
fix(modal): increased space between close button and what preceedes it

### DIFF
--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -54,7 +54,7 @@
   // Close
   --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg) + var(--pf-global--spacer--xs) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
   --pf-c-modal-box--c-button--Right: var(--pf-global--spacer--md);
-  --pf-c-modal-box--c-button--sibling--MarginRight: var(--pf-global--spacer--xl);
+  --pf-c-modal-box--c-button--sibling--MarginRight: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
 
   // Footer
   --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--lg);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3587

Verified this is correct in the react component. Core component is a little off since the icon isn't 16px wide.

Before
<img width="1063" alt="Screen Shot 2020-10-12 at 3 12 01 PM" src="https://user-images.githubusercontent.com/35148959/95786523-5cb9a080-0c9d-11eb-9fad-e3abdb9c6312.png">

After
<img width="1086" alt="Screen Shot 2020-10-12 at 3 11 04 PM" src="https://user-images.githubusercontent.com/35148959/95786522-5b887380-0c9d-11eb-81ca-1966bb47209d.png">
