### PR TITLE
fix(wizard): fixed expandable nav item toggle rotation/padding issue

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -508,6 +508,7 @@ import './Wizard.css'
 | `.pf-c-wizard__nav-item` | `<li>` | Initiates a step list item. **Required** |
 | `.pf-c-wizard__nav-link` | `<a>` | Initiates a step link. **Required** |
 | `.pf-c-wizard__nav-link-text` | `<span>` | Initiates the link text container. **Required when nav item is expandable** |
+| `.pf-c-wizard__nav-link-toggle` | `<span>` | Initiates the toggle container. **Required when nav item is expandable** |
 | `.pf-c-wizard__nav-link-toggle-icon` | `<span>` | Initiates the toggle icon container. **Required when nav item is expandable** |
 | `.pf-c-wizard__main` | `<main>`, `<div>` | Initiates the main container. **Required** Note: use the `<main>` element when when there are no other `<main>` elements on the page.|
 | `.pf-c-wizard__main-body` | `<div>` | Initiates the main container body section. **Required** |

--- a/src/patternfly/components/Wizard/wizard-nav-link-toggle.hbs
+++ b/src/patternfly/components/Wizard/wizard-nav-link-toggle.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-wizard__nav-link-toggle{{#if wizard-nav-link-toggle--modifier}} {{wizard-nav-link-toggle--modifier}}{{/if}}"
+  {{#if wizard-nav-link-toggle--attribute}}
+    {{{wizard-nav-link-toggle--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Wizard/wizard-nav-link.hbs
+++ b/src/patternfly/components/Wizard/wizard-nav-link.hbs
@@ -24,7 +24,9 @@
     {{#> wizard-nav-link-text}}
       {{> @partial-block}}
     {{/wizard-nav-link-text}}
-    {{> wizard-nav-link-toggle-icon}}
+    {{#> wizard-nav-link-toggle}}
+      {{> wizard-nav-link-toggle-icon}}
+    {{/wizard-nav-link-toggle}}
   {{else}}
     {{> @partial-block}}
   {{/if}}

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -52,9 +52,9 @@
   --pf-c-wizard__nav-list__nav-list__nav-link--m-current--FontWeight: var(--pf-global--FontWeight--normal); // remove at breaking change
 
   // Nav link toggle icon
-  --pf-c-wizard__nav-link-toggle-icon--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-wizard__nav-link-toggle-icon--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-wizard__nav-link-toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-wizard__nav-link-toggle--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-wizard__nav-link-toggle--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-wizard__nav-link-toggle--Color: var(--pf-global--Color--200);
   --pf-c-wizard__nav-link--hover__nav-link-toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-wizard__nav-link--focus__nav-link-toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-wizard__nav-link-toggle-icon--Transition: var(--pf-global--Transition);
@@ -465,12 +465,12 @@
 
   &:hover {
     --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--hover--Color);
-    --pf-c-wizard__nav-link-toggle-icon--Color: var(--pf-c-wizard__nav-link--hover__nav-link-toggle-icon--Color);
+    --pf-c-wizard__nav-link-toggle--Color: var(--pf-c-wizard__nav-link--hover__nav-link-toggle-icon--Color);
   }
 
   &:focus {
     --pf-c-wizard__nav-link--Color: var(--pf-c-wizard__nav-link--focus--Color);
-    --pf-c-wizard__nav-link-toggle-icon--Color: var(--pf-c-wizard__nav-link--focus__nav-link-toggle-icon--Color);
+    --pf-c-wizard__nav-link-toggle--Color: var(--pf-c-wizard__nav-link--focus__nav-link-toggle-icon--Color);
   }
 
   &.pf-m-current {
@@ -502,10 +502,14 @@
   flex-grow: 1;
 }
 
+.pf-c-wizard__nav-link-toggle {
+  padding-right: var(--pf-c-wizard__nav-link-toggle--PaddingRight);
+  padding-left: var(--pf-c-wizard__nav-link-toggle--PaddingLeft);
+  color: var(--pf-c-wizard__nav-link-toggle--Color);
+}
+
 .pf-c-wizard__nav-link-toggle-icon {
-  padding-right: var(--pf-c-wizard__nav-link-toggle-icon--PaddingRight);
-  padding-left: var(--pf-c-wizard__nav-link-toggle-icon--PaddingLeft);
-  color: var(--pf-c-wizard__nav-link-toggle-icon--Color);
+  display: inline-block;
   transition: var(--pf-c-wizard__nav-link-toggle-icon--Transition);
   transform: rotate(var(--pf-c-wizard__nav-link-toggle-icon--Rotate));
 }

--- a/src/patternfly/demos/CardView/examples/CardView.md
+++ b/src/patternfly/demos/CardView/examples/CardView.md
@@ -1,8 +1,6 @@
 ---
 id: 'Card view'
-beta: true
 section: demos
-cssPrefix: pf-d-card-view
 ---
 
 ## Examples


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4111

just separates the icon element that rotates from the toggle element that has padding for the toggle icon