### PR TITLE
Fix add gap to toolbar

### DIFF
--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -370,7 +370,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
           {{/toolbar-item}}
         {{/toolbar-group}}
       {{/toolbar-group}}
-      {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
       {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content}}
@@ -398,7 +397,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
       {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group"}}
         {{> toolbar-toggle toolbar-toggle--modifier="pf-m-expanded" toolbar-toggle--IsExpanded="true"}}
       {{/toolbar-group}}
-      {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
       {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content toolbar-expandable-content--IsExpanded="true"}}
@@ -525,7 +523,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
       {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group"}}
         {{> toolbar-toggle toolbar-toggle--modifier="pf-m-expanded" toolbar-toggle--IsExpanded="true"}}
       {{/toolbar-group}}
-      {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
       {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content toolbar-expandable-content--IsExpanded="true"}}
@@ -658,6 +655,8 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `aria-label="Collapse all"` | `.pf-c-toolbar__item.pf-m-expand-all.pf-m-expanded` | Provides an accessible label for the expand all item button. **Required** |
 
 ### Toggle group usage
+
+**Note:** Toggle group is set to `flex-wrap: nowrap` by default.
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,6 +13,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   // Content
   --pf-c-toolbar__content--PaddingRight: var(--pf-global--spacer--md); // remove at breaking change
   --pf-c-toolbar__content--PaddingLeft: var(--pf-global--spacer--md); // remove at breaking change
+  --pf-c-toolbar__content--m-chip-container--RowGap: var(--pf-global--spacer--md);
 
   // Gutters
   --pf-c-toolbar--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
@@ -34,8 +35,9 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar__expandable-content--m-expanded--GridRowGap: var(--pf-global--gutter--md);
 
   // Chip container
-  --pf-c-toolbar__group--m-chip-container--MarginTop: calc(var(--pf-global--spacer--md) * -1);
-  --pf-c-toolbar__group--m-chip-container__item--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-toolbar__group--m-chip-container--MarginTop: 0; // remove at breaking change
+  --pf-c-toolbar__group--m-chip-container__item--MarginTop: 0; // remove at breaking change
+  --pf-c-toolbar__group--m-chip-container--RowGap: var(--pf-global--spacer--md);
 
   // Base spacer - shared value
   --pf-c-toolbar--spacer--base: var(--pf-global--spacer--md);
@@ -101,8 +103,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   }
 
   position: relative;
-  row-gap: var(--pf-c-toolbar--RowGap);
   display: grid;
+  row-gap: var(--pf-c-toolbar--RowGap);
   padding-top: var(--pf-c-toolbar--PaddingTop);
   padding-bottom: var(--pf-c-toolbar--PaddingBottom);
   background-color: var(--pf-c-toolbar--BackgroundColor);
@@ -116,6 +118,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 // Divider
 .pf-c-toolbar__content-section,
 .pf-c-toolbar__group {
+  row-gap: var(--pf-c-toolbar--RowGap);
+
   // set this var here so specificity is 20
   > .pf-c-divider {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar--c-divider--m-vertical--spacer);
@@ -312,18 +316,26 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
 // Chip container
 // extend chip container layout access to __content to allow custom configurations
+.pf-c-toolbar__content.pf-m-chip-container {
+  row-gap: var(--pf-c-toolbar__content--m-chip-container--RowGap);
+}
+
+.pf-c-toolbar__content.pf-m-chip-container .pf-c-toolbar__group {
+  row-gap: var(--pf-c-toolbar__group--m-chip-container--RowGap);
+}
+
 .pf-c-toolbar__content.pf-m-chip-container,
 .pf-c-toolbar__group.pf-m-chip-container {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  margin-top: var(--pf-c-toolbar__group--m-chip-container--MarginTop);
-  grid-row-gap: 0;
+  margin-top: var(--pf-c-toolbar__group--m-chip-container--MarginTop); // remove at breaking change
+  // grid-row-gap: 0;
 
   .pf-c-toolbar__item {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar__item--spacer);
 
-    margin-top: var(--pf-c-toolbar__group--m-chip-container__item--MarginTop);
+    margin-top: var(--pf-c-toolbar__group--m-chip-container__item--MarginTop); // remove at breaking change
   }
 
   .pf-c-toolbar__group {
@@ -331,7 +343,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
     display: flex;
     flex-wrap: wrap;
-    grid-row-gap: 0;
+    // grid-row-gap: 0;
   }
 
   .pf-c-toolbar__group:last-child,

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -14,6 +14,9 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar__content--PaddingRight: var(--pf-global--spacer--md); // remove at breaking change
   --pf-c-toolbar__content--PaddingLeft: var(--pf-global--spacer--md); // remove at breaking change
 
+  // Content section
+  --pf-c-toolbar__content-section--RowGap: var(--pf-global--spacer--sm);
+
   // Gutters
   --pf-c-toolbar--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
   --pf-c-toolbar--m-page-insets--xl--inset: var(--pf-global--spacer--lg); // make this the default inset at breaking change
@@ -43,6 +46,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   // Spacer values
   --pf-c-toolbar__item--spacer: var(--pf-c-toolbar--spacer--base);
   --pf-c-toolbar__group--spacer: var(--pf-c-toolbar--spacer--base);
+  --pf-c-toolbar__group--RowGap: var(--pf-global--spacer--xs);
 
   // Toggle group
   --pf-c-toolbar__group--m-toggle-group--spacer: var(--pf-global--spacer--sm);
@@ -135,8 +139,10 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--spacer: var(--pf-c-toolbar__group--spacer);
 
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   margin-right: var(--pf-c-toolbar--spacer);
+  row-gap: var(--pf-c-toolbar__group--RowGap);
 
   // Button group
   &.pf-m-button-group {
@@ -172,6 +178,11 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   // Toggle group
   &.pf-m-toggle-group {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar__group--m-toggle-group--spacer);
+
+    &,
+    .pf-c-toolbar__group {
+      flex-wrap: nowrap;
+    }
 
     .pf-c-toolbar__group,
     .pf-c-toolbar__item {
@@ -267,6 +278,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 // Content section
 .pf-c-toolbar__content-section {
   width: 100%;
+  row-gap: var(--pf-c-toolbar__content-section--RowGap);
 }
 
 // Expandable content

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   // Content
   --pf-c-toolbar__content--PaddingRight: var(--pf-global--spacer--md); // remove at breaking change
   --pf-c-toolbar__content--PaddingLeft: var(--pf-global--spacer--md); // remove at breaking change
-  --pf-c-toolbar__content--m-chip-container--RowGap: var(--pf-global--spacer--md);
 
   // Gutters
   --pf-c-toolbar--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
@@ -35,9 +34,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar__expandable-content--m-expanded--GridRowGap: var(--pf-global--gutter--md);
 
   // Chip container
-  --pf-c-toolbar__group--m-chip-container--MarginTop: 0; // remove at breaking change
-  --pf-c-toolbar__group--m-chip-container__item--MarginTop: 0; // remove at breaking change
-  --pf-c-toolbar__group--m-chip-container--RowGap: var(--pf-global--spacer--md);
+  --pf-c-toolbar__group--m-chip-container--MarginTop: calc(var(--pf-global--spacer--md) * -1);
+  --pf-c-toolbar__group--m-chip-container__item--MarginTop: var(--pf-global--spacer--md);
 
   // Base spacer - shared value
   --pf-c-toolbar--spacer--base: var(--pf-global--spacer--md);
@@ -103,8 +101,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   }
 
   position: relative;
-  display: grid;
   row-gap: var(--pf-c-toolbar--RowGap);
+  display: grid;
   padding-top: var(--pf-c-toolbar--PaddingTop);
   padding-bottom: var(--pf-c-toolbar--PaddingBottom);
   background-color: var(--pf-c-toolbar--BackgroundColor);
@@ -118,8 +116,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 // Divider
 .pf-c-toolbar__content-section,
 .pf-c-toolbar__group {
-  row-gap: var(--pf-c-toolbar--RowGap);
-
   // set this var here so specificity is 20
   > .pf-c-divider {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar--c-divider--m-vertical--spacer);
@@ -316,26 +312,18 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
 // Chip container
 // extend chip container layout access to __content to allow custom configurations
-.pf-c-toolbar__content.pf-m-chip-container {
-  row-gap: var(--pf-c-toolbar__content--m-chip-container--RowGap);
-}
-
-.pf-c-toolbar__content.pf-m-chip-container .pf-c-toolbar__group {
-  row-gap: var(--pf-c-toolbar__group--m-chip-container--RowGap);
-}
-
 .pf-c-toolbar__content.pf-m-chip-container,
 .pf-c-toolbar__group.pf-m-chip-container {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  margin-top: var(--pf-c-toolbar__group--m-chip-container--MarginTop); // remove at breaking change
-  // grid-row-gap: 0;
+  margin-top: var(--pf-c-toolbar__group--m-chip-container--MarginTop);
+  grid-row-gap: 0;
 
   .pf-c-toolbar__item {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar__item--spacer);
 
-    margin-top: var(--pf-c-toolbar__group--m-chip-container__item--MarginTop); // remove at breaking change
+    margin-top: var(--pf-c-toolbar__group--m-chip-container__item--MarginTop);
   }
 
   .pf-c-toolbar__group {
@@ -343,7 +331,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
     display: flex;
     flex-wrap: wrap;
-    // grid-row-gap: 0;
+    grid-row-gap: 0;
   }
 
   .pf-c-toolbar__group:last-child,

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -139,7 +139,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--spacer: var(--pf-c-toolbar__group--spacer);
 
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   margin-right: var(--pf-c-toolbar--spacer);
   row-gap: var(--pf-c-toolbar__group--RowGap);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -178,11 +178,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   &.pf-m-toggle-group {
     --pf-c-toolbar--spacer: var(--pf-c-toolbar__group--m-toggle-group--spacer);
 
-    &,
-    .pf-c-toolbar__group {
-      flex-wrap: nowrap;
-    }
-
     .pf-c-toolbar__group,
     .pf-c-toolbar__item {
       display: none;

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -7,7 +7,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   --pf-l-flex--Display: flex;
   --pf-l-flex--FlexWrap: wrap;
   --pf-l-flex--AlignItems: baseline;
-  --pf-l-flex--RowGap: var(--pf-global--spacer--sm);
   --pf-l-flex--m-row--AlignItems: baseline;
   --pf-l-flex--m-row-reverse--AlignItems: baseline;
   --pf-l-flex--item--Order: 0;
@@ -22,8 +21,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
-  row-gap: var(--pf-l-flex--RowGap);
-  margin-trim: all;
 
   &:last-child {
     --pf-l-flex--spacer: 0;
@@ -310,19 +307,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
           &:last-child {
             --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
           }
-        }
-      }
-    }
-  }
-
-  // .pf-m-row-gap-{size}{-on-breakpoint}
-  @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
-    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
-
-    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
-      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
-        &.pf-m-row-gap-#{$spacer} {
-          --pf-l-flex--RowGap: #{$spacer-value};
         }
       }
     }

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -7,6 +7,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   --pf-l-flex--Display: flex;
   --pf-l-flex--FlexWrap: wrap;
   --pf-l-flex--AlignItems: baseline;
+  --pf-l-flex--RowGap: var(--pf-global--spacer--sm);
   --pf-l-flex--m-row--AlignItems: baseline;
   --pf-l-flex--m-row-reverse--AlignItems: baseline;
   --pf-l-flex--item--Order: 0;
@@ -21,6 +22,8 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
+  row-gap: var(--pf-l-flex--RowGap);
+  margin-trim: all;
 
   &:last-child {
     --pf-l-flex--spacer: 0;
@@ -307,6 +310,19 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
           &:last-child {
             --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
           }
+        }
+      }
+    }
+  }
+
+  // .pf-m-row-gap-{size}{-on-breakpoint}
+  @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
+        &.pf-m-row-gap-#{$spacer} {
+          --pf-l-flex--RowGap: #{$spacer-value};
         }
       }
     }


### PR DESCRIPTION
https://github.com/patternfly/patternfly/pull/3543

closes #3348 #3344 

@mcarrano @mceledonia I set `row-gap` for direct children of `content-sections` to `spacer--md`. For items within groups, I set the `row-gap` to `spacer--xs`. Wdyt?

Also, I set toggle groups to **nowrap**, as they are a special use case and imo should never wrap as their behavior has a specific functionality.

![Screen Shot 2020-10-01 at 3 10 43 PM](https://user-images.githubusercontent.com/5385435/94852698-489db580-03f8-11eb-9e56-bd92cb01f1a9.png)

![Screen Shot 2020-10-01 at 3 11 44 PM](https://user-images.githubusercontent.com/5385435/94852824-7256dc80-03f8-11eb-882b-6c739366a57e.png)


