### PR TITLE
fix(content): changed visited to declare color property

### DIFF
--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -114,7 +114,7 @@
   &.pf-m-visited a,
   a.pf-m-visited {
     &:visited {
-      --pf-c-content--a--Color: var(--pf-c-content--a--visited--Color);
+      color: var(--pf-c-content--a--visited--Color);
     }
   }
   // stylelint-enable

--- a/src/patternfly/components/Content/examples/Content.md
+++ b/src/patternfly/components/Content/examples/Content.md
@@ -64,7 +64,9 @@ cssPrefix: pf-c-content
   <em>justo sodales</em> elementum. Maecenas ultrices lacus quis neque consectetur, et lobortis nisi molestie.</p>
 <hr>
 <h3>Visited link example</h3>
-<a class="pf-m-visited" href="#">Visited link</a>
+<p>
+  <a class="pf-m-visited" href>Visited link</a>
+</p>
 <hr>
 <p>Sed sagittis enim ac tortor maximus rutrum. Nulla facilisi. Donec mattis vulputate risus in luctus. Maecenas vestibulum interdum
   commodo.


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4131

also wrapped the link in a `<p>` to improve the spacing and removed the value from `href`, which is how [MDN does it](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited)