### PR TITLE
fix(spinner): hid overflow from rotating elements

### DIFF
--- a/src/patternfly/components/Spinner/spinner.scss
+++ b/src/patternfly/components/Spinner/spinner.scss
@@ -14,6 +14,7 @@
 
   width: var(--pf-c-spinner--Width);
   height: var(--pf-c-spinner--Height);
+  overflow: hidden;
 
   // Modifiers change the variables for size variations
   &.pf-m-sm {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4207

--

reproduce the issue by applying `overflow: auto;` to `ul.pf-c-select__menu` on https://patternfly-pr-4208.surge.sh/components/select#loading