### PR TITLE
fix(drawer): limited drawer resize to desktop breakpoint

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -26,6 +26,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__panel--TransitionDuration: var(--pf-global--TransitionDuration);
   --pf-c-drawer__panel--TransitionProperty: margin, transform, box-shadow, flex-basis;
   --pf-c-drawer__panel--m-resizable--PaddingLeft: var(--pf-c-drawer__splitter--m-vertical--Width);
+  --pf-c-drawer__panel--m-resizable--FlexBasis: initial;
   --pf-c-drawer--m-panel-left__panel--m-resizable--PaddingRight: var(--pf-c-drawer__splitter--m-vertical--Width);
   --pf-c-drawer--m-panel-bottom__panel--m-resizable--PaddingTop: var(--pf-c-drawer__splitter--Height);
 
@@ -114,7 +115,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__splitter--m-vertical__splitter-handle--after--Height: #{pf-size-prem(12px)};
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--md--FlexBasis);
+    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer__panel--md--FlexBasis));
 
     // Responsive child padding
     --pf-c-drawer--child--PaddingTop: var(--pf-c-drawer--child--md--PaddingTop);
@@ -130,12 +131,12 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--xl--FlexBasis);
+    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer__panel--xl--FlexBasis));
     --pf-c-drawer__panel--MinWidth: var(--pf-c-drawer__panel--xl--MinWidth);
 
     &.pf-m-panel-bottom {
       --pf-c-drawer__panel--MinWidth: auto;
-      --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis);
+      --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis));
       --pf-c-drawer__panel--MinHeight: var(--pf-c-drawer--m-panel-bottom__panel--xl--MinHeight);
     }
   }

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -307,3 +307,4 @@ import './Drawer.css'
 | `.pf-m-no-background` | `.pf-c-drawer__section`, `.pf-c-drawer__content`, `.pf-c-drawer__panel` | Modifies the drawer body/panel background color to transparent. |
 | `.pf-m-width-{25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-c-drawer__panel` | Modifies the drawer panel width. |
 | `.pf-m-resizable` | `.pf-c-drawer__panel` | Modifies the drawer panel to be resizable. Intended for use with the `.pf-c-drawer__splitter` element. |
+| `--pf-c-drawer__panel--m-resizable--FlexBasis` |  `.pf-c-drawer` | Used to update the panel size on a resizable drawer. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3787

This adds a var `--pf-c-drawer__panel--m-resizable--FlexBasis` that can be used anywhere we want it to be able to override the panel `flex-basis`. It also moves the inline var from the panel to the parent drawer.