### PR TITLE
fix(context-selector): hid menu scroll unless there is overflow

### DIFF
--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -155,7 +155,7 @@
 
 .pf-c-context-selector__menu-list {
   max-height: var(--pf-c-context-selector__menu-list--MaxHeight);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .pf-c-context-selector__menu-list-item {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3872