### PR TITLE
fix(overflow-menu): added aria-expanded to examples

### DIFF
--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
@@ -14,7 +14,7 @@ The overflow menu relies on groups (`.pf-c-overflow-menu__group`) and items (`.p
 ### Simple collapsed
 ```hbs
 {{#> overflow-menu overflow-menu--id="overflow-menu-simple"}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Generic options" overflow-menu-dropdown-button-aria-expanded="true"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Generic options"}}
     {{#> overflow-menu-dropdown-item}}
       Item 1
     {{/overflow-menu-dropdown-item}}
@@ -143,7 +143,7 @@ The action group consists of a primary and secondary action. Any additional acti
 ### Additional options in dropdown (hidden)
 ```hbs
 {{#> overflow-menu overflow-menu--id="overflow-menu-simple-additional-options-hidden"}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="true"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options"}}
     {{#> overflow-menu-dropdown-item}}
       Primary
     {{/overflow-menu-dropdown-item}}
@@ -208,7 +208,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="true"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options"}}
     {{#> overflow-menu-dropdown-item}}
       Action 7
     {{/overflow-menu-dropdown-item}}
@@ -230,7 +230,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example" overflow-menu-dropdown-button-aria-expanded="true"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example"}}
     {{#> overflow-menu-dropdown-item}}
       Secondary
     {{/overflow-menu-dropdown-item}}
@@ -266,7 +266,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example" overflow-menu-dropdown-button-aria-expanded="true"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example"}}
     {{#> overflow-menu-dropdown-item}}
       Action 4
     {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
@@ -14,7 +14,7 @@ The overflow menu relies on groups (`.pf-c-overflow-menu__group`) and items (`.p
 ### Simple collapsed
 ```hbs
 {{#> overflow-menu overflow-menu--id="overflow-menu-simple"}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Generic options"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Generic options" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Item 1
     {{/overflow-menu-dropdown-item}}
@@ -143,7 +143,7 @@ The action group consists of a primary and secondary action. Any additional acti
 ### Additional options in dropdown (hidden)
 ```hbs
 {{#> overflow-menu overflow-menu--id="overflow-menu-simple-additional-options-hidden"}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Primary
     {{/overflow-menu-dropdown-item}}
@@ -208,7 +208,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Action 7
     {{/overflow-menu-dropdown-item}}
@@ -230,7 +230,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Secondary
     {{/overflow-menu-dropdown-item}}
@@ -266,7 +266,7 @@ The action group consists of a primary and secondary action. Any additional acti
       {{/overflow-menu-item}}
     {{/overflow-menu-group}}
   {{/overflow-menu-content}}
-  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example"}}
+  {{#> overflow-menu-control dropdown--IsExpanded="true" overflow-menu-button--aria-label="Dropdown for persistent example" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Action 4
     {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu-action-group-example.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-action-group-example.hbs
@@ -1,4 +1,4 @@
-{{#> overflow-menu overflow-menu-button--aria-label="Action group options" overflow-menu-dropdown-button-aria-expanded="{{overflow-menu-dropdown-button-aria-expanded}}"}}
+{{#> overflow-menu overflow-menu-button--aria-label="Action group options"}}
   {{#> overflow-menu-content}}
     {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
       {{#> overflow-menu-item}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
@@ -8,21 +8,25 @@
       {{{dropdown--attribute}}}
     {{/if}}>
     {{#if overflow-menu-control--IsControl}}
-      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-dropdown-button-aria-expanded '"')}}
-        {{#if dropdown--icon}}
-          <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
-        {{else}}
-          {{> dropdown-kebab-icon}}
-        {{/if}}
-      {{/button}}
+      {{#> wrapper overflow-menu-button--aria-expanded="true"}}
+        {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+          {{#if dropdown--icon}}
+            <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
+          {{else}}
+            {{> dropdown-kebab-icon}}
+          {{/if}}
+        {{/button}}
+      {{/wrapper}}
     {{else}}
-      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-dropdown-button-aria-expanded '"')}}
-        {{#if dropdown-icon}}
-          <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
-        {{else}}
-          {{> dropdown-kebab-icon}}
-        {{/if}}
-      {{/button}}
+      {{#> wrapper overflow-menu-button--aria-expanded="true"}}
+        {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+          {{#if dropdown-icon}}
+            <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
+          {{else}}
+            {{> dropdown-kebab-icon}}
+          {{/if}}
+        {{/button}}
+      {{/wrapper}}
     {{/if}}
     {{#if overflow-menu--UsesMenu}}
       {{> @partial-block}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
@@ -8,7 +8,7 @@
       {{{dropdown--attribute}}}
     {{/if}}>
     {{#if overflow-menu-control--IsControl}}
-      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" ' overflow-menu-dropdown-button-aria-expanded '')}}
+      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-dropdown-button-aria-expanded '"')}}
         {{#if dropdown--icon}}
           <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
         {{else}}
@@ -16,7 +16,7 @@
         {{/if}}
       {{/button}}
     {{else}}
-      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" ' overflow-menu-dropdown-button-aria-expanded '')}}
+      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-dropdown-button-aria-expanded '"')}}
         {{#if dropdown-icon}}
           <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
         {{else}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
@@ -8,25 +8,21 @@
       {{{dropdown--attribute}}}
     {{/if}}>
     {{#if overflow-menu-control--IsControl}}
-      {{#> wrapper overflow-menu-button--aria-expanded="true"}}
-        {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
-          {{#if dropdown--icon}}
-            <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
-          {{else}}
-            {{> dropdown-kebab-icon}}
-          {{/if}}
-        {{/button}}
-      {{/wrapper}}
+      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+        {{#if dropdown--icon}}
+          <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
+        {{else}}
+          {{> dropdown-kebab-icon}}
+        {{/if}}
+      {{/button}}
     {{else}}
-      {{#> wrapper overflow-menu-button--aria-expanded="true"}}
-        {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
-          {{#if dropdown-icon}}
-            <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
-          {{else}}
-            {{> dropdown-kebab-icon}}
-          {{/if}}
-        {{/button}}
-      {{/wrapper}}
+      {{#> button button--modifier="pf-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+        {{#if dropdown-icon}}
+          <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
+        {{else}}
+          {{> dropdown-kebab-icon}}
+        {{/if}}
+      {{/button}}
     {{/if}}
     {{#if overflow-menu--UsesMenu}}
       {{> @partial-block}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
@@ -2,7 +2,7 @@
   {{#if overflow-menu-control--attribute}}
     {{{overflow-menu-control--attribute}}}
   {{/if}}>
-
+  
   <div class="pf-c-dropdown{{#if dropdown--IsExpanded}} pf-m-expanded{{/if}}{{#if dropdown--modifier}} {{dropdown--modifier}}{{/if}}"
     {{#if dropdown--attribute}}
       {{{dropdown--attribute}}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.hbs
@@ -1,11 +1,11 @@
 {{#> wrapper overflow-menu-button--aria-expanded="true"}}
-  <div class="pf-c-overflow-menu{{#if overflow-menu--modifier}} {{overflow-menu--modifier}}{{/if}}"  
+<div class="pf-c-overflow-menu{{#if overflow-menu--modifier}} {{overflow-menu--modifier}}{{/if}}"  
   {{#if overflow-menu--attribute}}
     {{{overflow-menu--attribute}}}
   {{/if}}
   {{#if overflow-menu--id}}
     id="{{overflow-menu--id}}"
-    {{/if}}>
+  {{/if}}>
   {{> @partial-block}}
-  </div>
+</div>
 {{/wrapper}}

--- a/src/patternfly/components/OverflowMenu/overflow-menu.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.hbs
@@ -1,10 +1,10 @@
 {{#> wrapper overflow-menu-button--aria-expanded="true"}}
   <div class="pf-c-overflow-menu{{#if overflow-menu--modifier}} {{overflow-menu--modifier}}{{/if}}"  
-    {{#if overflow-menu--attribute}}
-      {{{overflow-menu--attribute}}}
-    {{/if}}
-    {{#if overflow-menu--id}}
-      id="{{overflow-menu--id}}"
+  {{#if overflow-menu--attribute}}
+    {{{overflow-menu--attribute}}}
+  {{/if}}
+  {{#if overflow-menu--id}}
+    id="{{overflow-menu--id}}"
     {{/if}}>
   {{> @partial-block}}
   </div>

--- a/src/patternfly/components/OverflowMenu/overflow-menu.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.hbs
@@ -1,9 +1,11 @@
-<div class="pf-c-overflow-menu{{#if overflow-menu--modifier}} {{overflow-menu--modifier}}{{/if}}"
-  {{#if overflow-menu--attribute}}
-    {{{overflow-menu--attribute}}}
-  {{/if}}
-  {{#if overflow-menu--id}}
-    id="{{overflow-menu--id}}"
-  {{/if}}>
+{{#> wrapper overflow-menu-button--aria-expanded="true"}}
+  <div class="pf-c-overflow-menu{{#if overflow-menu--modifier}} {{overflow-menu--modifier}}{{/if}}"  
+    {{#if overflow-menu--attribute}}
+      {{{overflow-menu--attribute}}}
+    {{/if}}
+    {{#if overflow-menu--id}}
+      id="{{overflow-menu--id}}"
+    {{/if}}>
   {{> @partial-block}}
-</div>
+  </div>
+{{/wrapper}}

--- a/src/patternfly/components/Toolbar/toolbar--template.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template.hbs
@@ -72,7 +72,7 @@ Options: [
 
             {{/overflow-menu-group}}
           {{/overflow-menu-content}}
-          {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown with additional options"}}
+          {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="false"}}
             {{#> overflow-menu-dropdown-item}}
               Action 7
             {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/Toolbar/toolbar--template.hbs
+++ b/src/patternfly/components/Toolbar/toolbar--template.hbs
@@ -72,7 +72,7 @@ Options: [
 
             {{/overflow-menu-group}}
           {{/overflow-menu-content}}
-          {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-dropdown-button-aria-expanded="false"}}
+          {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown with additional options" overflow-menu-button--aria-expanded="false"}}
             {{#> overflow-menu-dropdown-item}}
               Action 7
             {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
@@ -2,7 +2,7 @@
   {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-icon-button-group-example)}}
     {{#> overflow-menu overflow-menu-button--aria-label="Expand icon button overflow menu" overflow-menu--id=(concat toolbar--id '-icon-button-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
       {{#if toolbar-icon-button-group-example--control}}
-        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" dropdown--icon="fa-toolbox"}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" dropdown--icon="fa-toolbox" overflow-menu-dropdown-button-aria-expanded="false"}}
           {{#> overflow-menu-dropdown-item}}
             Edit
           {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
@@ -2,17 +2,31 @@
   {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-icon-button-group-example)}}
     {{#> overflow-menu overflow-menu-button--aria-label="Expand icon button overflow menu" overflow-menu--id=(concat toolbar--id '-icon-button-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
       {{#if toolbar-icon-button-group-example--control}}
-        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" dropdown--icon="fa-toolbox"}}
-          {{#> overflow-menu-dropdown-item}}
-            Edit
-          {{/overflow-menu-dropdown-item}}
-          {{#> overflow-menu-dropdown-item}}
-            Clone
-          {{/overflow-menu-dropdown-item}}
-          {{#> overflow-menu-dropdown-item}}
-            Sync
-          {{/overflow-menu-dropdown-item}}
-        {{/overflow-menu-control}}
+        {{#if toolbar-overflow-menu-example--IsExpanded}}
+          {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="true" dropdown--icon="fa-toolbox"}}
+            {{#> overflow-menu-dropdown-item}}
+              Edit
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
+              Clone
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
+              Sync
+            {{/overflow-menu-dropdown-item}}
+          {{/overflow-menu-control}}
+        {{else}}
+          {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="false" dropdown--icon="fa-toolbox"}}
+            {{#> overflow-menu-dropdown-item}}
+              Edit
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
+              Clone
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
+              Sync
+            {{/overflow-menu-dropdown-item}}
+          {{/overflow-menu-control}}
+        {{/if}}
       {{else}}
         {{#> overflow-menu-content}}
           {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-icon-button-group"}}

--- a/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-icon-button-group-example.hbs
@@ -2,7 +2,7 @@
   {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-icon-button-group-example)}}
     {{#> overflow-menu overflow-menu-button--aria-label="Expand icon button overflow menu" overflow-menu--id=(concat toolbar--id '-icon-button-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
       {{#if toolbar-icon-button-group-example--control}}
-        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" dropdown--icon="fa-toolbox" overflow-menu-dropdown-button-aria-expanded="false"}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" dropdown--icon="fa-toolbox"}}
           {{#> overflow-menu-dropdown-item}}
             Edit
           {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -17,7 +17,7 @@
           {{/overflow-menu-group}}
         {{/overflow-menu-content}}
       {{/if}}
-
+    
       {{#if toolbar-overflow-menu-example--persistent}}
         {{#> overflow-menu-content}}
           {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -1,49 +1,97 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-overflow-menu-example-toolbar-item--modifier)}}
-  {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+  {{#if toolbar-overflow-menu-example--IsExpanded}}
+    {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu-button--aria-expanded="true" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+      {{#if toolbar-overflow-menu-example--content}}
+        {{#> overflow-menu-content}}
+          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-primary"}}
+                Primary
+              {{/button}}
+            {{/overflow-menu-item}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-secondary"}}
+                Secondary
+              {{/button}}
+            {{/overflow-menu-item}}
+          {{/overflow-menu-group}}
+        {{/overflow-menu-content}}
+      {{/if}}
 
-    {{#if toolbar-overflow-menu-example--content}}
-      {{#> overflow-menu-content}}
-        {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-          {{#> overflow-menu-item}}
-            {{#> button button--modifier="pf-m-primary"}}
+      {{#if toolbar-overflow-menu-example--persistent}}
+        {{#> overflow-menu-content}}
+          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-primary"}}
+                Primary
+              {{/button}}
+            {{/overflow-menu-item}}
+          {{/overflow-menu-group}}
+        {{/overflow-menu-content}}
+      {{/if}}
+
+      {{#if toolbar-overflow-menu-example--control}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu"}}
+          {{#unless toolbar-overflow-menu-example--content}}
+            {{#> overflow-menu-dropdown-item}}
               Primary
-            {{/button}}
-          {{/overflow-menu-item}}
-          {{#> overflow-menu-item}}
-            {{#> button button--modifier="pf-m-secondary"}}
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
               Secondary
-            {{/button}}
-          {{/overflow-menu-item}}
-        {{/overflow-menu-group}}
-      {{/overflow-menu-content}}
-    {{/if}}
+            {{/overflow-menu-dropdown-item}}
+          {{/unless}}
+          {{#> overflow-menu-dropdown-item}}
+            Tertiary
+          {{/overflow-menu-dropdown-item}}
+        {{/overflow-menu-control}}
+      {{/if}}
+    {{/overflow-menu}}
+  {{else}}
+    {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu-button--aria-expanded="false" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+      {{#if toolbar-overflow-menu-example--content}}
+        {{#> overflow-menu-content}}
+          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-primary"}}
+                Primary
+              {{/button}}
+            {{/overflow-menu-item}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-secondary"}}
+                Secondary
+              {{/button}}
+            {{/overflow-menu-item}}
+          {{/overflow-menu-group}}
+        {{/overflow-menu-content}}
+      {{/if}}
 
-    {{#if toolbar-overflow-menu-example--persistent}}
-      {{#> overflow-menu-content}}
-        {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-          {{#> overflow-menu-item}}
-            {{#> button button--modifier="pf-m-primary"}}
+      {{#if toolbar-overflow-menu-example--persistent}}
+        {{#> overflow-menu-content}}
+          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+            {{#> overflow-menu-item}}
+              {{#> button button--modifier="pf-m-primary"}}
+                Primary
+              {{/button}}
+            {{/overflow-menu-item}}
+          {{/overflow-menu-group}}
+        {{/overflow-menu-content}}
+      {{/if}}
+
+      {{#if toolbar-overflow-menu-example--control}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu"}}
+          {{#unless toolbar-overflow-menu-example--content}}
+            {{#> overflow-menu-dropdown-item}}
               Primary
-            {{/button}}
-          {{/overflow-menu-item}}
-        {{/overflow-menu-group}}
-      {{/overflow-menu-content}}
-    {{/if}}
-
-    {{#if toolbar-overflow-menu-example--control}}
-      {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-dropdown-button-aria-expanded="true"}}
-        {{#unless toolbar-overflow-menu-example--content}}
+            {{/overflow-menu-dropdown-item}}
+            {{#> overflow-menu-dropdown-item}}
+              Secondary
+            {{/overflow-menu-dropdown-item}}
+          {{/unless}}
           {{#> overflow-menu-dropdown-item}}
-            Primary
+            Tertiary
           {{/overflow-menu-dropdown-item}}
-          {{#> overflow-menu-dropdown-item}}
-            Secondary
-          {{/overflow-menu-dropdown-item}}
-        {{/unless}}
-        {{#> overflow-menu-dropdown-item}}
-          Tertiary
-        {{/overflow-menu-dropdown-item}}
-      {{/overflow-menu-control}}
-    {{/if}}
-  {{/overflow-menu}}
+        {{/overflow-menu-control}}
+      {{/if}}
+    {{/overflow-menu}}
+  {{/if}}
 {{/toolbar-item}}

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -1,6 +1,6 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-overflow-menu-example-toolbar-item--modifier)}}
-  {{#if toolbar-overflow-menu-example--IsExpanded}}
-    {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu-button--aria-expanded="true" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+  {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+    {{#if dropdown--IsExpanded}}
       {{#if toolbar-overflow-menu-example--content}}
         {{#> overflow-menu-content}}
           {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
@@ -31,7 +31,7 @@
       {{/if}}
 
       {{#if toolbar-overflow-menu-example--control}}
-        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu"}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="true"}}
           {{#unless toolbar-overflow-menu-example--content}}
             {{#> overflow-menu-dropdown-item}}
               Primary
@@ -45,9 +45,7 @@
           {{/overflow-menu-dropdown-item}}
         {{/overflow-menu-control}}
       {{/if}}
-    {{/overflow-menu}}
-  {{else}}
-    {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu-button--aria-expanded="false" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
+    {{else}}
       {{#if toolbar-overflow-menu-example--content}}
         {{#> overflow-menu-content}}
           {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
@@ -78,7 +76,7 @@
       {{/if}}
 
       {{#if toolbar-overflow-menu-example--control}}
-        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu"}}
+        {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="false"}}
           {{#unless toolbar-overflow-menu-example--content}}
             {{#> overflow-menu-dropdown-item}}
               Primary
@@ -92,6 +90,6 @@
           {{/overflow-menu-dropdown-item}}
         {{/overflow-menu-control}}
       {{/if}}
-    {{/overflow-menu}}
-  {{/if}}
+    {{/if}}
+  {{/overflow-menu}}
 {{/toolbar-item}}

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -31,7 +31,7 @@
     {{/if}}
 
     {{#if toolbar-overflow-menu-example--control}}
-      {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-dropdown-button-aria-expanded="false"}}
+      {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-dropdown-button-aria-expanded="true"}}
         {{#unless toolbar-overflow-menu-example--content}}
           {{#> overflow-menu-dropdown-item}}
             Primary

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -31,7 +31,7 @@
     {{/if}}
 
     {{#if toolbar-overflow-menu-example--control}}
-      {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu"}}
+      {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-dropdown-button-aria-expanded="false"}}
         {{#unless toolbar-overflow-menu-example--content}}
           {{#> overflow-menu-dropdown-item}}
             Primary

--- a/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-overflow-menu-example.hbs
@@ -1,35 +1,36 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-overflow-menu ' toolbar-overflow-menu-example-toolbar-item--modifier)}}
   {{#> overflow-menu overflow-menu-button--aria-label="Expand button group overflow menu" overflow-menu--id=(concat toolbar--id '-overflow-menu') dropdown--IsExpanded=toolbar-overflow-menu-example--IsExpanded overflow-menu--modifier=toolbar-demo-overflow-menu--modifier overflow-menu--attribute=toolbar-demo-overflow-menu--attribute}}
-    {{#if dropdown--IsExpanded}}
-      {{#if toolbar-overflow-menu-example--content}}
-        {{#> overflow-menu-content}}
-          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-primary"}}
-                Primary
-              {{/button}}
-            {{/overflow-menu-item}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-secondary"}}
-                Secondary
-              {{/button}}
-            {{/overflow-menu-item}}
-          {{/overflow-menu-group}}
-        {{/overflow-menu-content}}
-      {{/if}}
     
-      {{#if toolbar-overflow-menu-example--persistent}}
-        {{#> overflow-menu-content}}
-          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-primary"}}
-                Primary
-              {{/button}}
-            {{/overflow-menu-item}}
-          {{/overflow-menu-group}}
-        {{/overflow-menu-content}}
-      {{/if}}
-
+    {{#if toolbar-overflow-menu-example--content}}
+      {{#> overflow-menu-content}}
+        {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+          {{#> overflow-menu-item}}
+            {{#> button button--modifier="pf-m-primary"}}
+              Primary
+            {{/button}}
+          {{/overflow-menu-item}}
+          {{#> overflow-menu-item}}
+            {{#> button button--modifier="pf-m-secondary"}}
+              Secondary
+            {{/button}}
+          {{/overflow-menu-item}}
+        {{/overflow-menu-group}}
+      {{/overflow-menu-content}}
+    {{/if}}
+  
+    {{#if toolbar-overflow-menu-example--persistent}}
+      {{#> overflow-menu-content}}
+        {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
+          {{#> overflow-menu-item}}
+            {{#> button button--modifier="pf-m-primary"}}
+              Primary
+            {{/button}}
+          {{/overflow-menu-item}}
+        {{/overflow-menu-group}}
+      {{/overflow-menu-content}}
+    {{/if}}
+    
+    {{#if dropdown--IsExpanded}}
       {{#if toolbar-overflow-menu-example--control}}
         {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="true"}}
           {{#unless toolbar-overflow-menu-example--content}}
@@ -46,35 +47,6 @@
         {{/overflow-menu-control}}
       {{/if}}
     {{else}}
-      {{#if toolbar-overflow-menu-example--content}}
-        {{#> overflow-menu-content}}
-          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-primary"}}
-                Primary
-              {{/button}}
-            {{/overflow-menu-item}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-secondary"}}
-                Secondary
-              {{/button}}
-            {{/overflow-menu-item}}
-          {{/overflow-menu-group}}
-        {{/overflow-menu-content}}
-      {{/if}}
-
-      {{#if toolbar-overflow-menu-example--persistent}}
-        {{#> overflow-menu-content}}
-          {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
-            {{#> overflow-menu-item}}
-              {{#> button button--modifier="pf-m-primary"}}
-                Primary
-              {{/button}}
-            {{/overflow-menu-item}}
-          {{/overflow-menu-group}}
-        {{/overflow-menu-content}}
-      {{/if}}
-
       {{#if toolbar-overflow-menu-example--control}}
         {{#> overflow-menu-control overflow-menu-button--aria-label="Overflow menu" overflow-menu-button--aria-expanded="false"}}
           {{#unless toolbar-overflow-menu-example--content}}

--- a/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
+++ b/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
@@ -1,5 +1,5 @@
 {{#> overflow-menu dropdown-menu--modifier="pf-m-align-right" overflow-menu--id=tabs--table-overflow-menu--id}}
-  {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-dropdown-button-aria-expanded="false"}}
+  {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-dropdown-button-aria-expanded="true"}}
     {{#> overflow-menu-dropdown-item}}
       Action Link
     {{/overflow-menu-dropdown-item}}

--- a/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
+++ b/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
@@ -1,7 +1,15 @@
 {{#> overflow-menu dropdown-menu--modifier="pf-m-align-right" overflow-menu--id=tabs--table-overflow-menu--id}}
-  {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-dropdown-button-aria-expanded="true"}}
-    {{#> overflow-menu-dropdown-item}}
-      Action Link
-    {{/overflow-menu-dropdown-item}}
-  {{/overflow-menu-control}}
+  {{#if dropdown--IsExpanded}}
+    {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-button--aria-expanded="true"}}
+      {{#> overflow-menu-dropdown-item}}
+        Action Link
+      {{/overflow-menu-dropdown-item}}
+    {{/overflow-menu-control}}
+  {{else}}
+    {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-button--aria-expanded="false"}}
+      {{#> overflow-menu-dropdown-item}}
+        Action Link
+      {{/overflow-menu-dropdown-item}}
+    {{/overflow-menu-control}}
+  {{/if}}
 {{/overflow-menu}}

--- a/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
+++ b/src/patternfly/demos/Tabs/templates/tabs--table-overflow-menu.hbs
@@ -1,5 +1,5 @@
 {{#> overflow-menu dropdown-menu--modifier="pf-m-align-right" overflow-menu--id=tabs--table-overflow-menu--id}}
-  {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table"}}
+  {{#> overflow-menu-control overflow-menu-button--aria-label="Dropdown for tabs table" overflow-menu-dropdown-button-aria-expanded="false"}}
     {{#> overflow-menu-dropdown-item}}
       Action Link
     {{/overflow-menu-dropdown-item}}


### PR DESCRIPTION
fixes #3773 

also added aria-expanded to the toolbar and tabs examples that use overflow menus