### PR TITLE
fix(drawer): changes to vars used to redefine panel flex-basis

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -27,7 +27,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer--m-panel-bottom__panel--md--MinHeight: 50%;
   --pf-c-drawer--m-panel-bottom__panel--xl--MinHeight: #{pf-size-prem(300px)};
   --pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis: #{pf-size-prem(300px)};
-  --pf-c-drawer__panel--m-resizable--FlexBasis: initial; // falls back by default
   --pf-c-drawer__panel--m-resizable--FlexDirection: row;
   --pf-c-drawer__panel--m-resizable--md--FlexBasis--min: var(--pf-c-drawer__splitter--m-vertical--Width);
   --pf-c-drawer--m-panel-bottom__panel--m-resizable--FlexDirection: column;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -12,24 +12,26 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__content--ZIndex: var(--pf-global--ZIndex--xs);
 
   // Panel
-  --pf-c-drawer__panel--FlexBasis: 100%;
-  --pf-c-drawer__panel--md--FlexBasis: 50%;
   --pf-c-drawer__panel--MinWidth: 50%; // change to __panel--md--MinWidth at breaking change
   --pf-c-drawer__panel--MaxHeight: auto;
-  --pf-c-drawer--m-panel-bottom__panel--md--MinHeight: 50%;
-  --pf-c-drawer__panel--xl--MinWidth: #{pf-size-prem(450px)};
-  --pf-c-drawer__panel--xl--FlexBasis: #{pf-size-prem(450px)};
-  --pf-c-drawer--m-panel-bottom__panel--xl--MinHeight: #{pf-size-prem(300px)};
-  --pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis: #{pf-size-prem(300px)};
   --pf-c-drawer__panel--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-drawer__panel--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-drawer__panel--TransitionDuration: var(--pf-global--TransitionDuration);
   --pf-c-drawer__panel--TransitionProperty: margin, transform, box-shadow, flex-basis;
-  --pf-c-drawer__panel--m-resizable--FlexBasis: initial;
+  --pf-c-drawer__panel--FlexBasis: 100%;
+  --pf-c-drawer__panel--md--FlexBasis--min: 0%;
+  --pf-c-drawer__panel--md--FlexBasis: 50%;
+  --pf-c-drawer__panel--md--FlexBasis--max: 100%;
+  --pf-c-drawer__panel--xl--MinWidth: #{pf-size-prem(450px)};
+  --pf-c-drawer__panel--xl--FlexBasis: #{pf-size-prem(450px)};
+  --pf-c-drawer--m-panel-bottom__panel--md--MinHeight: 50%;
+  --pf-c-drawer--m-panel-bottom__panel--xl--MinHeight: #{pf-size-prem(300px)};
+  --pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis: #{pf-size-prem(300px)};
+  --pf-c-drawer__panel--m-resizable--FlexBasis: initial; // falls back by default
   --pf-c-drawer__panel--m-resizable--FlexDirection: row;
-  --pf-c-drawer__panel--FlexBasis--min: var(--pf-c-drawer__splitter--m-vertical--Width);
+  --pf-c-drawer__panel--m-resizable--md--FlexBasis--min: var(--pf-c-drawer__splitter--m-vertical--Width);
   --pf-c-drawer--m-panel-bottom__panel--m-resizable--FlexDirection: column;
-  --pf-c-drawer--m-panel-bottom__panel--FlexBasis--min: var(--pf-c-drawer__splitter--Height);
+  --pf-c-drawer--m-panel-bottom__panel--m-resizable--md--FlexBasis--min: var(--pf-c-drawer__splitter--Height);
 
   // Child padding
   --pf-c-drawer--child--PaddingTop: var(--pf-global--spacer--md);
@@ -112,8 +114,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__splitter--m-vertical__splitter-handle--after--Height: #{pf-size-prem(12px)};
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer__panel--md--FlexBasis));
-
     // Responsive child padding
     --pf-c-drawer--child--PaddingTop: var(--pf-c-drawer--child--md--PaddingTop);
     --pf-c-drawer--child--PaddingRight: var(--pf-c-drawer--child--md--PaddingRight);
@@ -128,12 +128,10 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {
-    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer__panel--xl--FlexBasis));
     --pf-c-drawer__panel--MinWidth: var(--pf-c-drawer__panel--xl--MinWidth);
 
     &.pf-m-panel-bottom {
       --pf-c-drawer__panel--MinWidth: auto;
-      --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--m-resizable--FlexBasis, var(--pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis));
       --pf-c-drawer__panel--MinHeight: var(--pf-c-drawer--m-panel-bottom__panel--xl--MinHeight);
     }
   }
@@ -250,7 +248,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 .pf-c-drawer__panel {
   position: relative;
   z-index: var(--pf-c-drawer__panel--ZIndex);
-  flex-basis: #{"max(var(--pf-c-drawer__panel--FlexBasis--min), var(--pf-c-drawer__panel--FlexBasis))"};
+  flex-basis: var(--pf-c-drawer__panel--FlexBasis);
   order: 1;
   max-height: var(--pf-c-drawer__panel--MaxHeight);
   overflow: auto;
@@ -272,6 +270,23 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   &.pf-m-no-background {
     background-color: transparent;
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--md) {
+    --pf-c-drawer__panel--FlexBasis:
+      clamp(
+        var(--pf-c-drawer__panel--md--FlexBasis--min),
+        var(--pf-c-drawer__panel--md--FlexBasis),
+        var(--pf-c-drawer__panel--md--FlexBasis--max)
+      );
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    --pf-c-drawer__panel--md--FlexBasis: var(--pf-c-drawer__panel--xl--FlexBasis);
+
+    .pf-c-drawer.pf-m-panel-bottom & {
+      --pf-c-drawer__panel--md--FlexBasis: var(--pf-c-drawer--m-panel-bottom__panel--xl--FlexBasis);
+    }
   }
 }
 
@@ -407,6 +422,8 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     }
 
     > .pf-c-drawer__main > .pf-c-drawer__panel.pf-m-resizable {
+      --pf-c-drawer__panel--md--FlexBasis--min: var(--pf-c-drawer__panel--m-resizable--md--FlexBasis--min);
+
       &::after {
         width: 0;
         height: 0;
@@ -481,6 +498,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     }
 
     > .pf-c-drawer__main > .pf-c-drawer__panel.pf-m-resizable {
+      --pf-c-drawer__panel--md--FlexBasis--min: var(--pf-c-drawer--m-panel-bottom__panel--m-resizable--md--FlexBasis--min);
       --pf-c-drawer__panel--m-resizable--FlexDirection: var(--pf-c-drawer--m-panel-bottom__panel--m-resizable--FlexDirection);
 
       > .pf-c-drawer__splitter {
@@ -540,7 +558,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   @include pf-apply-breakpoint($breakpoint) {
     @each $width-value in $pf-c-drawer__panel--list--width {
       .pf-c-drawer__panel.pf-m-width-#{$width-value}#{$breakpoint-name} {
-        --pf-c-drawer__panel--FlexBasis: #{percentage($width-value / 100)};
+        --pf-c-drawer__panel--md--FlexBasis: #{percentage($width-value / 100)};
       }
     }
   }

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -308,4 +308,6 @@ import './Drawer.css'
 | `.pf-m-no-background` | `.pf-c-drawer__section`, `.pf-c-drawer__content`, `.pf-c-drawer__panel` | Modifies the drawer body/panel background color to transparent. |
 | `.pf-m-width-{25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-c-drawer__panel` | Modifies the drawer panel width. |
 | `.pf-m-resizable` | `.pf-c-drawer__panel` | Modifies the drawer panel to be resizable. Intended for use with the `.pf-c-drawer__splitter` element. |
-| `--pf-c-drawer__panel--m-resizable--FlexBasis` |  `.pf-c-drawer` | Used to update the panel size on a resizable drawer. |
+| `--pf-c-drawer__panel--md--FlexBasis--min` | `.pf-c-drawer__panel` | Defines the drawer panel minimum size. |
+| `--pf-c-drawer__panel--md--FlexBasis` | `.pf-c-drawer__panel` | Defines the drawer panel size. |
+| `--pf-c-drawer__panel--md--FlexBasis--max` | `.pf-c-drawer__panel` | Defines the drawer panel maximum size. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3804

Introduces these vars as a means to control the drawer width:

| Class | Applied to | Outcome |
| -- | -- | -- |
| `--pf-c-drawer__panel--md--FlexBasis--min` | `.pf-c-drawer__panel` | Defines the drawer panel minimum size. |
| `--pf-c-drawer__panel--md--FlexBasis` | `.pf-c-drawer__panel` | Defines the drawer panel size. |
| `--pf-c-drawer__panel--md--FlexBasis--max` | `.pf-c-drawer__panel` | Defines the drawer panel maximum size. |

These are all applied > the medium breakpoint, so they do not apply to the mobile layout, and they're applied via `flex-basis: clamp(--pf-c-drawer__panel--md--FlexBasis--min, --pf-c-drawer__panel--md--FlexBasis, --pf-c-drawer__panel--md--FlexBasis--max)`. 

The var `--pf-c-drawer__panel--FlexBasis` still serves to define `flex-basis` on `.pf-c-drawer__panel`, and can be used to override the panel with on all viewport widths. So it works like it did before, we're just dropping the `--m-resizable--FlexBasis` vars we added recently in favor of a single `--md--FlexBasis` var that has an initial value by the component and can be overridden by the consumer, our modifiers, and the resizable drawer that modifies the panel size on the fly.

The react component's `min/maxSize` props can set the `--min` and `--max` vars inline. The `--min` var also has an initial value in our component of the splitter's width (or height in a panel-bottom variation) on resizable drawers so the panel is always at least as wide/tall as the splitter.

And all of these vars are applied to `.pf-c-drawer__panel`.