### PR TITLE
chore(notification-drawer): updated demos so badge reflects drawer items

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -1,5 +1,5 @@
 {{#> notification-drawer-list}}
-  {{#> notification-drawer-list-item notification-drawer-list-item--IsInfo="true"}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsInfo="true" notification-drawer-list-item--IsRead=notification-drawer-basic-list--AllRead}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
       {{#> notification-drawer-list-item-header-title}}
@@ -16,7 +16,7 @@
       5 minutes ago
     {{/notification-drawer-list-item-timestamp}}
   {{/notification-drawer-list-item}}
-  {{#> notification-drawer-list-item notification-drawer-list-item--IsDanger="true"}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsDanger="true" notification-drawer-list-item--IsRead=notification-drawer-basic-list--AllRead}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
       {{#> notification-drawer-list-item-header-title}}
@@ -33,7 +33,7 @@
       10 minutes ago
     {{/notification-drawer-list-item-timestamp}}
   {{/notification-drawer-list-item}}
-  {{#> notification-drawer-list-item notification-drawer-list-item--IsDefault="true"}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsDefault="true" notification-drawer-list-item--IsRead=notification-drawer-basic-list--AllRead}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
       {{#> notification-drawer-list-item-header-title}}

--- a/src/patternfly/demos/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/demos/NotificationDrawer/examples/NotificationDrawer.md
@@ -22,7 +22,7 @@ section: components
 
 ### Expanded attention
 ```hbs isFullscreen
-{{> notification-drawer-demo id="drawer-expanded-attention" page-template-header-tools-notification-badge--badge--modifier="pf-m-attention" drawer-panel--IsOpen="true"}}
+{{> notification-drawer-demo id="drawer-expanded-attention" page-template-header-tools-notification-badge--badge--modifier="pf-m-attention" page-header-tools--IsAttention="true" drawer-panel--IsOpen="true"}}
 ```
 
 ### Expanded with groups

--- a/src/patternfly/demos/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/demos/NotificationDrawer/examples/NotificationDrawer.md
@@ -7,17 +7,27 @@ section: components
 
 ### Collapsed
 ```hbs isFullscreen
-{{> notification-drawer-demo id="drawer-collapsed-demo"}}
+{{> notification-drawer-demo id="drawer-collapsed"}}
 ```
 
-### Expanded basics
+### Expanded read
 ```hbs isFullscreen
-{{> notification-drawer-demo id="drawer-expanded-basics-demo" drawer-panel--IsOpen="true"}}
+{{> notification-drawer-demo id="drawer-expanded-read" drawer-panel--IsOpen="true" notification-drawer-basic-list--AllRead="true"}}
 ```
 
-### Expanded groups
+### Expanded unread
 ```hbs isFullscreen
-{{> notification-drawer-demo id="drawer-expanded-demo" drawer-demo--IsGroup="true" drawer-panel--IsOpen="true"}}
+{{> notification-drawer-demo id="drawer-expanded-unread" page-template-header-tools-notification-badge--badge--modifier="pf-m-unread" drawer-panel--IsOpen="true"}}
+```
+
+### Expanded attention
+```hbs isFullscreen
+{{> notification-drawer-demo id="drawer-expanded-attention" page-template-header-tools-notification-badge--badge--modifier="pf-m-attention" drawer-panel--IsOpen="true"}}
+```
+
+### Expanded with groups
+```hbs isFullscreen
+{{> notification-drawer-demo id="drawer-expanded-with-groups" page-template-header-tools-notification-badge--badge--modifier="pf-m-unread" drawer-demo--IsGroup="true" drawer-panel--IsOpen="true"}}
 ```
 
 ## Documentation

--- a/src/patternfly/demos/Page/page-template-header-tools-notification-badge.hbs
+++ b/src/patternfly/demos/Page/page-template-header-tools-notification-badge.hbs
@@ -2,7 +2,7 @@
   {{#if page-header-tools--IsNotificationSelected}}
     {{#> page-header-tools-item page-header-tools-item--modifier=(concat 'pf-m-selected ' page-template-header-tools-notification-badge--item--modifier)}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Unread notifications" aria-expanded="true"'}}
-        {{#> notification-badge notification-badge--modifier="pf-m-read"}}
+        {{#> notification-badge notification-badge--modifier=(concat 'pf-m-read ' page-template-header-tools-notification-badge--badge--modifier)}}
           {{#if page-header-tools--IsAttention}}
             <i class="pf-icon-attention-bell" aria-hidden="true"></i>
           {{else}}
@@ -14,7 +14,7 @@
   {{else}}
     {{#> page-header-tools-item page-header-tools-item--modifier=page-template-header-tools-notification-badge--item--modifier}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Unread notifications" aria-expanded="false"'}}
-        {{#> notification-badge notification-badge--modifier="pf-m-read"}}
+        {{#> notification-badge notification-badge--modifier=(concat 'pf-m-read ' page-template-header-tools-notification-badge--badge--modifier)}}
           {{#if page-header-tools--IsAttention}}
             <i class="pf-icon-attention-bell" aria-hidden="true"></i>
           {{else}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3371

@mceledonia @mcarrano this adds a read notification drawer demo, attention demo, and updates the other demo notification badges to unread. WDYT, does this look like you would expect? Also in the drawer demos, since there is no notification drawer in the drawer, should we update the header icon that toggles the drawer open/closed to be something other than the bell icon? 