### PR TITLE
fix(calendar-month): updated a11y per the react component

### DIFF
--- a/src/patternfly/components/CalendarMonth/calendar-month-date.hbs
+++ b/src/patternfly/components/CalendarMonth/calendar-month-date.hbs
@@ -1,10 +1,11 @@
 <button class="pf-c-calendar-month__date{{#if calendar-month-date--modifier}} {{calendar-month-date--modifier}}{{/if}}"
   type="button"
+  aria-label="{{calendar-month-date--date}} {{calendar-month--month}} {{calendar-month--year}}"
   {{#if calendar-month-dates-cell--IsDisabled}}
     disabled
   {{/if}}
   {{#if calendar-month-date--attribute}}
     {{{calendar-month-date--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{calendar-month-date--date}}
 </button>

--- a/src/patternfly/components/CalendarMonth/calendar-month-dates-cell.hbs
+++ b/src/patternfly/components/CalendarMonth/calendar-month-dates-cell.hbs
@@ -10,7 +10,5 @@
   {{#if calendar-month-dates-cell--attribute}}
     {{{calendar-month-dates-cell--attribute}}}
   {{/if}}>
-  {{#> calendar-month-date}}
-    {{> @partial-block}}
-  {{/calendar-month-date}}
+  {{> calendar-month-date}}
 </td>

--- a/src/patternfly/components/CalendarMonth/calendar-month-day.hbs
+++ b/src/patternfly/components/CalendarMonth/calendar-month-day.hbs
@@ -2,5 +2,6 @@
   {{#if calendar-month-day--attribute}}
     {{{calendar-month-day--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  <span class="pf-screen-reader">{{calendar-month-day--day}}</span>
+  <span aria-hidden="true">{{calendar-month-day--label}}</span>
 </th>

--- a/src/patternfly/components/CalendarMonth/calendar-month-days-row.hbs
+++ b/src/patternfly/components/CalendarMonth/calendar-month-days-row.hbs
@@ -2,5 +2,11 @@
   {{#if calendar-month-days-row--attribute}}
     {{{calendar-month-days-row--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{> calendar-month-day calendar-month-day--day="Sunday" calendar-month-day--label="S"}}
+  {{> calendar-month-day calendar-month-day--day="Monday" calendar-month-day--label="M"}}
+  {{> calendar-month-day calendar-month-day--day="Tuesday" calendar-month-day--label="T"}}
+  {{> calendar-month-day calendar-month-day--day="Wednesday" calendar-month-day--label="W"}}
+  {{> calendar-month-day calendar-month-day--day="Thursday" calendar-month-day--label="T"}}
+  {{> calendar-month-day calendar-month-day--day="Friday" calendar-month-day--label="F"}}
+  {{> calendar-month-day calendar-month-day--day="Saturday" calendar-month-day--label="S"}}
 </tr>

--- a/src/patternfly/components/CalendarMonth/calendar-month-header-month.hbs
+++ b/src/patternfly/components/CalendarMonth/calendar-month-header-month.hbs
@@ -2,5 +2,7 @@
   {{#if calendar-month-header-month--attribute}}
     {{{calendar-month-header-month--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#> select select-typeahead--Placeholder="Month" id=(concat calendar-month--id '-month-select')}}
+    {{calendar-month--month}}
+  {{/select}}
 </div>

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -33,7 +33,9 @@
   --pf-c-calendar-month__dates-cell--m-current__date--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-calendar-month__dates-cell--m-selected__date--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-calendar-month__dates-cell--m-selected__date--hover--BackgroundColor: var(--pf-global--active-color--100);
-  --pf-c-calendar-month__dates-cell--m-selected__date--focus--BackgroundColor: var(--pf-global--active-color--100);
+  --pf-c-calendar-month__dates-cell--m-selected__date--focus--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-calendar-month__dates-cell--m-selected__date--focus--after--BorderColor: var(--pf-global--primary-color--200);
+  --pf-c-calendar-month__date-cell--m-selected__date--focus--BoxShadow: 0 0 #{pf-size-prem(5px)} var(--pf-global--primary-color--100);
   --pf-c-calendar-month__dates-cell--m-selected__date--Color: var(--pf-global--Color--light-100);
   --pf-c-calendar-month__dates-cell--before--BackgroundColor: transparent;
   --pf-c-calendar-month__dates-cell--before--Top: var(--pf-c-calendar-month__dates-cell--PaddingTop);
@@ -59,6 +61,7 @@
   --pf-c-calendar-month__date--hover--BackgroundColor: var(--pf-global--palette--blue-50);
   --pf-c-calendar-month__date--focus--BackgroundColor: var(--pf-global--palette--blue-50);
   --pf-c-calendar-month__date--focus--after--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-calendar-month__date--focus--BoxShadow: none;
 
   @include pf-t-light;
 
@@ -156,6 +159,8 @@
     --pf-c-calendar-month__date--BackgroundColor: var(--pf-c-calendar-month__dates-cell--m-selected__date--BackgroundColor);
     --pf-c-calendar-month__date--hover--BackgroundColor: var(--pf-c-calendar-month__dates-cell--m-selected__date--hover--BackgroundColor);
     --pf-c-calendar-month__date--focus--BackgroundColor: var(--pf-c-calendar-month__dates-cell--m-selected__date--focus--BackgroundColor);
+    --pf-c-calendar-month__date--focus--after--BorderColor: var(--pf-c-calendar-month__dates-cell--m-selected__date--focus--after--BorderColor);
+    --pf-c-calendar-month__date--focus--BoxShadow: var(--pf-c-calendar-month__date-cell--m-selected__date--focus--BoxShadow);
     --pf-c-calendar-month__date--Color: var(--pf-c-calendar-month__dates-cell--m-selected__date--Color);
   }
 
@@ -203,6 +208,7 @@
     --pf-c-calendar-month__date--after--BorderColor: var(--pf-c-calendar-month__date--focus--after--BorderColor);
 
     outline: 0;
+    box-shadow: var(--pf-c-calendar-month__date--focus--BoxShadow);
   }
 
   &:disabled {

--- a/src/patternfly/components/CalendarMonth/examples/CalendarMonth.md
+++ b/src/patternfly/components/CalendarMonth/examples/CalendarMonth.md
@@ -8,18 +8,16 @@ cssPrefix: pf-c-calendar-month
 ## Examples
 ### Date selected
 ```hbs
-{{#> calendar-month calendar-month--id="calendar-month-date-selected"}}
+{{#> calendar-month calendar-month--id="calendar-month-date-selected" calendar-month--month="October" calendar-month--year="2020"}}
   {{#> calendar-month-header}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-prev-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Previous month"'}}
         <i class="fas fa-angle-left" aria-hidden="true"></i>
       {{/button}}
     {{/calendar-month-header-nav-control}}
-    {{#> calendar-month-header-month}}
-      {{#> select id=(concat calendar-month--id '-month-select')}}October{{/select}}
-    {{/calendar-month-header-month}}
+    {{> calendar-month-header-month}}
     {{#> calendar-month-header-year}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="2020" id="' calendar-month--id '-year" aria-label="Select year"')}}
+      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="' calendar-month--year '" id="' calendar-month--id '-year" aria-label="Select year"')}}
     {{/calendar-month-header-year}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-next-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Next month"'}}
@@ -29,61 +27,53 @@ cssPrefix: pf-c-calendar-month
   {{/calendar-month-header}}
   {{#> calendar-month-calendar}}
     {{#> calendar-month-days}}
-      {{#> calendar-month-days-row}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-        {{#> calendar-month-day}}M{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}W{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}F{{/calendar-month-day}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-      {{/calendar-month-days-row}}
+      {{> calendar-month-days-row}}
     {{/calendar-month-days}}
     {{#> calendar-month-dates}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}2{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}3{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}4{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}5{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="3"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="4"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="5"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}6{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}7{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}8{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsCurrent="true"}}9{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}10{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}11{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}12{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="6"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="7"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="8"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="9" calendar-month-dates-cell--IsCurrent="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="10"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="11"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="12"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}13{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}14{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}15{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}16{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}17{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}18{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}19{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="13"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="14"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="15"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="16"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="17"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="18"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="19"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}20{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsSelected="true"}}21{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}22{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}23{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}24{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}25{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}26{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="20"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="21" calendar-month-dates-cell--IsSelected="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="22"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="23"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="24"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="25"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="26"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}27{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}28{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}31{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}2{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="27"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="28"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="31"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2" calendar-month-dates-cell--IsAdjacentMonth="true"}}
       {{/calendar-month-dates-row}}
     {{/calendar-month-dates}}
   {{/calendar-month-calendar}}
@@ -92,7 +82,7 @@ cssPrefix: pf-c-calendar-month
 
 ### Range start date selected, end date hovered
 ```hbs
-{{#> calendar-month calendar-month--id="calendar-month-range-start-date-selected"}}
+{{#> calendar-month calendar-month--id="calendar-month-range-start-date-selected" calendar-month--month="October" calendar-month--year="2020"}}
   {{#> calendar-month-header}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-prev-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Previous month"'}}
@@ -100,10 +90,10 @@ cssPrefix: pf-c-calendar-month
       {{/button}}
     {{/calendar-month-header-nav-control}}
     {{#> calendar-month-header-month}}
-      {{#> select id=(concat calendar-month--id '-month-select')}}October{{/select}}
+      {{#> select select-typeahead--Placeholder="Month" id=(concat calendar-month--id '-month-select')}}{{calendar-month--month}}{{/select}}
     {{/calendar-month-header-month}}
     {{#> calendar-month-header-year}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="2020" id="' calendar-month--id '-year" aria-label="Select year"')}}
+      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="' calendar-month--year '" id="' calendar-month--id '-year" aria-label="Select year"')}}
     {{/calendar-month-header-year}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-next-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Next month"'}}
@@ -113,61 +103,53 @@ cssPrefix: pf-c-calendar-month
   {{/calendar-month-header}}
   {{#> calendar-month-calendar}}
     {{#> calendar-month-days}}
-      {{#> calendar-month-days-row}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-        {{#> calendar-month-day}}M{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}W{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}F{{/calendar-month-day}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-      {{/calendar-month-days-row}}
+      {{> calendar-month-days-row}}
     {{/calendar-month-days}}
     {{#> calendar-month-dates}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}2{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}3{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}4{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}5{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="3"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="4"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="5"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}6{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}7{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}8{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsCurrent="true"}}9{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}10{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true"}}11{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}12{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="6"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="7"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="8"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="9" calendar-month-dates-cell--IsCurrent="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="10"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="11" calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="12" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}13{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}14{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}15{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}16{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}17{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}18{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}19{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="13" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="14" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="15" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="16" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="17" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="18" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="19" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}20{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}21{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}22{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}23{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}24{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}25{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}26{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="20" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="21" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="22" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="23" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="24" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="25" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="26" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}27{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}28{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true" calendar-month-date--modifier="pf-m-hover"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}31{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}2{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="27" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="28" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true" calendar-month-date--modifier="pf-m-hover"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="31"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2" calendar-month-dates-cell--IsAdjacentMonth="true"}}
       {{/calendar-month-dates-row}}
     {{/calendar-month-dates}}
   {{/calendar-month-calendar}}
@@ -176,7 +158,7 @@ cssPrefix: pf-c-calendar-month
 
 ### Range end date selected, start date focused
 ```hbs
-{{#> calendar-month calendar-month--id="calendar-month-range-end-date-selected"}}
+{{#> calendar-month calendar-month--id="calendar-month-range-end-date-selected" calendar-month--month="October" calendar-month--year="2020"}}
   {{#> calendar-month-header}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-prev-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Previous month"'}}
@@ -184,10 +166,10 @@ cssPrefix: pf-c-calendar-month
       {{/button}}
     {{/calendar-month-header-nav-control}}
     {{#> calendar-month-header-month}}
-      {{#> select id=(concat calendar-month--id '-month-select')}}October{{/select}}
+      {{#> select select-typeahead--Placeholder="Month" id=(concat calendar-month--id '-month-select')}}{{calendar-month--month}}{{/select}}
     {{/calendar-month-header-month}}
     {{#> calendar-month-header-year}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="2020" id="' calendar-month--id '-year" aria-label="Select year"')}}
+      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="' calendar-month--year '" id="' calendar-month--id '-year" aria-label="Select year"')}}
     {{/calendar-month-header-year}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-next-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Next month"'}}
@@ -197,61 +179,53 @@ cssPrefix: pf-c-calendar-month
   {{/calendar-month-header}}
   {{#> calendar-month-calendar}}
     {{#> calendar-month-days}}
-      {{#> calendar-month-days-row}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-        {{#> calendar-month-day}}M{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}W{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}F{{/calendar-month-day}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-      {{/calendar-month-days-row}}
+      {{> calendar-month-days-row}}
     {{/calendar-month-days}}
     {{#> calendar-month-dates}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}2{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}3{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}4{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}5{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="3"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="4"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="5"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}6{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}7{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}8{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsCurrent="true"}}9{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}10{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true" calendar-month-date--modifier="pf-m-focus"}}11{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}12{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="6"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="7"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="8"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="9" calendar-month-dates-cell--IsCurrent="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="10"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="11" calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true" calendar-month-date--modifier="pf-m-focus"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="12" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}13{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}14{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}15{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}16{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}17{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}18{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}19{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="13" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="14" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="15" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="16" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="17" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="18" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="19" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}20{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}21{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}22{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}23{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}24{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}25{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}26{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="20" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="21" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="22" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="23" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="24" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="25" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="26" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}27{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}28{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}31{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}2{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="27" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="28" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="31"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2" calendar-month-dates-cell--IsAdjacentMonth="true"}}
       {{/calendar-month-dates-row}}
     {{/calendar-month-dates}}
   {{/calendar-month-calendar}}
@@ -260,7 +234,7 @@ cssPrefix: pf-c-calendar-month
 
 ### Range start and end dates selected
 ```hbs
-{{#> calendar-month calendar-month--id="calendar-month-range-start-and-end-dates-selected"}}
+{{#> calendar-month calendar-month--id="calendar-month-range-start-and-end-dates-selected" calendar-month--month="October" calendar-month--year="2020"}}
   {{#> calendar-month-header}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-prev-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Previous month"'}}
@@ -268,10 +242,10 @@ cssPrefix: pf-c-calendar-month
       {{/button}}
     {{/calendar-month-header-nav-control}}
     {{#> calendar-month-header-month}}
-      {{#> select id=(concat calendar-month--id '-month-select')}}October{{/select}}
+      {{#> select select-typeahead--Placeholder="Month" id=(concat calendar-month--id '-month-select')}}{{calendar-month--month}}{{/select}}
     {{/calendar-month-header-month}}
     {{#> calendar-month-header-year}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="2020" id="' calendar-month--id '-year" aria-label="Select year"')}}
+      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="' calendar-month--year '" id="' calendar-month--id '-year" aria-label="Select year"')}}
     {{/calendar-month-header-year}}
     {{#> calendar-month-header-nav-control calendar-month-header-nav-control--modifier="pf-m-next-month"}}
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Next month"'}}
@@ -281,61 +255,53 @@ cssPrefix: pf-c-calendar-month
   {{/calendar-month-header}}
   {{#> calendar-month-calendar}}
     {{#> calendar-month-days}}
-      {{#> calendar-month-days-row}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-        {{#> calendar-month-day}}M{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}W{{/calendar-month-day}}
-        {{#> calendar-month-day}}T{{/calendar-month-day}}
-        {{#> calendar-month-day}}F{{/calendar-month-day}}
-        {{#> calendar-month-day}}S{{/calendar-month-day}}
-      {{/calendar-month-days-row}}
+      {{> calendar-month-days-row}}
     {{/calendar-month-days}}
     {{#> calendar-month-dates}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}2{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}3{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}4{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}5{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="3"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="4"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="5"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell}}6{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}7{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}8{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsCurrent="true"}}9{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}10{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true"}}11{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}12{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="6"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="7"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="8"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="9" calendar-month-dates-cell--IsCurrent="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="10"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="11" calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsStartRange="true" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="12" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}13{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}14{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}15{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}16{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}17{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}18{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}19{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="13" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="14" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="15" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="16" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="17" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="18" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="19" calendar-month-dates-cell--IsInRange="true"}}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}20{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}21{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}22{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}23{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}24{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}25{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true"}}26{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="20" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="21" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="22" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="23" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="24" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="25" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
+        {{> calendar-month-dates-cell calendar-month-date--date="26" calendar-month-dates-cell--IsInRange="true" calendar-month-dates-cell--IsDisabled="true" }}
       {{/calendar-month-dates-row}}
       {{#> calendar-month-dates-row}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}27{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsInRange="true"}}28{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true"}}29{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}30{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell}}31{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}1{{/calendar-month-dates-cell}}
-        {{#> calendar-month-dates-cell calendar-month-dates-cell--IsAdjacentMonth="true"}}2{{/calendar-month-dates-cell}}
+        {{> calendar-month-dates-cell calendar-month-date--date="27" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="28" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="29" calendar-month-dates-cell--IsSelected="true" calendar-month-dates-cell--IsEndRange="true" calendar-month-dates-cell--IsInRange="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="30"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="31"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="1" calendar-month-dates-cell--IsAdjacentMonth="true"}}
+        {{> calendar-month-dates-cell calendar-month-date--date="2" calendar-month-dates-cell--IsAdjacentMonth="true"}}
       {{/calendar-month-dates-row}}
     {{/calendar-month-dates}}
   {{/calendar-month-calendar}}
@@ -347,8 +313,11 @@ cssPrefix: pf-c-calendar-month
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-hidden="true"` | `.pf-c-calendar-month__header-nav-control > button > [icon]` | Hides the nav control icon from assistive technologies. **Required** |
+| `aria-hidden="true"` | `.pf-c-calendar-month__day > span` | Hides the visual day of the month label from assistive technologies. **Required** |
+| `.pf-screen-reader` | `.pf-c-calendar-month__day > span` | Hides the full day of the month text visually. **Required** |
 | `aria-label="[Prev/Next] month"` | `.pf-c-calendar-month__header-nav-control` | Provides an accessible label for the nav controls. **Required** |
 | `disabled` | `.pf-c-calendar-month__date` | Indicates that a date is selected. **Required when the parent is `.pf-c-calendar-month__dates-cell.pf-m-disabled`** |
+| `aria-label="[date] [month] [year]"` | `.pf-c-calendar-month__date` | Provides an accessible label for the date button. **Required** |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/DatePicker/date-picker.hbs
+++ b/src/patternfly/components/DatePicker/date-picker.hbs
@@ -1,6 +1,6 @@
 <div class="pf-c-date-picker{{#if date-picker--modifier}} {{date-picker--modifier}}{{/if}}"
   {{#if date-picker--attribute}}
-    {{date-picker--attribute}}
+    {{{date-picker--attribute}}}
   {{/if}}>
   {{> date-picker-input}}
   {{#if date-picker-helper-text--text}}

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -5,6 +5,9 @@
   --pf-c-date-picker__helper-text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-date-picker__helper-text--Color: var(--pf-global--Color--100);
   --pf-c-date-picker__helper-text--m-error--Color: var(--pf-global--danger-color--100);
+  --pf-c-date-picker__input--c-form-control--Width: calc(var(--pf-c-date-picker__input--c-form-control--width-chars) * 1ch + var(--pf-c-date-picker__input--c-form-control--width-base));
+  --pf-c-date-picker__input--c-form-control--width-base: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm)); // form control left/right padding + status icon width and spacer
+  --pf-c-date-picker__input--c-form-control--width-chars: 10;
   --pf-c-date-picker__calendar--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-date-picker__calendar--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-date-picker__calendar--ZIndex: var(--pf-global--ZIndex--sm);
@@ -15,6 +18,7 @@
   --pf-c-date-picker__calendar--m-align-right--Left: auto;
 
   position: relative;
+  display: inline-block;
 }
 
 .pf-c-date-picker__helper-text {
@@ -24,6 +28,12 @@
 
   &.pf-m-error {
     --pf-c-date-picker__helper-text--Color: var(--pf-c-date-picker__helper-text--m-error--Color);
+  }
+}
+
+.pf-c-date-picker__input {
+  .pf-c-form-control {
+    width: var(--pf-c-date-picker__input--c-form-control--Width);
   }
 }
 

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -24,21 +24,59 @@ import './DatePicker.css'
 ### Helper text
 ```hbs
 {{#> date-picker date-picker--id="helper-text" date-picker-helper-text--text="Select a date."}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}
 {{/date-picker}}
 ```
 
 ### Invalid
 ```hbs
 {{#> date-picker date-picker--id="invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}
 {{/date-picker}}
 ```
 
 ### Expanded
 ```hbs
 {{#> date-picker date-picker--id="expanded" date-picker--IsExpanded="true"}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar pf-m-expanded" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Expanded date picker example"')}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}{{/date-picker}}
+```
+
+### Custom width input
+```hbs
+{{#> date-picker date-picker--id="basic" date-picker--attribute='style="--pf-c-date-picker__input--c-form-control--Width: 220px;"'}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="November 20, 2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}
+{{/date-picker}}
+```
+
+### Custom width input based on number of characters
+```hbs
+{{#> date-picker date-picker--id="basic" date-picker--attribute='style="--pf-c-date-picker__input--c-form-control--width-chars: 17;"'}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="November 20, 2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}
 {{/date-picker}}
 ```
 

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -12,7 +12,12 @@ import './DatePicker.css'
 ### Basic
 ```hbs
 {{#> date-picker date-picker--id="basic"}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+  {{#> input-group}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+    {{/button}}
+  {{/input-group}}
 {{/date-picker}}
 ```
 

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -13,7 +13,7 @@ import './DatePicker.css'
 ```hbs
 {{#> date-picker date-picker--id="basic"}}
   {{#> input-group}}
-    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+    {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
     {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
       <i class="fas fa-calendar-alt" aria-hidden="true"></i>
     {{/button}}
@@ -24,21 +24,21 @@ import './DatePicker.css'
 ### Helper text
 ```hbs
 {{#> date-picker date-picker--id="helper-text" date-picker-helper-text--text="Select a date."}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
 {{/date-picker}}
 ```
 
 ### Invalid
 ```hbs
 {{#> date-picker date-picker--id="invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'aria-invalid="true" type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Basic date picker example"')}}
 {{/date-picker}}
 ```
 
 ### Expanded
 ```hbs
 {{#> date-picker date-picker--id="expanded" date-picker--IsExpanded="true"}}
-  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar pf-m-expanded" form-control--attribute=(concat 'type="text" value="03/05/2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Expanded date picker example"')}}
+  {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar pf-m-expanded" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Expanded date picker example"')}}
 {{/date-picker}}
 ```
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3679

> if a cell has .pf-m-selected applied you cannot tell when its button has :focus applied since the borders overlap

@mcarrano do you want to do something about this? We could use a blue shadow on focus or something like that?

![Nov-20-2020 14-46-36](https://user-images.githubusercontent.com/35148959/99848355-3cec8680-2b3f-11eb-842f-4c8e41fab0bf.gif)
