### PR TITLE
fix(a11y): fix for accessibility issue in nav section title

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -40,7 +40,7 @@ import './Navigation.css'
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
   {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title1"'}}
-    {{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
+    {{#> nav-section-title nav-section-title--attribute='id="grouped-title1" aria-label="grouped-title1"'}}
       Section title 1
     {{/nav-section-title}}
     {{#> nav-list}}
@@ -62,7 +62,7 @@ import './Navigation.css'
     {{/nav-list}}
   {{/nav-section}}
   {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title2"'}}
-    {{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
+    {{#> nav-section-title nav-section-title--attribute='id="grouped-title2" aria-label="grouped-title2"'}}
       Section title 2
     {{/nav-section-title}}
     {{#> nav-list}}


### PR DESCRIPTION
hi @mcoker, while working on the accessibility in a new keycloak-admin-ui, I have noticed accessibility issue "Hadings should not be empty" in the Nav component in the PF lib as follows. I used axe devtools chrome extension by deque to find this issue.
![keycloak-a11-issue](https://user-images.githubusercontent.com/4890675/125774999-c12fe846-2294-417c-b95f-3025cb9c79ce.png)

 I think I have found a fix for the issue by simply adding aria-label to nav section title as follows: 
![adding-aria-label-1](https://user-images.githubusercontent.com/4890675/125775195-4a94a5f3-85cb-4c24-8b44-6dff688c0ac4.png)

This fix will help us to remove the accessibility issue with the following result: 
![after-adding-aria-label-result-2](https://user-images.githubusercontent.com/4890675/125775289-b921703f-3b20-4a8f-ab57-b4629a20815b.png)

Please let me know if this fix will fix the issue or if you think there is an alternative way to fix it. Many thanks!
