### PR TITLE
fix(drawer): added light-200 variation for grey background

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -5,10 +5,12 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 .pf-c-drawer {
   // Section
   --pf-c-drawer__section--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-drawer__section--m-light-200--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   // Content
   --pf-c-drawer__content--FlexBasis: 100%;
   --pf-c-drawer__content--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-drawer__content--m-light-200--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-drawer__content--ZIndex: var(--pf-global--ZIndex--xs);
 
   // Panel
@@ -16,6 +18,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --pf-c-drawer__panel--MaxHeight: auto;
   --pf-c-drawer__panel--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-drawer__panel--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-drawer__panel--m-light-200--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-drawer__panel--TransitionDuration: var(--pf-global--TransitionDuration);
   --pf-c-drawer__panel--TransitionProperty: margin, transform, box-shadow, flex-basis;
   --pf-c-drawer__panel--FlexBasis: 100%;
@@ -206,7 +209,11 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   background-color: var(--pf-c-drawer__section--BackgroundColor);
 
   &.pf-m-no-background {
-    background-color: transparent;
+    --pf-c-drawer__section--BackgroundColor: transparent;
+  }
+
+  &.pf-m-light-200 {
+    --pf-c-drawer__section--BackgroundColor: var(--pf-c-drawer__section--m-light-200--BackgroundColor);
   }
 }
 
@@ -229,17 +236,21 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 // Content
 .pf-c-drawer__content {
-  > .pf-c-drawer__body {
-    padding: var(--pf-c-drawer__content--child--PaddingTop) var(--pf-c-drawer__content--child--PaddingRight) var(--pf-c-drawer__content--child--PaddingBottom) var(--pf-c-drawer__content--child--PaddingLeft);
-  }
-
   z-index: var(--pf-c-drawer__content--ZIndex);
   flex-basis: var(--pf-c-drawer__content--FlexBasis);
   order: 0;
   background-color: var(--pf-c-drawer__content--BackgroundColor);
 
   &.pf-m-no-background {
-    background-color: transparent;
+    --pf-c-drawer__content--BackgroundColor: transparent;
+  }
+
+  &.pf-m-light-200 {
+    --pf-c-drawer__content--BackgroundColor: var(--pf-c-drawer__content--m-light-200--BackgroundColor);
+  }
+
+  > .pf-c-drawer__body {
+    padding: var(--pf-c-drawer__content--child--PaddingTop) var(--pf-c-drawer__content--child--PaddingRight) var(--pf-c-drawer__content--child--PaddingBottom) var(--pf-c-drawer__content--child--PaddingLeft);
   }
 }
 
@@ -268,7 +279,11 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   &.pf-m-no-background {
-    background-color: transparent;
+    --pf-c-drawer__panel--BackgroundColor: transparent;
+  }
+
+  &.pf-m-light-200 {
+    --pf-c-drawer__panel--BackgroundColor: var(--pf-c-drawer__panel--m-light-200--BackgroundColor);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--md) {

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -258,6 +258,21 @@ import './Drawer.css'
 {{/drawer}}
 ```
 
+### Content, panel, and section with grey background
+```hbs
+{{#> drawer drawer--id="content-panel-section-with-grey-background" drawer-panel--IsOpen="true"}}
+  {{#> drawer-section drawer-section--modifier="pf-m-light-200"}}
+    drawer-section
+  {{/drawer-section}}
+  {{#> drawer-main}}
+    {{#> drawer-content drawer-content--modifier="pf-m-light-200"}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+    {{/drawer-content}}
+    {{> drawer-example-panel drawer-panel--modifier="pf-m-light-200"}}
+  {{/drawer-main}}
+{{/drawer}}
+```
+
 ### Accessibility
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -258,14 +258,11 @@ import './Drawer.css'
 {{/drawer}}
 ```
 
-### Content, panel, and section with grey background
+### Panel with light-200 background
 ```hbs
-{{#> drawer drawer--id="content-panel-section-with-grey-background" drawer-panel--IsOpen="true"}}
-  {{#> drawer-section drawer-section--modifier="pf-m-light-200"}}
-    drawer-section
-  {{/drawer-section}}
-  {{#> drawer-main}}
-    {{#> drawer-content drawer-content--modifier="pf-m-light-200"}}
+{{#> drawer drawer--id="panel-with-light-200-background" drawer-panel--IsOpen="true"}}
+ {{#> drawer-main}}
+    {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
     {{/drawer-content}}
     {{> drawer-example-panel drawer-panel--modifier="pf-m-light-200"}}

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -306,6 +306,7 @@ import './Drawer.css'
 | `.pf-m-padding` | `.pf-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-c-drawer__body` | Modifies the element to remove padding. |
 | `.pf-m-no-background` | `.pf-c-drawer__section`, `.pf-c-drawer__content`, `.pf-c-drawer__panel` | Modifies the drawer body/panel background color to transparent. |
+| `.pf-m-light-200` | `.pf-c-drawer__section`, `.pf-c-drawer__content`, `.pf-c-drawer__panel` | Modifies the drawer body/panel background color to light grey. |
 | `.pf-m-width-{25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-c-drawer__panel` | Modifies the drawer panel width. |
 | `.pf-m-resizable` | `.pf-c-drawer__panel` | Modifies the drawer panel to be resizable. Intended for use with the `.pf-c-drawer__splitter` element. |
 | `--pf-c-drawer__panel--md--FlexBasis--min` | `.pf-c-drawer__panel` | Defines the drawer panel minimum size. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3813

@mcarrano @mceledonia I added this variation as `pf-m-light-200`. I'd like to be consistent as we use a variation like this going forward. Our page sections are `--pf-global--BackgroundColor-200` by default, and we use `pf-m-light` as the variation name to turn it white, so we have that precedent to work with. I'm thinking we can keep `pf-m-light` to represent white/`--pf-global--BackgroundColor-100`, and use `pf-m-light-200` for `--pf-global--BackgroundColor-200`. That will also allow us to apply this to other components in the same way. Sound OK?