### PR TITLE
fix(menu): disabled pointer events on disabled list item

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -313,10 +313,7 @@
     --pf-c-menu__item-action--Color: var(--pf-c-menu__list-item--m-disabled__item-action--Color);
     --pf-c-menu__item-toggle-icon: var(--pf-c-menu__list-item--m-disabled__item-toggle-icon--Color);
 
-    .pf-c-menu__item,
-    .pf-c-menu__item-action {
-      pointer-events: none;
-    }
+    pointer-events: none;
   }
 
   &.pf-m-load {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4101

@mattnolting can you think of a reason we wouldn't just disable pointer events on the top level `li` instead of disabling them on the children?