### PR TITLE
feat(card-demo): added demos for horizontal cards

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -119,6 +119,9 @@
   align-items: center;
 
   .pf-c-card__title {
+    --pf-c-card--first-child--PaddingTop: 0;
+    --pf-c-card__title--not--last-child--PaddingBottom: 0;
+
     padding: 0;
   }
 }

--- a/src/patternfly/components/List/examples/List.md
+++ b/src/patternfly/components/List/examples/List.md
@@ -60,6 +60,23 @@ cssPrefix: pf-c-list
 {{/list}}
 ```
 
+### Plain
+```hbs
+{{#> list list--type="ul" list--modifier="pf-m-plain"}}
+  <li>Donec blandit a lorem id convallis.</li>
+  <li>Integer in volutpat libero.</li>
+  <li>Donec a diam tellus.
+    {{#> list newcontext}}
+      <li>Donec blandit a lorem id convallis.</li>
+      <li>Cras gravida arcu at diam gravida gravida.</li>
+      <li>Integer in volutpat libero.</li>
+    {{/list}}
+  </li>
+  <li>Aenean nec tortor orci.</li>
+  <li>Vivamus maximus ultricies pulvinar.</li>
+{{/list}}
+```
+
 ## Documentation
 ### Overview
 Non-inline lists can be nested up to any level.
@@ -68,4 +85,5 @@ Non-inline lists can be nested up to any level.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-list` | `<ul>, <ol>` | Initiates a list. **Required**  |
-| `.pf-m-inline` | `.pf-c-list` |  Modifies for inline list style. |
+| `.pf-m-inline` | `.pf-c-list` | Displays list items inline. |
+| `.pf-m-plain` | `.pf-c-list` |  Removes the list marker and base indentation. |

--- a/src/patternfly/components/List/list.scss
+++ b/src/patternfly/components/List/list.scss
@@ -18,8 +18,14 @@
     margin-top: var(--pf-c-list--li--MarginTop);
   }
 
-  @at-root ul#{&}:not(.pf-m-inline) { // targets ul.pf-c-list that is not .pf-m-inline
+  @at-root ul#{&} {
     list-style: var(--pf-c-list--ul--ListStyle);
+  }
+
+  &.pf-m-plain {
+    --pf-c-list--PaddingLeft: 0;
+
+    list-style: none;
   }
 
   &.pf-m-inline {
@@ -27,6 +33,7 @@
 
     display: flex;
     flex-wrap: wrap;
+    list-style: none;
 
     li {
       --pf-c-list--li--MarginTop: 0;

--- a/src/patternfly/demos/Card/examples/CardView.md
+++ b/src/patternfly/demos/Card/examples/CardView.md
@@ -78,3 +78,208 @@ wrapperTag: div
   {{/page-main}}
 {{/page}}
 ```
+
+### Horizontal grid collapsed
+```hbs
+{{#> card card--id="card-demo-horizontal-grid-collapsed"}}
+  {{#> card-header}}
+    {{> card-header-toggle}}
+    {{#> card-actions}}
+      {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+      {{/dropdown}}
+    {{/card-actions}}
+    {{#> level level--modifier="pf-m-gutter"}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Getting started
+      {{/card-title}}
+      {{#> label-group label-group--id="label-group-basic"}}
+        {{#> label-group-main}}
+          {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
+            {{#> label-group-list-item}}
+              {{#> label label--modifier="pf-m-blue"}}
+                {{#> label-icon}}
+                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                {{/label-icon}}
+                Set up your cluster
+              {{/label}}
+            {{/label-group-list-item}}
+            {{#> label-group-list-item}}
+              {{#> label label--modifier="pf-m-purple"}}
+                {{#> label-icon}}
+                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                {{/label-icon}}
+                Guided tours
+              {{/label}}
+            {{/label-group-list-item}}
+            {{#> label-group-list-item}}
+              {{#> label label--modifier="pf-m-green"}}
+                {{#> label-icon}}
+                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                {{/label-icon}}
+                Quick starts
+              {{/label}}
+            {{/label-group-list-item}}
+            {{#> label-group-list-item}}
+              {{#> label label--IsOverflow="true"}}
+                1 more
+              {{/label}}
+            {{/label-group-list-item}}
+          {{/label-group-list}}
+        {{/label-group-main}}
+      {{/label-group}}
+    {{/level}}
+  {{/card-header}}
+{{/card}}
+```
+
+### Horizontal grid expanded
+```hbs
+{{#> card card--id="card-demo-horizontal-grid-expanded" card--modifier="pf-m-expanded"}}
+  {{#> card-header}}
+    {{> card-header-toggle}}
+    {{#> card-actions}}
+      {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+      {{/dropdown}}
+    {{/card-actions}}
+    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+      Getting started
+    {{/card-title}}
+  {{/card-header}}
+  {{#> card-expandable-content}}
+    {{#> card-body}}
+      {{#> grid grid--modifier="pf-m-all-6-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"}}
+        {{#> l-flex l-flex--modifier="pf-m-space-items-lg pf-m-column pf-m-align-items-flex-start"}}
+          {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-column pf-m-align-items-flex-start pf-m-grow"}}
+            {{#> label label--modifier="pf-m-blue"}}
+              {{#> label-icon}}
+                <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+              {{/label-icon}}
+              Set up your cluster
+            {{/label}}
+            <p>Continue setting up your cluster to access all you cain in the Console</p>
+            {{#> list list--modifier="pf-m-plain"}}
+              <li>
+                <a href="#">Add identity provider</a>
+              </li>
+              <li>
+                <a href="#">Configure alert receivers</a>
+              </li>
+              <li>
+                <a href="#">Configure default ingress certificate</a>
+              </li>
+            {{/list}}
+          {{/l-flex}}
+          {{#> button-link button-link--modifier="pf-m-link pf-m-inline" button-link--attribute='href="#"'}}
+            View all set up cluster steps
+            {{#> button-icon button-icon--modifier="pf-m-end"}}
+              <i class="fas fa-arrow-right" aria-hidden="true"></i>
+            {{/button-icon}}
+          {{/button-link}}
+        {{/l-flex}}
+        {{#> l-flex l-flex--modifier="pf-m-space-items-lg pf-m-column pf-m-align-items-flex-start"}}
+          {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-column pf-m-align-items-flex-start pf-m-grow"}}
+            {{#> label label--modifier="pf-m-purple"}}
+              {{#> label-icon}}
+                <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+              {{/label-icon}}
+              Guided tours
+            {{/label}}
+            <p>Tour some of the key features around the console</p>
+            {{#> list list--modifier="pf-m-plain"}}
+              <li>
+                <a href="#">Tour the console</a>
+              </li>
+              <li>
+                <a href="#">Explore the Developer perspective</a>
+              </li>
+            {{/list}}
+          {{/l-flex}}
+          {{#> button-link button-link--modifier="pf-m-link pf-m-inline" button-link--attribute='href="#"'}}
+            View all guided tours
+            {{#> button-icon button-icon--modifier="pf-m-end"}}
+              <i class="fas fa-arrow-right" aria-hidden="true"></i>
+            {{/button-icon}}
+          {{/button-link}}
+        {{/l-flex}}
+        {{#> l-flex l-flex--modifier="pf-m-space-items-lg pf-m-column pf-m-align-items-flex-start"}}
+          {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-column pf-m-align-items-flex-start pf-m-grow"}}
+            {{#> label label--modifier="pf-m-green"}}
+              {{#> label-icon}}
+                <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+              {{/label-icon}}
+              Quick starts
+            {{/label}}
+            <p>Get started with features using our step-by-step documentation</p>
+            {{#> list list--modifier="pf-m-plain"}}
+              <li>
+                <a href="#">Getting started with Serverless</a>
+              </li>
+              <li>
+                <a href="#">Explore virtualization</a>
+              </li>
+              <li>
+                <a href="#">Build pipelines</a>
+              </li>
+            {{/list}}
+          {{/l-flex}}
+          {{#> button-link button-link--modifier="pf-m-link pf-m-inline" button-link--attribute='href="#"'}}
+            View all quick starts
+            {{#> button-icon button-icon--modifier="pf-m-end"}}
+              <i class="fas fa-arrow-right" aria-hidden="true"></i>
+            {{/button-icon}}
+          {{/button-link}}
+        {{/l-flex}}
+        {{#> l-flex l-flex--modifier="pf-m-space-items-lg pf-m-column pf-m-align-items-flex-start"}}
+          {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-column pf-m-align-items-flex-start pf-m-grow"}}
+            {{#> label label--modifier="pf-m-orange"}}
+              {{#> label-icon}}
+                <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+              {{/label-icon}}
+              Learning resources
+            {{/label}}
+            <p>Learn about new features within the Console and get started with demo apps</p>
+            {{#> list list--modifier="pf-m-plain"}}
+              <li>
+                <a href="#">See what's possible with the Explore page</a>
+              </li>
+              <li>
+                <a href="#">OpenShift 4.5: Top Tasks <i class="fas fa-external-link-alt" aria-hidden="true"></i></a>
+              </li>
+              <li>
+                <a href="#">Try a demo app</a>
+              </li>
+            {{/list}}
+          {{/l-flex}}
+          {{#> button-link button-link--modifier="pf-m-link pf-m-inline" button-link--attribute='href="#"'}}
+            View all learning resources
+            {{#> button-icon button-icon--modifier="pf-m-end"}}
+              <i class="fas fa-arrow-right" aria-hidden="true"></i>
+            {{/button-icon}}
+          {{/button-link}}
+        {{/l-flex}}
+      {{/grid}}
+    {{/card-body}}
+  {{/card-expandable-content}}
+{{/card}}
+```
+
+### Horizontal split
+```hbs
+{{#> card card--id="card-demo-horizontal-split" card--modifier="pf-m-flat"}}
+  {{#> grid grid--modifier="pf-m-all-6-col-on-md"}}
+    {{#> grid-item grid-item--modifier="pf-d-card__media-item" grid-item--attribute='style="min-height: 200px; background: center / cover url(\'/assets/images/pfbg_992@2x.jpg\'); "'}}
+    {{/grid-item}}
+    {{#> grid-item}}
+      {{#> card-title}}
+        Headline
+      {{/card-title}}
+      {{#> card-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse arcu purus, lobortis nec euismod eu, tristique ut sapien. Nullam turpis lectus, aliquet sit amet volutpat eu, semper eget quam. Maecenas in tempus diam. Aenean interdum velit sed massa aliquet, sit amet malesuada nulla hendrerit. Aenean non faucibus odio. Etiam non metus turpis. Praesent sollicitudin elit neque, id ullamcorper nibh faucibus eget.
+      {{/card-body}}
+      {{#> card-footer}}
+        {{#> button button--modifier="pf-m-tertiary"}}Call to action{{/button}}
+      {{/card-footer}}
+    {{/grid-item}}
+  {{/grid}}
+{{/card}}
+```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3555
fixes https://github.com/patternfly/patternfly/issues/1635

Along with adding the card demos, I needed to update 2 things:

* Added a plain list variant. This removes the bullet and left padding of a list. The demo shows a top level plain list with a nested regular list. That was filed in a separate issue - https://github.com/patternfly/patternfly/issues/1635
* Fixed a bug where - if the card title is a child of pf-c-card__header, we remove all padding. There was a bug where if the title was the first-child in __header, it was assigned a padding-top, and if it was not the last child, it got a padding-bottom.