### PR TITLE
refactor(mixins): remove breakpoint map in pf-apply-breakpoint function

### DIFF
--- a/src/patternfly/components/DescriptionList/description-list-order.scss
+++ b/src/patternfly/components/DescriptionList/description-list-order.scss
@@ -6,7 +6,7 @@ $pf-c-description-list-order--limit: 12;
   @each $breakpoint, $breakpoint-value in $pf-c-description-list-order--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-description-list-order--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @for $i from 0 through $pf-c-description-list-order--limit {
         .pf-m-order-#{$i}#{$breakpoint-name} {
           order: #{$i};

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -87,7 +87,7 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "md", "lg",
   @each $breakpoint, $breakpoint-value in $pf-c-description-list--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-description-list--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       &.pf-m-1-col#{$breakpoint-name} {
         --pf-c-description-list--GridTemplateColumns--count: var(--pf-c-description-list--m-1-col--GridTemplateColumns--count);
       }

--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -53,7 +53,7 @@ $pf-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "xl"
   @each $breakpoint, $breakpoint-value in $pf-c-divider--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-divider--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-divider--spacer-map {
         @if $spacer == none {
           $spacer-value: 0%;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -539,7 +539,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     $breakpoint: "md";
   }
 
-  @include pf-apply-breakpoint($breakpoint, $pf-c-drawer--breakpoint-map--width) {
+  @include pf-apply-breakpoint($breakpoint) {
     @each $width-value in $pf-c-drawer__panel--list--width {
       .pf-c-drawer__panel.pf-m-width-#{$width-value}#{$breakpoint-name} {
         --pf-c-drawer__panel--FlexBasis: #{percentage($width-value / 100)};
@@ -556,7 +556,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     $breakpoint: "md";
   }
 
-  @include pf-apply-breakpoint($breakpoint, $pf-c-drawer--breakpoint-map) {
+  @include pf-apply-breakpoint($breakpoint) {
     // Drawer and inline
     .pf-c-drawer.pf-m-inline#{$breakpoint-name},
     .pf-c-drawer.pf-m-static#{$breakpoint-name} {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -360,7 +360,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   @each $breakpoint, $breakpoint-value in $pf-c-dropdown--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-dropdown--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       &.pf-m-align-right#{$breakpoint-name} {
         right: 0;
       }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -523,7 +523,7 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
   @each $breakpoint, $breakpoint-value in $pf-c-page--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-page--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       &.pf-m-padding#{$breakpoint-name} {
         padding: var(--pf-c-page__main-section--PaddingTop) var(--pf-c-page__main-section--PaddingRight) var(--pf-c-page__main-section--PaddingBottom) var(--pf-c-page__main-section--PaddingLeft);
       }

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -272,7 +272,7 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   @each $breakpoint, $breakpoint-value in $pf-c-pagination--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-pagination--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       &.pf-m-display-summary#{$breakpoint-name} {
         --pf-c-pagination__nav--Display: var(--pf-c-pagination--m-display-summary__nav--Display);
         --pf-c-pagination__nav--Visibility: var(--pf-c-pagination--m-display-summary__nav--Visibility);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -471,7 +471,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-tabs--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-tabs--spacer-map {
         &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
           --pf-c-tabs--inset: #{$spacer-value};

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -356,7 +356,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 @each $breakpoint, $breakpoint-value in $pf-c-toolbar--breakpoint-map {
   $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-  @include pf-apply-breakpoint($breakpoint, $pf-c-toolbar--breakpoint-map) {
+  @include pf-apply-breakpoint($breakpoint) {
     .pf-m-toggle-group.pf-m-show#{$breakpoint-name} {
       --pf-c-toolbar--spacer: var(--pf-c-toolbar__group--m-toggle-group--m-show--spacer);
 
@@ -382,7 +382,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-toolbar--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       // Align right
       .pf-c-toolbar__item.pf-m-align-right#{$breakpoint-name},
       .pf-c-toolbar__group.pf-m-align-right#{$breakpoint-name} {
@@ -432,7 +432,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @each $breakpoint, $breakpoint-value in $pf-c-toolbar--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-toolbar--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-toolbar--spacer-map {
         .pf-m-space-items-#{$spacer}#{$breakpoint-name} {
           > * {
@@ -451,7 +451,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @each $breakpoint, $breakpoint-value in $pf-c-toolbar--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-toolbar--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-toolbar--spacer-map {
         .pf-m-spacer-#{$spacer}#{$breakpoint-name} {
           --pf-c-toolbar--spacer: #{$spacer-value};
@@ -467,7 +467,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @each $breakpoint, $breakpoint-value in $pf-c-toolbar--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-c-toolbar--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-toolbar--inset-map {
         &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
           --pf-c-toolbar--inset: #{$spacer-value};

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -68,7 +68,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       // display
       &.pf-m-flex#{$breakpoint-name} {
         display: var(--pf-l-flex--Display);
@@ -280,7 +280,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
         &.pf-m-space-items-#{$spacer}#{$breakpoint-name} {
           > * {
@@ -299,7 +299,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+    @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
         .pf-m-spacer-#{$spacer}#{$breakpoint-name} {
           --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -184,7 +184,7 @@
 }
 
 // Apply media query if value is passed
-@mixin pf-apply-breakpoint($breakpoint, $breakpoint-map: $pf-global--breakpoint-name-map) {
+@mixin pf-apply-breakpoint($breakpoint) {
   @if ($breakpoint == "null" or $breakpoint == "base" or $breakpoint == "") {
     @content;
   }


### PR DESCRIPTION
closes #3751 .
`$breakpoint-map` is not needed and I have removed it from the function and anywhere we call the function.