### PR TITLE
feat(button): added active state for buttons, links

### DIFF
--- a/src/patternfly/base/_globals.scss
+++ b/src/patternfly/base/_globals.scss
@@ -120,6 +120,10 @@
       --pf-global--link--Color: var(--pf-global--link--Color--hover);
       --pf-global--link--TextDecoration: var(--pf-global--link--TextDecoration--hover);
     }
+
+    &:active {
+      --pf-global--link--TextDecoration: var(--pf-global--link--TextDecoration--active);
+    }
   }
 
   button,

--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -205,6 +205,7 @@
   --pf-global--link--Color--dark--hover: #{$pf-global--link--Color--dark--hover};
   --pf-global--link--TextDecoration: #{$pf-global--link--TextDecoration};
   --pf-global--link--TextDecoration--hover: #{$pf-global--link--TextDecoration--hover};
+  --pf-global--link--TextDecoration--active: #{$pf-global--link--TextDecoration--active};
 
   // Borders
   --pf-global--BorderWidth--sm: #{$pf-global--BorderWidth--sm};

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -34,7 +34,7 @@
   --pf-c-button--m-primary--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-primary--focus--BackgroundColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-primary--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-button--m-primary--active--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-primary--active--BackgroundColor: var(--pf-global--palette--blue-600);
   --pf-c-button--m-primary--active--Color: var(--pf-global--Color--light-100);
 
   // Secondary btn
@@ -48,7 +48,7 @@
   --pf-c-button--m-secondary--focus--after--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-button--m-secondary--focus--Color: var(--pf-global--primary-color--100);
   --pf-c-button--m-secondary--active--BackgroundColor: transparent;
-  --pf-c-button--m-secondary--active--after--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-button--m-secondary--active--after--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--active--Color: var(--pf-global--primary-color--100);
 
   // Secondary danger
@@ -75,7 +75,7 @@
   --pf-c-button--m-tertiary--focus--BackgroundColor: transparent;
   --pf-c-button--m-tertiary--focus--after--BorderColor: var(--pf-global--Color--100);
   --pf-c-button--m-tertiary--focus--Color: var(--pf-global--Color--100);
-  --pf-c-button--m-tertiary--active--BackgroundColor: transparent;
+  --pf-c-button--m-tertiary--active--BackgroundColor: var(--pf-global--palette--black-150);
   --pf-c-button--m-tertiary--active--after--BorderColor: var(--pf-global--Color--100);
   --pf-c-button--m-tertiary--active--Color: var(--pf-global--Color--100);
 
@@ -86,8 +86,8 @@
   --pf-c-button--m-warning--hover--Color: var(--pf-global--Color--dark-100);
   --pf-c-button--m-warning--focus--BackgroundColor: var(--pf-global--palette--gold-500);
   --pf-c-button--m-warning--focus--Color: var(--pf-global--Color--dark-100);
-  --pf-c-button--m-warning--active--BackgroundColor: var(--pf-global--palette--gold-500);
-  --pf-c-button--m-warning--active--Color: var(--pf-global--Color--dark-100);
+  --pf-c-button--m-warning--active--BackgroundColor: var(--pf-global--warning-color--200);
+  --pf-c-button--m-warning--active--Color: var(--pf-global--Color--light-100);
 
   // Danger btn
   --pf-c-button--m-danger--BackgroundColor: var(--pf-global--danger-color--100);
@@ -96,7 +96,7 @@
   --pf-c-button--m-danger--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-danger--focus--BackgroundColor: var(--pf-global--danger-color--200);
   --pf-c-button--m-danger--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-button--m-danger--active--BackgroundColor: var(--pf-global--danger-color--200);
+  --pf-c-button--m-danger--active--BackgroundColor: var(--pf-global--danger-color--300);
   --pf-c-button--m-danger--active--Color: var(--pf-global--Color--light-100);
 
   // Link btn
@@ -110,8 +110,9 @@
   --pf-c-button--m-link--active--Color: var(--pf-global--link--Color--hover);
   --pf-c-button--m-link--disabled--BackgroundColor: transparent;
   --pf-c-button--m-link--m-inline--FontSize: inherit;
-  --pf-c-button--m-link--m-inline--hover--TextDecoration: var(--pf-global--link--TextDecoration--hover);
   --pf-c-button--m-link--m-inline--hover--Color: var(--pf-global--link--Color--hover);
+  --pf-c-button--m-link--m-inline--hover--TextDecoration: var(--pf-global--link--TextDecoration--hover);
+  --pf-c-button--m-link--m-inline--active--TextDecoration: var(--pf-global--link--TextDecoration--active);
 
   // Link danger
   --pf-c-button--m-link--m-danger--BackgroundColor: transparent;
@@ -433,6 +434,10 @@
         --pf-c-button--m-link--Color: var(--pf-c-button--m-link--m-inline--hover--Color);
 
         text-decoration: var(--pf-c-button--m-link--m-inline--hover--TextDecoration);
+      }
+
+      &:active {
+        text-decoration: var(--pf-c-button--m-link--m-inline--active--TextDecoration);
       }
     }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -87,7 +87,7 @@
   --pf-c-button--m-warning--focus--BackgroundColor: var(--pf-global--palette--gold-500);
   --pf-c-button--m-warning--focus--Color: var(--pf-global--Color--dark-100);
   --pf-c-button--m-warning--active--BackgroundColor: var(--pf-global--warning-color--200);
-  --pf-c-button--m-warning--active--Color: var(--pf-global--Color--light-100);
+  --pf-c-button--m-warning--active--Color: var(--pf-global--Color--dark-100);
 
   // Danger btn
   --pf-c-button--m-danger--BackgroundColor: var(--pf-global--danger-color--100);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -64,6 +64,7 @@
   --pf-c-content--a--TextDecoration: var(--pf-global--link--TextDecoration);
   --pf-c-content--a--hover--Color: var(--pf-global--link--Color--hover);
   --pf-c-content--a--hover--TextDecoration: var(--pf-global--link--TextDecoration--hover);
+  --pf-c-content--a--active--TextDecoration: var(--pf-global--link--TextDecoration--active);
 
   // Blockquote
   --pf-c-content--blockquote--PaddingTop: var(--pf-global--spacer--md);
@@ -106,6 +107,10 @@
     &:hover {
       --pf-c-content--a--Color: var(--pf-c-content--a--hover--Color);
       --pf-c-content--a--TextDecoration: var(--pf-c-content--a--hover--TextDecoration);
+    }
+
+    &:active {
+      --pf-c-content--a--TextDecoration: var(--pf-c-content--a--active--TextDecoration);
     }
   }
 

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -228,6 +228,7 @@ $pf-global--link--Color--dark:            $pf-global--primary-color--100 !defaul
 $pf-global--link--Color--dark--hover:     $pf-global--primary-color--200 !default;
 $pf-global--link--TextDecoration:         none !default;
 $pf-global--link--TextDecoration--hover:  underline !default;
+$pf-global--link--TextDecoration--active: none !default;
 
 // List
 $pf-global--ListStyle: disc outside !default;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3898

@mcarrano @doruskova since we're updating the inline link styles to remove the underline on `:active`, I'm assuming we'll also want to update the global link styles to match? I've done that in this PR, though I wonder if that will be a breaking change as it could seem unexpected and users may have styled other parts of their product to mimic PF links, and now their active styling may not match ours.