### PR TITLE
fix(toolbar): added explicit text-overflow

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -201,6 +201,11 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
     color: var(--pf-c-form-control--placeholder--Color);
   }
 
+  &::placeholder,
+  &[placeholder] {
+    text-overflow: ellipsis;
+  }
+
   &:not(textarea) {
     height: var(--pf-c-form-control--Height);
 

--- a/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
@@ -1,7 +1,7 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-search-filter ' toolbar-item-search-filter--modifier)}}
   {{#> input-group input-group--attribute=(concat 'aria-label="search filter" role="group"')}}
     {{> dropdown dropdown--id=(concat toolbar--id '-' button--id) dropdown-toggle--text="Name"}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" id="' toolbar--id '-' button--id '-search-filter-input" name="' toolbar--id '-search-filter-input" aria-label="input with dropdown and button" aria-describedby="' toolbar--id '-' button--id '-button"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" id="' toolbar--id '-' button--id '-search-filter-input" name="' toolbar--id '-search-filter-input" aria-label="input with dropdown and button" aria-describedby="' toolbar--id '-' button--id '-button" placeholder="Filter by exact term"')}}
     {{/form-control}}
   {{/input-group}}
 {{/toolbar-item}}


### PR DESCRIPTION
closes #3449 

It appears to solve the `overflow ellipsis` setting `text-overflow: ellipsis;` to `::placeholder && [placeholder]` works. WDYT??

