### PR TITLE
feat(popover): add position options

### DIFF
--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -87,9 +87,9 @@ import './Popover.css'
 {{/popover}}
 ```
 
-### Left with start and end positions
+### Left with top and bottom positions
 ```hbs
-{{#> popover popover--modifier="pf-m-left pf-m-start" popover--attribute='aria-labelledby="popover-left-start-header" aria-describedby="popover-left-start-body"'}}
+{{#> popover popover--modifier="pf-m-left-top" popover--attribute='aria-labelledby="popover-left-start-header" aria-describedby="popover-left-start-body"'}}
   {{#> popover-content}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -106,7 +106,7 @@ import './Popover.css'
   {{/popover-content}}
 {{/popover}}
 <br />
-{{#> popover popover--modifier="pf-m-left pf-m-end" popover--attribute='aria-labelledby="popover-left-end-header" aria-describedby="popover-left-end-body"'}}
+{{#> popover popover--modifier="pf-m-left-bottom" popover--attribute='aria-labelledby="popover-left-end-header" aria-describedby="popover-left-end-body"'}}
   {{#> popover-content}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -124,9 +124,9 @@ import './Popover.css'
 {{/popover}}
 ```
 
-### Bottom with start and end positions
+### Bottom with left and right positions
 ```hbs
-{{#> popover popover--modifier="pf-m-bottom pf-m-start" popover--attribute='aria-labelledby="popover-bottom-start-header" aria-describedby="popover-bottom-start-body"'}}
+{{#> popover popover--modifier="pf-m-bottom-left" popover--attribute='aria-labelledby="popover-bottom-start-header" aria-describedby="popover-bottom-start-body"'}}
   {{#> popover-content}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -143,7 +143,7 @@ import './Popover.css'
   {{/popover-content}}
 {{/popover}}
 <br />
-{{#> popover popover--modifier="pf-m-bottom pf-m-end" popover--attribute='aria-labelledby="popover-bottom-end-header" aria-describedby="popover-bottom-end-body"'}}
+{{#> popover popover--modifier="pf-m-bottom-right" popover--attribute='aria-labelledby="popover-bottom-end-header" aria-describedby="popover-bottom-end-body"'}}
   {{#> popover-content}}
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -231,11 +231,9 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. See [title component](/documentation/core/components/title) for more info.|
 | `.pf-c-popover__body` | `<div>` |  The popover's body text. **Required** |
 | `.pf-c-popover__footer` | `<footer>` | Initiates a popover footer. |
-| `.pf-m-left` | `.pf-c-popover` | Positions the popover to the left of the element. |
-| `.pf-m-right` | `.pf-c-popover` | Positions the popover to the right of the element. |
-| `.pf-m-top` | `.pf-c-popover` | Positions the popover to the top of the element. |
-| `.pf-m-bottom` | `.pf-c-popover` | Positions the popover to the bottom of the element. |
-| `.pf-m-start` | `.pf-c-popover` | Positions the popover to the start of the element. |
-| `.pf-m-end` | `.pf-c-popover` | Positions the popover to the end of the element. |
+| `.pf-m-left{-top/bottom}` | `.pf-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}` | `.pf-c-popover` | Positions the popover to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}` | `.pf-c-popover` | Positions the popover to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}` | `.pf-c-popover` | Positions the popover to the bottom (or bottom left/bottom right) of the element. |
 | `.pf-m-no-padding` | `.pf-c-popover` | Removes the outer padding from the popover content. |
 | `.pf-m-width-auto` | `.pf-c-popover` | Allows popover width to be defined by the popover content. |

--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -87,6 +87,80 @@ import './Popover.css'
 {{/popover}}
 ```
 
+### Left with start and end positions
+```hbs
+{{#> popover popover--modifier="pf-m-left pf-m-start" popover--attribute='aria-labelledby="popover-left-start-header" aria-describedby="popover-left-start-body"'}}
+  {{#> popover-content}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-left-start-header"'}}
+        Popover header
+    {{/title}}
+    {{#> popover-body popover-body--attribute='id="popover-left-start-body"'}}
+      This popover is to the left and at the start position
+    {{/popover-body}}
+    {{#> popover-footer}}
+      Popover footer
+    {{/popover-footer}}
+  {{/popover-content}}
+{{/popover}}
+<br />
+{{#> popover popover--modifier="pf-m-left pf-m-end" popover--attribute='aria-labelledby="popover-left-end-header" aria-describedby="popover-left-end-body"'}}
+  {{#> popover-content}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-left-end-header"'}}
+        Popover header
+    {{/title}}
+    {{#> popover-body popover-body--attribute='id="popover-left-end-body"'}}
+      This popover is to the left and at the end position
+    {{/popover-body}}
+    {{#> popover-footer}}
+      Popover footer
+    {{/popover-footer}}
+  {{/popover-content}}
+{{/popover}}
+```
+
+### Bottom with start and end positions
+```hbs
+{{#> popover popover--modifier="pf-m-bottom pf-m-start" popover--attribute='aria-labelledby="popover-bottom-start-header" aria-describedby="popover-bottom-start-body"'}}
+  {{#> popover-content}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-bottom-start-header"'}}
+        Popover header
+    {{/title}}
+    {{#> popover-body popover-body--attribute='id="popover-bottom-start-body"'}}
+      This popover is to the bottom and at the start position
+    {{/popover-body}}
+    {{#> popover-footer}}
+      Popover footer
+    {{/popover-footer}}
+  {{/popover-content}}
+{{/popover}}
+<br />
+{{#> popover popover--modifier="pf-m-bottom pf-m-end" popover--attribute='aria-labelledby="popover-bottom-end-header" aria-describedby="popover-bottom-end-body"'}}
+  {{#> popover-content}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-bottom-end-header"'}}
+        Popover header
+    {{/title}}
+    {{#> popover-body popover-body--attribute='id="popover-bottom-end-body"'}}
+      This popover is to the bottom and at the end position
+    {{/popover-body}}
+    {{#> popover-footer}}
+      Popover footer
+    {{/popover-footer}}
+  {{/popover-content}}
+{{/popover}}
+```
+
 ### Without header/footer
 ```hbs
 {{#> popover popover--modifier="pf-m-right" popover--attribute='aria-label="Popover with no header example" aria-describedby="popover-no-header-body"'}}
@@ -161,5 +235,7 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-m-right` | `.pf-c-popover` | Positions the popover to the right of the element. |
 | `.pf-m-top` | `.pf-c-popover` | Positions the popover to the top of the element. |
 | `.pf-m-bottom` | `.pf-c-popover` | Positions the popover to the bottom of the element. |
+| `.pf-m-start` | `.pf-c-popover` | Positions the popover to the start of the element. |
+| `.pf-m-end` | `.pf-c-popover` | Positions the popover to the end of the element. |
 | `.pf-m-no-padding` | `.pf-c-popover` | Removes the outer padding from the popover content. |
 | `.pf-m-width-auto` | `.pf-c-popover` | Allows popover width to be defined by the popover content. |

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -29,6 +29,8 @@
   --pf-c-popover__arrow--m-left--TranslateX: 50%;
   --pf-c-popover__arrow--m-left--TranslateY: -50%;
   --pf-c-popover__arrow--m-left--Rotate: 45deg;
+  --pf-c-popover__arrow--m-start--Left: var(--pf-c-popover__arrow--Width);
+  --pf-c-popover__arrow--m-start--Top: var(--pf-c-popover__arrow--Height);
 
   // Close
   --pf-c-popover--c-button--MarginLeft: var(--pf-global--spacer--sm);
@@ -92,6 +94,36 @@
       top: 50%;
       left: 0;
       transform: translateX(var(--pf-c-popover__arrow--m-right--TranslateX)) translateY(var(--pf-c-popover__arrow--m-right--TranslateY)) rotate(var(--pf-c-popover__arrow--m-right--Rotate));
+    }
+  }
+
+  &.pf-m-left.pf-m-start,
+  &.pf-m-right.pf-m-start {
+    .pf-c-popover__arrow {
+      top: var(--pf-c-popover__arrow--m-start--Top);
+    }
+  }
+
+  &.pf-m-left.pf-m-end,
+  &.pf-m-right.pf-m-end {
+    .pf-c-popover__arrow {
+      top: auto;
+      bottom: 0;
+    }
+  }
+
+  &.pf-m-top.pf-m-start,
+  &.pf-m-bottom.pf-m-start {
+    .pf-c-popover__arrow {
+      left: var(--pf-c-popover__arrow--m-start--Left);
+    }
+  }
+
+  &.pf-m-top.pf-m-end,
+  &.pf-m-bottom.pf-m-end {
+    .pf-c-popover__arrow {
+      right: 0;
+      left: auto;
     }
   }
 }

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -29,8 +29,6 @@
   --pf-c-popover__arrow--m-left--TranslateX: 50%;
   --pf-c-popover__arrow--m-left--TranslateY: -50%;
   --pf-c-popover__arrow--m-left--Rotate: 45deg;
-  --pf-c-popover__arrow--m-start--Left: var(--pf-c-popover__arrow--Width);
-  --pf-c-popover__arrow--m-start--Top: var(--pf-c-popover__arrow--Height);
 
   // Close
   --pf-c-popover--c-button--MarginLeft: var(--pf-global--spacer--sm);
@@ -65,7 +63,9 @@
     --pf-c-popover--MaxWidth: none;
   }
 
-  &.pf-m-top {
+  &.pf-m-top,
+  &.pf-m-top-left,
+  &.pf-m-top-right {
     .pf-c-popover__arrow {
       bottom: 0;
       left: 50%;
@@ -73,7 +73,9 @@
     }
   }
 
-  &.pf-m-bottom {
+  &.pf-m-bottom,
+  &.pf-m-bottom-left,
+  &.pf-m-bottom-right {
     .pf-c-popover__arrow {
       top: 0;
       left: 50%;
@@ -81,7 +83,9 @@
     }
   }
 
-  &.pf-m-left {
+  &.pf-m-left,
+  &.pf-m-left-top,
+  &.pf-m-left-bottom {
     .pf-c-popover__arrow {
       top: 50%;
       right: 0;
@@ -89,7 +93,9 @@
     }
   }
 
-  &.pf-m-right {
+  &.pf-m-right,
+  &.pf-m-right-top,
+  &.pf-m-right-bottom {
     .pf-c-popover__arrow {
       top: 50%;
       left: 0;
@@ -97,30 +103,30 @@
     }
   }
 
-  &.pf-m-left.pf-m-start,
-  &.pf-m-right.pf-m-start {
+  &.pf-m-left-top,
+  &.pf-m-right-top {
     .pf-c-popover__arrow {
-      top: var(--pf-c-popover__arrow--m-start--Top);
+      top: var(--pf-c-popover__arrow--Height);
     }
   }
 
-  &.pf-m-left.pf-m-end,
-  &.pf-m-right.pf-m-end {
+  &.pf-m-left-bottom,
+  &.pf-m-right-bottom {
     .pf-c-popover__arrow {
       top: auto;
       bottom: 0;
     }
   }
 
-  &.pf-m-top.pf-m-start,
-  &.pf-m-bottom.pf-m-start {
+  &.pf-m-top-left,
+  &.pf-m-bottom-left {
     .pf-c-popover__arrow {
-      left: var(--pf-c-popover__arrow--m-start--Left);
+      left: var(--pf-c-popover__arrow--Width);
     }
   }
 
-  &.pf-m-top.pf-m-end,
-  &.pf-m-bottom.pf-m-end {
+  &.pf-m-top-right,
+  &.pf-m-bottom-right {
     .pf-c-popover__arrow {
       right: 0;
       left: auto;


### PR DESCRIPTION
This adds modifiers `.pf-m-start` and `.pf-m-end` to the popover in order to adjust the arrow when the position of the popover is at the start (top for left and right; left for top and bottom) and the end (bottom for left and right; right for top and bottom). 

Fixes #3930 