### PR TITLE
feat(accordion): added display-lg, support multiple bodies

### DIFF
--- a/src/patternfly/components/Accordion/accordion-expanded-content.hbs
+++ b/src/patternfly/components/Accordion/accordion-expanded-content.hbs
@@ -3,7 +3,5 @@
   {{#if accordion-expanded-content--attribute}}
     {{{accordion-expanded-content--attribute}}}
   {{/if}}>
-  {{#> accordion-expanded-content-body}}
-    {{> @partial-block}}
-  {{/accordion-expanded-content-body}}
+  {{> @partial-block}}
 </{{#if accordion--IsDefinitionList}}dd{{else}}div{{/if}}>

--- a/src/patternfly/components/Accordion/accordion-toggle.hbs
+++ b/src/patternfly/components/Accordion/accordion-toggle.hbs
@@ -1,4 +1,10 @@
 <{{#if accordion--IsDefinitionList}}dt>{{else}}h3>{{/if}}<button class="pf-c-accordion__toggle{{#if accordion-toggle--IsExpanded}} pf-m-expanded{{/if}}{{#if accordion-toggle--modifier}} {{accordion-toggle--modifier}}{{/if}}"
+  type="button"
+  {{#if accordion-toggle--IsExpanded}}
+   aria-expanded="true"
+  {{else}}
+   aria-expanded="false"
+ {{/if}}
  {{#if accordion-toggle--attribute}}
    {{{accordion-toggle--attribute}}}
  {{/if}}>

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,6 +1,8 @@
 .pf-c-accordion {
   // accordion
   --pf-c-accordion--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-accordion--m-display-lg--BorderTopWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-display-lg--BorderTopColor: var(--pf-global--BorderColor--100);
 
   // accordion toggle
   --pf-c-accordion__toggle--PaddingTop: var(--pf-global--spacer--sm);
@@ -8,6 +10,7 @@
   --pf-c-accordion__toggle--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-accordion__toggle--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-accordion__toggle--before--BackgroundColor: transparent;
+  --pf-c-accordion__toggle--before--Top: 0;
   --pf-c-accordion__toggle--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-accordion__toggle--focus--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-accordion__toggle--active--BackgroundColor: var(--pf-global--BackgroundColor--200);
@@ -29,21 +32,109 @@
   --pf-c-accordion__toggle--m-expanded__toggle-icon--Rotate: 90deg;
 
   // accordion expanded content
+  --pf-c-accordion__expanded-content--Color: var(--pf-global--Color--200);
+  --pf-c-accordion__expanded-content--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-accordion__expanded-content--m-expanded__expanded-content-body--before--BackgroundColor: var(--pf-global--primary-color--100);
+  --pf-c-accordion__expanded-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
   --pf-c-accordion__expanded-content-body--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-accordion__expanded-content-body--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-accordion__expanded-content-body--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-accordion__expanded-content--Color: var(--pf-global--Color--200);
-  --pf-c-accordion__expanded-content--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-accordion__expanded-content-body--expanded-content-body--PaddingTop: 0;
   --pf-c-accordion__expanded-content-body--before--BackgroundColor: transparent;
   --pf-c-accordion__expanded-content-body--before--Width: var(--pf-global--BorderWidth--lg);
-  --pf-c-accordion__expanded-content--m-expanded__expanded-content-body--before--BackgroundColor: var(--pf-global--primary-color--100);
-  --pf-c-accordion__expanded-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
+  --pf-c-accordion__expanded-content-body--before--Top: 0;
+
+  // large
+  --pf-c-accordion--m-display-lg__toggle--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-accordion--m-display-lg__toggle--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-accordion--m-display-lg__toggle--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-accordion--m-display-lg__toggle--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-accordion--m-display-lg__toggle--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
+  --pf-c-accordion--m-display-lg__toggle--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-accordion--m-display-lg__toggle--hover__toggle-text--Color: var(--pf-global--Color--100);
+  --pf-c-accordion--m-display-lg__toggle--active__toggle-text--Color: var(--pf-global--Color--100);
+  --pf-c-accordion--m-display-lg__toggle--active__toggle-text--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-accordion--m-display-lg__toggle--focus__toggle-text--Color: var(--pf-global--Color--100);
+  --pf-c-accordion--m-display-lg__toggle--focus__toggle-text--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--Color: var(--pf-global--Color--100);
+  --pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-accordion--m-display-lg__toggle--before--Top: calc(-1 * var(--pf-global--BorderWidth--sm));
+  --pf-c-accordion--m-display-lg__toggle--after--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-accordion--m-display-lg__toggle--after--BorderTopWidth: 0;
+  --pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-display-lg__expanded-content--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-accordion--m-display-lg__expanded-content--Color: var(--pf-global--Color--100);
+  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingTop: 0;
+  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor: var(--pf-global--BorderColor--100);
+
 
   // This component always needs to be light
   @include pf-t-light;
 
   background-color: var(--pf-c-accordion--BackgroundColor);
+
+  &.pf-m-display-lg {
+    --pf-c-accordion__toggle--PaddingTop: var(--pf-c-accordion--m-display-lg__toggle--PaddingTop);
+    --pf-c-accordion__toggle--PaddingRight: var(--pf-c-accordion--m-display-lg__toggle--PaddingRight);
+    --pf-c-accordion__toggle--PaddingBottom: var(--pf-c-accordion--m-display-lg__toggle--PaddingBottom);
+    --pf-c-accordion__toggle--PaddingLeft: var(--pf-c-accordion--m-display-lg__toggle--PaddingLeft);
+    --pf-c-accordion__toggle--FontFamily: var(--pf-c-accordion--m-display-lg__toggle--FontFamily);
+    --pf-c-accordion__toggle--FontSize: var(--pf-c-accordion--m-display-lg__toggle--FontSize);
+    --pf-c-accordion__toggle--hover__toggle-text--Color: var(--pf-c-accordion--m-display-lg__toggle--hover__toggle-text--Color);
+    --pf-c-accordion__toggle--active__toggle-text--Color: var(--pf-c-accordion--m-display-lg__toggle--active__toggle-text--Color);
+    --pf-c-accordion__toggle--active__toggle-text--FontWeight: var(--pf-c-accordion--m-display-lg__toggle--active__toggle-text--FontWeight);
+    --pf-c-accordion__toggle--focus__toggle-text--Color: var(--pf-c-accordion--m-display-lg__toggle--focus__toggle-text--Color);
+    --pf-c-accordion__toggle--focus__toggle-text--FontWeight: var(--pf-c-accordion--m-display-lg__toggle--focus__toggle-text--FontWeight);
+    --pf-c-accordion__toggle--m-expanded__toggle-text--Color: var(--pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--Color);
+    --pf-c-accordion__toggle--m-expanded__toggle-text--FontWeight: var(--pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--FontWeight);
+    --pf-c-accordion__toggle--before--Top: var(--pf-c-accordion--m-display-lg__toggle--before--Top);
+    --pf-c-accordion__expanded-content-body--PaddingTop: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingTop);
+    --pf-c-accordion__expanded-content-body--PaddingRight: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingRight);
+    --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom);
+    --pf-c-accordion__expanded-content-body--PaddingLeft: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingLeft);
+    --pf-c-accordion__expanded-content--FontSize: var(--pf-c-accordion--m-display-lg__expanded-content--FontSize);
+    --pf-c-accordion__expanded-content--Color: var(--pf-c-accordion--m-display-lg__expanded-content--Color);
+
+    border-top: var(--pf-c-accordion--m-display-lg--BorderTopWidth) solid var(--pf-c-accordion--m-display-lg--BorderTopColor);
+
+    // rename --after vars to --before in breaking change release
+    .pf-c-accordion__toggle {
+      &::before {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        content: "";
+        border: solid var(--pf-c-accordion--m-display-lg__toggle--after--BorderColor);
+        border-width: var(--pf-c-accordion--m-display-lg__toggle--after--BorderTopWidth) 0 var(--pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth);
+      }
+
+      &.pf-m-expanded {
+        --pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth: 0;
+      }
+    }
+
+    // rename --after vars to --before in breaking change release
+    // stylelint-disable selector-max-class
+    .pf-c-accordion__expanded-content.pf-m-expanded .pf-c-accordion__expanded-content-body:last-child {
+      &::before {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        content: "";
+        border-bottom: var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth) solid var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor);
+      }
+    }
+    // stylelint-enable
+  }
 }
 
 .pf-c-accordion__toggle {
@@ -53,11 +144,14 @@
   justify-content: space-between;
   width: 100%;
   padding: var(--pf-c-accordion__toggle--PaddingTop) var(--pf-c-accordion__toggle--PaddingRight) var(--pf-c-accordion__toggle--PaddingBottom) var(--pf-c-accordion__toggle--PaddingLeft);
+  font-family: var(--pf-c-accordion__toggle--FontFamily, inherit);
+  font-size: var(--pf-c-accordion__toggle--FontSize, inherit);
   border: 0;
 
-  &::before {
+  // rename --before vars to --after in breaking change release
+  &::after {
     position: absolute;
-    top: 0;
+    top: var(--pf-c-accordion__toggle--before--Top);
     bottom: 0;
     left: 0;
     width: var(--pf-c-accordion__toggle--before--Width);
@@ -133,7 +227,8 @@
   position: relative;
   padding: var(--pf-c-accordion__expanded-content-body--PaddingTop) var(--pf-c-accordion__expanded-content-body--PaddingRight) var(--pf-c-accordion__expanded-content-body--PaddingBottom) var(--pf-c-accordion__expanded-content-body--PaddingLeft);
 
-  &::before {
+  // rename --before vars to --after in breaking change release
+  &::after {
     position: absolute;
     top: 0;
     bottom: 0;

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,8 +1,6 @@
 .pf-c-accordion {
   // accordion
   --pf-c-accordion--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-accordion--m-display-lg--BorderTopWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-accordion--m-display-lg--BorderTopColor: var(--pf-global--BorderColor--100);
 
   // accordion toggle
   --pf-c-accordion__toggle--PaddingTop: var(--pf-global--spacer--sm);
@@ -59,10 +57,6 @@
   --pf-c-accordion--m-display-lg__toggle--focus__toggle-text--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--Color: var(--pf-global--Color--100);
   --pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-global--FontWeight--normal);
-  --pf-c-accordion--m-display-lg__toggle--before--Top: calc(-1 * var(--pf-global--BorderWidth--sm));
-  --pf-c-accordion--m-display-lg__toggle--after--BorderColor: var(--pf-global--BorderColor--100);
-  --pf-c-accordion--m-display-lg__toggle--after--BorderTopWidth: 0;
-  --pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-accordion--m-display-lg__expanded-content--FontSize: var(--pf-global--FontSize--md);
   --pf-c-accordion--m-display-lg__expanded-content--Color: var(--pf-global--Color--100);
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingTop: 0;
@@ -70,9 +64,16 @@
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-accordion--m-display-lg__expanded-content-body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor: var(--pf-global--BorderColor--100);
 
+  // bordered
+  --pf-c-accordion--m-bordered--BorderTopWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-bordered--BorderTopColor: var(--pf-global--BorderColor--100);
+  --pf-c-accordion--m-bordered__toggle--before--Top: calc(-1 * var(--pf-global--BorderWidth--sm));
+  --pf-c-accordion--m-bordered__toggle--after--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-accordion--m-bordered__toggle--after--BorderTopWidth: 0;
+  --pf-c-accordion--m-bordered__toggle--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-bordered__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-accordion--m-bordered__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor: var(--pf-global--BorderColor--100);
 
   // This component always needs to be light
   @include pf-t-light;
@@ -93,7 +94,6 @@
     --pf-c-accordion__toggle--focus__toggle-text--FontWeight: var(--pf-c-accordion--m-display-lg__toggle--focus__toggle-text--FontWeight);
     --pf-c-accordion__toggle--m-expanded__toggle-text--Color: var(--pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--Color);
     --pf-c-accordion__toggle--m-expanded__toggle-text--FontWeight: var(--pf-c-accordion--m-display-lg__toggle--m-expanded__toggle-text--FontWeight);
-    --pf-c-accordion__toggle--before--Top: var(--pf-c-accordion--m-display-lg__toggle--before--Top);
     --pf-c-accordion__expanded-content-body--PaddingTop: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingTop);
     --pf-c-accordion__expanded-content-body--PaddingRight: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingRight);
     --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom);
@@ -101,7 +101,15 @@
     --pf-c-accordion__expanded-content--FontSize: var(--pf-c-accordion--m-display-lg__expanded-content--FontSize);
     --pf-c-accordion__expanded-content--Color: var(--pf-c-accordion--m-display-lg__expanded-content--Color);
 
-    border-top: var(--pf-c-accordion--m-display-lg--BorderTopWidth) solid var(--pf-c-accordion--m-display-lg--BorderTopColor);
+    .pf-c-accordion__expanded-content-body:last-child {
+      --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-c-accordion--m-display-lg__expanded-content-body--last-child--PaddingBottom);
+    }
+  }
+
+  &.pf-m-bordered {
+    --pf-c-accordion__toggle--before--Top: var(--pf-c-accordion--m-bordered__toggle--before--Top);
+
+    border-top: var(--pf-c-accordion--m-bordered--BorderTopWidth) solid var(--pf-c-accordion--m-bordered--BorderTopColor);
 
     // rename --after vars to --before in breaking change release
     .pf-c-accordion__toggle {
@@ -112,12 +120,12 @@
         bottom: 0;
         left: 0;
         content: "";
-        border: solid var(--pf-c-accordion--m-display-lg__toggle--after--BorderColor);
-        border-width: var(--pf-c-accordion--m-display-lg__toggle--after--BorderTopWidth) 0 var(--pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth);
+        border: solid var(--pf-c-accordion--m-bordered__toggle--after--BorderColor);
+        border-width: var(--pf-c-accordion--m-bordered__toggle--after--BorderTopWidth) 0 var(--pf-c-accordion--m-bordered__toggle--after--BorderBottomWidth);
       }
 
       &.pf-m-expanded {
-        --pf-c-accordion--m-display-lg__toggle--after--BorderBottomWidth: 0;
+        --pf-c-accordion--m-bordered__toggle--after--BorderBottomWidth: 0;
       }
     }
 
@@ -133,14 +141,10 @@
             bottom: 0;
             left: 0;
             content: "";
-            border-bottom: var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth) solid var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor);
+            border-bottom: var(--pf-c-accordion--m-bordered__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth) solid var(--pf-c-accordion--m-bordered__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor);
           }
         }
       }
-    }
-
-    .pf-c-accordion__expanded-content-body:last-child {
-      --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-c-accordion--m-display-lg__expanded-content-body--last-child--PaddingBottom);
     }
     // stylelint-enable
   }

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -67,7 +67,8 @@
   --pf-c-accordion--m-display-lg__expanded-content--Color: var(--pf-global--Color--100);
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingTop: 0;
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-accordion--m-display-lg__expanded-content-body--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-accordion--m-display-lg__expanded-content-body--last-child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-accordion--m-display-lg__expanded-content-body--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor: var(--pf-global--BorderColor--100);
@@ -121,17 +122,25 @@
     }
 
     // rename --after vars to --before in breaking change release
-    // stylelint-disable selector-max-class
-    .pf-c-accordion__expanded-content.pf-m-expanded .pf-c-accordion__expanded-content-body:last-child {
-      &::before {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        content: "";
-        border-bottom: var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth) solid var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor);
+    // stylelint-disable selector-max-class, max-nesting-depth
+    .pf-c-accordion__expanded-content {
+      &.pf-m-expanded {
+        .pf-c-accordion__expanded-content-body:last-child {
+          &::before {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            content: "";
+            border-bottom: var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomWidth) solid var(--pf-c-accordion--m-display-lg__expanded-content--m-expanded__expanded-content-body--last-child--after--BorderBottomColor);
+          }
+        }
       }
+    }
+
+    .pf-c-accordion__expanded-content-body:last-child {
+      --pf-c-accordion__expanded-content-body--PaddingBottom: var(--pf-c-accordion--m-display-lg__expanded-content-body--last-child--PaddingBottom);
     }
     // stylelint-enable
   }
@@ -236,5 +245,9 @@
     width: var(--pf-c-accordion__expanded-content-body--before--Width);
     content: "";
     background-color: var(--pf-c-accordion__expanded-content-body--before--BackgroundColor);
+  }
+
+  & + & {
+    --pf-c-accordion__expanded-content-body--PaddingTop: var(--pf-c-accordion__expanded-content-body--expanded-content-body--PaddingTop);
   }
 }

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -176,9 +176,54 @@ cssPrefix: pf-c-accordion
 {{/accordion}}
 ```
 
-### Large
+### Bordered
 ```hbs
-{{#> accordion accordion--modifier="pf-m-display-lg"}}
+{{#> accordion accordion--modifier="pf-m-bordered"}}
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+{{/accordion}}
+```
+
+### Large bordered
+```hbs
+{{#> accordion accordion--modifier="pf-m-display-lg pf-m-bordered"}}
   {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
@@ -265,6 +310,7 @@ In these examples `.pf-c-accordion` uses `<dl>`, `.pf-c-accordion__toggle` uses 
 | `.pf-c-accordion__toggle-icon` | `<span>` | Initiates the toggle icon wrapper. **Required** |
 | `.pf-c-accordion__expanded-content` | `<div>`, `<dd>` | Initiates expanded content. **Must be paired with a button** |
 | `.pf-c-accordion__expanded-content-body` | `<div>` | Initiates expanded content body. **Required** |
+| `.pf-m-bordered` | `.pf-c-accordion` | Modifies the accordion to add borders between items. |
 | `.pf-m-display-lg` | `.pf-c-accordion` | Modifies the accordion for large display styling. This variation is for marketing/web use cases. |
 | `.pf-m-expanded` | `.pf-c-accordion__toggle`, `.pf-c-accordion__expanded-content` | Modifies the accordion button and expanded content for the expanded state. |
 | `.pf-m-fixed` | `.pf-c-accordion__expanded-content` | Modifies the expanded content for the fixed state. |

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -8,44 +8,54 @@ cssPrefix: pf-c-accordion
 ### Fluid
 ```hbs
 {{#> accordion}}
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute='aria-expanded="true"'}}
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
     {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 {{/accordion}}
 ```
@@ -53,46 +63,60 @@ cssPrefix: pf-c-accordion
 ### Fixed
 ```hbs
 {{#> accordion}}
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsFixed="true"}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute='aria-expanded="true"'}}
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
     {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true" accordion-expanded-content--IsFixed="true"}}
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsFixed="true"}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsFixed="true"}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsFixed="true"}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 {{/accordion}}
 ```
@@ -100,44 +124,117 @@ cssPrefix: pf-c-accordion
 ### Definition list
 ```hbs
 {{#> accordion accordion--IsDefinitionList="true"}}
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute='aria-expanded="true"'}}
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
     {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 
-  {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
+  {{#> accordion-toggle}}
     {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
   {{/accordion-toggle}}
   {{#> accordion-expanded-content}}
-    This text is hidden
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+{{/accordion}}
+```
+
+### Large
+```hbs
+{{#> accordion accordion--modifier="pf-m-display-lg"}}
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content accordion-expanded-content--IsExpanded="true"}}
+    {{#> accordion-expanded-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expanded-content-body}}
+    {{#> accordion-expanded-content-body}}
+    {{#> button button--modifier="pf-m-link pf-m-inline pf-m-display-lg"}}
+      Call to action
+      {{#> button-icon button-icon--modifier="pf-m-end"}}
+        <i class="fas fa-arrow-right" aria-hidden="true"></i>
+      {{/button-icon}}
+    {{/button}}
+    {{/accordion-expanded-content-body}}
+  {{/accordion-expanded-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+  {{/accordion-toggle}}
+  {{#> accordion-expanded-content}}
+    {{#> accordion-expanded-content-body}}
+      This text is hidden
+    {{/accordion-expanded-content-body}}
   {{/accordion-expanded-content}}
 {{/accordion}}
 ```
@@ -168,5 +265,6 @@ In these examples `.pf-c-accordion` uses `<dl>`, `.pf-c-accordion__toggle` uses 
 | `.pf-c-accordion__toggle-icon` | `<span>` | Initiates the toggle icon wrapper. **Required** |
 | `.pf-c-accordion__expanded-content` | `<div>`, `<dd>` | Initiates expanded content. **Must be paired with a button** |
 | `.pf-c-accordion__expanded-content-body` | `<div>` | Initiates expanded content body. **Required** |
+| `.pf-m-display-lg` | `.pf-c-accordion` | Modifies the accordion for large display styling. This variation is for marketing/web use cases. |
 | `.pf-m-expanded` | `.pf-c-accordion__toggle`, `.pf-c-accordion__expanded-content` | Modifies the accordion button and expanded content for the expanded state. |
 | `.pf-m-fixed` | `.pf-c-accordion__expanded-content` | Modifies the expanded content for the fixed state. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3865

* Adds web/marketing variation
* Moves the pseudo elements around a little to support the border overlap
* Adds support for multiple `__expanded-content-body` elements

@ajacobs21e @mcarrano can you also verify the spacing between adjacent sections is correct in the regular/fixed example? https://patternfly-pr-3888.surge.sh/components/accordion#fixed