### PR TITLE
feat(form): added info text to group label

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -196,7 +196,7 @@ cssPrefix: pf-c-form
 ```
 ### Label with additional info
 ```hbs
-{{#> form form--id="form-vertical"}}
+{{#> form form--id="form-additional-info"}}
   {{#> form-group form-group--id="-name"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
@@ -561,7 +561,7 @@ cssPrefix: pf-c-form
 | `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
 | `.pf-c-form__label-text` | `<span>` |  Initiates a form label text. **Required** |
 | `.pf-c-form__label-required` | `<span>` |  Initiates a form label required indicator. |
-| `.pf-c-form__group-label-main` | `<div>` |  Initiates a form group main label container. |
+| `.pf-c-form__group-label-main` | `<div>` |  Initiates a form group label main container. |
 | `.pf-c-form__group-label-info` | `<div>` |  Initiates a form group info label. |
 | `.pf-c-form__group-label-help` | `<button>` | Initiates a field level help button. |
 | `.pf-c-form__group-control` | `<div>` |  Initiates a form group control section. |

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -194,7 +194,27 @@ cssPrefix: pf-c-form
   {{/form-group}}
 {{/form}}
 ```
-
+### Label with additional info
+```hbs
+{{#> form form--id="form-vertical"}}
+  {{#> form-group form-group--id="-name"}}
+    {{#> form-group-label form-group-label-info="true"}}
+      {{#> form-group-label-main}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
+          Name
+        {{/form-label}}
+        {{> form-group-label-help}}
+      {{/form-group-label-main}}
+      {{#> form-group-label-info}}
+        info
+      {{/form-group-label-info}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+{{/form}}
+```
 ### Action group
 ```hbs
 {{#> form}}
@@ -210,7 +230,6 @@ cssPrefix: pf-c-form
   {{/form-group}}
 {{/form}}
 ```
-
 ### Field groups
 ```hbs
 {{#> form form--id="form-expandable-field-groups"}}
@@ -542,6 +561,8 @@ cssPrefix: pf-c-form
 | `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
 | `.pf-c-form__label-text` | `<span>` |  Initiates a form label text. **Required** |
 | `.pf-c-form__label-required` | `<span>` |  Initiates a form label required indicator. |
+| `.pf-c-form__group-label-main` | `<div>` |  Initiates a form group main label container. |
+| `.pf-c-form__group-label-info` | `<div>` |  Initiates a form group info label. |
 | `.pf-c-form__group-label-help` | `<button>` | Initiates a field level help button. |
 | `.pf-c-form__group-control` | `<div>` |  Initiates a form group control section. |
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |
@@ -560,6 +581,7 @@ cssPrefix: pf-c-form
 | `.pf-c-form__field-group-header-actions` | `<div>` | Initiates the form field group actions container. |
 | `.pf-c-form__field-group-body` | `<div>` | Initiates the form field group body. |
 | `.pf-m-horizontal` | `.pf-c-form` | Modifies form for a horizontal layout. |
+| `.pf-m-info` | `.pf-c-form__group-label` | Modifies the form group label to contain form group label info. |
 | `.pf-m-action` | `.pf-c-form__group` | Modifies form group margin-top. |
 | `.pf-m-success` | `.pf-c-form__helper-text` | Modifies text color of helper text for success state. |
 | `.pf-m-warning` | `.pf-c-form__helper-text` | Modifies text color of helper text for warning state. |

--- a/src/patternfly/components/Form/form-group-label-info.hbs
+++ b/src/patternfly/components/Form/form-group-label-info.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-form__group-label-info{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
-  {{#if form-label--attribute}}
-    {{{form-label--attribute}}}
+<div class="pf-c-form__group-label-info{{#if form-group-label-info--modifier}} {{form-group-label-info--modifier}}{{/if}}"
+  {{#if form-group-label-info--attribute}}
+    {{{form-group-label-info--attribute}}}
   {{/if}}>
     {{>@partial-block}}
 </div>

--- a/src/patternfly/components/Form/form-group-label-info.hbs
+++ b/src/patternfly/components/Form/form-group-label-info.hbs
@@ -2,5 +2,5 @@
   {{#if form-group-label-info--attribute}}
     {{{form-group-label-info--attribute}}}
   {{/if}}>
-    {{>@partial-block}}
+  {{>@partial-block}}
 </div>

--- a/src/patternfly/components/Form/form-group-label-info.hbs
+++ b/src/patternfly/components/Form/form-group-label-info.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-form__group-label-info{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
+  {{#if form-label--attribute}}
+    {{{form-label--attribute}}}
+  {{/if}}>
+    {{>@partial-block}}
+</div>

--- a/src/patternfly/components/Form/form-group-label-main.hbs
+++ b/src/patternfly/components/Form/form-group-label-main.hbs
@@ -1,8 +1,6 @@
-<div class="pf-c-form__group-label-main{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
-  {{#if form-label--attribute}}
-    {{{form-label--attribute}}}
+<div class="pf-c-form__group-label-main{{#if form-group-label-main--modifier}} {{form-group-label-main--modifier}}{{/if}}"
+  {{#if form-group-label-main--attribute}}
+    {{{form-group-label-main--attribute}}}
   {{/if}}>
-  {{#> form-label}}
     {{>@partial-block}}
-  {{/form-label}}
 </div>

--- a/src/patternfly/components/Form/form-group-label-main.hbs
+++ b/src/patternfly/components/Form/form-group-label-main.hbs
@@ -1,0 +1,8 @@
+<div class="pf-c-form__group-label-main{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
+  {{#if form-label--attribute}}
+    {{{form-label--attribute}}}
+  {{/if}}>
+  {{#> form-label}}
+    {{>@partial-block}}
+  {{/form-label}}
+</div>

--- a/src/patternfly/components/Form/form-group-label-main.hbs
+++ b/src/patternfly/components/Form/form-group-label-main.hbs
@@ -2,5 +2,5 @@
   {{#if form-group-label-main--attribute}}
     {{{form-group-label-main--attribute}}}
   {{/if}}>
-    {{>@partial-block}}
+  {{>@partial-block}}
 </div>

--- a/src/patternfly/components/Form/form-group-label.hbs
+++ b/src/patternfly/components/Form/form-group-label.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-form__group-label{{#if form-group-label--modifier}} {{form-group-label--modifier}}{{/if}}"
+<div class="pf-c-form__group-label {{#if form-group-label-info}}pf-m-info{{/if}}{{#if form-group-label--modifier}} {{form-group-label--modifier}}{{/if}}"
   {{#if form-group-label--attribute}}
     {{{form-group-label--attribute}}}
   {{/if}}>
-  {{>@partial-block}}
+    {{>@partial-block}}  
 </div>

--- a/src/patternfly/components/Form/form-group-label.hbs
+++ b/src/patternfly/components/Form/form-group-label.hbs
@@ -2,5 +2,5 @@
   {{#if form-group-label--attribute}}
     {{{form-group-label--attribute}}}
   {{/if}}>
-    {{>@partial-block}}  
+  {{>@partial-block}}  
 </div>

--- a/src/patternfly/components/Form/form-group-label.hbs
+++ b/src/patternfly/components/Form/form-group-label.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-form__group-label {{#if form-group-label-info}}pf-m-info{{/if}}{{#if form-group-label--modifier}} {{form-group-label--modifier}}{{/if}}"
+<div class="pf-c-form__group-label{{#if form-group-label-info}} pf-m-info{{/if}}{{#if form-group-label--modifier}} {{form-group-label--modifier}}{{/if}}"
   {{#if form-group-label--attribute}}
     {{{form-group-label--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -42,6 +42,9 @@
   --pf-c-form__group-label-help--hover--Color: var(--pf-global--Color--100);
   --pf-c-form__group-label-help--focus--Color: var(--pf-global--Color--100);
 
+  // Form group label info
+  --pf-c-form__group-label-info--MarginLeft: var(--pf-global--spacer--sm);
+
   // Group control
   --pf-c-form__group-control--m-inline--child--MarginRight: var(--pf-global--spacer--lg);
   --pf-c-form__group-control__helper-text--MarginBottom: var(--pf-global--spacer--xs);
@@ -188,6 +191,18 @@
   --pf-c-form__helper-text--MarginTop: 0;
 
   padding-bottom: var(--pf-c-form__group-label--PaddingBottom);
+
+  &.pf-m-info {
+    display: flex;
+  }
+}
+
+.pf-c-form__group-label-main {
+  flex-grow: 1;
+}
+
+.pf-c-form__group-label-info {
+  margin-left: var(--pf-c-form__group-label-info--MarginLeft);
 }
 
 .pf-c-form__label {

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -44,6 +44,7 @@
 
   // Form group label info
   --pf-c-form__group-label-info--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-form__group-label-info--FontSize: var(--pf-global--FontSize--sm);
 
   // Group control
   --pf-c-form__group-control--m-inline--child--MarginRight: var(--pf-global--spacer--lg);
@@ -194,6 +195,7 @@
 
   &.pf-m-info {
     display: flex;
+    align-items: flex-end;
   }
 }
 
@@ -203,6 +205,7 @@
 
 .pf-c-form__group-label-info {
   margin-left: var(--pf-c-form__group-label-info--MarginLeft);
+  font-size: var(--pf-c-form__group-label-info--FontSize);
 }
 
 .pf-c-form__label {


### PR DESCRIPTION
This adds an optional main and info element within the form-group-label to position the contents of the info opposite the current label text. See it as the "Label with additional info" example on the form component.

Fixes #4171 