### PR TITLE
fix(drawer): fixed bottom variant issues in safari

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -230,7 +230,7 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 // Main area
 .pf-c-drawer__main {
   display: flex;
-  flex-grow: 1;
+  flex: 1;
   overflow: hidden;
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3857

`flex-basis: 100%` on `__content` isn't working in a vertical layout because its parent `__main` doesn't have a height. 