### PR TITLE
fix(docs): fixed missing outlines for utilities examples

### DIFF
--- a/src/patternfly/utilities/Flex/examples/Flex.css
+++ b/src/patternfly/utilities/Flex/examples/Flex.css
@@ -1,5 +1,5 @@
 .ws-core-u-flex .pf-u-display-flex,
-.ws-core-u-flex .ws-core-flex-item,
+.ws-core-u-flex .ws-example-flex-item,
 .ws-core-u-flex .pf-u-display-inline-flex {
   flex-wrap: wrap;
   padding: .5rem !important;
@@ -12,14 +12,14 @@
   min-height: 160px;
 }
 
-#ws-core-u-flex-aligned-content .ws-core-flex-item {
+#ws-core-u-flex-aligned-content .ws-example-flex-item {
   height: 40px;
 }
 
-.ws-core-u-flex-md {
+.ws-example-u-flex-md {
   height: 60px;
 }
 
-.ws-core-u-flex-lg {
+.ws-example-u-flex-lg {
   height: 80px;
 }

--- a/src/patternfly/utilities/Sizing/examples/Sizing.css
+++ b/src/patternfly/utilities/Sizing/examples/Sizing.css
@@ -1,4 +1,4 @@
-.ws-core-u-sizing-item {
+.ws-example-u-sizing-item {
   padding: .5rem !important;
   border: 2px dashed #393f44;
 }

--- a/src/patternfly/utilities/Spacing/examples/Spacing.css
+++ b/src/patternfly/utilities/Spacing/examples/Spacing.css
@@ -1,4 +1,4 @@
-.ws-core-u-spacing .ws-core-flex-item,
+.ws-core-u-spacing .ws-example-flex-item,
 .ws-core-u-spacing .pf-u-display-flex {
   padding: .5rem;
   border: 2px dashed #393f44;


### PR DESCRIPTION
Closes #3823 

This PR fixes workspace selectors for flex, spacing, & sizing utilities examples to restore missing outlines.

Note: this was originally file as a PF-Org issue but the change was required here & will update in Org when it bumps the PF version at next release.