### PR TITLE
fix(dropdown): support dropdown menu alignment on different breakpoint

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,3 +1,6 @@
+
+$pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
+
 .pf-c-dropdown {
   // Toggle
   --pf-c-dropdown__toggle--PaddingTop: var(--pf-global--spacer--form-element);
@@ -355,8 +358,19 @@
   background-clip: padding-box;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
-  &.pf-m-align-right {
-    right: 0;
+  @each $breakpoint, $breakpoint-value in $pf-c-dropdown--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-c-dropdown--breakpoint-map) {
+      &.pf-m-align-right#{$breakpoint-name} {
+        right: 0;
+      }
+
+      // unset alignment set for .pf-m-align-right
+      &.pf-m-align-left#{$breakpoint-name} {
+        right: unset;
+      }
+    }
   }
 
   .pf-c-dropdown.pf-m-top & {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -367,7 +367,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 
       // unset alignment set for .pf-m-align-right
       &.pf-m-align-left#{$breakpoint-name} {
-        right: unset;
+        right: auto;
       }
     }
   }

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,4 +1,3 @@
-
 $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-dropdown {

--- a/src/patternfly/components/Dropdown/examples/Dropdown.css
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.css
@@ -2,6 +2,7 @@
 #ws-core-c-dropdown-kebab,
 #ws-core-c-dropdown-kebab-align-right,
 #ws-core-c-dropdown-align-right,
+#ws-core-c-dropdown-align-on-different-breakpoint,
 #ws-core-c-dropdown-align-top,
 #ws-core-c-dropdown-primary-toggle,
 #ws-core-c-dropdown-menu-item-icons {
@@ -12,6 +13,11 @@
 #ws-core-c-dropdown-align-right {
   display: flex;
   justify-content: flex-end;
+}
+
+#ws-core-c-dropdown-align-on-different-breakpoint {
+  display: flex;
+  justify-content: center;
 }
 
 #ws-core-c-dropdown-align-top {

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -57,6 +57,15 @@ import './Dropdown.css'
 {{/dropdown}}
 ```
 
+### Align on different breakpoint
+```hbs
+{{#> dropdown id="dropdown-align-on-different-breakpoint" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown-menu--modifier="pf-m-align-right-on-lg pf-m-align-left-on-2xl"}}
+  {{#> dropdown-toggle-text}}
+    Dropdown
+  {{/dropdown-toggle-text}}
+{{/dropdown}}
+```
+
 ### Align top
 ```hbs
 {{#> dropdown id="dropdown-align-top" dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
@@ -255,7 +264,8 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__group-title` | `<h1>` | Defines the title for a group of items in the dropdown menu. |
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state. |
 | `.pf-m-top` | `.pf-c-dropdown` | Modifies to display the menu above the toggle. |
-| `.pf-m-align-right` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the right edge of the toggle. |
+| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the left edge of the toggle. |
+| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the right edge of the toggle. |
 | `.pf-m-split-button` | `.pf-c-dropdown__toggle` | Modifies the dropdown toggle area to allow for interactive elements. |
 | `.pf-m-action` | `.pf-c-dropdown__toggle.pf-m-split-button` | Modifies the dropdown toggle for when an action is placed beside a toggle button in a split button dropdown. |
 | `.pf-m-text` | `.pf-c-dropdown__menu-item` | Modifies a menu item to be non-interactive text. |


### PR DESCRIPTION
closes #3069 .
Now it's not only support `pf-m-align-right-on-[breakpoint]` but also support `pf-m-align-left-on-[breakpoint]`, so you can set your style like `pf-m-align-right-on-md pf-m-align-left-on-xl`.