### PR TITLE
fix(wizard): set in page wizard page section to shrink so footer/nav are sticky

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -205,7 +205,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `.pf-c-page__main-nav` | `<section>` |   Creates a container to nest the navigation component in the main page area. |
 | `.pf-c-page__main-breadcrumb` | `<section>` |   Creates a container to nest the breadcrumb component in the main page area. |
 | `.pf-c-page__main-section` | `<section>` |  Creates a section container in the main page area. **Note: The last/only `.pf-c-page__main-section` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
-| `.pf-c-page__main-wizard` | `<section>` | Creates a container to nest the wizard component in the mian page area. |
+| `.pf-c-page__main-wizard` | `<section>` | Creates a container to nest the wizard component in the main page area. |
 | `.pf-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required when using `.pf-m-limit-width` on `.pf-c-page__main-section`** |
 | `.pf-c-page__main-group` | `<div>` | Creates the group of `.pf-c-page__main-*` sections. Can be used in combination with `.pf-m-sticky-[top/bottom]` to make multiple sections sticky. |
 | `.pf-c-page__drawer` | `<div>` |  Creates a container for the drawer component when placing the main page element in the drawer body. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -156,7 +156,6 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
     --pf-c-page__main-breadcrumb--PaddingLeft: var(--pf-c-page__main-breadcrumb--xl--PaddingLeft);
   }
 
-
   // Wizard main section
   --pf-c-page__main-wizard--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-page__main-wizard--BorderTopColor: var(--pf-global--BorderColor--100);
@@ -549,9 +548,18 @@ $pf-c-page--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl",
 }
 
 .pf-c-page__main-wizard {
-  flex-grow: 1;
+  flex: 1 1;
+  min-height: 0;
   background-color: var(--pf-c-page__main-wizard--BackgroundColor);
   border-top: var(--pf-c-page__main-wizard--BorderTopWidth) solid var(--pf-c-page__main-wizard--BorderTopColor);
+
+  &:first-child {
+    --pf-c-page__main-wizard--BorderTopWidth: 0;
+  }
+}
+
+.pf-c-page__main-wizard .pf-c-page__main-body {
+  min-height: 0;
 }
 
 .pf-c-page__main-group {

--- a/src/patternfly/components/Wizard/__wizard-form.hbs
+++ b/src/patternfly/components/Wizard/__wizard-form.hbs
@@ -1,0 +1,58 @@
+{{#> form form--id=(concat wizard--id "-form")}}
+  {{#> form-group form-group--id="-field1"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 1{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+  {{#> form-group form-group--id="-field2"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 2{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+    {{#> form-group form-group--id="-field3"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 3{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+    {{#> form-group form-group--id="-field4"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 4{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+    {{#> form-group form-group--id="-field5"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 5{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+    {{#> form-group form-group--id="-field6"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 6{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+    {{#> form-group form-group--id="-field7"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 7{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+{{/form}}

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -10,7 +10,7 @@ import './Wizard.css'
 ## Examples
 ### Basic
 ```hbs isFullscreen
-{{#> wizard}}
+{{#> wizard wizard--id="wizard-basic"}}
   {{#> wizard-header}}
     {{#> button button--modifier="pf-m-plain pf-c-wizard__close" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -77,7 +77,7 @@ import './Wizard.css'
           {{/wizard-nav-list}}
         {{/wizard-nav}}
       {{#> wizard-main}}
-        <p>Wizard content goes here</p>
+        {{> __wizard-form}}
       {{/wizard-main}}
     {{/wizard-inner-wrap}}
     {{#> wizard-footer}}
@@ -166,7 +166,7 @@ import './Wizard.css'
         {{/wizard-nav-list}}
       {{/wizard-nav}}
       {{#> wizard-main}}
-        <p>Wizard content goes here</p>
+        {{> __wizard-form}}
       {{/wizard-main}}
     {{/wizard-inner-wrap}}
     {{#> wizard-footer}}

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -174,6 +174,7 @@
   --pf-c-wizard__footer--xl--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-wizard__footer--xl--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--xl--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-wizard__footer--BoxShadow: var(--pf-global--BoxShadow--sm-top);
   --pf-c-wizard__footer--child--MarginRight: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--child--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-wizard__footer-cancel--MarginLeft: calc(var(--pf-global--spacer--2xl) - var(--pf-c-wizard__footer--child--MarginRight));
@@ -487,6 +488,13 @@
     &:not(:last-child) {
       margin-right: var(--pf-c-wizard__footer--child--MarginRight);
     }
+  }
+
+  // Limit shadow to a child of modal and main-wizard since we can ensure wizard footer is fixed in those usages
+  // Make a regular style in a breaking change release
+  .pf-c-page__main-wizard &,
+  .pf-c-modal-box & {
+    box-shadow: var(--pf-c-wizard__footer--BoxShadow);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -144,6 +144,7 @@
   // Outer wrap
   --pf-c-wizard__outer-wrap--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-wizard__outer-wrap--lg--PaddingLeft: var(--pf-c-wizard__nav--Width);
+  --pf-c-wizard__outer-wrap--MinHeight: #{pf-size-prem(250px)};
 
   // Main
   --pf-c-wizard__main--ZIndex: var(--pf-global--ZIndex--xs);
@@ -314,7 +315,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  min-height: 0;
+  min-height: var(--pf-c-wizard__outer-wrap--MinHeight);
   background-color: var(--pf-c-wizard__outer-wrap--BackgroundColor);
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -166,6 +166,8 @@
   }
 
   // Footer
+  --pf-c-wizard__footer--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-wizard__footer--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-wizard__footer--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard__footer--PaddingBottom: var(--pf-global--spacer--sm);
@@ -477,10 +479,12 @@
 }
 
 .pf-c-wizard__footer {
+  z-index: var(--pf-c-wizard__footer--ZIndex);
   display: flex;
   flex-wrap: wrap;
   flex-shrink: 0;
   padding: var(--pf-c-wizard__footer--PaddingTop) var(--pf-c-wizard__footer--PaddingRight) var(--pf-c-wizard__footer--PaddingBottom) var(--pf-c-wizard__footer--PaddingLeft);
+  background-color: var(--pf-c-wizard__footer--BackgroundColor);
 
   > * {
     margin-bottom: var(--pf-c-wizard__footer--child--MarginBottom);

--- a/src/patternfly/demos/Wizard/examples/Wizard.md
+++ b/src/patternfly/demos/Wizard/examples/Wizard.md
@@ -77,7 +77,7 @@ wrapperTag: div
                 {{/wizard-nav-list}}
               {{/wizard-nav}}
             {{#> wizard-main}}
-              <p>Wizard content goes here</p>
+              {{> __wizard-form}}
             {{/wizard-main}}
           {{/wizard-inner-wrap}}
           {{#> wizard-footer}}
@@ -172,7 +172,7 @@ wrapperTag: div
               {{/wizard-nav-list}}
             {{/wizard-nav}}
             {{#> wizard-main}}
-              <p>Wizard content goes here</p>
+              {{> __wizard-form}}
             {{/wizard-main}}
           {{/wizard-inner-wrap}}
           {{#> wizard-footer}}
@@ -313,7 +313,7 @@ wrapperTag: div
                 {{/wizard-nav-list}}
               {{/wizard-nav}}
             {{#> wizard-main wizard-main--type="div"}}
-              <p>Wizard content goes here</p>
+              {{> __wizard-form}}
             {{/wizard-main}}
           {{/wizard-inner-wrap}}
           {{#> wizard-footer}}
@@ -454,7 +454,7 @@ wrapperTag: div
                 {{/wizard-nav-list}}
               {{/wizard-nav}}
             {{#> wizard-main wizard-main--type="div"}}
-              <p>Wizard content goes here</p>
+              {{> __wizard-form}}
             {{/wizard-main}}
           {{/wizard-inner-wrap}}
           {{#> wizard-footer}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3255

@mcarrano this adds a top box-shadow to the wizard footer when the wizard is 1) used in a modal, 2) used in the special page component section currently needed to add the wizard to the page. Those are the places where we should be able to guarantee the wizard footer remains sticky, so a shadow seems appropriate. I didn't add it globally to any wizard footer since, if the footer doesn't remain sticky as it should, the shadow will look out of place. So this means we may end up with some wizard footers that have a shadow, and ones that don't, even if the wizard footer is sticky since the wizard wasn't used in a modal or the special page section. That seems like a fair compromise since the wizard footers don't have a shadow currently, so nothing changes there. WDYT about that? Should we just wait and add a shadow to the footer in a breaking change to avoid a potential inconsistency with some footers having a shadow, and some not?