### PR TITLE
feat(radio, check): added standalone variation, cursor styles

### DIFF
--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -16,6 +16,15 @@
   grid-gap: var(--pf-c-check--GridGap);
   align-items: start;
   justify-items: start;
+
+  &.pf-m-standalone {
+    --pf-c-check--GridGap: 0;
+    --pf-c-check__input--Height: auto;
+    --pf-c-check__input--MarginTop: 0;
+
+    display: inline-grid;
+    line-height: 1;
+  }
 }
 
 .pf-c-check__label {

--- a/src/patternfly/components/Check/examples/Check.md
+++ b/src/patternfly/components/Check/examples/Check.md
@@ -63,7 +63,7 @@ cssPrefix: pf-c-check
 ### Standalone input
 ```hbs
 {{#> check check--modifier="pf-m-standalone"}}
-  {{#> check-input check-input--attribute='id="check-standalone-input" name="check-standalone-input"'}}{{/check-input}}
+  {{#> check-input check-input--attribute='id="check-standalone-input" name="check-standalone-input" aria-label="Standalone input"'}}{{/check-input}}
 {{/check}}
 ```
 

--- a/src/patternfly/components/Check/examples/Check.md
+++ b/src/patternfly/components/Check/examples/Check.md
@@ -60,6 +60,13 @@ cssPrefix: pf-c-check
 {{/check}}
 ```
 
+### Standalone input
+```hbs
+{{#> check check--modifier="pf-m-standalone"}}
+  {{#> check-input check-input--attribute='id="check-standalone-input" name="check-standalone-input"'}}{{/check-input}}
+{{/check}}
+```
+
 ## Documentation
 ### Overview
 The Check component is provided for use cases outside of forms. If it is used without label text ensure some sort of label for assistive technologies. (for example: `aria-label`)
@@ -78,4 +85,5 @@ If you extend this component or modify the styles of this component, then make s
 | `.pf-c-check__input` | `<input type="checkbox">` |  Initiates a check input. **Required**  |
 | `.pf-c-check__label` | `<label>`, `<span>` |  Initiates a label. **Required**  |
 | `.pf-c-check__description` | `<div>` |  Initiates a check description. |
-| `.pf-m-disabled` | `.pf-c-check__label` |  Initiates a disabled style for labels. **Required when input is disabled** |
+| `.pf-m-standalone` | `.pf-c-radio` |  Modifies the check component for use with a standalone `<input type="checkbox">`. **Required when there is no label** |
+| `.pf-m-disabled` | `.pf-c-check__label` |  Modifies the check component for the disabled state. **Required when input is disabled** |

--- a/src/patternfly/components/Check/examples/Check.md
+++ b/src/patternfly/components/Check/examples/Check.md
@@ -85,5 +85,5 @@ If you extend this component or modify the styles of this component, then make s
 | `.pf-c-check__input` | `<input type="checkbox">` |  Initiates a check input. **Required**  |
 | `.pf-c-check__label` | `<label>`, `<span>` |  Initiates a label. **Required**  |
 | `.pf-c-check__description` | `<div>` |  Initiates a check description. |
-| `.pf-m-standalone` | `.pf-c-radio` |  Modifies the check component for use with a standalone `<input type="checkbox">`. **Required when there is no label** |
+| `.pf-m-standalone` | `.pf-c-check` |  Modifies the check component for use with a standalone `<input type="checkbox">`. **Required when there is no label** |
 | `.pf-m-disabled` | `.pf-c-check__label` |  Modifies the check component for the disabled state. **Required when input is disabled** |

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -335,6 +335,10 @@
   align-self: flex-start;
   height: var(--pf-c-data-list__check--Height);
   margin-top: var(--pf-c-data-list__check--MarginTop);
+
+  > input {
+    cursor: pointer;
+  }
 }
 
 .pf-c-data-list__item-draggable-button {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -229,7 +229,9 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
       align-items: center;
       cursor: pointer;
 
-      input {
+      > input,
+      .pf-c-check {
+        cursor: pointer;
         transform: translateY(var(--pf-c-dropdown__toggle--m-split-button__toggle-check__input--TranslateY));
       }
     }

--- a/src/patternfly/components/DualListSelector/dual-list-selector-item-check.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-item-check.hbs
@@ -3,8 +3,12 @@
     {{{dual-list-selector-item-check--attribute}}}
   {{/if}}>
   {{#if dual-list-selector-item--IsSelected}}
-    <input type="checkbox" id="check-{{{dual-list-selector-item--id}}}" checked aria-label="Dual list selector item check checked">
+    {{#> check check--modifier="pf-m-standalone"}}
+      {{> check-input check-input--attribute=(concat 'id="check-' dual-list-selector-item--id '" checked aria-label="Dual list selector item check checked"')}}
+    {{/check}}
   {{else}}
-    <input type="checkbox" id="check-{{{dual-list-selector-item--id}}}" aria-label="Dual list selector item check">
+    {{#> check check--modifier="pf-m-standalone"}}
+      {{> check-input check-input--attribute=(concat 'id="check-' dual-list-selector-item--id '" aria-label="Dual list selector item check"')}}
+    {{/check}}
   {{/if}}
 </span>

--- a/src/patternfly/components/Radio/examples/Radio.md
+++ b/src/patternfly/components/Radio/examples/Radio.md
@@ -61,6 +61,13 @@ cssPrefix: pf-c-radio
 {{/radio}}
 ```
 
+### Standalone
+```hbs
+{{#> radio radio--modifier="pf-m-standalone"}}
+  {{#> radio-input radio-input--attribute='id="radio-standalone" name="exampleRadioStandalone"'}}{{/radio-input}}
+{{/radio}}
+```
+
 ## Documentation
 ### Overview
 The Radio component is provided for use cases outside of forms. If it is used without label text ensure some sort of label for assistive technologies. (for example: `aria-label`)
@@ -79,4 +86,5 @@ If you extend this component or modify the styles of this component, then make s
 | `.pf-c-radio__input` | `<input type="radio">` |  Initiates a radio input. **Required**  |
 | `.pf-c-radio__label` | `<label>`, `<span>` |  Initiates a label. **Required**  |
 | `.pf-c-radio__description` | `<div>` | Initiates a radio description. |
-| `.pf-m-disabled` | `.pf-c-radio__label` |  Initiates a disabled style for labels. **Required when input is disabled** |
+| `.pf-m-standalone` | `.pf-c-radio` |  Modifies the radio component for use with a standalone `<input type="radio">`. **Required when there is no label** |
+| `.pf-m-disabled` | `.pf-c-radio__label` |  Modifies the radio component for the disabled state. **Required when input is disabled** |

--- a/src/patternfly/components/Radio/examples/Radio.md
+++ b/src/patternfly/components/Radio/examples/Radio.md
@@ -61,10 +61,10 @@ cssPrefix: pf-c-radio
 {{/radio}}
 ```
 
-### Standalone
+### Standalone input
 ```hbs
 {{#> radio radio--modifier="pf-m-standalone"}}
-  {{#> radio-input radio-input--attribute='id="radio-standalone" name="exampleRadioStandalone"'}}{{/radio-input}}
+  {{#> radio-input radio-input--attribute='id="radio-standalone" name="exampleRadioStandalone" aria-label="Standalone input"'}}{{/radio-input}}
 {{/radio}}
 ```
 

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -17,6 +17,15 @@
   grid-gap: var(--pf-c-radio--GridGap);
   align-items: start;
   justify-items: start;
+
+  &.pf-m-standalone {
+    --pf-c-radio--GridGap: 0;
+    --pf-c-radio__input--Height: auto;
+    --pf-c-radio__input--MarginTop: 0;
+
+    display: inline-grid;
+    line-height: 1;
+  }
 }
 
 .pf-c-radio__label {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -637,6 +637,10 @@
 // Check table cell
 .pf-c-table__check {
   --pf-c-table--cell--FontSize: var(--pf-c-table__check--input--FontSize);
+
+  > input {
+    cursor: pointer;
+  }
 }
 
 // Favorite body cell

--- a/src/patternfly/components/TreeView/tree-view-node-check.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-check.hbs
@@ -3,8 +3,12 @@
     {{{tree-view-node-check--attribute}}}
   {{/if}}>
   {{#if tree-view-node-check--IsChecked}}
-    <input type="checkbox" id="check-{{{tree-view-node--id}}}" checked aria-label="Tree view node check checked">
+    {{#> check check--modifier="pf-m-standalone"}}
+      {{> check-input check-input--attribute=(concat 'id="check-' tree-view-node--id '" checked aria-label="Tree view node check checked"')}}
+    {{/check}}
   {{else}}
-    <input type="checkbox" id="check-{{{tree-view-node--id}}}" aria-label="Tree view node check">
+    {{#> check check--modifier="pf-m-standalone"}}
+      {{> check-input check-input--attribute=(concat 'id="check-' tree-view-node--id '" aria-label="Tree view node check"')}}
+    {{/check}}
   {{/if}}
 </span>

--- a/src/patternfly/demos/Card/card-view-demo-template-gallery.hbs
+++ b/src/patternfly/demos/Card/card-view-demo-template-gallery.hbs
@@ -4,7 +4,9 @@
         <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -22,7 +24,9 @@
         <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -40,7 +44,9 @@
         <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -58,7 +64,9 @@
         <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -76,7 +84,9 @@
       <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -94,7 +104,9 @@
         <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -112,7 +124,9 @@
         <img src="/assets/images/camel-dropbox_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -130,7 +144,9 @@
         <img src="/assets/images/camel-infinispan_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -148,7 +164,9 @@
         <img src="/assets/images/FuseConnector_Icons_REST.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}
@@ -167,7 +185,9 @@
         <img src="/assets/images/camel-swagger-java_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+          {{#> check check--modifier="pf-m-standalone"}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+          {{/check}}
         {{/card-actions}}
       {{/card-header}}
       {{#> card-title}}

--- a/src/patternfly/demos/PrimaryDetail/primary-detail-card-view.hbs
+++ b/src/patternfly/demos/PrimaryDetail/primary-detail-card-view.hbs
@@ -4,7 +4,9 @@
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -22,7 +24,9 @@
       <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -40,7 +44,9 @@
       <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -58,7 +64,9 @@
       <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -76,7 +84,9 @@
     <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
     {{#> card-actions}}
       {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-      <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+      {{#> check check--modifier="pf-m-standalone"}}
+        {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+      {{/check}}
     {{/card-actions}}
   {{/card-header}}
   {{#> card-title}}
@@ -94,7 +104,9 @@
       <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -112,7 +124,9 @@
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -130,7 +144,9 @@
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -148,7 +164,9 @@
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}
@@ -166,7 +184,9 @@
       <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-        <input type="checkbox" id="{{card--id}}-check" name="{{card--id}}-check" aria-labelledby="{{card--id}}-check-label">
+        {{#> check check--modifier="pf-m-standalone"}}
+          {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+        {{/check}}
       {{/card-actions}}
     {{/card-header}}
     {{#> card-title}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3288
fixes https://github.com/patternfly/patternfly/issues/3311

@mcarrano @mattnolting @mceledonia this adds a "pf-m-standalone" variation to the check and radio components for use when the radio/check is just a single input with no label/description. Previously, the components required a label. This PR updates our beta components that use a regular checkbox (tree view, dual list selector) and card view demo checkboxes to use the standalone variation of the checkbox component instead of regular checkboxes.

I tested using the standalone checkbox/radio components in our existing non-beta components (table, data list, split button dropdown toggles) and it works fine, though you could argue it might be breaking if users are relying on the existing input that's used in those components. It's probably OK, but I wouldn't want to inadvertently introduce a layout problem there if users have custom styles for the existing inputs that don't transfer to the new radio/checkbox component. So to address the pointer style issue from #3288 in existing components that have regular checkboxes , I've added `pointer: cursor;` styles to those inputs. And in a breaking change, we can update table, data list, etc to use the checkbox/radio components.

Re: the target area/size for inputs, I think we should explore that in a separate issue. I'm thinking to be able to do that consistently/reliably, we'll want to use custom checkbox/radio elements. 