### PR TITLE
fix(dropdown): Increase spacer

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,9 +1,9 @@
 .pf-c-dropdown {
   // Toggle
   --pf-c-dropdown__toggle--PaddingTop: var(--pf-global--spacer--form-element);
-  --pf-c-dropdown__toggle--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-dropdown__toggle--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-dropdown__toggle--PaddingBottom: var(--pf-global--spacer--form-element);
-  --pf-c-dropdown__toggle--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-dropdown__toggle--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-dropdown__toggle--MinWidth: var(--pf-global--target-size--MinWidth);
   --pf-c-dropdown__toggle--FontSize: var(--pf-global--FontSize--md);
   --pf-c-dropdown__toggle--FontWeight: var(--pf-global--FontWeight--normal);


### PR DESCRIPTION
So this bug was a little odd - the examples Katie noted were React examples, so those will need to be updated.

I updated the spacer to reflect what other buttons are using per advice from @mcarrano and @mceledonia. I was also told to use an overflow menu in the toolbar, but it looks like we're already using it for the Core examples. I think React will need to be updated to reflect that suggestion and fix the remaining issues there.

Fixes https://github.com/patternfly/patternfly/issues/3437.