### PR TITLE
feat(helper-text): added helper text component

### DIFF
--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -148,4 +148,15 @@ cssPrefix: pf-c-helper-text
 {{/helper-text}}
 ```
 
-## Documentation
+### Usage
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-helper-text` | `<div>`, `<ul>` |  Initiates the helper text component. **Required**  |
+| `.pf-c-helper-text__item` | `<div>`, `<li>` |  Initiates a helper text item. **Required**  |
+| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon.  |
+| `.pf-c-helper-text__item-text` | `<span>` |  Initiates a helper text item text. **Required**  |
+| `.pf-m-dynamic` | `.pf-c-helper-text__item` |  Modifies a helper text item to be dynamic. For use when the item changes state as the form field the text is associated with is updated. |
+| `.pf-m-indeterminate` | `.pf-c-helper-text__item` |  Modifies a helper text item for indeterminate state styles. |
+| `.pf-m-warning` | `.pf-c-helper-text__item` |  Modifies a helper text item for warning state styles. |
+| `.pf-m-success` | `.pf-c-helper-text__item` |  Modifies a helper text item for success state styles. |
+| `.pf-m-invalid` | `.pf-c-helper-text__item` |  Modifies a helper text item for invalid state styles. |

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -1,0 +1,151 @@
+---
+id: 'Helper text'
+beta: true
+section: components
+cssPrefix: pf-c-helper-text
+---
+
+## Examples
+### Basic
+```hbs
+{{#> helper-text}}
+  {{#> helper-text-item}}
+    {{#> helper-text-item-text}}This is default helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-indeterminate"}}
+    {{#> helper-text-item-text}}This is indeterminate helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-warning"}}
+    {{#> helper-text-item-text}}This is warning helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-success"}}
+    {{#> helper-text-item-text}}This is success helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-invalid"}}
+    {{#> helper-text-item-text}}This is invalid helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+```
+
+### Icon
+```hbs
+{{#> helper-text}}
+  {{#> helper-text-item}}
+    {{> helper-text-item-icon helper-text-item-icon--type="info"}}
+    {{#> helper-text-item-text}}This is default helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-indeterminate"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="question"}}
+    {{#> helper-text-item-text}}This is indeterminate helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-warning"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="exclamation-triangle"}}
+    {{#> helper-text-item-text}}This is warning helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-success"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="check-circle"}}
+    {{#> helper-text-item-text}}This is success helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-invalid"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="exclamation-circle"}}
+    {{#> helper-text-item-text}}This is invalid helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+```
+
+### Dynamic
+```hbs
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
+    {{#> helper-text-item-text}}This is default helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
+    {{#> helper-text-item-text}}This is indeterminate helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-warning"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="exclamation-triangle"}}
+    {{#> helper-text-item-text}}This is warning helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-success"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="check"}}
+    {{#> helper-text-item-text}}This is success helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+
+{{#> helper-text}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-invalid"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="times"}}
+    {{#> helper-text-item-text}}This is invalid helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+```
+
+### Dynamic list
+```hbs
+{{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
+    {{#> helper-text-item-text}}Must be at least 14 characters{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
+    {{#> helper-text-item-text}}Cannot contain any variation of the word "redhat"{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
+    {{#> helper-text-item-text}}Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+<br>
+{{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-success"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="check"}}
+    {{#> helper-text-item-text}}Must be at least 14 characters{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-invalid"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="times"}}
+    {{#> helper-text-item-text}}Cannot contain any variation of the word "redhat"{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-success"}}
+    {{> helper-text-item-icon helper-text-item-icon--type="check"}}
+    {{#> helper-text-item-text}}Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+```
+
+## Documentation

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -6,7 +6,7 @@ cssPrefix: pf-c-helper-text
 ---
 
 ## Examples
-### Basic
+### Static
 ```hbs
 {{#> helper-text}}
   {{#> helper-text-item}}
@@ -77,6 +77,21 @@ cssPrefix: pf-c-helper-text
 {{/helper-text}}
 ```
 
+### Multiple static
+```hbs
+{{#> helper-text}}
+  {{#> helper-text-item}}
+    {{#> helper-text-item-text}}This is default helper text{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item}}
+    {{#> helper-text-item-text}}This is another default helper text in the same block{{/helper-text-item-text}}
+  {{/helper-text-item}}
+  {{#> helper-text-item}}
+    {{#> helper-text-item-text}}And this is more default text in the same block{{/helper-text-item-text}}
+  {{/helper-text-item}}
+{{/helper-text}}
+```
+
 ### Dynamic
 ```hbs
 {{#> helper-text}}
@@ -117,21 +132,6 @@ cssPrefix: pf-c-helper-text
 
 ### Dynamic list
 ```hbs
-{{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
-    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
-    {{#> helper-text-item-text}}Must be at least 14 characters{{/helper-text-item-text}}
-  {{/helper-text-item}}
-  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
-    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
-    {{#> helper-text-item-text}}Cannot contain any variation of the word "redhat"{{/helper-text-item-text}}
-  {{/helper-text-item}}
-  {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-indeterminate"}}
-    {{> helper-text-item-icon helper-text-item-icon--type="minus"}}
-    {{#> helper-text-item-text}}Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols{{/helper-text-item-text}}
-  {{/helper-text-item}}
-{{/helper-text}}
-<br>
 {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
   {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-success"}}
     {{> helper-text-item-icon helper-text-item-icon--type="check"}}

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -151,10 +151,10 @@ cssPrefix: pf-c-helper-text
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-helper-text` | `<div>`, `<ul>` |  Initiates the helper text component. **Required**  |
-| `.pf-c-helper-text__item` | `<div>`, `<li>` |  Initiates a helper text item. **Required**  |
-| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon.  |
-| `.pf-c-helper-text__item-text` | `<span>` |  Initiates a helper text item text. **Required**  |
+| `.pf-c-helper-text` | `<div>`, `<ul>` |  Initiates the helper text component. **Required** |
+| `.pf-c-helper-text__item` | `<div>`, `<li>` |  Initiates a helper text item. **Required** |
+| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon. **Required when used in `.pf-c-helper-text__item.pf-m-dynamic`** |
+| `.pf-c-helper-text__item-text` | `<span>` |  Initiates a helper text item text. **Required** |
 | `.pf-m-dynamic` | `.pf-c-helper-text__item` |  Modifies a helper text item to be dynamic. For use when the item changes state as the form field the text is associated with is updated. |
 | `.pf-m-indeterminate` | `.pf-c-helper-text__item` |  Modifies a helper text item for indeterminate state styles. |
 | `.pf-m-warning` | `.pf-c-helper-text__item` |  Modifies a helper text item for warning state styles. |

--- a/src/patternfly/components/HelperText/helper-text-item-icon.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-icon.hbs
@@ -1,0 +1,10 @@
+<span class="pf-c-helper-text__item-icon{{#if helper-text-item-icon--modifier}} {{helper-text-item-icon--modifier}}{{/if}}"
+  {{#if helper-text-item-icon--attribute}}
+    {{{helper-text-item-icon--attribute}}}
+  {{/if}}>
+  {{#if @partial-block}}
+    {{>@partial-block}}
+  {{else}}
+    <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
+  {{/if}}
+</span>

--- a/src/patternfly/components/HelperText/helper-text-item-text.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-helper-text__item-text{{#if helper-text-item-text--modifier}} {{helper-text-item-text--modifier}}{{/if}}"
+  {{#if helper-text-item-text--attribute}}
+    {{{helper-text-item-text--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</span>

--- a/src/patternfly/components/HelperText/helper-text-item.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item.hbs
@@ -1,0 +1,6 @@
+<{{#if helper-text-item--type}}{{helper-text-item--type}}{{else}}div{{/if}} class="pf-c-helper-text__item{{#if helper-text-item--modifier}} {{helper-text-item--modifier}}{{/if}}"
+  {{#if helper-text-item--attribute}}
+    {{{helper-text-item--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</{{#if helper-text-item--type}}{{helper-text-item--type}}{{else}}div{{/if}}>

--- a/src/patternfly/components/HelperText/helper-text.hbs
+++ b/src/patternfly/components/HelperText/helper-text.hbs
@@ -1,0 +1,6 @@
+<{{#if helper-text--type}}{{helper-text--type}}{{else}}div{{/if}} class="pf-c-helper-text{{#if helper-text--modifier}} {{helper-text--modifier}}{{/if}}"
+  {{#if helper-text--attribute}}
+    {{{helper-text--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</{{#if helper-text--type}}{{helper-text--type}}{{else}}div{{/if}}>

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -1,5 +1,5 @@
 .pf-c-helper-text {
-  --pf-c-helper-text--Gap: var(--pf-global--spacer--sm);
+  --pf-c-helper-text--Gap: var(--pf-global--spacer--xs);
   --pf-c-helper-text--FontSize: var(--pf-global--FontSize--sm);
 
   // item

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -3,11 +3,16 @@
   --pf-c-helper-text--FontSize: var(--pf-global--FontSize--sm);
 
   // item
-  --pf-c-helper-text__item--Color: var(--pf-global--Color--100);
-  --pf-c-helper-text__item--m-indeterminate--Color: var(--pf-global--Color--200);
-  --pf-c-helper-text__item--m-warning--Color: var(--pf-global--warning-color--100);
-  --pf-c-helper-text__item--m-success--Color: var(--pf-global--success-color--100);
-  --pf-c-helper-text__item--m-invalid--Color: var(--pf-global--danger-color--100);
+  --pf-c-helper-text__item-icon--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text__item-text--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text__item-icon--m-indeterminate--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text__item-text--m-indeterminate--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text__item-icon--m-warning--Color: var(--pf-global--warning-color--100);
+  --pf-c-helper-text__item-text--m-warning--Color: var(--pf-global--warning-color--200);
+  --pf-c-helper-text__item-icon--m-success--Color: var(--pf-global--success-color--100);
+  --pf-c-helper-text__item-text--m-success--Color: var(--pf-global--success-color--200);
+  --pf-c-helper-text__item-icon--m-invalid--Color: var(--pf-global--danger-color--100);
+  --pf-c-helper-text__item-text--m-invalid--Color: var(--pf-global--danger-color--200);
 
   // dynamic
   --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-global--Color--100);
@@ -19,7 +24,7 @@
   --pf-c-helper-text--m-dynamic--m-success__item-icon--Color: var(--pf-global--success-color--100);
   --pf-c-helper-text--m-dynamic--m-success__item-text--Color: var(--pf-global--Color--200);
   --pf-c-helper-text--m-dynamic--m-invalid__item-icon--Color: var(--pf-global--danger-color--100);
-  --pf-c-helper-text--m-dynamic--m-invalid__item-text--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text--m-dynamic--m-invalid__item-text--Color: var(--pf-global--Color--200);
 
   // icon
   --pf-c-helper-text__item-icon--MarginRight: var(--pf-global--spacer--xs);
@@ -33,43 +38,46 @@
 
 .pf-c-helper-text__item {
   display: flex;
-  color: var(--pf-c-helper-text__item--Color);
 
   &.pf-m-indeterminate {
-    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-indeterminate--Color);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text__item-icon--m-indeterminate--Color);
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text__item-text--m-indeterminate--Color);
     --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-indeterminate__item-icon--Color);
     --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-indeterminate__item-text--Color);
   }
 
   &.pf-m-warning {
-    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-warning--Color);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text__item-icon--m-warning--Color);
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text__item-text--m-warning--Color);
     --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-warning__item-icon--Color);
     --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-warning__item-text--Color);
   }
 
   &.pf-m-success {
-    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-success--Color);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text__item-icon--m-success--Color);
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text__item-text--m-success--Color);
     --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-success__item-icon--Color);
     --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-success__item-text--Color);
   }
 
   &.pf-m-invalid {
-    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-invalid--Color);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text__item-icon--m-invalid--Color);
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text__item-text--m-invalid--Color);
     --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-invalid__item-icon--Color);
     --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-invalid__item-text--Color);
   }
 
   &.pf-m-dynamic {
-    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text--m-dynamic__item-text--Color, inherit);
-    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text--m-dynamic__item-icon--Color, inherit);
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text--m-dynamic__item-text--Color);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text--m-dynamic__item-icon--Color);
   }
 }
 
 .pf-c-helper-text__item-icon {
   margin-right: var(--pf-c-helper-text__item-icon--MarginRight);
-  color: var(--pf-c-helper-text__item-icon--Color, inherit);
+  color: var(--pf-c-helper-text__item-icon--Color);
 }
 
 .pf-c-helper-text__item-text {
-  color: var(--pf-c-helper-text__item-text--Color, inherit);
+  color: var(--pf-c-helper-text__item-text--Color);
 }

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -1,0 +1,75 @@
+.pf-c-helper-text {
+  --pf-c-helper-text--Gap: var(--pf-global--spacer--sm);
+  --pf-c-helper-text--FontSize: var(--pf-global--FontSize--sm);
+
+  // item
+  --pf-c-helper-text__item--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text__item--m-indeterminate--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text__item--m-warning--Color: var(--pf-global--warning-color--100);
+  --pf-c-helper-text__item--m-success--Color: var(--pf-global--success-color--100);
+  --pf-c-helper-text__item--m-invalid--Color: var(--pf-global--danger-color--100);
+
+  // dynamic
+  --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-global--Color--100);
+  --pf-c-helper-text--m-dynamic--m-indeterminate__item-icon--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text--m-dynamic--m-indeterminate__item-text--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text--m-dynamic--m-warning__item-icon--Color: var(--pf-global--warning-color--100);
+  --pf-c-helper-text--m-dynamic--m-warning__item-text--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text--m-dynamic--m-success__item-icon--Color: var(--pf-global--success-color--100);
+  --pf-c-helper-text--m-dynamic--m-success__item-text--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text--m-dynamic--m-invalid__item-icon--Color: var(--pf-global--danger-color--100);
+  --pf-c-helper-text--m-dynamic--m-invalid__item-text--Color: var(--pf-global--Color--100);
+
+  // icon
+  --pf-c-helper-text__item-icon--MarginRight: var(--pf-global--spacer--xs);
+
+  // text
+
+  display: grid;
+  gap: var(--pf-c-helper-text--Gap);
+  font-size: var(--pf-c-helper-text--FontSize);
+}
+
+.pf-c-helper-text__item {
+  display: flex;
+  color: var(--pf-c-helper-text__item--Color);
+
+  &.pf-m-indeterminate {
+    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-indeterminate--Color);
+    --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-indeterminate__item-icon--Color);
+    --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-indeterminate__item-text--Color);
+  }
+
+  &.pf-m-warning {
+    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-warning--Color);
+    --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-warning__item-icon--Color);
+    --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-warning__item-text--Color);
+  }
+
+  &.pf-m-success {
+    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-success--Color);
+    --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-success__item-icon--Color);
+    --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-success__item-text--Color);
+  }
+
+  &.pf-m-invalid {
+    --pf-c-helper-text__item--Color: var(--pf-c-helper-text__item--m-invalid--Color);
+    --pf-c-helper-text--m-dynamic__item-icon--Color: var(--pf-c-helper-text--m-dynamic--m-invalid__item-icon--Color);
+    --pf-c-helper-text--m-dynamic__item-text--Color: var(--pf-c-helper-text--m-dynamic--m-invalid__item-text--Color);
+  }
+
+  &.pf-m-dynamic {
+    --pf-c-helper-text__item-text--Color: var(--pf-c-helper-text--m-dynamic__item-text--Color, inherit);
+    --pf-c-helper-text__item-icon--Color: var(--pf-c-helper-text--m-dynamic__item-icon--Color, inherit);
+  }
+}
+
+.pf-c-helper-text__item-icon {
+  margin-right: var(--pf-c-helper-text__item-icon--MarginRight);
+  color: var(--pf-c-helper-text__item-icon--Color, inherit);
+}
+
+.pf-c-helper-text__item-text {
+  color: var(--pf-c-helper-text__item-text--Color, inherit);
+}

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -24,7 +24,7 @@
   --pf-c-helper-text--m-dynamic--m-success__item-icon--Color: var(--pf-global--success-color--100);
   --pf-c-helper-text--m-dynamic--m-success__item-text--Color: var(--pf-global--Color--200);
   --pf-c-helper-text--m-dynamic--m-invalid__item-icon--Color: var(--pf-global--danger-color--100);
-  --pf-c-helper-text--m-dynamic--m-invalid__item-text--Color: var(--pf-global--Color--200);
+  --pf-c-helper-text--m-dynamic--m-invalid__item-text--Color: var(--pf-global--Color--100);
 
   // icon
   --pf-c-helper-text__item-icon--MarginRight: var(--pf-global--spacer--xs);

--- a/src/patternfly/components/_all.scss
+++ b/src/patternfly/components/_all.scss
@@ -36,6 +36,7 @@
 @import "./Form/form.scss";
 @import "./FormControl/form-control.scss";
 @import "./Hint/hint.scss";
+@import "./HelperText/helper-text.scss";
 @import "./InlineEdit/inline-edit.scss";
 @import "./InputGroup/input-group.scss";
 @import "./JumpLinks/jump-links.scss";


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4017

Preview - https://patternfly-pr-4089.surge.sh/components/helper-text

Adds 2 types of helper texts:

### Static
This is the default helper text. With static helper text, the text color and icon color are the same. By default the text and optional icon are black. Indeterminate is grey, warning is yellow, success is green, invalid is red.

### Dynamic
This is an opt in to the helper text component. By default a dynamic helper text and icon are black. Intermediate is grey, warning has yellow icon and grey text, success has green icon and grey text, and invalid has red icon and black text.

A helper text component is a block made up of helper text items. There can be one or more items, and if there are multiple items in a helper text block, there is a `xs` spacer between items. A block of multiple items can be [regular divs](https://patternfly-pr-4089.surge.sh/components/helper-text/#multiple-static) (in the case of regular helper text that isn't necessarily a list), or an [HTML list](https://patternfly-pr-4089.surge.sh/components/helper-text/#dynamic-list) (particularly useful in dynamic/validation helper text).