### PR TITLE
feat(pagination): added layout mods

### DIFF
--- a/src/patternfly/components/Pagination/examples/Pagination.md
+++ b/src/patternfly/components/Pagination/examples/Pagination.md
@@ -89,27 +89,27 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a
 {{/pagination}}
 ```
 
-### Top with display navigation modifier
+### Top with display full modifier
 ```hbs
-{{#> pagination pagination--id="pagination-top-with-navigation-modifier" pagination--modifier="pf-m-display-navigation"}}
+{{#> pagination pagination--id="pagination-top-with-full-modifier" pagination--modifier="pf-m-display-full"}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
   {{> pagination-nav-content}}
 {{/pagination}}
 ```
 
-### Top with responsive display summary and display navigation modifiers
+### Top with responsive display summary and display full modifiers
 ```hbs
-{{#> pagination pagination--id="pagination-top-with-responsive-summary-navigation-modifiers" pagination--modifier="pf-m-display-summary pf-m-display-navigation-on-lg pf-m-display-summary-on-xl pf-m-display-navigation-on-2xl"}}
+{{#> pagination pagination--id="pagination-top-with-responsive-summary-navigation-modifiers" pagination--modifier="pf-m-display-summary pf-m-display-full-on-lg pf-m-display-summary-on-xl pf-m-display-full-on-2xl"}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
   {{> pagination-nav-content}}
 {{/pagination}}
 ```
 
-### Compact display navigation modifier
+### Compact display full modifier
 ```hbs
-{{#> pagination pagination--id="pagination-compact-with-navigation-modifier" pagination--IsCompact="true" pagination--modifier="pf-m-display-navigation"}}
+{{#> pagination pagination--id="pagination-compact-with-full-modifier" pagination--IsCompact="true" pagination--modifier="pf-m-display-full"}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
   {{> pagination-nav-content}}
@@ -142,8 +142,8 @@ Note: `<button>` or `<a>` elements can be used in `.pf-c-pagination__nav-page-se
 | `.pf-c-pagination__nav` | `<nav>` |  Initiates pagination nav. |
 | `.pf-c-pagination__nav-control` | `<div>` |  Initiates pagination nav control. |
 | `.pf-c-pagination__nav-page-select` | `<div>` |  Initiates pagination nav page select. |
-| `.pf-m-display-summary{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for summary pagination component styles. |
-| `.pf-m-display-navigation{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for navigation pagination component styles. |
+| `.pf-m-display-summary{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for summary display pagination component styles. |
+| `.pf-m-display-full{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for full display pagination component styles. |
 | `.pf-m-bottom` | `.pf-c-pagination` | Modifies for bottom pagination component styles. |
 | `.pf-m-compact` | `.pf-c-pagination` | Modifies for compact pagination component styles. |
 | `.pf-m-static` | `.pf-c-pagination.pf-m-bottom` | Modifies bottom pagination to not be positioned sticky on summary. |

--- a/src/patternfly/components/Pagination/examples/Pagination.md
+++ b/src/patternfly/components/Pagination/examples/Pagination.md
@@ -6,7 +6,7 @@ cssPrefix: pf-c-pagination
 
 ## Examples
 ### Top
-```hbs isFullscreen
+```hbs
 {{#> pagination}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu options-menu id="pagination-options-menu-top-example" options-menu--IsText="true"}}
@@ -15,7 +15,7 @@ cssPrefix: pf-c-pagination
 ```
 
 ### Top expanded
-```hbs isFullscreen
+```hbs
 {{#> pagination}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu options-menu--IsExpanded="true" id="pagination-options-menu-top-expanded-example" options-menu--IsText="true"}}
@@ -24,7 +24,7 @@ cssPrefix: pf-c-pagination
 ```
 
 ### Top sticky
-```hbs isFullscreen
+```hbs
 {{#> pagination pagination--modifier="pf-m-sticky"}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu options-menu id="pagination-options-menu-top-example" options-menu--IsText="true"}}
@@ -40,7 +40,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a
 ```
 
 ### Bottom
-```hbs isFullscreen
+```hbs
 {{#> pagination pagination--modifier="pf-m-bottom"}}
   {{> pagination-options-menu id="pagination-options-menu-bottom-example" options-menu--IsText="true" pagination-options-menu--modifier="pf-m-top"}}
   {{> pagination-nav-content}}
@@ -48,7 +48,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a
 ```
 
 ### Bottom sticky
-```hbs isFullscreen
+```hbs
 <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.</div>
 <br><br>
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.</div>
@@ -63,7 +63,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a
 ```
 
 ### Top disabled
-```hbs isFullscreen
+```hbs
 {{#> pagination}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu id="pagination-options-menu-top-disabled-example" options-menu--IsText="true" options-menu-toggle--IsDisabled="true"}}
@@ -72,10 +72,46 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a
 ```
 
 ### Compact
-```hbs isFullscreen
+```hbs
 {{#> pagination pagination--IsCompact="true"}}
   {{> pagination-total-items-content}}
   {{> pagination-options-menu options-menu id="pagination-options-menu-compact-example" options-menu--IsText="true"}}
+  {{> pagination-nav-content}}
+{{/pagination}}
+```
+
+### Top with display summary modifier
+```hbs
+{{#> pagination pagination--id="pagination-top-with-summary-modifier" pagination--modifier="pf-m-display-summary"}}
+  {{> pagination-total-items-content}}
+  {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
+  {{> pagination-nav-content}}
+{{/pagination}}
+```
+
+### Top with display navigation modifier
+```hbs
+{{#> pagination pagination--id="pagination-top-with-navigation-modifier" pagination--modifier="pf-m-display-navigation"}}
+  {{> pagination-total-items-content}}
+  {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
+  {{> pagination-nav-content}}
+{{/pagination}}
+```
+
+### Top with responsive display summary and display navigation modifiers
+```hbs
+{{#> pagination pagination--id="pagination-top-with-responsive-summary-navigation-modifiers" pagination--modifier="pf-m-display-summary pf-m-display-navigation-on-lg pf-m-display-summary-on-xl pf-m-display-navigation-on-2xl"}}
+  {{> pagination-total-items-content}}
+  {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
+  {{> pagination-nav-content}}
+{{/pagination}}
+```
+
+### Compact display navigation modifier
+```hbs
+{{#> pagination pagination--id="pagination-compact-with-navigation-modifier" pagination--IsCompact="true" pagination--modifier="pf-m-display-navigation"}}
+  {{> pagination-total-items-content}}
+  {{> pagination-options-menu id=(concat pagination--id '-options-menu') options-menu--IsText="true"}}
   {{> pagination-nav-content}}
 {{/pagination}}
 ```
@@ -102,13 +138,15 @@ Note: `<button>` or `<a>` elements can be used in `.pf-c-pagination__nav-page-se
 | -- | -- | -- |
 | `.pf-c-pagination` | `<div>` |  Initiates pagination. |
 | `.pf-c-pagination__current` | `<div>` |  Initiates element to display currently displayed items for use in responsive view. Only needed for default pagination, not `.pf-m-bottom`. |
-| `.pf-c-pagination__total-items` | `<div>` | Initiates element to replace the options menu on mobile. |
+| `.pf-c-pagination__total-items` | `<div>` | Initiates element to replace the options menu on summary. |
 | `.pf-c-pagination__nav` | `<nav>` |  Initiates pagination nav. |
 | `.pf-c-pagination__nav-control` | `<div>` |  Initiates pagination nav control. |
 | `.pf-c-pagination__nav-page-select` | `<div>` |  Initiates pagination nav page select. |
+| `.pf-m-display-summary{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for summary pagination component styles. |
+| `.pf-m-display-navigation{-on-[breakpoint]}` | `.pf-c-pagination` | Modifies for navigation pagination component styles. |
 | `.pf-m-bottom` | `.pf-c-pagination` | Modifies for bottom pagination component styles. |
 | `.pf-m-compact` | `.pf-c-pagination` | Modifies for compact pagination component styles. |
-| `.pf-m-static` | `.pf-c-pagination.pf-m-bottom` | Modifies bottom pagination to not be positioned sticky on mobile. |
+| `.pf-m-static` | `.pf-c-pagination.pf-m-bottom` | Modifies bottom pagination to not be positioned sticky on summary. |
 | `.pf-m-sticky` | `.pf-c-pagination` | Modifies the pagination to be sticky to its container. It will be sticky to the top of the container by default, and sticky to the bottom of the container when applied to `.pf-c-pagination.pf-m-bottom`. |
 | `.pf-m-first` | `.pf-c-pagination__nav-control` | Indicates the control is for the first page button. |
 | `.pf-m-prev` | `.pf-c-pagination__nav-control` | Indicates the control is for the previous page button. |

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -15,8 +15,8 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   --pf-c-pagination__nav--Visibility: hidden;
   --pf-c-pagination--m-display-summary__nav--Display: none;
   --pf-c-pagination--m-display-summary__nav--Visibility: hidden;
-  --pf-c-pagination--m-display-navigation__nav--Display: inline-flex;
-  --pf-c-pagination--m-display-navigation__nav--Visibility: visible;
+  --pf-c-pagination--m-display-full__nav--Display: inline-flex;
+  --pf-c-pagination--m-display-full__nav--Visibility: visible;
 
   // nav control
   --pf-c-pagination__nav-control--c-button--PaddingRight: var(--pf-global--spacer--sm);
@@ -47,8 +47,8 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   --pf-c-pagination__total-items--Visibility: visible;
   --pf-c-pagination--m-display-summary__total-items--Display: block;
   --pf-c-pagination--m-display-summary__total-items--Visibility: visible;
-  --pf-c-pagination--m-display-navigation__total-items--Display: none;
-  --pf-c-pagination--m-display-navigation__total-items--Visibility: hidden;
+  --pf-c-pagination--m-display-full__total-items--Display: none;
+  --pf-c-pagination--m-display-full__total-items--Visibility: hidden;
 
   // top
   --pf-c-pagination--m-sticky--BackgroundColor: var(--pf-global--BackgroundColor--100);
@@ -77,8 +77,8 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   --pf-c-pagination--c-options-menu--Visibility: hidden;
   --pf-c-pagination--m-display-summary--c-options-menu--Display: none;
   --pf-c-pagination--m-display-summary--c-options-menu--Visibility: hidden;
-  --pf-c-pagination--m-display-navigation--c-options-menu--Display: inline-flex;
-  --pf-c-pagination--m-display-navigation--c-options-menu--Visibility: visible;
+  --pf-c-pagination--m-display-full--c-options-menu--Display: inline-flex;
+  --pf-c-pagination--m-display-full--c-options-menu--Visibility: visible;
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-pagination--m-bottom__nav-control--c-button--PaddingTop: var(--pf-c-pagination--m-bottom__nav-control--c-button--md--PaddingTop);
@@ -267,7 +267,7 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   visibility: var(--pf-c-pagination__total-items--Visibility);
 }
 
-/* stylelint-disable no-duplicate-selectors */
+// stylelint-disable no-duplicate-selectors
 .pf-c-pagination {
   @each $breakpoint, $breakpoint-value in $pf-c-pagination--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
@@ -282,15 +282,15 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
         --pf-c-pagination__total-items--Visibility: var(--pf-c-pagination--m-display-summary__total-items--Visibility);
       }
 
-      &.pf-m-display-navigation#{$breakpoint-name} {
-        --pf-c-pagination__nav--Display: var(--pf-c-pagination--m-display-navigation__nav--Display);
-        --pf-c-pagination__nav--Visibility: var(--pf-c-pagination--m-display-navigation__nav--Visibility);
-        --pf-c-pagination--c-options-menu--Display: var(--pf-c-pagination--m-display-navigation--c-options-menu--Display);
-        --pf-c-pagination--c-options-menu--Visibility: var(--pf-c-pagination--m-display-navigation--c-options-menu--Visibility);
-        --pf-c-pagination__total-items--Display: var(--pf-c-pagination--m-display-navigation__total-items--Display);
-        --pf-c-pagination__total-items--Visibility: var(--pf-c-pagination--m-display-navigation__total-items--Visibility);
+      &.pf-m-display-full#{$breakpoint-name} {
+        --pf-c-pagination__nav--Display: var(--pf-c-pagination--m-display-full__nav--Display);
+        --pf-c-pagination__nav--Visibility: var(--pf-c-pagination--m-display-full__nav--Visibility);
+        --pf-c-pagination--c-options-menu--Display: var(--pf-c-pagination--m-display-full--c-options-menu--Display);
+        --pf-c-pagination--c-options-menu--Visibility: var(--pf-c-pagination--m-display-full--c-options-menu--Visibility);
+        --pf-c-pagination__total-items--Display: var(--pf-c-pagination--m-display-full__total-items--Display);
+        --pf-c-pagination__total-items--Visibility: var(--pf-c-pagination--m-display-full__total-items--Visibility);
       }
     }
   }
 }
-/* stylelint-enable */
+// stylelint-enable

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -1,14 +1,24 @@
+$pf-c-pagination--breakpoint-map: build-breakpoint-map();
+
 .pf-c-pagination {
-  // Base
+  // children
   --pf-c-pagination--child--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-pagination--m-bottom--child--MarginRight: 0;
   --pf-c-pagination--m-bottom--child--md--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-pagination--m-compact--child--MarginRight: var(--pf-global--spacer--sm);
 
-  // Dropdown
+  // dropdown
   --pf-c-pagination--c-options-menu__toggle--FontSize: var(--pf-global--FontSize--sm);
 
-  // Nav
+  // nav
+  --pf-c-pagination__nav--Display: none;
+  --pf-c-pagination__nav--Visibility: hidden;
+  --pf-c-pagination--m-display-summary__nav--Display: none;
+  --pf-c-pagination--m-display-summary__nav--Visibility: hidden;
+  --pf-c-pagination--m-display-navigation__nav--Display: inline-flex;
+  --pf-c-pagination--m-display-navigation__nav--Visibility: visible;
+
+  // nav control
   --pf-c-pagination__nav-control--c-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-pagination__nav-control--c-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-pagination__nav-control--c-button--FontSize: var(--pf-global--FontSize--md);
@@ -23,7 +33,7 @@
   --pf-c-pagination--m-bottom__nav-control--c-button--md--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-pagination--m-compact__nav-control--nav-control--MarginLeft: var(--pf-global--spacer--md);
 
-  // Nav page select
+  // nav page select
   --pf-c-pagination__nav-page-select--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-pagination__nav-page-select--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-pagination__nav-page-select--PaddingRight: var(--pf-global--spacer--md);
@@ -32,7 +42,15 @@
   --pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;
   --pf-c-pagination__nav-page-select--c-form-control--Width: calc(var(--pf-c-pagination__nav-page-select--c-form-control--width-base) + (var(--pf-c-pagination__nav-page-select--c-form-control--width-chars) * 1ch));
 
-  // Top
+  // total items
+  --pf-c-pagination__total-items--Display: block;
+  --pf-c-pagination__total-items--Visibility: visible;
+  --pf-c-pagination--m-display-summary__total-items--Display: block;
+  --pf-c-pagination--m-display-summary__total-items--Visibility: visible;
+  --pf-c-pagination--m-display-navigation__total-items--Display: none;
+  --pf-c-pagination--m-display-navigation__total-items--Visibility: hidden;
+
+  // top
   --pf-c-pagination--m-sticky--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-pagination--m-sticky--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-pagination--m-sticky--md--PaddingTop: var(--pf-global--spacer--md);
@@ -42,7 +60,7 @@
   --pf-c-pagination--m-sticky--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-pagination--m-sticky--Top: 0;
 
-  // Bottom
+  // bottom
   --pf-c-pagination--m-bottom--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-pagination--m-bottom--BoxShadow: var(--pf-global--BoxShadow--sm-top);
   --pf-c-pagination--m-bottom--Bottom: 0;
@@ -54,6 +72,14 @@
   --pf-c-pagination--m-bottom--xl--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-pagination--m-bottom--m-sticky--BoxShadow: var(--pf-global--BoxShadow--sm-top);
 
+  // options menu
+  --pf-c-pagination--c-options-menu--Display: none;
+  --pf-c-pagination--c-options-menu--Visibility: hidden;
+  --pf-c-pagination--m-display-summary--c-options-menu--Display: none;
+  --pf-c-pagination--m-display-summary--c-options-menu--Visibility: hidden;
+  --pf-c-pagination--m-display-navigation--c-options-menu--Display: inline-flex;
+  --pf-c-pagination--m-display-navigation--c-options-menu--Visibility: visible;
+
   @media screen and (min-width: $pf-global--breakpoint--md) {
     --pf-c-pagination--m-bottom__nav-control--c-button--PaddingTop: var(--pf-c-pagination--m-bottom__nav-control--c-button--md--PaddingTop);
     --pf-c-pagination--m-bottom__nav-control--c-button--PaddingRight: var(--pf-c-pagination--m-bottom__nav-control--c-button--md--PaddingRight);
@@ -62,6 +88,12 @@
     --pf-c-pagination--m-bottom--child--MarginRight: var(--pf-c-pagination--m-bottom--child--md--MarginRight);
     --pf-c-pagination--m-bottom__nav-control--c-button--OutlineOffset: 0;
     --pf-c-pagination--m-bottom--BoxShadow: none;
+    --pf-c-pagination--c-options-menu--Display: inline-flex;
+    --pf-c-pagination--c-options-menu--Visibility: visible;
+    --pf-c-pagination__nav--Display: inline-flex;
+    --pf-c-pagination__nav--Visibility: visible;
+    --pf-c-pagination__total-items--Display: none;
+    --pf-c-pagination__total-items--Visibility: hidden;
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
@@ -78,18 +110,9 @@
     margin-right: var(--pf-c-pagination--child--MarginRight);
   }
 
-  // Top pagination
-  &:not(.pf-m-bottom) {
-    .pf-c-options-menu,
-    .pf-c-pagination__nav {
-      display: none;
-      visibility: hidden;
-
-      @media screen and (min-width: $pf-global--breakpoint--md) {
-        display: flex;
-        visibility: visible;
-      }
-    }
+  .pf-c-options-menu {
+    display: var(--pf-c-pagination--c-options-menu--Display);
+    visibility: var(--pf-c-pagination--c-options-menu--Visibility);
   }
 
   &.pf-m-bottom {
@@ -131,12 +154,15 @@
 
     .pf-c-options-menu {
       position: absolute;
+      display: block;
+      visibility: visible;
     }
 
     .pf-c-pagination__nav {
       display: flex;
       flex-basis: 100%;
       justify-content: space-between;
+      visibility: visible;
     }
 
     @media screen and (min-width: $pf-global--breakpoint--md) {
@@ -194,12 +220,14 @@
   }
 }
 
-// Nav
+// nav
 .pf-c-pagination__nav {
-  display: inline-flex;
+  display: var(--pf-c-pagination__nav--Display);
   justify-content: flex-end;
+  visibility: var(--pf-c-pagination__nav--Visibility);
 }
 
+// nav control
 .pf-c-pagination__nav-control {
   .pf-c-button {
     padding-right: var(--pf-c-pagination__nav-control--c-button--PaddingRight);
@@ -212,7 +240,7 @@
   }
 }
 
-// Nav page element
+// nav page element
 .pf-c-pagination__nav-page-select {
   display: flex;
   align-items: center;
@@ -233,10 +261,36 @@
   }
 }
 
-// Mobile element for total-items items
+// display-summary element for total-items items
 .pf-c-pagination__total-items {
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    display: none;
-    visibility: hidden;
+  display: var(--pf-c-pagination__total-items--Display);
+  visibility: var(--pf-c-pagination__total-items--Visibility);
+}
+
+/* stylelint-disable no-duplicate-selectors */
+.pf-c-pagination {
+  @each $breakpoint, $breakpoint-value in $pf-c-pagination--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-c-pagination--breakpoint-map) {
+      &.pf-m-display-summary#{$breakpoint-name} {
+        --pf-c-pagination__nav--Display: var(--pf-c-pagination--m-display-summary__nav--Display);
+        --pf-c-pagination__nav--Visibility: var(--pf-c-pagination--m-display-summary__nav--Visibility);
+        --pf-c-pagination--c-options-menu--Display: var(--pf-c-pagination--m-display-summary--c-options-menu--Display);
+        --pf-c-pagination--c-options-menu--Visibility: var(--pf-c-pagination--m-display-summary--c-options-menu--Visibility);
+        --pf-c-pagination__total-items--Display: var(--pf-c-pagination--m-display-summary__total-items--Display);
+        --pf-c-pagination__total-items--Visibility: var(--pf-c-pagination--m-display-summary__total-items--Visibility);
+      }
+
+      &.pf-m-display-navigation#{$breakpoint-name} {
+        --pf-c-pagination__nav--Display: var(--pf-c-pagination--m-display-navigation__nav--Display);
+        --pf-c-pagination__nav--Visibility: var(--pf-c-pagination--m-display-navigation__nav--Visibility);
+        --pf-c-pagination--c-options-menu--Display: var(--pf-c-pagination--m-display-navigation--c-options-menu--Display);
+        --pf-c-pagination--c-options-menu--Visibility: var(--pf-c-pagination--m-display-navigation--c-options-menu--Visibility);
+        --pf-c-pagination__total-items--Display: var(--pf-c-pagination--m-display-navigation__total-items--Display);
+        --pf-c-pagination__total-items--Visibility: var(--pf-c-pagination--m-display-navigation__total-items--Visibility);
+      }
+    }
   }
 }
+/* stylelint-enable */


### PR DESCRIPTION
closes #3561 

Caveat: the new modifiers DO NOT apply to `.pf-c-pagination.pf-m-bottom` as `.pf-m-bottom` has a unique and specific, presentation. 

@mcoker removed the `isFullscreen` tag as the examples are difficult to scan in component context.