### PR TITLE
fix(menu): cleaned up examples, code

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -32,8 +32,8 @@ import './Menu.css'
           {{/menu-item-main}}
         {{/menu-item}}
       {{/menu-list-item}}
-      {{#> menu-list-item menu-list-item--modifier="pf-m-disabled"}}
-        {{#> menu-item menu-item--attribute="disabled"}}
+      {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+        {{#> menu-item}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
             Disabled action
@@ -41,8 +41,8 @@ import './Menu.css'
           {{/menu-item-main}}
         {{/menu-item}}
       {{/menu-list-item}}
-      {{#> menu-list-item menu-list-item--modifier="pf-m-disabled"}}
-        {{#> menu-item menu-item--IsLink="true" menu-item--modifier='aria-disabled="true" tabindex="-1"'}}
+      {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+        {{#> menu-item menu-item--IsLink="true"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
             Disabled link
@@ -116,7 +116,7 @@ import './Menu.css'
           {{/menu-item-main}}
         {{/menu-item}}
       {{/menu-list-item}}
-      {{#> menu-list-item}}
+      {{#> menu-list-item menu-list-item--IsDisabled="true"}}
         {{#> menu-item}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
@@ -529,7 +529,7 @@ import './Menu.css'
           {{/menu-item-description}}
         {{/menu-item}}
       {{/menu-list-item}}
-      {{#> menu-list-item menu-list-item--modifier="pf-m-disabled"}}
+      {{#> menu-list-item menu-list-item--IsDisabled="true"}}
         {{#> menu-item}}
           {{#> menu-item-main}}
             {{#> menu-item-icon}}
@@ -595,18 +595,17 @@ import './Menu.css'
               {{#> menu-item-text}}
                 Item 2
               {{/menu-item-text}}
-              {{> menu-item-select-icon}}
             {{/menu-item-main}}
           {{/menu-item}}
           {{#> menu-item-action menu-item-action--attribute='aria-label="Alert"'}}
             <i class="fas fa-fw fa-bell" aria-hidden="true"></i>
           {{/menu-item-action}}
         {{/menu-list-item}}
-        {{#> menu-list-item}}
-          {{#> menu-item menu-item--modifier="pf-m-selected"}}
+        {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+          {{#> menu-item}}
             {{#> menu-item-main}}
               {{#> menu-item-text}}
-                Item 3
+                Item 3 disabled
               {{/menu-item-text}}
               {{> menu-item-select-icon}}
             {{/menu-item-main}}
@@ -694,11 +693,11 @@ import './Menu.css'
           {{/menu-item}}
           {{> menu-item-action menu-item-action--IsFavorite="true"}}
         {{/menu-list-item}}
-        {{#> menu-list-item}}
+        {{#> menu-list-item menu-list-item--IsDisabled="true"}}
           {{#> menu-item menu-item--IsLink="true" menu-item--attribute='target="_blank"'}}
             {{#> menu-item-main}}
               {{#> menu-item-text}}
-                Item 2
+                Item 2 disabled
               {{/menu-item-text}}
               {{> menu-item-external-icon}}
             {{/menu-item-main}}
@@ -839,9 +838,9 @@ import './Menu.css'
 | `.pf-c-menu__list` | `<ul>` | Initiates the menu list. **Required** |
 | `.pf-c-menu__list-item` | `<li>` | Initiates the menu list item. **Required** |
 | `.pf-c-menu__item` | `<button>`, `<a>`, `<div>` | Initiates the menu item. **Required** |
-| `.pf-c-menu__item-main` | `<div>` | Initiates the menu item main container. **Required** |
+| `.pf-c-menu__item-main` | `<span>` | Initiates the menu item main container. **Required** |
 | `.pf-c-menu__item-text` | `<span>` | Initiates the menu item text. **Required** |
-| `.pf-c-menu__item-description` | `<div>` | Initiates the menu item description. |
+| `.pf-c-menu__item-description` | `<span>` | Initiates the menu item description. |
 | `.pf-c-menu__item-group` | `<section>` | Initiates the menu item group. |
 | `.pf-c-menu__item-group-title` | `<h1>` | Initiates the menu item group title. |
 | `.pf-c-menu__item-icon` | `<span>` | Initiates the menu item icon. |

--- a/src/patternfly/components/Menu/menu-item-action.hbs
+++ b/src/patternfly/components/Menu/menu-item-action.hbs
@@ -1,4 +1,8 @@
 <button class="pf-c-menu__item-action{{#if menu-item-action--IsFavorite}} pf-m-favorite{{/if}}{{#if menu-item-action--IsFavorited}} pf-m-favorited{{/if}}{{#if menu-item-action--modifier}} {{menu-item-action--modifier}}{{/if}}"
+  type="button"
+  {{#if menu-list-item--IsDisabled}}
+    disabled
+  {{/if}}
   {{#if menu-item-action--IsFavorited}}
     aria-label="Starred"
   {{else if menu-item-action--IsFavorite}}

--- a/src/patternfly/components/Menu/menu-item-description.hbs
+++ b/src/patternfly/components/Menu/menu-item-description.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-menu__item-description{{#if menu-item-description--modifier}} {{menu-item-description--modifier}}{{/if}}"
+<span class="pf-c-menu__item-description{{#if menu-item-description--modifier}} {{menu-item-description--modifier}}{{/if}}"
   {{#if menu-item-description--attribute}}
     {{{menu-item-description--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</span>

--- a/src/patternfly/components/Menu/menu-item-main.hbs
+++ b/src/patternfly/components/Menu/menu-item-main.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-menu__item-main{{#if menu-item-main--modifier}} {{menu-item-main--modifier}}{{/if}}"
+<span class="pf-c-menu__item-main{{#if menu-item-main--modifier}} {{menu-item-main--modifier}}{{/if}}"
   {{#if menu-item-main--attribute}}
     {{{menu-item-main--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</span>

--- a/src/patternfly/components/Menu/menu-item.hbs
+++ b/src/patternfly/components/Menu/menu-item.hbs
@@ -1,8 +1,15 @@
 <{{# if menu-item--IsLink}}a{{else}}button{{/if}} class="pf-c-menu__item{{#if menu-item--modifier}} {{menu-item--modifier}}{{/if}}"
   {{#if menu-item--IsLink}}
     href="#"
+    {{#if menu-list-item--IsDisabled}}
+      aria-disabled="true"
+      tabindex="-1"
+    {{/if}}
   {{else}}
     type="button"
+    {{#if menu-list-item--IsDisabled}}
+      disabled
+    {{/if}}
   {{/if}}
   {{#if menu-item--attribute}}
     {{{menu-item--attribute}}}

--- a/src/patternfly/components/Menu/menu-list-item.hbs
+++ b/src/patternfly/components/Menu/menu-list-item.hbs
@@ -1,4 +1,11 @@
-<li class="pf-c-menu__list-item{{#if menu-list-item--modifier}} {{menu-list-item--modifier}}{{/if}}{{#unless menu-list-item--IsCurrentReset}}{{#if menu-list-item--IsCurrentPath}} pf-m-current-path{{/if}}{{/unless}}"
+<li class="pf-c-menu__list-item
+  {{~#unless menu-list-item--IsCurrentReset}}
+    {{#if menu-list-item--IsCurrentPath}} pf-m-current-path{{/if}}
+  {{/unless}}
+  {{~#if menu-list-item--IsDisabled}}
+    pf-m-disabled
+  {{/if}}
+  {{~#if menu-list-item--modifier}} {{menu-list-item--modifier}}{{/if}}"
   {{#if menu-list-item--attribute}}
     {{{menu-list-item--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -2,7 +2,7 @@
   @include pf-t-light;
 
   // Menu
-  --pf-c-menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-menu--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -20,9 +20,9 @@
 
   // List item
   --pf-c-menu__list-item--Color: var(--pf-global--Color--100);
-  --pf-c-menu__list-item--hover--Color: var(--pf-global--Color--100);
   --pf-c-menu__list-item--BackgroundColor: transparent;
-  --pf-c-menu__list-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
+  --pf-c-menu__list-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-menu__list-item--focus-within--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   // Menu item
   --pf-c-menu__item--PaddingTop: var(--pf-global--spacer--sm);
@@ -33,7 +33,7 @@
   --pf-c-menu__item--FontSize: var(--pf-global--FontSize--md);
   --pf-c-menu__item--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-menu__item--LineHeight: var(--pf-global--LineHeight--md);
-  --pf-c-menu__item--disabled--Color: var(--pf-global--Color--dark-200);
+  --pf-c-menu__list-item--m-disabled__item--Color: var(--pf-global--disabled-color--100);
 
   // Group
   --pf-c-menu__group-title--PaddingTop: var(--pf-c-menu__item--PaddingTop);
@@ -41,8 +41,8 @@
   --pf-c-menu__group-title--PaddingBottom: var(--pf-c-menu__item--PaddingBottom);
   --pf-c-menu__group-title--PaddingLeft: var(--pf-c-menu__item--PaddingLeft);
   --pf-c-menu__group-title--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-menu__group-title--FontWeight: var(--pf-global--FontWeight--semi-bold);
-  --pf-c-menu__group-title--Color: var(--pf-global--Color--dark-200);
+  --pf-c-menu__group-title--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-menu__group-title--Color: var(--pf-global--Color--200);
 
   // Description
   --pf-c-menu__item-description--FontSize: var(--pf-global--FontSize--xs);
@@ -54,6 +54,7 @@
   // Toggle icon
   --pf-c-menu__item-toggle-icon--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-menu__item-toggle-icon--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu__list-item--m-disabled__item-toggle-icon--Color: var(--pf-global--disabled-color--200);
 
   // Text + toggle
   --pf-c-menu__item-text--item-toggle-icon--MarginLeft: var(--pf-global--spacer--sm);
@@ -67,21 +68,23 @@
   --pf-c-menu__item-select-icon--FontSize: var(--pf-global--icon--FontSize--sm);
 
   // External icon
-  --pf-c-menu__item-main__external-icon--MarginLeft: var(--pf-global--spacer--sm);
-  --pf-c-menu__item-main__external-icon--Color: var(--pf-global--link--Color);
-  --pf-c-menu__item-main__external-icon--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-menu__item-external-icon--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu__item-external-icon--Color: var(--pf-global--link--Color);
+  --pf-c-menu__item-external-icon--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-menu__item-external-icon--Opacity: 0;
 
   // Action
   --pf-c-menu__item-action--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-menu__item-action--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-menu__item-action--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-menu__item-action--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-menu__item-action-icon--Color: var(--pf-global--Color--dark-200);
+  --pf-c-menu__item-action--Color: var(--pf-global--Color--200);
   --pf-c-menu__item-action-icon--Height: calc(var(--pf-c-menu__item--FontSize) * var(--pf-c-menu__item--LineHeight));
-  --pf-c-menu__item-action--hover__icon--Color: var(--pf-global--Color--dark-100);
+  --pf-c-menu__item-action--hover__icon--Color: var(--pf-global--Color--100);
   --pf-c-menu__item-action--m-favorite__icon--Color: var(--pf-global--disabled-color--200);
   --pf-c-menu__item-action--m-favorite__icon--FontSize: var(--pf-global--icon--FontSize--sm);
   --pf-c-menu__item-action--m-favorite--m-favorited__icon--Color: var(--pf-global--palette--gold-400);
+  --pf-c-menu__list-item--m-disabled__item-action--Color: var(--pf-global--disabled-color--200);
 
   // Drilldown
   --pf-c-menu--m-drilldown--Width: auto;
@@ -193,20 +196,23 @@
   color: var(--pf-c-menu__list-item--Color);
   background-color: var(--pf-c-menu__list-item--BackgroundColor);
 
-  &:hover:not(.pf-m-disabled),
-  &:focus-within:not(.pf-m-disabled) {
-    --pf-c-menu__list-item--Color: var(--pf-c-menu__list-item--hover--Color);
+  &:hover {
     --pf-c-menu__list-item--BackgroundColor: var(--pf-c-menu__list-item--hover--BackgroundColor);
+  }
 
-    .pf-c-menu__item-external-icon {
-      opacity: 1;
-    }
+  &:focus-within {
+    --pf-c-menu__list-item--BackgroundColor: var(--pf-c-menu__list-item--focus-within--BackgroundColor);
   }
 
   &.pf-m-disabled {
-    .pf-c-menu__item {
-      --pf-c-menu__item--Color: var(--pf-c-menu__item--disabled--Color);
+    --pf-c-menu__list-item--hover--BackgroundColor: transparent;
+    --pf-c-menu__list-item--focus-within--BackgroundColor: transparent;
+    --pf-c-menu__item--Color: var(--pf-c-menu__list-item--m-disabled__item--Color);
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__list-item--m-disabled__item-action--Color);
+    --pf-c-menu__item-toggle-icon: var(--pf-c-menu__list-item--m-disabled__item-toggle-icon--Color);
 
+    .pf-c-menu__item,
+    .pf-c-menu__item-action {
       pointer-events: none;
     }
   }
@@ -234,10 +240,9 @@
     text-decoration: none;
   }
 
-  &:disabled {
-    --pf-c-menu__item--Color: var(--pf-c-menu__item--disabled--Color);
-
-    pointer-events: none;
+  &:hover,
+  &:focus {
+    --pf-c-menu__item-external-icon--Opacity: 1;
   }
 
   &.pf-m-selected {
@@ -251,13 +256,14 @@
   display: flex;
   align-items: center;
   width: 100%;
+}
 
-  .pf-c-menu__item-external-icon {
-    margin-left: var(--pf-c-menu__item-main__external-icon--MarginLeft);
-    font-size: var(--pf-c-menu__item-main__external-icon--FontSize);
-    color: var(--pf-c-menu__item-main__external-icon--Color);
-    opacity: 0;
-  }
+
+.pf-c-menu__item-external-icon {
+  margin-left: var(--pf-c-menu__item-external-icon--MarginLeft);
+  font-size: var(--pf-c-menu__item-external-icon--FontSize);
+  color: var(--pf-c-menu__item-external-icon--Color);
+  opacity: var(--pf-c-menu__item-external-icon--Opacity);
 }
 
 // Item text
@@ -294,6 +300,7 @@
 .pf-c-menu__item-toggle-icon {
   padding-right: var(--pf-c-menu__item-toggle-icon--PaddingRight);
   padding-left: var(--pf-c-menu__item-toggle-icon--PaddingLeft);
+  color: var(--pf-c-menu__item-toggle-icon, inherit);
 }
 
 .pf-c-menu__item-text + .pf-c-menu__item-toggle-icon {
@@ -319,18 +326,19 @@
   padding-right: var(--pf-c-menu__item-action--PaddingRight);
   padding-bottom: var(--pf-c-menu__item-action--PaddingBottom);
   padding-left: var(--pf-c-menu__item-action--PaddingLeft);
+  color: var(--pf-c-menu__item-action--Color);
   border: none;
 
   &:hover,
   &:focus {
-    --pf-c-menu__item-action-icon--Color: var(--pf-c-menu__item-action--hover__icon--Color);
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--hover__icon--Color);
   }
 
   &.pf-m-favorite {
-    --pf-c-menu__item-action-icon--Color: var(--pf-c-menu__item-action--m-favorite__icon--Color);
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite__icon--Color);
 
     &.pf-m-favorited {
-      --pf-c-menu__item-action-icon--Color: var(--pf-c-menu__item-action--m-favorite--m-favorited__icon--Color);
+      --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite--m-favorited__icon--Color);
     }
 
     .pf-c-menu__item-action-icon {
@@ -343,5 +351,4 @@
   display: flex;
   align-items: center;
   height: var(--pf-c-menu__item-action-icon--Height);
-  color: var(--pf-c-menu__item-action-icon--Color);
 }

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -79,12 +79,15 @@
   --pf-c-menu__item-action--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-menu__item-action--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu__item-action--Color: var(--pf-global--Color--200);
-  --pf-c-menu__item-action-icon--Height: calc(var(--pf-c-menu__item--FontSize) * var(--pf-c-menu__item--LineHeight));
-  --pf-c-menu__item-action--hover__icon--Color: var(--pf-global--Color--100);
-  --pf-c-menu__item-action--m-favorite__icon--Color: var(--pf-global--disabled-color--200);
-  --pf-c-menu__item-action--m-favorite__icon--FontSize: var(--pf-global--icon--FontSize--sm);
-  --pf-c-menu__item-action--m-favorite--m-favorited__icon--Color: var(--pf-global--palette--gold-400);
+  --pf-c-menu__item-action--hover--Color: var(--pf-global--Color--100);
+  --pf-c-menu__item-action--m-favorite--Color: var(--pf-global--disabled-color--200);
+  --pf-c-menu__item-action--m-favorited--Color: var(--pf-global--palette--gold-400);
+  --pf-c-menu__item-action--m-favorited--hover--Color: var(--pf-global--palette--gold-500);
   --pf-c-menu__list-item--m-disabled__item-action--Color: var(--pf-global--disabled-color--200);
+
+  // Action icon
+  --pf-c-menu__item-action-icon--Height: calc(var(--pf-c-menu__item--FontSize) * var(--pf-c-menu__item--LineHeight));
+  --pf-c-menu__item-action--m-favorite__icon--FontSize: var(--pf-global--icon--FontSize--sm);
 
   // Drilldown
   --pf-c-menu--m-drilldown--Width: auto;
@@ -329,21 +332,22 @@
   color: var(--pf-c-menu__item-action--Color);
   border: none;
 
-  &:hover,
-  &:focus {
-    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--hover__icon--Color);
-  }
-
   &.pf-m-favorite {
-    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite__icon--Color);
-
-    &.pf-m-favorited {
-      --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite--m-favorited__icon--Color);
-    }
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite--Color);
 
     .pf-c-menu__item-action-icon {
       font-size: var(--pf-c-menu__item-action--m-favorite__icon--FontSize);
     }
+  }
+
+  &.pf-m-favorited {
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorited--Color);
+    --pf-c-menu__item-action--hover--Color: var(--pf-c-menu__item-action--m-favorited--hover--Color);
+  }
+
+  &:hover,
+  &:focus {
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--hover--Color);
   }
 }
 

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -80,7 +80,6 @@
   --pf-c-menu__item-action--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu__item-action--Color: var(--pf-global--Color--200);
   --pf-c-menu__item-action--hover--Color: var(--pf-global--Color--100);
-  --pf-c-menu__item-action--m-favorite--Color: var(--pf-global--disabled-color--200);
   --pf-c-menu__item-action--m-favorited--Color: var(--pf-global--palette--gold-400);
   --pf-c-menu__item-action--m-favorited--hover--Color: var(--pf-global--palette--gold-500);
   --pf-c-menu__list-item--m-disabled__item-action--Color: var(--pf-global--disabled-color--200);
@@ -333,8 +332,6 @@
   border: none;
 
   &.pf-m-favorite {
-    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--m-favorite--Color);
-
     .pf-c-menu__item-action-icon {
       font-size: var(--pf-c-menu__item-action--m-favorite__icon--FontSize);
     }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3675

* Clean up hbs/examples
* Add disabled examples under actions and favorites
* Change item-main and item-description to spans
* Disable item action if parent item is disabled
* Clean up external icon var names
* Use proper global vars
* Update disabled item action, toggle icon colors

@mcarrano can you verify that if an item is disabled that any children actions should also be disabled? I added some new disabled examples to review under expanded toggle, links, actions, and favorites.