### PR TITLE
fix(calendar-month): removed focus outline, fixed selected styling

### DIFF
--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -148,13 +148,13 @@
     --pf-c-calendar-month__dates-cell--before--Right: var(--pf-c-calendar-month__dates-cell--m-in-range--m-end-range--before--Right);
   }
 
+  &.pf-m-adjacent-month {
+    --pf-c-calendar-month__date--Color: var(--pf-c-calendar-month__dates-cell--m-adjacent-month__date--Color);
+  }
+
   &.pf-m-selected {
     --pf-c-calendar-month__date--BackgroundColor: var(--pf-c-calendar-month__dates-cell--m-selected__date--BackgroundColor);
     --pf-c-calendar-month__date--Color: var(--pf-c-calendar-month__dates-cell--m-selected__date--Color);
-  }
-
-  &.pf-m-adjacent-month {
-    --pf-c-calendar-month__date--Color: var(--pf-c-calendar-month__dates-cell--m-adjacent-month__date--Color);
   }
 
   &.pf-m-disabled {
@@ -202,6 +202,8 @@
   &:focus,
   &.pf-m-focus {
     --pf-c-calendar-month__date--after--BorderColor: var(--pf-c-calendar-month__date--focus--after--BorderColor);
+
+    outline: 0;
 
     .pf-c-calendar-month__dates-cell.pf-m-start-range:not(.pf-m-selected) &,
     .pf-c-calendar-month__dates-cell.pf-m-end-range:not(.pf-m-selected) & {


### PR DESCRIPTION
part of https://github.com/patternfly/patternfly/issues/3668

* Removes default browser focus outline
* Fixes adjacent month selected styling