### PR TITLE
feat(alert): added examples to support custom alert icon

### DIFF
--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -291,6 +291,27 @@ cssPrefix: pf-c-alert
 {{/alert}}
 ```
 
+### Custom icon
+```hbs
+{{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success alert"'}}
+  {{#> alert-icon alert-icon--type="cog"}}
+  {{/alert-icon}}
+  {{#> alert-title}}
+    {{#> screen-reader}}Success alert:{{/screen-reader}}
+      Success alert title
+  {{/alert-title}}
+{{/alert}}
+<br>
+{{#> alert alert--modifier="pf-m-success pf-m-inline" alert--attribute='aria-label="Success alert"'}}
+  {{#> alert-icon alert-icon--type="cog"}}
+  {{/alert-icon}}
+  {{#> alert-title}}
+    {{#> screen-reader}}Success alert:{{/screen-reader}}
+      Success alert title
+  {{/alert-title}}
+{{/alert}}
+```
+
 ## Documentation
 ### Overview
 Add a modifier class to the default alert to change the color: `.pf-m-success`, `.pf-m-danger`, `.pf-m-warning`, or `.pf-m-info`.


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3257

@mcarrano there are no changes in core outside of adding the examples. Any icon can be dropped into any of the alert variations and it will take on the properties of the existing supported icons. Was there anything else we need to support with custom icons?