### PR TITLE
feat(search-input): added autocomplete

### DIFF
--- a/src/patternfly/components/SearchInput/examples/SearchInput.css
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.css
@@ -1,11 +1,8 @@
-#ws-core-c-search-input-advanced-search-expanded {
+#ws-core-c-search-input-advanced-search-expanded,
+#ws-core-c-search-input-advanced-search-expanded-with-autocomplete {
   height: 550px;
 }
 
 #ws-core-c-search-input-autocomplete {
   height: 250px;
-}
-
-#ws-core-c-search-input-autocomplete-final-option {
-  height: 150px;
 }

--- a/src/patternfly/components/SearchInput/examples/SearchInput.css
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.css
@@ -6,3 +6,7 @@
 #ws-core-c-search-input-autocomplete {
   height: 250px;
 }
+
+#ws-core-c-search-input-autocomplete-last-option-hint {
+  height: 150px;
+}

--- a/src/patternfly/components/SearchInput/examples/SearchInput.css
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.css
@@ -1,3 +1,11 @@
 #ws-core-c-search-input-advanced-search-expanded {
   height: 550px;
 }
+
+#ws-core-c-search-input-autocomplete {
+  height: 250px;
+}
+
+#ws-core-c-search-input-autocomplete-final-option {
+  height: 150px;
+}

--- a/src/patternfly/components/SearchInput/examples/SearchInput.md
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.md
@@ -109,6 +109,76 @@ import './SearchInput.css'
 {{/search-input}}
 ```
 
+### Advanced search expanded with autocomplete
+```hbs
+{{#> search-input search-input--placeholder="username:admin firstname:joe" search-input--value="username:root firstname:n" search-input--IsAdvancedSearch="true" search-input--IsExpanded="true"}}
+  {{#> search-input-menu}}
+    {{#> search-input-menu-body}}
+      {{#> form form--id="advanced-search-input-form"}}
+        {{#> form-group form-group--id="-username"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Username
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="root" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-firstname"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              First name
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="n" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-group"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Group
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-email"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Email
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--modifier="pf-m-action"}}
+        {{#> form-actions}}
+          {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+            Submit
+          {{/button}}
+          {{#> button button--modifier="pf-m-link" button--IsReset="true"}}
+            Reset
+          {{/button}}
+        {{/form-actions}}
+      {{/form-group}}
+      {{/form}}
+    {{/search-input-menu-body}}
+  {{/search-input-menu}}
+  {{#> search-input-menu}}
+    {{#> search-input-menu-list}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="nancy"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="ned"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="neil"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="nicole"}}
+    {{/search-input-menu-list}}
+  {{/search-input-menu}}
+{{/search-input}}
+```
+
 ### Accessibility
 | Attributes | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/SearchInput/examples/SearchInput.md
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.md
@@ -109,6 +109,17 @@ import './SearchInput.css'
 {{/search-input}}
 ```
 
+### Autocomplete last option hint
+```hbs
+{{#> search-input search-input--id="search-input-autocomplete-last-option-hint" search-input--IsAutocomplete="true" search-input--placeholder="Keyword search" search-input--value="apples" search-input--hint-text="appleseed"}}
+  {{#> search-input-menu}}
+    {{#> search-input-menu-list}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="appleseed"}}
+    {{/search-input-menu-list}}
+  {{/search-input-menu}}
+{{/search-input}}
+```
+
 ### Advanced search expanded with autocomplete
 ```hbs
 {{#> search-input search-input--placeholder="username:admin firstname:joe" search-input--value="username:root firstname:n" search-input--IsAdvancedSearch="true" search-input--IsExpanded="true"}}
@@ -192,6 +203,8 @@ import './SearchInput.css'
 | `aria-expanded="[true/false]"` | `.pf-c-button` | Indicates whether the advanced search menu is expanded or collapsed. **Required** |
 | `id` | `.pf-c-search-input__text-input` | Assigns an ID that is used with `aria-labelledby` on `.pf-c-search-input__menu-list`. **Required when using autocomplete** |
 | `aria-labelledby="[id of text input]"` | `.pf-c-search-input__menu-list` | Gives the menu list an accessible label. **Required when using autocomplete** |
+| `disabled` | `.pf-c-search-input__text-input.pf-m-hint` | Disables the hint text input from being submitted with the search input. **Required when using hint text** |
+| `aria-hidden="true"` | `.pf-c-search-input__text-input.pf-m-hint` | Hides the hint text input from assistive technology. **Required when using hint text** |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -211,3 +224,4 @@ import './SearchInput.css'
 | `.pf-c-search-input__menu-list-item` | `<div>` | Initiates the search input dropdown menu list item. |
 | `.pf-c-search-input__menu-item` | `<div>` | Initiates the search input dropdown menu item. |
 | `.pf-c-search-input__menu-item-text` | `<span>` | Initiates the search input dropdown menu item text. |
+| `.pf-m-hint` | `.pf-c-search-input__text-input` | Modifies the text input for hint text styles. |

--- a/src/patternfly/components/SearchInput/examples/SearchInput.md
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.md
@@ -37,58 +37,74 @@ import './SearchInput.css'
 ```hbs
 {{#> search-input search-input--placeholder="username:admin firstname:joe" search-input--value="username:root firstname:ned" search-input--IsAdvancedSearch="true" search-input--IsExpanded="true"}}
   {{#> search-input-menu}}
-    {{#> form form--id="advanced-search-input-form"}}
-      {{#> form-group form-group--id="-username"}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
-            Username
-          {{/form-label}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="root" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
-        {{/form-group-control}}
+    {{#> search-input-menu-body}}
+      {{#> form form--id="advanced-search-input-form"}}
+        {{#> form-group form-group--id="-username"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Username
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="root" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-firstname"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              First name
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="ned" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-group"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Group
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--id="-email"}}
+          {{#> form-group-label}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+              Email
+            {{/form-label}}
+          {{/form-group-label}}
+          {{#> form-group-control}}
+            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+          {{/form-group-control}}
+        {{/form-group}}
+        {{#> form-group form-group--modifier="pf-m-action"}}
+        {{#> form-actions}}
+          {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+            Submit
+          {{/button}}
+          {{#> button button--modifier="pf-m-link" button--IsReset="true"}}
+            Reset
+          {{/button}}
+        {{/form-actions}}
       {{/form-group}}
-      {{#> form-group form-group--id="-firstname"}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
-            First name
-          {{/form-label}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="ned" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
-        {{/form-group-control}}
-      {{/form-group}}
-      {{#> form-group form-group--id="-group"}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
-            Group
-          {{/form-label}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
-        {{/form-group-control}}
-      {{/form-group}}
-      {{#> form-group form-group--id="-email"}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
-            Email
-          {{/form-label}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
-        {{/form-group-control}}
-      {{/form-group}}
-      {{#> form-group form-group--modifier="pf-m-action"}}
-      {{#> form-actions}}
-        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-          Submit
-        {{/button}}
-        {{#> button button--modifier="pf-m-link" button--IsReset="true"}}
-          Reset
-        {{/button}}
-      {{/form-actions}}
-    {{/form-group}}
-    {{/form}}
+      {{/form}}
+    {{/search-input-menu-body}}
+  {{/search-input-menu}}
+{{/search-input}}
+```
+
+### Autocomplete
+```hbs
+{{#> search-input search-input--id="search-input-autocomplete" search-input--IsAutocomplete="true" search-input--placeholder="Keyword search" search-input--value="app"}}
+  {{#> search-input-menu}}
+    {{#> search-input-menu-list}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="apple"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="appleby"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="appleseed"}}
+      {{> search-input-menu-list-item search-input-menu-list-item--text="appleton"}}
+    {{/search-input-menu-list}}
   {{/search-input-menu}}
 {{/search-input}}
 ```
@@ -104,6 +120,8 @@ import './SearchInput.css'
 | `aria-label="Search"` | `.pf-c-button` | Provides an accessible label for the search button. **Required** |
 | `aria-label="Advanced search"` | `.pf-c-button` | Provides an accessible label for the advanced search toggle. **Required** |
 | `aria-expanded="[true/false]"` | `.pf-c-button` | Indicates whether the advanced search menu is expanded or collapsed. **Required** |
+| `id` | `.pf-c-search-input__text-input` | Assigns an ID that is used with `aria-labelledby` on `.pf-c-search-input__menu-list`. **Required when using autocomplete** |
+| `aria-labelledby="[id of text input]"` | `.pf-c-search-input__menu-list` | Gives the menu list an accessible label. **Required when using autocomplete** |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -117,4 +135,9 @@ import './SearchInput.css'
 | `.pf-c-search-input__count` | `<span>` | Initiates the item count container. |
 | `.pf-c-search-input__nav` | `<span>` | Initiates the navigable buttons container. |
 | `.pf-c-search-input__clear` | `<span>` | Initiates the clear button container. **Required when there is text in the search input** |
-| `.pf-c-search-input__menu` | `<div>` | Initiates the clear button container. **Required when there is text in the search input** |
+| `.pf-c-search-input__menu` | `<div>` | Initiates the search input dropdown menu. |
+| `.pf-c-search-input__menu-body` | `<div>` | Initiates the search input dropdown menu body element. |
+| `.pf-c-search-input__menu-list` | `<div>` | Initiates the search input dropdown menu list. |
+| `.pf-c-search-input__menu-list-item` | `<div>` | Initiates the search input dropdown menu list item. |
+| `.pf-c-search-input__menu-item` | `<div>` | Initiates the search input dropdown menu item. |
+| `.pf-c-search-input__menu-item-text` | `<span>` | Initiates the search input dropdown menu item text. |

--- a/src/patternfly/components/SearchInput/search-input-menu-body.hbs
+++ b/src/patternfly/components/SearchInput/search-input-menu-body.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-search-input__menu-body{{#if search-input-menu-body--modifier}} {{search-input-menu-body--modifier}}{{/if}}"
+  {{#if search-input-menu-body--attribute}}
+    {{{search-input-menu-body--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/SearchInput/search-input-menu-item-text.hbs
+++ b/src/patternfly/components/SearchInput/search-input-menu-item-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-search-input__menu-item-text{{#if search-input-menu-item-text--modifier}} {{search-input-menu-item-text--modifier}}{{/if}}"
+  {{#if search-input-menu-item-text--attribute}}
+    {{{search-input-menu-item-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/SearchInput/search-input-menu-item.hbs
+++ b/src/patternfly/components/SearchInput/search-input-menu-item.hbs
@@ -1,0 +1,11 @@
+<{{#if search-input-menu-item--IsLink}}a{{else}}button{{/if}} class="pf-c-search-input__menu-item{{#if search-input-menu-item--modifier}} {{search-input-menu-item--modifier}}{{/if}}"
+  {{#if search-input-menu-item--IsLink}}
+    href="#"
+  {{else}}
+    type="button"
+  {{/if}}
+  {{#if search-input-menu-item--attribute}}
+    {{{search-input-menu-item--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{#if search-input-menu-item--IsLink}}a{{else}}button{{/if}}>

--- a/src/patternfly/components/SearchInput/search-input-menu-list-item.hbs
+++ b/src/patternfly/components/SearchInput/search-input-menu-list-item.hbs
@@ -1,0 +1,10 @@
+<li class="pf-c-search-input__menu-list-item{{#if search-input-menu-list-item--modifier}} {{search-input-menu-list-item--modifier}}{{/if}}"
+  {{#if search-input-menu-list-item--attribute}}
+    {{{search-input-menu-list-item--attribute}}}
+  {{/if}}>
+  {{#> search-input-menu-item}}
+    {{#> search-input-menu-item-text}}
+      {{search-input-menu-list-item--text}}
+    {{/search-input-menu-item-text}}
+  {{/search-input-menu-item}}
+</li>

--- a/src/patternfly/components/SearchInput/search-input-menu-list.hbs
+++ b/src/patternfly/components/SearchInput/search-input-menu-list.hbs
@@ -1,0 +1,6 @@
+<ul class="pf-c-search-input__menu-list{{#if search-input-menu-list--modifier}} {{search-input-menu-list--modifier}}{{/if}}"
+  {{#if search-input-menu-list--attribute}}
+    {{{search-input-menu-list--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</ul>

--- a/src/patternfly/components/SearchInput/search-input-text-input.hbs
+++ b/src/patternfly/components/SearchInput/search-input-text-input.hbs
@@ -1,13 +1,23 @@
-<input class="pf-c-search-input__text-input{{#if search-input-text-input--modifier}} {{search-input-text-input--modifier}}{{/if}}"
+<input class="pf-c-search-input__text-input
+  {{~#if search-input-text-input--IsHintText}} pf-m-hint{{/if}}
+  {{~#if search-input-text-input--modifier}} {{search-input-text-input--modifier}}{{/if}}"
   {{#if search-input--IsAutocomplete}}
-    id="{{search-input--id}}-text-input"
+    {{#unless search-input--hint-text}}
+      id="{{search-input--id}}-text-input"
+    {{/unless}}
   {{/if}}
   type="text"
+  {{#if search-input-text-input--IsHintText}}
+    disabled
+    aria-hidden="true"
+  {{/if}}
   {{#if search-input--placeholder}}
     placeholder="{{search-input--placeholder}}"
     aria-label="{{search-input--placeholder}}"
   {{/if}}
-  {{#if search-input--value}}
+  {{#if search-input-text-input--IsHintText}}
+    value="{{search-input--hint-text}}"
+  {{else if search-input--value}}
     value="{{search-input--value}}"
   {{/if}}
   {{#if search-input-text-input--attribute}}

--- a/src/patternfly/components/SearchInput/search-input-text-input.hbs
+++ b/src/patternfly/components/SearchInput/search-input-text-input.hbs
@@ -1,4 +1,7 @@
 <input class="pf-c-search-input__text-input{{#if search-input-text-input--modifier}} {{search-input-text-input--modifier}}{{/if}}"
+  {{#if search-input--IsAutocomplete}}
+    id="{{search-input--id}}-text-input"
+  {{/if}}
   type="text"
   {{#if search-input--placeholder}}
     placeholder="{{search-input--placeholder}}"

--- a/src/patternfly/components/SearchInput/search-input-text.hbs
+++ b/src/patternfly/components/SearchInput/search-input-text.hbs
@@ -3,5 +3,8 @@
     {{search-input-text--attribute}}
   {{/if}}>
   {{> search-input-icon}}
+  {{#if search-input--hint-text}}
+    {{> search-input-text-input search-input-text-input--IsHintText="true"}}
+  {{/if}}
   {{> search-input-text-input}}
 </span>

--- a/src/patternfly/components/SearchInput/search-input.scss
+++ b/src/patternfly/components/SearchInput/search-input.scss
@@ -31,16 +31,28 @@
   --pf-c-search-input__utilities--c-button--PaddingLeft: var(--pf-global--spacer--xs);
 
   // Menu
-  --pf-c-search-input__menu--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-search-input__menu--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-search-input__menu--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-search-input__menu--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-body--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-body--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-body--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-body--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-search-input__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-search-input__menu--BoxShadow: var(--pf-global--BoxShadow--md);
   --pf-c-search-input__menu--Top: calc(100% + var(--pf-global--spacer--xs));
   --pf-c-search-input__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-search-input--m-top__menu--Top: 0;
   --pf-c-search-input--m-top__menu--TranslateY: calc(-100% - var(--pf-global--spacer--xs));
+
+  // Autocomplete menu
+  --pf-c-search-input__menu-list--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-search-input__menu-list--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-search-input__menu-item--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-search-input__menu-item--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-item--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-search-input__menu-item--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-search-input__menu-item--Color: var(--pf-global--Color--100);
+  --pf-c-search-input__menu-item--BackgroundColor: transparent;
+  --pf-c-search-input__menu-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-search-input__menu-item--focus--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   position: relative;
 }
@@ -135,7 +147,6 @@
   top: var(--pf-c-search-input__menu--Top);
   z-index: var(--pf-c-search-input__menu--ZIndex);
   min-width: 100%;
-  padding: var(--pf-c-search-input__menu--PaddingTop) var(--pf-c-search-input__menu--PaddingRight) var(--pf-c-search-input__menu--PaddingBottom) var(--pf-c-search-input__menu--PaddingLeft);
   background-color: var(--pf-c-search-input__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--pf-c-search-input__menu--BoxShadow);
@@ -145,4 +156,39 @@
 
     transform: translateY(var(--pf-c-search-input--m-top__menu--TranslateY));
   }
+}
+
+.pf-c-search-input__menu-body {
+  padding: var(--pf-c-search-input__menu-body--PaddingTop) var(--pf-c-search-input__menu-body--PaddingRight) var(--pf-c-search-input__menu-body--PaddingBottom) var(--pf-c-search-input__menu-body--PaddingLeft);
+}
+
+.pf-c-search-input__menu-list {
+  padding-top: var(--pf-c-search-input__menu-list--PaddingTop);
+  padding-bottom: var(--pf-c-search-input__menu-list--PaddingBottom);
+}
+
+.pf-c-search-input__menu-item {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  padding-top: var(--pf-c-search-input__menu-item--PaddingTop);
+  padding-right: var(--pf-c-search-input__menu-item--PaddingRight);
+  padding-bottom: var(--pf-c-search-input__menu-item--PaddingBottom);
+  padding-left: var(--pf-c-search-input__menu-item--PaddingLeft);
+  color: var(--pf-c-search-input__menu-item--Color);
+  text-align: left;
+  background-color: var(--pf-c-search-input__menu-item--BackgroundColor);
+  border: none;
+
+  &:hover {
+    --pf-c-search-input__menu-item--BackgroundColor: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
+  }
+
+  &:focus {
+    --pf-c-search-input__menu-item--BackgroundColor: var(--pf-c-search-input__menu-item--focus--BackgroundColor);
+  }
+}
+
+.pf-c-search-input__menu-item-text {
+  flex-grow: 1;
 }

--- a/src/patternfly/components/SearchInput/search-input.scss
+++ b/src/patternfly/components/SearchInput/search-input.scss
@@ -16,6 +16,7 @@
   --pf-c-search-input__text-input--PaddingBottom: var(--pf-global--spacer--form-element);
   --pf-c-search-input__text-input--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-search-input__text-input--MinWidth: 6ch;
+  --pf-c-search-input__text-input--m-hint--Color: var(--pf-global--Color--dark-200); // matches placeholder text color
 
   // Icon
   --pf-c-search-input__icon--Left: var(--pf-global--spacer--sm);
@@ -68,6 +69,7 @@
 }
 
 .pf-c-search-input__text {
+  position: relative;
   flex: 1;
 
   &::before,
@@ -116,6 +118,13 @@
   min-width: var(--pf-c-search-input__text-input--MinWidth);
   padding: var(--pf-c-search-input__text-input--PaddingTop) var(--pf-c-search-input__text-input--PaddingRight) var(--pf-c-search-input__text-input--PaddingBottom) var(--pf-c-search-input__text-input--PaddingLeft);
   border: 0;
+
+  &.pf-m-hint {
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: var(--pf-c-search-input__text-input--m-hint--Color);
+  }
 }
 
 .pf-c-search-input__utilities {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3863

@mcarrano 

* This does not add the hint/grey text that finishes the search term in the text input when there is a single option in the autocomplete box. That part isn't obvious how to implement since the text there is a regular text input and you can't style text like that in a text input. If that feature is a requirement, I'd like to have a follow-up issue to investigate how to best do that.
* We have the option to use the menu component here. I didn't implement it that way, and just made this list a feature of the search input component since we wouldn't be able to promote the search input component until we promoted the menu component. If that's OK, or we anticipate wanting to support features of the menu component in this list (descriptions, favorites, etc), I can update this component to use the menu component instead.