### PR TITLE
feat(form): added demos, section title, stack control group mod

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -53,7 +53,7 @@ cssPrefix: pf-c-form
       {{/form-label}}
       {{> form-group-label-help}}
     {{/form-group-label}}
-    {{#> form-group-control}}
+    {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
       {{#> check}}
         {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '"')}}Option 1{{/check-label}}

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -81,8 +81,21 @@ cssPrefix: pf-c-form
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-form-section-1-input" name="' form--id '-form-section-1-input" required')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
+    {{#> form-group}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id '-form-section-1-input-2"')}}
+          Form section 1 inputs
+        {{/form-label}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-form-section-1-input-2" name="' form--id '-form-section-1-input-2" required')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
   {{/form-section}}
   {{#> form-section}}
+    {{#> form-section-title}}
+      Section 2 title (optional)
+    {{/form-section-title}}
     {{#> form-group}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id '-form-section-2-input"')}}
@@ -91,6 +104,16 @@ cssPrefix: pf-c-form
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-form-section-2-input" name="' form--id '-form-section-2-input" required')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+    {{#> form-group}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id '-form-section-2-input-2"')}}
+          Form section 2 inputs
+        {{/form-label}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-form-section-2-input-2" name="' form--id '-form-section-2-input-2" required')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
   {{/form-section}}
@@ -513,6 +536,7 @@ cssPrefix: pf-c-form
 | -- | -- | -- |
 | `.pf-c-form` | `<form>` |  Initiates a standard form. **Required** |
 | `.pf-c-form__section` | `<div>, <section>` |  Initiates a form section. |
+| `.pf-c-form__section-title` | `<div>` |  Initiates a form section title. |
 | `.pf-c-form__group` | `<div>` |  Initiates a form group. |
 | `.pf-c-form__group-label` | `<div>` |  Initiates a form group label. |
 | `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
@@ -544,4 +568,5 @@ cssPrefix: pf-c-form
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
 | `.pf-m-no-padding-top` | `.pf-c-form__group-label` | Removes top padding from the label element for labels adjacent to an element that isn't a form control. |
 | `.pf-m-inline` | `.pf-c-form__group-control` | Modifies form group children to be inline (this is primarily for radio buttons and checkboxes). |
+| `.pf-m-stack` | `.pf-c-form__group-control` | Modifies form group children to be stacked with space between children. |
 | `.pf-m-expanded` | `.pf-c-form__field-group` | Modifies an expandable field group for the expanded state. |

--- a/src/patternfly/components/Form/form-section-title.hbs
+++ b/src/patternfly/components/Form/form-section-title.hbs
@@ -2,5 +2,5 @@
   {{#if form-section-title--attribute}}
     {{{form-section-title--attribute}}}
   {{/if}}>
-  {{>@partial-block}}
+  {{> @partial-block}}
 </div>

--- a/src/patternfly/components/Form/form-section-title.hbs
+++ b/src/patternfly/components/Form/form-section-title.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-form__section-title{{#if form-section-title--modifier}} {{form-section-title--modifier}}{{/if}}"
+  {{#if form-section-title--attribute}}
+    {{{form-section-title--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</div>

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -45,7 +45,8 @@
   // Group control
   --pf-c-form__group-control--m-inline--child--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-form__group-control__helper-text--MarginBottom: var(--pf-global--spacer--xs);
-  --pf-c-form__group-control--m-stack--child--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-grid__group-control--m-stack--Gap: var(--pf-global--spacer--sm);
+  --pf-c-grid__group-control--m-stack__helper-text--MarginTop: calc(var(--pf-c-grid__group-control--m-stack--Gap) * -1 + var(--pf-c-form__helper-text--MarginTop--base));
 
   // Actions
   --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
@@ -58,7 +59,8 @@
   --pf-c-form__actions--MarginLeft: calc(var(--pf-c-form__actions--child--MarginLeft) * -1);
 
   // Helper text
-  --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--xs);
+  --pf-c-form__helper-text--MarginTop--base: var(--pf-global--spacer--xs);
+  --pf-c-form__helper-text--MarginTop: var(--pf-c-form__helper-text--MarginTop--base);
   --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
 
@@ -123,7 +125,7 @@
   --pf-c-form__field-group-body__field-group--last-child--MarginBottom: calc(var(--pf-c-form__field-group-body--PaddingBottom) * -1);
 
   display: grid;
-  grid-gap: var(--pf-c-form--GridGap);
+  gap: var(--pf-c-form--GridGap);
 
   &.pf-m-horizontal {
     --pf-c-form__group-label--PaddingBottom: 0;
@@ -261,12 +263,10 @@
   }
 
   &.pf-m-stack {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    gap: var(--pf-c-grid__group-control--m-stack--Gap);
 
-    > * + *:not(.pf-c-form__helper-text) {
-      margin-top: var(--pf-c-form__group-control--m-stack--child--MarginTop);
-    }
+    --pf-c-form__helper-text--MarginTop: var(--pf-c-grid__group-control--m-stack__helper-text--MarginTop);
   }
 
   .pf-c-form__helper-text:first-child {

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -38,10 +38,14 @@
   --pf-c-form__group-label-help--MarginLeft: calc(var(--pf-c-form__group-label-help--PaddingLeft) * -1 + var(--pf-global--spacer--xs));
   --pf-c-form__group-label-help--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-form__group-label-help--TranslateY: #{pf-size-prem(2px)};
+  --pf-c-form__group-label-help--Color: var(--pf-global--Color--200);
+  --pf-c-form__group-label-help--hover--Color: var(--pf-global--Color--100);
+  --pf-c-form__group-label-help--focus--Color: var(--pf-global--Color--100);
 
   // Group control
   --pf-c-form__group-control--m-inline--child--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-form__group-control__helper-text--MarginBottom: var(--pf-global--spacer--xs);
+  --pf-c-form__group-control--m-stack--child--MarginTop: var(--pf-global--spacer--sm);
 
   // Actions
   --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
@@ -71,6 +75,11 @@
   // Section
   --pf-c-form__section--MarginTop: var(--pf-global--spacer--xl);
   --pf-c-form__section--Gap: var(--pf-global--gutter--md);
+
+  // Section title
+  --pf-c-form__section-title--FontSize: var(--pf-global--FontSize--lg);
+  --pf-c-form__section-title--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-form__section-title--MarginBottom: calc(var(--pf-global--spacer--sm) * -1);
 
   // Field groups
   --pf-c-form__field-group--border-width-base: var(--pf-global--BorderWidth--sm);
@@ -169,6 +178,12 @@
   }
 }
 
+.pf-c-form__section-title {
+  margin-bottom: var(--pf-c-form__section-title--MarginBottom);
+  font-size: var(--pf-c-form__section-title--FontSize);
+  font-weight: var(--pf-c-form__section-title--FontWeight);
+}
+
 .pf-c-form__group-label {
   --pf-c-form__helper-text--MarginTop: 0;
 
@@ -217,8 +232,17 @@
   margin-left: var(--pf-c-form__group-label-help--MarginLeft);
   font-size: var(--pf-c-form__group-label-help--FontSize);
   line-height: 1;
+  color: var(--pf-c-form__group-label-help--Color);
   border: 0;
   transform: translateY(var(--pf-c-form__group-label-help--TranslateY));
+
+  &:hover {
+    --pf-c-form__group-label-help--Color: var(--pf-c-form__group-label-help--hover--Color);
+  }
+
+  &:focus-within {
+    --pf-c-form__group-label-help--Color: var(--pf-c-form__group-label-help--focus--Color);
+  }
 }
 
 
@@ -229,6 +253,19 @@
 
     > * {
       margin-right: var(--pf-c-form__group-control--m-inline--child--MarginRight);
+    }
+
+    > :last-child {
+      --pf-c-form__group-control--m-inline--child--MarginRight: 0;
+    }
+  }
+
+  &.pf-m-stack {
+    display: flex;
+    flex-direction: column;
+
+    > * + *:not(.pf-c-form__helper-text) {
+      margin-top: var(--pf-c-form__group-control--m-stack--child--MarginTop);
     }
   }
 

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -314,7 +314,7 @@ section: components
     {{/form-group}}
     {{#> form-group form-group--id="-uris"}}
       {{#> form-group-label}}
-        {{#> form-label form-label--attribute=(concat 'id="' form--id form-group--id '"') required="true"}}Valid Redirect URIs{{/form-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Valid redirect URIs{{/form-label}}
         {{> form-group-label-help}}
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -319,7 +319,7 @@ section: components
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-1" name="' form--id form-group--id '-1"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-input-1" name="' form--id form-group--id '-input-1" aria-labelledby="' form--id form-group--id ' ' form--id form-group--id '-input-1"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -319,19 +319,19 @@ section: components
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-1"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-1" name="' form--id form-group--id '-1"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-2"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-2" name="' form--id form-group--id '-2"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-3"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-3" name="' form--id form-group--id '-3"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -331,7 +331,7 @@ section: components
           {{/button}}
         {{/input-group}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-3" name="' form--id form-group--id '-3"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-input-3" name="' form--id form-group--id '-input-3" aria-labelledby="' form--id form-group--id ' ' form--id form-group--id '-input-3"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -314,7 +314,7 @@ section: components
     {{/form-group}}
     {{#> form-group form-group--id="-uris"}}
       {{#> form-group-label}}
-        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Valid redirect URIs{{/form-label}}
+        {{#> form-label form-label--attribute=(concat 'id="' form--id form-group--id '"') required="true"}}Valid redirect URIs{{/form-label}}
         {{> form-group-label-help}}
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -314,7 +314,7 @@ section: components
     {{/form-group}}
     {{#> form-group form-group--id="-uris"}}
       {{#> form-group-label}}
-        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Valid Redirect URIs{{/form-label}}
+        {{#> form-label form-label--attribute=(concat 'id="' form--id form-group--id '"') required="true"}}Valid Redirect URIs{{/form-label}}
         {{> form-group-label-help}}
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -325,7 +325,7 @@ section: components
           {{/button}}
         {{/input-group}}
         {{#> input-group}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-2" name="' form--id form-group--id '-2"')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-input-2" name="' form--id form-group--id '-input-2" aria-labelledby="' form--id form-group--id ' ' form--id form-group--id '-input-2"')}}{{/form-control}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
             <i class="fas fa-minus-circle" aria-hidden="true"></i>
           {{/button}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -18,23 +18,24 @@ section: components
   {{/form-group}}
   {{#> form-group form-group--id="-email"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Email{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Email{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="email" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="email" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-phone"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Phone number{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Phone number{{/form-label}}
+      {{> form-group-label-help}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="tel" id="' form--id form-group--id '" name="' form--id form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="tel" placeholder="Example, (555) 555-5555" id="' form--id form-group--id '" name="' form--id form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-contact"}}
     {{#> form-group-label}}
-      {{#> form-label required="true"}}How can we contact you?{{/form-label}}
+      {{#> form-label}}How can we contact you?{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
       {{#> check}}
@@ -47,15 +48,7 @@ section: components
       {{/check}}
       {{#> check}}
         {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Please don't contact me{{/check-label}}
-      {{/check}}
-  {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id="-updates"}}
-    {{#> form-group-control}}
-      {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '"')}}I'd like updates via email{{/check-label}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Mail{{/check-label}}
       {{/check}}
     {{/form-group-control}}
   {{/form-group}}
@@ -96,43 +89,32 @@ section: components
       {{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
-  {{#> form-group form-group--id="-title"}}
+  {{#> form-group form-group--id="-phone"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Your title{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Phone number{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="select" form-control--attribute=(concat 'id="' form--id form-group--id '" name="' form--id form-group--id '"')}}
-        <option value="" selected>Please choose</option>
-        <option value="Mr">Mr</option>
-        <option value="Miss">Miss</option>
-        <option value="Mrs">Mrs</option>
-        <option value="Ms">Ms</option>
-        <option value="Dr">Dr</option>
-        <option value="Other">Other</option>
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="tel" placeholder="Example, (555) 555-5555" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}
       {{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
-  {{#> form-group form-group--id="-exp"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Your experience{{/form-label}}
+   {{#> form-group form-group--id="-contact"}}
+    {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
+      {{#> form-label }}How can we contact you?{{/form-label}}
+      {{> form-group-label-help}}
     {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="textarea" form-control--attribute=(concat 'name="' form--id form-group--id '" id="' form--id form-group--id '"')}}{{/form-control}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id="-follow-up"}}
-    {{#> form-group-control}}
+    {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '"')}}Follow up via email{{/check-label}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Email{{/check-label}}
       {{/check}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id="-remember"}}
-    {{#> form-group-control}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '"')}}Remember my password for 30 days{{/check-label}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Phone{{/check-label}}
+      {{/check}}
+      {{#> check}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Mail{{/check-label}}
       {{/check}}
     {{/form-group-control}}
   {{/form-group}}
@@ -279,5 +261,98 @@ section: components
       {{/form-group-control}}
     {{/form-group}}
   {{/grid}}
+{{/form}}
+```
+
+### Sections with repeatable fields
+```hbs
+{{#> form form--id="form-demo-sections-repeatable-fields"}}
+  {{#> form-section}}
+    {{#> form-section-title}}
+      General settings
+    {{/form-section-title}}
+    {{#> form-group form-group--id="-clientid"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Client ID{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+    {{#> form-group form-group--id="-name"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+    {{#> form-group form-group--id="-description"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Description{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+  {{/form-section}}
+  {{#> form-section}}
+    {{#> form-section-title}}
+      Access settings
+    {{/form-section-title}}
+    {{#> form-group form-group--id="-rooturl"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Root URL{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+    {{#> form-group form-group--id="-uris"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Valid Redirect URIs{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
+        {{#> input-group}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-1"')}}{{/form-control}}
+          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+            <i class="fas fa-minus-circle" aria-hidden="true"></i>
+          {{/button}}
+        {{/input-group}}
+        {{#> input-group}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-2"')}}{{/form-control}}
+          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+            <i class="fas fa-minus-circle" aria-hidden="true"></i>
+          {{/button}}
+        {{/input-group}}
+        {{#> input-group}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '-3"')}}{{/form-control}}
+          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+            <i class="fas fa-minus-circle" aria-hidden="true"></i>
+          {{/button}}
+        {{/input-group}}
+        {{#> button button--modifier="pf-m-link pf-m-inline"}}
+          {{#> button-icon button-icon--modifier="pf-m-start"}}
+            <i class="fas fa-plus-circle" aria-hidden="true"></i>
+          {{/button-icon}}
+          Add valid redirect URI
+        {{/button}}
+      {{/form-group-control}}
+    {{/form-group}}
+    {{#> form-group form-group--id="-home-url"}}
+      {{#> form-group-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Home URL{{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{/form-group-control}}
+    {{/form-group}}
+  {{/form-section}}
 {{/form}}
 ```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3380

Adds a `pf-m-stack` variation to control groups (similar to `pf-m-inline`) that creates a stacking layout and space between children in form control groups.

Added section titles.

Updated and added forms from #3380.