### PR TITLE
feat(toolbar-demos): added toolbar back to demos

### DIFF
--- a/src/patternfly/components/DataList/data-list-grid.scss
+++ b/src/patternfly/components/DataList/data-list-grid.scss
@@ -62,7 +62,7 @@
     }
 
     &.pf-m-no-fill {
-      flex-grow: 0;
+      flex: none;
     }
 
     &.pf-m-flex-2 { flex-grow: 2; }

--- a/src/patternfly/components/Pagination/pagination-nav.hbs
+++ b/src/patternfly/components/Pagination/pagination-nav.hbs
@@ -1,5 +1,9 @@
 <nav class="pf-c-pagination__nav{{#if pagination-nav--modifier}} {{pagination-nav--modifier}}{{/if}}"
-  aria-label="Pagination"
+  {{#if pagination-nav--aria-label}}
+    aria-label="{{pagination-nav--aria-label}}"
+  {{else}}
+    aria-label="Pagination"
+  {{/if}}
   {{#if pagination-nav--attribute}}
     {{{pagination-nav--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Toolbar/examples/Toolbar.css
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.css
@@ -1,16 +1,20 @@
-#ws-core-e-toolbar-toggle-group-on-mobile-filters-collapsed-expandable-content-expanded {
+#ws-core-e-toolbar-toggle-group-on-mobile-filters-collapsed-expandable-content-expanded,
+#ws-core-c-toolbar-toggle-group-on-mobile-filters-collapsed-expandable-content-expanded {
   min-height: 19rem;
 }
 
-#ws-core-e-toolbar-expanded-elements {
+#ws-core-e-toolbar-expanded-elements,
+#ws-core-c-toolbar-expanded-elements {
   min-height: 18rem;
 }
 
-#ws-core-e-toolbar-stacked-on-mobile-filters-collapsed-expandable-content-expanded {
+#ws-core-e-toolbar-stacked-on-mobile-filters-collapsed-expandable-content-expanded,
+#ws-core-c-toolbar-stacked-on-mobile-filters-collapsed-expandable-content-expanded {
   min-height: 18rem;
 }
 
-#ws-core-e-toolbar-selected-filters-on-mobile-filters-collapsed-expandable-content-expanded {
+#ws-core-e-toolbar-selected-filters-on-mobile-filters-collapsed-expandable-content-expanded,
+#ws-core-c-toolbar-selected-filters-on-mobile-filters-collapsed-expandable-content-expanded {
   min-height: 28rem;
 }
 
@@ -20,16 +24,36 @@
 #ws-core-e-toolbar-adjusted-spacers .pf-c-toolbar,
 #ws-core-e-toolbar-adjusted-spacers .pf-c-toolbar__item,
 #ws-core-e-toolbar-adjusted-group-spacers .pf-c-toolbar,
-#ws-core-e-toolbar-adjusted-group-spacers .pf-c-toolbar__item {
+#ws-core-e-toolbar-adjusted-group-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-simple .pf-c-toolbar,
+#ws-core-c-toolbar-simple .pf-c-toolbar__group,
+#ws-core-c-toolbar-simple .pf-c-toolbar__item,
+#ws-core-c-toolbar-adjusted-spacers .pf-c-toolbar,
+#ws-core-c-toolbar-adjusted-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-adjusted-group-spacers .pf-c-toolbar,
+#ws-core-c-toolbar-adjusted-group-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-insets .pf-c-toolbar,
+#ws-core-c-toolbar-insets .pf-c-toolbar__item,
+#ws-core-c-toolbar-page-insets .pf-c-toolbar,
+#ws-core-c-toolbar-page-insets .pf-c-toolbar__item {
   border: 2px dashed #393f44;
 }
 
-#ws-core-e-toolbar-simple .pf-c-toolbar__group .pf-c-toolbar__item {
+#ws-core-e-toolbar-simple .pf-c-toolbar__group .pf-c-toolbar__item,
+#ws-core-c-toolbar-simple .pf-c-toolbar__group .pf-c-toolbar__item {
   border: none;
 }
 
 #ws-core-e-toolbar-simple .pf-c-toolbar__item,
 #ws-core-e-toolbar-adjusted-spacers .pf-c-toolbar__item,
-#ws-core-e-toolbar-adjusted-group-spacers .pf-c-toolbar__item {
+#ws-core-e-toolbar-adjusted-group-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-simple .pf-c-toolbar__item,
+#ws-core-c-toolbar-adjusted-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-adjusted-group-spacers .pf-c-toolbar__item,
+#ws-core-c-toolbar-insets .pf-c-toolbar,
+#ws-core-c-toolbar-insets .pf-c-toolbar__item,
+#ws-core-c-toolbar-page-insets .pf-c-toolbar,
+#ws-core-c-toolbar-page-insets .pf-c-toolbar__item {
+
   padding: .5rem;
 }

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -371,7 +371,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
         {{/toolbar-group}}
       {{/toolbar-group}}
       {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
-      {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content}}
       {{#> toolbar-group toolbar-group--modifier="pf-m-chip-container"}}
@@ -399,7 +398,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
         {{> toolbar-toggle toolbar-toggle--modifier="pf-m-expanded" toolbar-toggle--IsExpanded="true"}}
       {{/toolbar-group}}
       {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
-      {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content toolbar-expandable-content--IsExpanded="true"}}
       {{> toolbar-item-search-filter button--id="expanded-content"}}
@@ -526,7 +524,6 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
         {{> toolbar-toggle toolbar-toggle--modifier="pf-m-expanded" toolbar-toggle--IsExpanded="true"}}
       {{/toolbar-group}}
       {{> toolbar-icon-button-group-example toolbar-icon-button-group-example--IsOverflowMenu="true" toolbar-icon-button-group-example--control="true"}}
-      {{> toolbar-overflow-menu-example toolbar-overflow-menu-example--control="true"}}
     {{/toolbar-content-section}}
     {{#> toolbar-expandable-content toolbar-expandable-content--IsExpanded="true"}}
       {{#> toolbar-group}}

--- a/src/patternfly/components/Toolbar/toolbar--template--content.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template--content.hbs
@@ -1,0 +1,55 @@
+{{!-- expand all --}}
+{{#if toolbar--template--HasExpandAll}}
+  {{> toolbar-item-expand-all}}
+{{/if}}
+
+{{!-- bulk selector --}}
+{{#if toolbar--template--HasBulkSelect}}
+  {{> toolbar-item-bulk-select}}
+{{/if}}
+
+{{!-- context selector --}}
+{{#if toolbar--template--HasContextSelector}}
+  {{#> toolbar-item}}
+    {{> toolbar-item-context-selector}}
+  {{/toolbar-item}}
+{{/if}}
+
+{{!-- search filter --}}
+{{#if toolbar--template--HasSearchFilter}}
+  {{> toolbar-item-search-filter}}
+{{/if}}
+
+{{!-- dropdown --}}
+{{#if toolbar--template--HasDropdown}}
+  {{#> toolbar-item}}
+    {{#> select select--attribute="style='width: 150px'" id=(concat toolbar--id '-select-status') select-toggle--icon="fas fa-bookmark"}}
+      Status
+    {{/select}}
+  {{/toolbar-item}}
+{{/if}}
+
+{{!-- filter --}}
+{{#if toolbar--template--HasFilter}}
+  {{#> toolbar-item}}
+    {{#> select id=(concat toolbar--id '-select-checkbox-status') select--IsCheckboxSelect="true"}}
+      Status
+    {{/select}}
+  {{/toolbar-item}}
+{{/if}}
+
+{{!-- filter group --}}
+{{#if toolbar--template--HasFilterGroup}}
+  {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+    {{#> toolbar-item}}
+      {{#> select id=(concat toolbar--id '-select-checkbox-status') select--IsCheckboxSelect="true"}}
+        Status
+      {{/select}}
+    {{/toolbar-item}}
+    {{#> toolbar-item}}
+      {{#> select id=(concat toolbar--id '-select-checkbox-risk') select--IsCheckboxSelect="true"}}
+        Risk
+      {{/select}}
+    {{/toolbar-item}}
+  {{/toolbar-group}}
+{{/if}}

--- a/src/patternfly/components/Toolbar/toolbar--template--filter-group.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template--filter-group.hbs
@@ -1,0 +1,12 @@
+{{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+  {{#> toolbar-item}}
+    {{#> select id=(concat toolbar--id '-select-checkbox-status') select--IsCheckboxSelect="true"}}
+      Status
+    {{/select}}
+  {{/toolbar-item}}
+  {{#> toolbar-item}}
+    {{#> select id=(concat toolbar--id '-select-checkbox-risk') select--IsCheckboxSelect="true"}}
+      Risk
+    {{/select}}
+  {{/toolbar-item}}
+{{/toolbar-group}}

--- a/src/patternfly/components/Toolbar/toolbar--template.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template.hbs
@@ -1,0 +1,126 @@
+{{!--
+Options: [
+  toolbar--template--HasToggleGroup
+  toolbar--template--HasBulkSelect
+  toolbar--template--HasContextSelector
+  toolbar--template--HasSearchFilter
+  toolbar--template--HasFilterGroup
+  toolbar--template--HasDropdown0
+  toolbar--template--HasSortButton
+  toolbar--template--HasOverflowMenu
+  toolbar--template--HasOverflowMenuSecondButton
+  toolbar--template--HasIconButtonGroup
+  toolbar--template--HasViewToggle
+  toolbar--template--HasNoPagination
+] --}}
+
+{{#> toolbar}}
+  {{#> toolbar-content}}
+    {{#> toolbar-content-section toolbar-content-section--modifier="pf-m-nowrap"}}
+
+      {{!-- partial --}}
+      {{#if @partial-block}}
+        {{> @partial-block}}
+      {{/if}}
+
+      {{!-- toggle group --}}
+      {{#if toolbar--template--HasToggleGroup}}
+        {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show-on-lg"}}
+          {{> toolbar-toggle toolbar-toggle--IsExpanded="false"}}
+          {{> toolbar--template--content}}
+        {{/toolbar-group}}
+      {{else}}
+        {{> toolbar--template--content}}
+      {{/if}}
+
+      {{!-- sort --}}
+      {{#if toolbar--template--HasSortButton}}
+        {{#> toolbar-item}}
+          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Edit"'}}
+            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+          {{/button}}
+        {{/toolbar-item}}
+      {{/if}}
+
+      {{!-- overflow menu --}}
+      {{#if toolbar--template--HasOverflowMenu}}
+        {{#> overflow-menu overflow-menu--id="overflow-menu-simple-additional-options-visible"}}
+          {{#> overflow-menu-content overflow-menu-content--modifier="pf-u-display-none pf-u-display-flex-on-lg"}}
+            {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+              {{#> overflow-menu-item}}
+                {{#> button button--modifier="pf-m-primary"}}
+                  Create instance
+                {{/button}}
+              {{/overflow-menu-item}}
+
+              {{!-- second button --}}
+              {{#if toolbar--template--HasOverflowMenuSecondButton}}
+                {{#> overflow-menu-item}}
+                  {{#> button button--modifier="pf-m-secondary"}}
+                    Action
+                  {{/button}}
+                {{/overflow-menu-item}}
+              {{/if}}
+
+            {{/overflow-menu-group}}
+          {{/overflow-menu-content}}
+          {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown with additional options"}}
+            {{#> overflow-menu-dropdown-item}}
+              Action 7
+            {{/overflow-menu-dropdown-item}}
+          {{/overflow-menu-control}}
+        {{/overflow-menu}}
+      {{/if}}
+
+      {{!-- icon button group --}}
+      {{#if toolbar--template--HasIconButtonGroup}}
+        {{#> toolbar-group toolbar-group--modifier="pf-m-icon-button-group"}}
+          {{#> toolbar-item}}
+            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Edit"'}}
+              <i class="fas fa-edit" aria-hidden="true"></i>
+            {{/button}}
+          {{/toolbar-item}}
+          {{#> toolbar-item}}
+            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Clone"'}}
+              <i class="fas fa-clone" aria-hidden="true"></i>
+            {{/button}}
+          {{/toolbar-item}}
+          {{#> toolbar-item}}
+            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sync"'}}
+              <i class="fas fa-sync" aria-hidden="true"></i>
+            {{/button}}
+          {{/toolbar-item}}
+        {{/toolbar-group}}
+      {{/if}}
+
+      {{!-- view toggle --}}
+      {{#if toolbar--template--HasViewToggle}}
+        {{#> toolbar-group toolbar-group--modifier="pf-m-icon-button-group pf-m-align-right"}}
+          {{#> toolbar-item}}
+            {{#> button button--modifier="pf-m-plain pf-m-active" button--attribute='aria-label="Grid view"'}}
+              <i class="fas fa-th" aria-hidden="true"></i>
+            {{/button}}
+          {{/toolbar-item}}
+          {{#> toolbar-item}}
+            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="List view"'}}
+              <i class="fas fa-list-ul" aria-hidden="true"></i>
+            {{/button}}
+          {{/toolbar-item}}
+        {{/toolbar-group}}
+      {{/if}}
+
+      {{!-- pagination --}}
+      {{#unless toolbar--template--HasNoPagination}}
+        {{#> toolbar-item toolbar-item--modifier='pf-m-pagination'}}
+          {{#> pagination pagination--IsCompact="true"}}
+            {{> pagination-options-menu id="pagination-options-menu-bottom-example" options-menu--IsText="true"}}
+            {{> pagination-nav-content pagination-nav--aria-label="Toolbar pagination"}}
+          {{/pagination}}
+        {{/toolbar-item}}
+      {{/unless}}
+    {{/toolbar-content-section}}
+
+    {{!-- expandable content --}}
+    {{> toolbar-expandable-content}}
+  {{/toolbar-content}}
+{{/toolbar}}

--- a/src/patternfly/components/Toolbar/toolbar--template.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template.hbs
@@ -113,8 +113,8 @@ Options: [
       {{#unless toolbar--template--HasNoPagination}}
         {{#> toolbar-item toolbar-item--modifier='pf-m-pagination'}}
           {{#> pagination pagination--IsCompact="true"}}
-            {{> pagination-options-menu id="pagination-options-menu-bottom-example" options-menu--IsText="true"}}
-            {{> pagination-nav-content pagination-nav--aria-label="Toolbar pagination"}}
+            {{> pagination-options-menu id=(concat toolbar--id '-top-pagination') options-menu--IsText="true"}}
+            {{> pagination-nav-content pagination-nav--aria-label="Toolbar top pagination"}}
           {{/pagination}}
         {{/toolbar-item}}
       {{/unless}}

--- a/src/patternfly/components/Toolbar/toolbar-item-context-selector.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-context-selector.hbs
@@ -1,0 +1,72 @@
+{{#> context-selector context-selector--id=(concat toolbar--id '-context-selector') context-selector--label-text="Selected project"}}
+  {{#> context-selector-toggle context-selector-toggle--attribute=(concat 'id="' context-selector--id '-toggle"' 'aria-labelledby="' context-selector--id '-label ' context-selector--id '-toggle"')}}
+    {{#> context-selector-toggle-text}}
+      My project
+    {{/context-selector-toggle-text}}
+    {{#> context-selector-toggle-icon}}
+    {{/context-selector-toggle-icon}}
+  {{/context-selector-toggle}}
+  {{#> context-selector-menu}}
+    {{#> context-selector-menu-search}}
+      {{#> input-group}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
+        {{/form-control}}
+        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
+          <i class="fas fa-search" aria-hidden="true"></i>
+        {{/button}}
+      {{/input-group}}
+    {{/context-selector-menu-search}}
+    {{#> context-selector-menu-menu}}
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          My project
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          OpenShift cluster
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          Production Ansible
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          AWS
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          Azure
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          My project
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          OpenShift cluster
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          Production Ansible
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          AWS
+        {{/context-selector-menu-menu-item}}
+      </li>
+      <li>
+        {{#> context-selector-menu-menu-item}}
+          Azure
+        {{/context-selector-menu-menu-item}}
+      </li>
+    {{/context-selector-menu-menu}}
+  {{/context-selector-menu}}
+{{/context-selector}}

--- a/src/patternfly/components/Toolbar/toolbar.hbs
+++ b/src/patternfly/components/Toolbar/toolbar.hbs
@@ -1,6 +1,6 @@
 <div class="pf-c-toolbar{{#if toolbar--modifier}} {{toolbar--modifier}}{{/if}}"
   {{#if toolbar--id}}
-    id="{{{toolbar--id}}}"
+    id="{{toolbar--id}}"
   {{/if}}
   {{#if toolbar--attribute}}
     {{{toolbar--attribute}}}

--- a/src/patternfly/demos/Card/examples/CardView.md
+++ b/src/patternfly/demos/Card/examples/CardView.md
@@ -69,10 +69,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light pf-m-no-padding"}}
       {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasBulkSelect="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasFilter="true" toolbar--template--HasToggleGroup="true"}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-fill"}}
       {{> card-view-demo-template-gallery}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-light pf-m-sticky-bottom"}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-light pf-m-sticky-bottom pf-m-no-fill"}}
       {{#> pagination pagination--modifier="pf-m-bottom"}}
         {{> pagination-options-menu id="pagination-options-menu-bottom-example" options-menu--IsText="true" pagination-options-menu--modifier="pf-m-top"}}
         {{> pagination-nav-content}}

--- a/src/patternfly/demos/Card/examples/CardView.md
+++ b/src/patternfly/demos/Card/examples/CardView.md
@@ -66,6 +66,9 @@ wrapperTag: div
         <p>This is a demo that showcases Patternfly Cards. </p>
       {{/content}}
     {{/page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-light pf-m-no-padding"}}
+      {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasBulkSelect="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasFilter="true" toolbar--template--HasToggleGroup="true" pagination--modifier="pf-m-hidden pf-m-visible-on-sm"}}
+    {{/page-main-section}}
     {{#> page-main-section}}
       {{> card-view-demo-template-gallery}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Card/examples/CardView.md
+++ b/src/patternfly/demos/Card/examples/CardView.md
@@ -67,7 +67,7 @@ wrapperTag: div
       {{/content}}
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-light pf-m-no-padding"}}
-      {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasBulkSelect="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasFilter="true" toolbar--template--HasToggleGroup="true" pagination--modifier="pf-m-hidden pf-m-visible-on-sm"}}
+      {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasBulkSelect="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasFilter="true" toolbar--template--HasToggleGroup="true"}}
     {{/page-main-section}}
     {{#> page-main-section}}
       {{> card-view-demo-template-gallery}}

--- a/src/patternfly/demos/DataList/data-list--action-buttons.hbs
+++ b/src/patternfly/demos/DataList/data-list--action-buttons.hbs
@@ -1,0 +1,8 @@
+{{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
+  {{#> button button--modifier="pf-m-secondary"}}
+    Action
+  {{/button}}
+  {{#> button button--modifier="pf-m-link"}}
+    Link
+  {{/button}}
+{{/data-list-cell}}

--- a/src/patternfly/demos/DataList/data-list--icon-text.hbs
+++ b/src/patternfly/demos/DataList/data-list--icon-text.hbs
@@ -1,0 +1,12 @@
+{{#> l-flex l-flex--modifier="pf-m-space-items-xs"}}
+  {{#> l-flex-item}}
+    {{#if data-list--icon-text--icon}}
+      <i class="fas fa-{{data-list--icon-text--icon}}" aria-hidden="true"></i>
+    {{else}}
+      <i class="fas fa-code-branch" aria-hidden="true"></i>
+    {{/if}}
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    <span>{{data-list--icon-text--text}}</span>
+  {{/l-flex-item}}
+{{/l-flex}}

--- a/src/patternfly/demos/DataList/data-list-actionable-data-list.hbs
+++ b/src/patternfly/demos/DataList/data-list-actionable-data-list.hbs
@@ -8,15 +8,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-1}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
@@ -29,15 +22,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-2}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
@@ -50,15 +36,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left pf-m-flex-2"}}
           {{> data-list-content-3}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
@@ -71,15 +50,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left pf-m-flex-2"}}
           {{> data-list-content-4}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 {{/data-list}}

--- a/src/patternfly/demos/DataList/data-list-content-1.hbs
+++ b/src/patternfly/demos/DataList/data-list-content-1.hbs
@@ -1,23 +1,18 @@
-<div>
-  <div>
-    <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly</p>
-    <small>Working repo for PatternFly 4 <a href="">https://pf4.patternfly.org/</a></small>
-  </div>
-  <div class="pf-l-flex pf-m-wrap">
-    <div>
-      <i class="fas fa-code-branch" aria-hidden="true"></i>
-      10
-    </div>
-    <div>
-      <i class="fas fa-code" aria-hidden="true"></i>
-      4
-    </div>
-    <div>
-      <i class="fas fa-cube" aria-hidden="true"></i>
-      5
-    </div>
-    <div>
+{{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-md"}}
+  {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+    {{#> l-flex-item}}
+      <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly</p>
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      <small>Working repo for PatternFly 4 <a href="">https://pf4.patternfly.org/</a></small>
+    {{/l-flex-item}}
+  {{/l-flex}}
+  {{#> l-flex l-flex--modifier="pf-m-wrap"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code-branch" data-list--icon-text--text="10"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code" data-list--icon-text--text="4"}}
+    {{> data-list--icon-text data-list--icon-text--icon="cube" data-list--icon-text--text="5"}}
+    {{#> l-flex-item}}
       Updated 2 days ago
-    </div>
-  </div>
-</div>
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/l-flex}}

--- a/src/patternfly/demos/DataList/data-list-content-2.hbs
+++ b/src/patternfly/demos/DataList/data-list-content-2.hbs
@@ -1,35 +1,21 @@
-<div>
-  <div>
-    <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly-elements</p>
-    <small>PatternFly elements</small>
-  </div>
-  <div class="pf-l-flex pf-m-wrap">
-    <div>
-      <i class="fas fa-code-branch" aria-hidden="true"></i>
-      5
-    </div>
-    <div>
-      <i class="fas fa-code" aria-hidden="true"></i>
-      9
-    </div>
-    <div>
-      <i class="fas fa-cube" aria-hidden="true"></i>
-      2
-    </div>
-    <div>
-      <i class="fas fa-check-circle" aria-hidden="true"></i>
-      11
-    </div>
-    <div>
-      <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-      4
-    </div>
-    <div>
-      <i class="fas fa-times-circle" aria-hidden="true"></i>
-      1
-    </div>
-    <div>
+{{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-md"}}
+  {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+    {{#> l-flex-item}}
+      <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly-elements</p>
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      <small>PatternFly elements</small>
+    {{/l-flex-item}}
+  {{/l-flex}}
+  {{#> l-flex l-flex--modifier="pf-m-wrap"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code-branch" data-list--icon-text--text="5"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code" data-list--icon-text--text="9"}}
+    {{> data-list--icon-text data-list--icon-text--icon="cube" data-list--icon-text--text="2"}}
+    {{> data-list--icon-text data-list--icon-text--icon="check-circle" data-list--icon-text--text="11"}}
+    {{> data-list--icon-text data-list--icon-text--icon="exclamation-triangle" data-list--icon-text--text="4"}}
+    {{> data-list--icon-text data-list--icon-text--icon="times-circle" data-list--icon-text--text="1"}}
+    {{#> l-flex-item}}
       Updated 2 days ago
-    </div>
-  </div>
-</div>
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/l-flex}}

--- a/src/patternfly/demos/DataList/data-list-content-4.hbs
+++ b/src/patternfly/demos/DataList/data-list-content-4.hbs
@@ -1,23 +1,18 @@
-<div>
-  <div>
-    <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly</p>
-    <small>Working repo for PatternFly 4 <a href="">https://pf4.patternfly.org/</a></small>
-  </div>
-  <div class="pf-l-flex pf-m-wrap">
-    <div>
-      <i class="fas fa-code-branch" aria-hidden="true"></i>
-      10
-    </div>
-    <div>
-      <i class="fas fa-code" aria-hidden="true"></i>
-      4
-    </div>
-    <div>
-      <i class="fas fa-cube" aria-hidden="true"></i>
-      5
-    </div>
-    <div>
+{{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-md"}}
+  {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+    {{#> l-flex-item}}
+      <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly</p>
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      <small>Working repo for PatternFly 4 <a href="">https://pf4.patternfly.org/</a></small>
+    {{/l-flex-item}}
+  {{/l-flex}}
+  {{#> l-flex l-flex--modifier="pf-m-wrap"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code-branch" data-list--icon-text--text="10"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code" data-list--icon-text--text="4"}}
+    {{> data-list--icon-text data-list--icon-text--icon="cube" data-list--icon-text--text="5"}}
+    {{#> l-flex-item}}
       Updated 2 days ago
-    </div>
-  </div>
-</div>
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/l-flex}}

--- a/src/patternfly/demos/DataList/data-list-content-5.hbs
+++ b/src/patternfly/demos/DataList/data-list-content-5.hbs
@@ -1,35 +1,21 @@
-<div>
-  <div>
-    <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly-elements</p>
-    <small>PatternFly elements</small>
-  </div>
-  <div class="pf-l-flex pf-m-wrap">
-    <div>
-      <i class="fas fa-code-branch" aria-hidden="true"></i>
-      5
-    </div>
-    <div>
-      <i class="fas fa-code" aria-hidden="true"></i>
-      9
-    </div>
-    <div>
-      <i class="fas fa-cube" aria-hidden="true"></i>
-      2
-    </div>
-    <div>
-      <i class="fas fa-check-circle" aria-hidden="true"></i>
-      11
-    </div>
-    <div>
-      <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-      4
-    </div>
-    <div>
-      <i class="fas fa-times-circle" aria-hidden="true"></i>
-      1
-    </div>
-    <div>
+{{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-md"}}
+  {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+    {{#> l-flex-item}}
+      <p id='{{data-list--id}}-{{data-list-item--id}}'>patternfly-elements</p>
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      <small>PatternFly elements</small>
+    {{/l-flex-item}}
+  {{/l-flex}}
+  {{#> l-flex l-flex--modifier="pf-m-wrap"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code-branch" data-list--icon-text--text="5"}}
+    {{> data-list--icon-text data-list--icon-text--icon="code" data-list--icon-text--text="9"}}
+    {{> data-list--icon-text data-list--icon-text--icon="cube" data-list--icon-text--text="2"}}
+    {{> data-list--icon-text data-list--icon-text--icon="check-circle" data-list--icon-text--text="11"}}
+    {{> data-list--icon-text data-list--icon-text--icon="exclamation-triangle" data-list--icon-text--text="4"}}
+    {{> data-list--icon-text data-list--icon-text--icon="times-circle" data-list--icon-text--text="1"}}
+    {{#> l-flex-item}}
       Updated 2 days ago
-    </div>
-  </div>
-</div>
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/l-flex}}

--- a/src/patternfly/demos/DataList/data-list-expandable-data-list.hbs
+++ b/src/patternfly/demos/DataList/data-list-expandable-data-list.hbs
@@ -9,15 +9,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-1}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
     {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-1" aria-label="Content details"'}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
@@ -36,17 +29,10 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-2}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
-   {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Content details"'}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
@@ -80,15 +66,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-4}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
     {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-4" aria-label="Content details"'}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
@@ -106,15 +85,8 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-5}}
         {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
-      {{#> data-list-item-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Action
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Action
-        {{/button}}
-      {{/data-list-item-action}}
     {{/data-list-item-row}}
     {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-5" aria-label="Content details"'}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}

--- a/src/patternfly/demos/DataList/data-list-simple-data-list.hbs
+++ b/src/patternfly/demos/DataList/data-list-simple-data-list.hbs
@@ -5,14 +5,7 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-1}}
         {{/data-list-cell}}
-        {{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Secondary
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Link button
-          {{/button}}
-        {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -23,14 +16,7 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-2}}
         {{/data-list-cell}}
-        {{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Secondary
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Link button
-          {{/button}}
-        {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -41,14 +27,7 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-3}}
         {{/data-list-cell}}
-        {{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Secondary
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Link button
-          {{/button}}
-        {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -59,14 +38,7 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-4}}
         {{/data-list-cell}}
-        {{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Secondary
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Link button
-          {{/button}}
-        {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -77,14 +49,7 @@
         {{#> data-list-cell data-list-cell--modifier="pf-m-align-left"}}
           {{> data-list-content-5}}
         {{/data-list-cell}}
-        {{#> data-list-cell data-list-cell--modifier="pf-m-align-right pf-m-no-fill"}}
-          {{#> button button--modifier="pf-m-secondary"}}
-            Secondary
-          {{/button}}
-          {{#> button button--modifier="pf-m-link"}}
-            Link button
-          {{/button}}
-        {{/data-list-cell}}
+        {{> data-list--action-buttons}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}

--- a/src/patternfly/demos/DataList/examples/DataList.md
+++ b/src/patternfly/demos/DataList/examples/DataList.md
@@ -27,6 +27,7 @@ wrapperTag: div
     {{#> page-main-section}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasContextSelector="true" toolbar--template--HasOverflowMenu="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-lg"}}
         {{> data-list-simple-data-list}}
         {{> data-list-pagination-footer}}
       {{/card}}

--- a/src/patternfly/demos/DataList/examples/DataList.md
+++ b/src/patternfly/demos/DataList/examples/DataList.md
@@ -24,10 +24,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasContextSelector="true" toolbar--template--HasOverflowMenu="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-lg"}}
         {{> data-list-simple-data-list}}
         {{> data-list-pagination-footer}}
       {{/card}}
@@ -55,7 +54,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasBulkSelect="true" toolbar--template--HasContextSelector="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true"}}
         {{> data-list-actionable-data-list}}
@@ -85,7 +84,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasBulkSelect="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true"}}
         {{> data-list-expandable-data-list}}
@@ -115,7 +114,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true"}}
         {{> data-list-simple-data-list}}

--- a/src/patternfly/demos/DataList/examples/DataList.md
+++ b/src/patternfly/demos/DataList/examples/DataList.md
@@ -24,8 +24,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasContextSelector="true" toolbar--template--HasOverflowMenu="true"}}
         {{> data-list-simple-data-list}}
         {{> data-list-pagination-footer}}
       {{/card}}
@@ -53,8 +54,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasBulkSelect="true" toolbar--template--HasContextSelector="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true"}}
         {{> data-list-actionable-data-list}}
         {{> data-list-pagination-footer}}
       {{/card}}
@@ -82,8 +84,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasBulkSelect="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true"}}
         {{> data-list-expandable-data-list}}
         {{> data-list-pagination-footer}}
       {{/card}}
@@ -111,8 +114,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true"}}
         {{> data-list-simple-data-list}}
         {{> data-list-pagination-footer-static}}
       {{/card}}

--- a/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
+++ b/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
@@ -29,8 +29,8 @@ wrapperTag: div
 
         <!-- Content -->
         {{#> drawer-content}}
-          {{> primary-detail-toolbar}}
-          {{> primary-detail-data-list}}
+          {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
+          {{> data-list-simple-data-list}}
         {{/drawer-content}}
 
         <!-- Panel -->
@@ -83,8 +83,8 @@ wrapperTag: div
 
         <!-- Content -->
         {{#> drawer-content}}
-          {{> primary-detail-toolbar}}
-          {{> primary-detail-data-list}}
+          {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
+          {{> data-list-simple-data-list}}
         {{/drawer-content}}
 
 
@@ -138,8 +138,8 @@ wrapperTag: div
 
         <!-- Content -->
         {{#> drawer-content drawer-content--modifier="pf-m-no-background" drawer-body--modifier="pf-m-padding"}}
-          {{> primary-detail-toolbar}}
-          {{> primary-detail-data-list}}
+          {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasToggleGroup="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
+          {{> data-list-simple-data-list}}
         {{/drawer-content}}
 
         <!-- Panel -->
@@ -184,7 +184,7 @@ wrapperTag: div
       }}
 
       {{#> drawer-section}}
-        {{> primary-detail-toolbar primary-detail-toolbar--HasViewToggle="true"}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasToggleGroup="true" toolbar--template--HasBulkSelect="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true" toolbar--template--HasViewToggle="true"}}
         {{#> divider divider--type="div"}}{{/divider}}
       {{/drawer-section}}
 
@@ -290,10 +290,8 @@ wrapperTag: div
 
           <!-- Content -->
           {{#> drawer-content}}
-            {{#> drawer-body}}
-              {{> primary-detail-card-toolbar}}
-              {{> primary-detail-card-data-list}}
-            {{/drawer-body}}
+            {{> primary-detail-card-toolbar}}
+            {{> primary-detail-card-data-list}}
           {{/drawer-content}}
 
           <!-- Panel -->
@@ -340,10 +338,8 @@ wrapperTag: div
 
       <!-- Content -->
       {{#> drawer-content}}
-        {{#> drawer-body}}
-          {{> primary-detail-toolbar}}
-          {{> primary-detail-data-list}}
-        {{/drawer-body}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--modifier="pf-m-page-insets" toolbar--template--HasDropdown="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true"}}
+        {{> data-list-simple-data-list}}
       {{/drawer-content}}
 
       <!-- Panel -->

--- a/src/patternfly/demos/PrimaryDetail/primary-detail-panel-body.hbs
+++ b/src/patternfly/demos/PrimaryDetail/primary-detail-panel-body.hbs
@@ -7,6 +7,7 @@
       progress__value="33"
       progress__description="Title"
       progress__id=(concat primary-detail-template--id "-progress-example1")
+      progress-bar--attribute='aria-label="Progress 1"'
     }}
     {{/progress}}
   {{/l-flex-item}}
@@ -15,6 +16,7 @@
       progress__value="66"
       progress__description="Title"
       progress__id=(concat primary-detail-template--id "-progress-example2")
+      progress-bar--attribute='aria-label="Progress 2"'
     }}
     {{/progress}}
   {{/l-flex-item}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -30,7 +30,6 @@ wrapperTag: div
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl" page-main-section--IsLimitWidth="true"}}
       {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
-      {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
       {{> table-simple-table}}
       {{> table-pagination-footer}}
     {{/page-main-section}}
@@ -60,7 +59,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true" toolbar--template--HasIconButtonGroup="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-xl"}}
         {{> table-sortable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -91,7 +89,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasExpandAll="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-expandable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -122,7 +119,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-lg"}}
         {{> table-compact-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -153,7 +149,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-compound-expansion-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -240,7 +235,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table}}
         {{> table-pagination-footer-static}}
       {{/card}}
@@ -271,7 +265,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table}}
       {{/card}}
     {{/page-main-section}}
@@ -333,7 +326,6 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
-        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table table-simple-table--modifier="pf-m-sticky-header"}}
         {{> table-pagination-footer}}
       {{/card}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -28,8 +28,9 @@ wrapperTag: div
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum suscipit venenatis enim, ut ultrices metus ornare at. Curabitur vel nibh id leo finibus suscipit. Curabitur eu tellus lectus. Vivamus lacus leo, lobortis ac convallis ac, dapibus vel ligula. Suspendisse vitae felis at augue blandit sollicitudin. Sed erat metus, pellentesque vel accumsan vitae, tincidunt id erat. Mauris et pharetra felis. Duis at nisi leo. Nam blandit dui dui, in euismod est dapibus sed. Vivamus sed dolor ullamcorper, euismod orci efficitur, ornare leo. Sed sit amet sollicitudin nulla. Nunc tristique sem ut est laoreet efficitur. Cras tristique finibus risus, eget fringilla tellus porta vitae. Duis id nunc ultricies, ultrices nibh vel, sollicitudin tellus.</p>
       {{/content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--IsLimitWidth="true"}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl" page-main-section--IsLimitWidth="true"}}
       {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
+      {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
       {{> table-simple-table}}
       {{> table-pagination-footer}}
     {{/page-main-section}}
@@ -56,9 +57,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true" toolbar--template--HasIconButtonGroup="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-xl"}}
         {{> table-sortable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -86,9 +88,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasExpandAll="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-expandable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -116,9 +119,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-lg"}}
         {{> table-compact-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -146,9 +150,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-compound-expansion-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -176,7 +181,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> table-loading-table}}
       {{/card}}
@@ -204,7 +209,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> table-empty-state-table}}
       {{/card}}
@@ -232,9 +237,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table}}
         {{> table-pagination-footer-static}}
       {{/card}}
@@ -242,7 +248,6 @@ wrapperTag: div
   {{/page-main}}
 {{/page}}
 ```
-
 
 ### Column management modal
 ```hbs isFullscreen
@@ -263,9 +268,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table}}
       {{/card}}
     {{/page-main-section}}
@@ -324,9 +330,10 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl"}}
       {{#> card}}
         {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
+        {{> divider divider--type="div" divider--modifier="pf-u-hidden pf-u-display-flex-on-md"}}
         {{> table-simple-table table-simple-table--modifier="pf-m-sticky-header"}}
         {{> table-pagination-footer}}
       {{/card}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -28,7 +28,8 @@ wrapperTag: div
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum suscipit venenatis enim, ut ultrices metus ornare at. Curabitur vel nibh id leo finibus suscipit. Curabitur eu tellus lectus. Vivamus lacus leo, lobortis ac convallis ac, dapibus vel ligula. Suspendisse vitae felis at augue blandit sollicitudin. Sed erat metus, pellentesque vel accumsan vitae, tincidunt id erat. Mauris et pharetra felis. Duis at nisi leo. Nam blandit dui dui, in euismod est dapibus sed. Vivamus sed dolor ullamcorper, euismod orci efficitur, ornare leo. Sed sit amet sollicitudin nulla. Nunc tristique sem ut est laoreet efficitur. Cras tristique finibus risus, eget fringilla tellus porta vitae. Duis id nunc ultricies, ultrices nibh vel, sollicitudin tellus.</p>
       {{/content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md pf-m-light" page-main-section--IsLimitWidth="true"}}
+    {{#> page-main-section page-main-section--IsLimitWidth="true"}}
+      {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasSortButton="true" toolbar--template--HasOverflowMenu="true"}}
       {{> table-simple-table}}
       {{> table-pagination-footer}}
     {{/page-main-section}}
@@ -55,8 +56,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasOverflowMenu="true" toolbar--template--HasOverflowMenuSecondButton="true" toolbar--template--HasIconButtonGroup="true"}}
         {{> table-sortable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -84,8 +86,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true" toolbar--template--HasExpandAll="true"}}
         {{> table-expandable-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -113,8 +116,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
         {{> table-compact-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -142,8 +146,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
         {{> table-compound-expansion-table}}
         {{> table-pagination-footer}}
       {{/card}}
@@ -227,8 +232,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
         {{> table-simple-table}}
         {{> table-pagination-footer-static}}
       {{/card}}
@@ -257,8 +263,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
         {{> table-simple-table}}
       {{/card}}
     {{/page-main-section}}
@@ -317,8 +324,9 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-md"}}
+    {{#> page-main-section}}
       {{#> card}}
+        {{> toolbar--template toolbar--id=(concat page--id '-toolbar') toolbar--template--HasBulkSelect="true" toolbar--template--HasToggleGroup="true" toolbar--template--HasSearchFilter="true" toolbar--template--HasFilterGroup="true" toolbar--template--HasSortButton="true"}}
         {{> table-simple-table table-simple-table--modifier="pf-m-sticky-header"}}
         {{> table-pagination-footer}}
       {{/card}}

--- a/src/patternfly/demos/Table/table-compound-expansion-table.hbs
+++ b/src/patternfly/demos/Table/table-compound-expansion-table.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-xl" table--expandable="true" table--attribute='aria-label="Compound expandable table example"'}}
+{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Compound expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true" table-th--modifier="pf-m-width-30"}}

--- a/src/patternfly/demos/Table/table-expandable-table.hbs
+++ b/src/patternfly/demos/Table/table-expandable-table.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-xl" table--expandable="true" table--attribute='aria-label="Expandable table example"'}}
+{{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-md" table--expandable="true" table--attribute='aria-label="Expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-td}}{{/table-td}}


### PR DESCRIPTION
closes #3040 

**Previews:**
- `data-list` - https://patternfly-pr-3753.surge.sh/components/data-list/html-demos
- `table` - https://patternfly-pr-3753.surge.sh/components/table/html-demos
- `primary-detail` - https://patternfly-pr-3753.surge.sh/demos/primary-detail
- `card-view` - https://patternfly-pr-3753.surge.sh/components/card/html-demos

This PR includes a configurable `toolbar` template. It is usable across all components and demos.