### PR TITLE
fix(drawer): replace clamp in resizable drawer for browser support

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -297,7 +297,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    flex-basis: var(--pf-c-drawer__panel--md--FlexBasis);
+    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--md--FlexBasis);
 
     .pf-c-drawer:not(.pf-m-panel-bottom) & {
       min-width: var(--pf-c-drawer__panel--md--FlexBasis--min);

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -297,17 +297,11 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-drawer__panel--FlexBasis: var(--pf-c-drawer__panel--md--FlexBasis);
-
-    .pf-c-drawer:not(.pf-m-panel-bottom) & {
-      min-width: var(--pf-c-drawer__panel--md--FlexBasis--min);
-      max-width: var(--pf-c-drawer__panel--md--FlexBasis--max);
-    }
-
-    .pf-m-panel-bottom & {
-      min-height: var(--pf-c-drawer__panel--md--FlexBasis--min);
-      max-height: var(--pf-c-drawer__panel--md--FlexBasis--max);
-    }
+    --pf-c-drawer__panel--FlexBasis:
+      max(
+        var(--pf-c-drawer__panel--md--FlexBasis--min),
+        min(var(--pf-c-drawer__panel--md--FlexBasis), var(--pf-c-drawer__panel--md--FlexBasis--max))
+      );
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -297,12 +297,17 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   @media screen and (min-width: $pf-global--breakpoint--md) {
-    --pf-c-drawer__panel--FlexBasis:
-      clamp(
-        var(--pf-c-drawer__panel--md--FlexBasis--min),
-        var(--pf-c-drawer__panel--md--FlexBasis),
-        var(--pf-c-drawer__panel--md--FlexBasis--max)
-      );
+    flex-basis: var(--pf-c-drawer__panel--md--FlexBasis);
+
+    .pf-c-drawer:not(.pf-m-panel-bottom) & {
+      min-width: var(--pf-c-drawer__panel--md--FlexBasis--min);
+      max-width: var(--pf-c-drawer__panel--md--FlexBasis--max);
+    }
+
+    .pf-m-panel-bottom & {
+      min-height: var(--pf-c-drawer__panel--md--FlexBasis--min);
+      max-height: var(--pf-c-drawer__panel--md--FlexBasis--max);
+    }
   }
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {


### PR DESCRIPTION
Closes #3851 

This PR replaces `clamp` used in the resizable drawer with `min/max` functions [as described here](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()) to increase browser support for Safari 13.