### PR TITLE
fix(switch): adjust space between switch and label

### DIFF
--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -156,7 +156,6 @@
 .pf-c-switch__label {
   display: inline-block;
   grid-column: 2;
-  padding-left: var(--pf-c-switch__label--PaddingLeft);
   color: var(--pf-c-switch__label--Color);
   vertical-align: top;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3880

Looks like this was a bug introduced in https://github.com/patternfly/patternfly/pull/3749/