### PR TITLE
feat: drop '?#iefix' for font face definitions

### DIFF
--- a/src/patternfly/assets/fonts/overpass-mono-webfont/overpass-mono.css
+++ b/src/patternfly/assets/fonts/overpass-mono-webfont/overpass-mono.css
@@ -3,7 +3,7 @@
 @font-face {
   font-family: 'overpass-mono';
   src: url('overpass-mono-light.eot');
-  src: url('overpass-mono-light.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-mono-light.eot') format('embedded-opentype'),
        url('overpass-mono-light.woff2') format('woff2'),
        url('overpass-mono-light.woff') format('woff'),
        url('overpass-mono-light.ttf')  format('truetype');
@@ -16,7 +16,7 @@
 @font-face {
   font-family: 'overpass-mono';
   src: url('overpass-mono-regular.eot');
-  src: url('overpass-mono-regular.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-mono-regular.eot') format('embedded-opentype'),
        url('overpass-mono-regular.woff2') format('woff2'),
        url('overpass-mono-regular.woff') format('woff'),
        url('overpass-mono-regular.ttf')  format('truetype');
@@ -29,7 +29,7 @@
 @font-face {
   font-family: 'overpass-mono';
   src: url('overpass-mono-semibold.eot');
-  src: url('overpass-mono-semibold.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-mono-semibold.eot') format('embedded-opentype'),
        url('overpass-mono-semibold.woff2') format('woff2'),
        url('overpass-mono-semibold.woff') format('woff'),
        url('overpass-mono-semibold.ttf')  format('truetype');
@@ -42,7 +42,7 @@
 @font-face {
   font-family: 'overpass-mono';
   src: url('overpass-mono-bold.eot');
-  src: url('overpass-mono-bold.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-mono-bold.eot') format('embedded-opentype'),
        url('overpass-mono-bold.woff2') format('woff2'),
        url('overpass-mono-bold.woff') format('woff'),
        url('overpass-mono-bold.ttf')  format('truetype');

--- a/src/patternfly/assets/fonts/overpass-webfont/overpass.css
+++ b/src/patternfly/assets/fonts/overpass-webfont/overpass.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-thin.eot');
-  src: url('overpass-thin.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-thin.eot') format('embedded-opentype'),
        url('overpass-thin.woff2') format('woff2'),
        url('overpass-thin.woff') format('woff'),
        url('overpass-thin.ttf')  format('truetype');
@@ -12,7 +12,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-thin-italic.eot');
-  src: url('overpass-thin-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-thin-italic.eot') format('embedded-opentype'),
        url('overpass-thin-italic.woff2') format('woff2'),
        url('overpass-thin-italic.woff') format('woff'),
        url('overpass-thin-italic.ttf')  format('truetype');
@@ -24,7 +24,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-extralight.eot');
-  src: url('overpass-extralight.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-extralight.eot') format('embedded-opentype'),
        url('overpass-extralight.woff2') format('woff2'),
        url('overpass-extralight.woff') format('woff'),
        url('overpass-extralight.ttf')  format('truetype');
@@ -35,7 +35,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-extralight-italic.eot');
-  src: url('overpass-extralight-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-extralight-italic.eot') format('embedded-opentype'),
        url('overpass-extralight-italic.woff2') format('woff2'),
        url('overpass-extralight-italic.woff') format('woff'),
        url('overpass-extralight-italic.ttf')  format('truetype');
@@ -48,7 +48,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-light.eot');
-  src: url('overpass-light.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-light.eot') format('embedded-opentype'),
        url('overpass-light.woff2') format('woff2'),
        url('overpass-light.woff') format('woff'),
        url('overpass-light.ttf')  format('truetype');
@@ -59,7 +59,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-light-italic.eot');
-  src: url('overpass-light-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-light-italic.eot') format('embedded-opentype'),
        url('overpass-light-italic.woff2') format('woff2'),
        url('overpass-light-italic.woff') format('woff'),
        url('overpass-light-italic.ttf')  format('truetype');
@@ -72,7 +72,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-regular.eot');
-  src: url('overpass-regular.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-regular.eot') format('embedded-opentype'),
        url('overpass-regular.woff2') format('woff2'),
        url('overpass-regular.woff') format('woff'),
        url('overpass-regular.ttf')  format('truetype');
@@ -83,7 +83,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-italic.eot');
-  src: url('overpass-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-italic.eot') format('embedded-opentype'),
        url('overpass-italic.woff2') format('woff2'),
        url('overpass-italic.woff') format('woff'),
        url('overpass-italic.ttf')  format('truetype');
@@ -97,7 +97,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-semibold.eot');
-  src: url('overpass-semibold.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-semibold.eot') format('embedded-opentype'),
        url('overpass-semibold.woff2') format('woff2'),
        url('overpass-semibold.woff') format('woff'),
        url('overpass-semibold.ttf')  format('truetype');
@@ -108,7 +108,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-semibold-italic.eot');
-  src: url('overpass-semibold-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-semibold-italic.eot') format('embedded-opentype'),
        url('overpass-semibold-italic.woff2') format('woff2'),
        url('overpass-semibold-italic.woff') format('woff'),
        url('overpass-semibold-italic.ttf')  format('truetype');
@@ -122,7 +122,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-bold.eot');
-  src: url('overpass-bold.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-bold.eot') format('embedded-opentype'),
        url('overpass-bold.woff2') format('woff2'),
        url('overpass-bold.woff') format('woff'),
        url('overpass-bold.ttf')  format('truetype');
@@ -133,7 +133,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-bold-italic.eot');
-  src: url('overpass-bold-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-bold-italic.eot') format('embedded-opentype'),
        url('overpass-bold-italic.woff2') format('woff2'),
        url('overpass-bold-italic.woff') format('woff'),
        url('overpass-bold-italic.ttf')  format('truetype');
@@ -146,7 +146,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-extrabold.eot');
-  src: url('overpass-extrabold.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-extrabold.eot') format('embedded-opentype'),
        url('overpass-extrabold.woff2') format('woff2'),
        url('overpass-extrabold.woff') format('woff'),
        url('overpass-extrabold.ttf')  format('truetype');
@@ -157,7 +157,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-extrabold-italic.eot');
-  src: url('overpass-extrabold-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-extrabold-italic.eot') format('embedded-opentype'),
        url('overpass-extrabold-italic.woff2') format('woff2'),
        url('overpass-extrabold-italic.woff') format('woff'),
        url('overpass-extrabold-italic.ttf')  format('truetype');
@@ -169,7 +169,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-heavy.eot');
-  src: url('overpass-heavy.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-heavy.eot') format('embedded-opentype'),
        url('overpass-heavy.woff2') format('woff2'),
        url('overpass-heavy.woff') format('woff'),
        url('overpass-heavy.ttf')  format('truetype');
@@ -180,7 +180,7 @@
 @font-face {
   font-family: 'overpass';
   src: url('overpass-heavy-italic.eot');
-  src: url('overpass-heavy-italic.eot?#iefix') format('embedded-opentype'),
+  src: url('overpass-heavy-italic.eot') format('embedded-opentype'),
        url('overpass-heavy-italic.woff2') format('woff2'),
        url('overpass-heavy-italic.woff') format('woff'),
        url('overpass-heavy-italic.ttf')  format('truetype');

--- a/src/patternfly/assets/pficon/pficon.scss
+++ b/src/patternfly/assets/pficon/pficon.scss
@@ -1,7 +1,7 @@
 @font-face {
 	font-family: "pficon";
 	src: url('#{$pf-global--fonticon-path}/pficon.eot');
-	src: url('#{$pf-global--fonticon-path}/pficon.eot?#iefix') format('eot'),
+	src: url('#{$pf-global--fonticon-path}/pficon.eot') format('eot'),
 		url('#{$pf-global--fonticon-path}/pficon.woff2') format('woff2'),
 		url('#{$pf-global--fonticon-path}/pficon.woff') format('woff'),
 		url('#{$pf-global--fonticon-path}/pficon.ttf') format('truetype'),

--- a/src/patternfly/base/_fa-icons.scss
+++ b/src/patternfly/base/_fa-icons.scss
@@ -14,7 +14,7 @@
       font-weight: 900;
       src: url("#{$fa-font-path}/fa-solid-900.eot");
       src:
-        url("#{$fa-font-path}/fa-solid-900.eot?#iefix") format("embedded-opentype"),
+        url("#{$fa-font-path}/fa-solid-900.eot") format("embedded-opentype"),
         url("#{$fa-font-path}/fa-solid-900.woff2") format("woff2"),
         url("#{$fa-font-path}/fa-solid-900.woff") format("woff"),
         url("#{$fa-font-path}/fa-solid-900.ttf") format("truetype"),

--- a/src/patternfly/base/_fonts.scss
+++ b/src/patternfly/base/_fonts.scss
@@ -9,7 +9,7 @@
 @font-face {
   font-family: "RedHatDisplay";
   src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Regular.eot");
-  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Regular.eot?#iefix") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Regular.woff") format("woff");
+  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Regular.eot") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Regular.woff") format("woff");
   font-style: normal;
   font-weight: 300;
   text-rendering: optimizeLegibility;
@@ -18,7 +18,7 @@
 @font-face {
   font-family: "RedHatDisplay";
   src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Medium.eot");
-  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Medium.eot?#iefix") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Medium.woff") format("woff");
+  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Medium.eot") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Medium.woff") format("woff");
   font-style: normal;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -27,7 +27,7 @@
 @font-face {
   font-family: "RedHatDisplay";
   src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Bold.eot");
-  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Bold.eot?#iefix") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Bold.woff") format("woff");
+  src: url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Bold.eot") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatDisplay/RedHatDisplay-Bold.woff") format("woff");
   font-style: normal;
   font-weight: 700;
   text-rendering: optimizeLegibility;
@@ -36,7 +36,7 @@
 @font-face {
   font-family: "RedHatText";
   src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Regular.eot");
-  src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Regular.eot?#iefix") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatText/RedHatText-Regular.woff") format("woff");
+  src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Regular.eot") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatText/RedHatText-Regular.woff") format("woff");
   font-style: normal;
   font-weight: 400;
   text-rendering: optimizeLegibility;
@@ -45,7 +45,7 @@
 @font-face {
   font-family: "RedHatText";
   src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Medium.eot");
-  src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Medium.eot?#iefix") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatText/RedHatText-Medium.woff") format("woff");
+  src: url("#{$pf-global--font-path}/RedHatText/RedHatText-Medium.eot") format("embedded-opentype"), url("#{$pf-global--font-path}/RedHatText/RedHatText-Medium.woff") format("woff");
   font-style: normal;
   font-weight: 700;
   text-rendering: optimizeLegibility;
@@ -60,7 +60,7 @@
     font-weight: 200;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.eot"); // IE9 Compat Modes
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin.ttf")  format("truetype"); // Safari, Android, iOS
@@ -72,7 +72,7 @@
     font-weight: 200;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-thin-italic.ttf")  format("truetype");
@@ -84,7 +84,7 @@
     font-weight: 300;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight.ttf")  format("truetype");
@@ -96,7 +96,7 @@
     font-weight: 300;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extralight-italic.ttf")  format("truetype");
@@ -108,7 +108,7 @@
     font-weight: 400;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-light.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-light.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-light.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light.ttf")  format("truetype");
@@ -120,7 +120,7 @@
     font-weight: 400;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-light-italic.ttf")  format("truetype");
@@ -132,7 +132,7 @@
     font-weight: 500;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-regular.ttf")  format("truetype");
@@ -144,7 +144,7 @@
     font-weight: 500;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-italic.ttf")  format("truetype");
@@ -156,7 +156,7 @@
     font-weight: 600;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold.ttf")  format("truetype");
@@ -168,7 +168,7 @@
     font-weight: 600;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-semibold-italic.ttf")  format("truetype");
@@ -180,7 +180,7 @@
     font-weight: 700;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold.ttf")  format("truetype");
@@ -192,7 +192,7 @@
     font-weight: 700;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-bold-italic.ttf")  format("truetype");
@@ -204,7 +204,7 @@
     font-weight: 800;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold.ttf")  format("truetype");
@@ -216,7 +216,7 @@
     font-weight: 800;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-extrabold-italic.ttf")  format("truetype");
@@ -228,7 +228,7 @@
     font-weight: 900;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy.ttf")  format("truetype");
@@ -240,7 +240,7 @@
     font-weight: 900;
     src: url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-webfont/overpass-heavy-italic.ttf")  format("truetype");
@@ -254,7 +254,7 @@
     font-weight: 300;
     src: url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-light.ttf")  format("truetype");
@@ -266,7 +266,7 @@
     font-weight: 400;
     src: url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-regular.ttf")  format("truetype");
@@ -278,7 +278,7 @@
     font-weight: 500;
     src: url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-semibold.ttf")  format("truetype");
@@ -290,7 +290,7 @@
     font-weight: 600;
     src: url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.eot");
     src:
-      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.eot?#iefix") format("embedded-opentype"),
+      url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.eot") format("embedded-opentype"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.woff2") format("woff2"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.woff") format("woff"),
       url("#{$pf-global--font-path}/overpass-mono-webfont/overpass-mono-bold.ttf")  format("truetype");


### PR DESCRIPTION
Removes the `?#iefix` suffix for loading `.eot` fonts, this is a workaround for Internet Explorer 8 and older to load [ensure fonts are loaded properly](https://stackoverflow.com/questions/14207425/css-font-face-iefix). This is no longer needed as this browser is not supported by Patternfly.

The motivation for removing this is that it causes [issues](https://github.com/evanw/esbuild/issues/826) with more modern bundlers such as Snowpack (which uses `esbuild` under the hood.