### PR TITLE
feat(sass): dynamically check whether math.div is defined

### DIFF
--- a/src/patternfly/sass-utilities/div.import.scss
+++ b/src/patternfly/sass-utilities/div.import.scss
@@ -1,3 +1,11 @@
 // This will only be imported by dart-sass thanks to the `.import` extension.
 // See https://github.com/patternfly/patternfly/issues/4096#issuecomment-859055362
-@forward "sass:math" show div;
+@use "sass:map";
+@use "sass:math";
+@use "sass:meta";
+
+$-use-math-div: map.has-key(meta.module-functions("math"), "div");
+
+@function div($number1, $number2) {
+  @return if($-use-math-div, math.div($number1, $number2), $number1 / $number2);
+}


### PR DESCRIPTION
In order to support older versions of dart sass.

Reason:
-----------

In cockpit we still include PF3 which in turn brings in bootstrap which is not compatible with dart sass. Therefore we are stuck with versoin "sass": "~1.32.0" which is the last without deprecation warnings about division which we don't have control over. (of course until we remove PF3 from out dependencies)

Without this fix when we update to newer PF ("@patternfly/patternfly": "4.115.2") we get the following error:
```
SassError: Undefined operation "div(div(1px, 1px), 16) * 1rem".
   ╷
12 │   @return div(pf-strip-unit($pxval), $base) * 1rem;
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  node_modules/@patternfly/patternfly/sass-utilities/functions.scss 12:11       pf-size-prem()
  node_modules/@patternfly/patternfly/sass-utilities/scss-variables.scss 94:30  @import
  node_modules/@patternfly/patternfly/sass-utilities/_all.scss 5:9              @import
  node_modules/@patternfly/patternfly/patternfly-base.scss 1:9  
```
With this fix it works fine. 