### PR TITLE
feat(card): added variation to remove actions negative margin offset

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -208,7 +208,6 @@
   padding-left: var(--pf-c-card__actions--PaddingLeft);
   margin: var(--pf-c-card__header-toggle--MarginTop) var(--pf-c-card__header-toggle--MarginRight) var(--pf-c-card__header-toggle--MarginBottom) auto;
 
-
   > * + * {
     margin-left: var(--pf-c-card__actions--child--MarginLeft);
   }
@@ -217,6 +216,11 @@
   + .pf-c-card__body,
   + .pf-c-card__footer {
     padding: 0;
+  }
+
+  &.pf-m-no-offset {
+    --pf-c-card__header-toggle--MarginTop: 0;
+    --pf-c-card__header-toggle--MarginBottom: 0;
   }
 }
 

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -82,6 +82,24 @@ import './Card.css'
 {{/card}}
 ```
 
+### Actions with no offset
+```hbs
+{{#> card card--id="card-action-no-offset"}}
+  {{#> card-header}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> button button--modifier="pf-m-primary"}}Action{{/button}}
+    {{/card-actions}}
+    {{#> title title--modifier="pf-m-2xl" title--attribute=(concat 'id="' card--id '-check-label"')}}This is a card title{{/title}}
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+```
+
 ### With only image in head
 ```hbs
 {{#> card card--id="card-image-head-example"}}
@@ -443,3 +461,4 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-m-expanded` | `.pf-c-card` | Modifies the card for the expanded state. |
 | `.pf-m-toggle-right` | `.pf-c-card__header` | Modifies the expandable card header toggle to be positioned at flex-end. |
 | `.pf-m-full-height` | `.pf-c-card` | Modifies the card to full height of its parent. |
+| `.pf-m-no-offset` | `.pf-c-card__actions` | Removes the negative vertical margins on the actions element intended to align the action content with the card title. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3959

There is an obvious problem with the way the actions element's negative margin 1) uses the wrong vars and 2) doesn't work in a lot of cases, like the problem in #3959. We have an issue to clean this up (https://github.com/patternfly/patternfly/issues/3924) but it will be a breaking change. 