### PR TITLE
fix(jump-links): mark only top-level item as current

### DIFF
--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -10,7 +10,7 @@
   --pf-c-jump-links--m-vertical__list--PaddingLeft: 0;
   --pf-c-jump-links__list--FlexDirection: row;
   --pf-c-jump-links--m-vertical__list--FlexDirection: column;
-  --pf-c-jump-links__list--before--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-jump-links__list--before--BorderColor: transparent;
   --pf-c-jump-links__list--before--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-jump-links__list--before--BorderRightWidth: 0;
   --pf-c-jump-links__list--before--BorderBottomWidth: 0;
@@ -157,9 +157,6 @@
     --pf-c-jump-links__link--before--BorderLeftWidth: var(--pf-c-jump-links__item--m-current__link--before--BorderLeftWidth);
     --pf-c-jump-links__link--before--BorderColor: var(--pf-c-jump-links__item--m-current__link--before--BorderColor);
     --pf-c-jump-links__link-text--Color: var(--pf-c-jump-links__item--m-current__link-text--Color);
-  }
-  &.pf-m-current > .pf-c-jump-links__list::before {
-    border-color: transparent;
   }
 }
 // stylelint-enable

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -10,7 +10,7 @@
   --pf-c-jump-links--m-vertical__list--PaddingLeft: 0;
   --pf-c-jump-links__list--FlexDirection: row;
   --pf-c-jump-links--m-vertical__list--FlexDirection: column;
-  --pf-c-jump-links__list--before--BorderColor: transparent;
+  --pf-c-jump-links__list--before--BorderColor: var(--pf-global--BorderColor--100);
   --pf-c-jump-links__list--before--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-jump-links__list--before--BorderRightWidth: 0;
   --pf-c-jump-links__list--before--BorderBottomWidth: 0;
@@ -152,6 +152,8 @@
 
 // stylelint-disable
 .pf-c-jump-links__item {
+  --pf-c-jump-links__list--before--BorderColor: transparent;
+
   &.pf-m-current > .pf-c-jump-links__link {
     --pf-c-jump-links__link--before--BorderTopWidth: var(--pf-c-jump-links__item--m-current__link--before--BorderTopWidth);
     --pf-c-jump-links__link--before--BorderLeftWidth: var(--pf-c-jump-links__item--m-current__link--before--BorderLeftWidth);

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -152,11 +152,14 @@
 
 // stylelint-disable
 .pf-c-jump-links__item {
-  &.pf-m-current {
+  &.pf-m-current > .pf-c-jump-links__link {
     --pf-c-jump-links__link--before--BorderTopWidth: var(--pf-c-jump-links__item--m-current__link--before--BorderTopWidth);
     --pf-c-jump-links__link--before--BorderLeftWidth: var(--pf-c-jump-links__item--m-current__link--before--BorderLeftWidth);
     --pf-c-jump-links__link--before--BorderColor: var(--pf-c-jump-links__item--m-current__link--before--BorderColor);
     --pf-c-jump-links__link-text--Color: var(--pf-c-jump-links__item--m-current__link-text--Color);
+  }
+  &.pf-m-current > .pf-c-jump-links__list {
+    margin-top: 0;
   }
 }
 // stylelint-enable

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -158,8 +158,8 @@
     --pf-c-jump-links__link--before--BorderColor: var(--pf-c-jump-links__item--m-current__link--before--BorderColor);
     --pf-c-jump-links__link-text--Color: var(--pf-c-jump-links__item--m-current__link-text--Color);
   }
-  &.pf-m-current > .pf-c-jump-links__list {
-    margin-top: 0;
+  &.pf-m-current > .pf-c-jump-links__list::before {
+    border-color: transparent;
   }
 }
 // stylelint-enable


### PR DESCRIPTION
fixes #3683 .
Now when you set the top-level item as current, it will no longer mark the whole subsection under this item as current.