### PR TITLE
fix(select): updated typeahead text input height to match form control

### DIFF
--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -51,7 +51,7 @@
   // Select input for typeahead
   --pf-c-select__toggle-typeahead--FlexBasis: 10em;
   --pf-c-select__toggle-typeahead--BackgroundColor: transparent;
-  --pf-c-select__toggle-typeahead--BorderTop: none;
+  --pf-c-select__toggle-typeahead--BorderTop: var(--pf-global--BorderWidth--sm) solid transparent;
   --pf-c-select__toggle-typeahead--BorderRight: none;
   --pf-c-select__toggle-typeahead--BorderLeft: none;
 
@@ -59,7 +59,7 @@
   --pf-c-select__toggle-typeahead--MinWidth: #{pf-size-prem(120px)};
 
   // This is really var(--pf-c-form-control--PaddingBottom) but has to be recalculated instead of reusing another component's variable
-  --pf-c-select__toggle-typeahead--focus--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm));
+  --pf-c-select__toggle-typeahead--focus--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--md));
 
   //  Select toggle icon + toggle text
   --pf-c-select__toggle-icon--toggle-text--MarginLeft: var(--pf-global--spacer--xs);
@@ -367,18 +367,17 @@
   flex-grow: 1;
   min-width: var(--pf-c-select__toggle-typeahead--MinWidth);
   background-color: var(--pf-c-select__toggle-typeahead--BackgroundColor);
-  border-top: var(--pf-c-select__toggle-typeahead--BorderTop);
+  border-top: var(--pf-c-select__toggle-typeahead--BorderTop); // remove and define border-top-color w/ &.pf-c-form-control at breaking change
   border-right: var(--pf-c-select__toggle-typeahead--BorderRight);
-  border-bottom-color: inherit;
-  border-bottom-style: inherit;
-  border-bottom-width: inherit;
   border-left: var(--pf-c-select__toggle-typeahead--BorderLeft);
   flex-shrink: 0;
 
+  &.pf-c-form-control {
+    border-bottom-color: transparent;
+  }
+
   &:focus {
-    // Set the bottom padding to allow for the bottom border width of the containing toggle
-    // This is really var(--pf-c-form-control--PaddingBottom) but has to be recalculated instead of reusing another component's variable
-    padding-bottom: var(--pf-c-select__toggle-typeahead--focus--PaddingBottom);
+    padding-bottom: var(--pf-c-select__toggle-typeahead--focus--PaddingBottom); // remove at breaking change
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3987

this will allow us to remove the toggle button in a typeahead select and the select toggle height will remain the same height (36px)