### PR TITLE
fix(form-group): updated form group role

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -46,7 +46,7 @@ cssPrefix: pf-c-form
       {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Textarea example"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
-  {{#> form-group form-group--id="-checkbox"}}
+  {{#> form-group form-group--IsCheckGroup="true" form-group--id="-checkbox"}}
     {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
       {{#> form-label}}
         Label (no top padding)
@@ -544,8 +544,10 @@ cssPrefix: pf-c-form
 | `aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` | Form fields with related `.pf-c-form__helper-text` require this attribute. Usage `<input aria-describedby="{helper_text_id}">`.  |
 | `aria-invalid="true" aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` |  When form validation fails `aria-describedby` is used to communicate the error to the user. These attributes need to be handled with Javascript so that `aria-describedby` only references help text that explains the error, and so that `aria-invalid="true"` is only present when validation fails. For proper styling of errors `aria-invalid="true"` is required. |
 | `aria-hidden="true"` | `.pf-c-form__label-required` |  Hides the required indicator from assistive technologies. |
+| `id` | `.pf-c-form__group-label` | Generates an `id` for use in the `aria-labelledby` attribute in a checkbox or radio form group. |
 | `id` | `.pf-c-form__field-group-title-text` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |
 | `id` | `.pf-c-form__field-group-toggle-button > button` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |
+| `aria-labelledby="{label id}"` | `.pf-c-form__group` | Provides an accessible label for the checkbox or radio field group. |
 | `aria-label` | `.pf-c-form__field-group-toggle-button > button` | Provides an accessible label for the field group toggle button. |
 | `aria-labelledby="{title id} {toggle button id}"` | `.pf-c-form__field-group-toggle-button > button` | Provides an accessible label for the field group toggle button. |
 | `aria-expanded="true/false"` | `.pf-c-form__field-group-toggle-button > button` | Indicates whether the field group body is visible or hidden. |
@@ -558,7 +560,7 @@ cssPrefix: pf-c-form
 | `.pf-c-form__section-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`, `<div>` |  Initiates a form section title. |
 | `.pf-c-form__group` | `<div>` |  Initiates a form group. |
 | `.pf-c-form__group-label` | `<div>` |  Initiates a form group label. |
-| `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
+| `.pf-c-form__label` | `<label>`, `<span>` |  Initiates a form label. **Required** |
 | `.pf-c-form__label-text` | `<span>` |  Initiates a form label text. **Required** |
 | `.pf-c-form__label-required` | `<span>` |  Initiates a form label required indicator. |
 | `.pf-c-form__group-label-main` | `<div>` |  Initiates a form group label main container. |

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -544,6 +544,8 @@ cssPrefix: pf-c-form
 | `aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` | Form fields with related `.pf-c-form__helper-text` require this attribute. Usage `<input aria-describedby="{helper_text_id}">`.  |
 | `aria-invalid="true" aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` |  When form validation fails `aria-describedby` is used to communicate the error to the user. These attributes need to be handled with Javascript so that `aria-describedby` only references help text that explains the error, and so that `aria-invalid="true"` is only present when validation fails. For proper styling of errors `aria-invalid="true"` is required. |
 | `aria-hidden="true"` | `.pf-c-form__label-required` |  Hides the required indicator from assistive technologies. |
+| `role="group"` | `.pf-c-form__group` | Provides group role for checkbox groups. **Required for checkbox groups** |
+| `role="radiogroup"` | `.pf-c-form__group` | Provides group role for radio input groups. **Required for radio input groups** |
 | `id` | `.pf-c-form__group-label` | Generates an `id` for use in the `aria-labelledby` attribute in a checkbox or radio form group. |
 | `id` | `.pf-c-form__field-group-title-text` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |
 | `id` | `.pf-c-form__field-group-toggle-button > button` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |

--- a/src/patternfly/components/Form/form-group-label.hbs
+++ b/src/patternfly/components/Form/form-group-label.hbs
@@ -1,6 +1,9 @@
 <div class="pf-c-form__group-label{{#if form-group-label-info}} pf-m-info{{/if}}{{#if form-group-label--modifier}} {{form-group-label--modifier}}{{/if}}"
+  {{~#if form-group--IsCheckGroup}}
+    id="{{form--id}}{{form-group--id}}-legend"
+  {{/if}}
   {{#if form-group-label--attribute}}
     {{{form-group-label--attribute}}}
   {{/if}}>
-  {{>@partial-block}}  
+  {{>@partial-block}}
 </div>

--- a/src/patternfly/components/Form/form-group.hbs
+++ b/src/patternfly/components/Form/form-group.hbs
@@ -1,4 +1,8 @@
 <div class="pf-c-form__group{{#if form-group--modifier}} {{form-group--modifier}}{{/if}}"
+  {{~#if form-group--IsCheckGroup}}
+    role="group"
+    aria-labelledby="{{form--id}}{{form-group--id}}-legend"
+  {{/if}}
   {{#if form-group--attribute}}
     {{{form-group--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Form/form-group.hbs
+++ b/src/patternfly/components/Form/form-group.hbs
@@ -1,6 +1,10 @@
 <div class="pf-c-form__group{{#if form-group--modifier}} {{form-group--modifier}}{{/if}}"
   {{~#if form-group--IsCheckGroup}}
-    role="group"
+    {{#if form-group--IsRadioGroup}}
+      role="radiogroup"
+    {{else}}
+      role="group"
+    {{/if}}
     aria-labelledby="{{form--id}}{{form-group--id}}-legend"
   {{/if}}
   {{#if form-group--attribute}}

--- a/src/patternfly/components/Form/form-label.hbs
+++ b/src/patternfly/components/Form/form-label.hbs
@@ -1,4 +1,4 @@
-<label class="pf-c-form__label{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
+<{{#if form-group--IsCheckGroup}}span{{else}}label{{/if}} class="pf-c-form__label{{#if form-label--modifier}} {{form-label--modifier}}{{/if}}"
   {{#if form-label--attribute}}
     {{{form-label--attribute}}}
   {{/if}}>
@@ -8,4 +8,4 @@
   {{#if required}}
     {{> form-label-required}}
   {{/if}}
-</label>
+</{{#if form-group--IsCheckGroup}}span{{else}}label{{/if}}>

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -31,7 +31,7 @@ wrapperTag: div
             {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
-          {{#> check}}
+            {{#> check}}
               {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
               {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
             {{/check}}
@@ -75,7 +75,7 @@ wrapperTag: div
             {{#> form-control controlType="input" input="true" form-control--attribute='required type="password" id="invalid-login-demo-form-password" name="invalid-login-demo-form-password" aria-invalid="true"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
-          {{#> check}}
+            {{#> check}}
               {{#> check-input check-input--attribute='type="checkbox" id="invalid-login-demo-checkbox" name="invalid-login-demo-checkbox"'}}{{/check-input}}
               {{#> check-label check-label--attribute='for="invalid-login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
             {{/check}}
@@ -124,7 +124,7 @@ wrapperTag: div
             {{/input-group}}
           {{/form-group}}
           {{#> form-group}}
-          {{#> check}}
+            {{#> check}}
               {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
               {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
             {{/check}}
@@ -173,7 +173,7 @@ wrapperTag: div
             {{/input-group}}
           {{/form-group}}
           {{#> form-group}}
-          {{#> check}}
+            {{#> check}}
               {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
               {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
             {{/check}}

--- a/src/patternfly/components/SearchInput/examples/SearchInput.md
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.md
@@ -85,15 +85,15 @@ import './SearchInput.css'
           {{/form-group-control}}
         {{/form-group}}
         {{#> form-group form-group--modifier="pf-m-action"}}
-        {{#> form-actions}}
-          {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Submit
-          {{/button}}
-          {{#> button button--modifier="pf-m-link" button--IsReset="true"}}
-            Reset
-          {{/button}}
-        {{/form-actions}}
-      {{/form-group}}
+          {{#> form-actions}}
+            {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+              Submit
+            {{/button}}
+            {{#> button button--modifier="pf-m-link" button--IsReset="true"}}
+              Reset
+            {{/button}}
+          {{/form-actions}}
+        {{/form-group}}
       {{/form}}
     {{/search-input-menu-body}}
   {{/search-input-menu}}

--- a/src/patternfly/demos/Alert/examples/horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/examples/horizontal-form.hbs
@@ -56,7 +56,7 @@
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
-    {{#> form-group}}
+    {{#> form-group form-group--IsCheckGroup="true" form-group--id="-check-group"}}
       {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id '-form-experience"') required='true'}}
           Your experience
@@ -69,7 +69,7 @@
             <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
           {{/form-helper-text-icon}}
             This is a requied field
-          {{/form-helper-text}}
+        {{/form-helper-text}}
         {{#> check}}
           {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox1" name="alt-form-checkbox1"'}}{{/check-input}}
           {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}

--- a/src/patternfly/demos/Alert/examples/stacked-form.hbs
+++ b/src/patternfly/demos/Alert/examples/stacked-form.hbs
@@ -62,7 +62,7 @@
         This is a required field
       {{/form-helper-text}}
     {{/form-group}}
-    {{#> form-group}}
+    {{#> form-group form-group--IsCheckGroup="true" form-group--id="-check-group"}}
       {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id '-form-experience"') required='true'}}
           How can we contact you?

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -39,15 +39,15 @@ section: components
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Email{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Phone{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Mail{{/check-label}}
       {{/check}}
     {{/form-group-control}}
@@ -105,16 +105,62 @@ section: components
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Email{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Phone{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
         {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Mail{{/check-label}}
+      {{/check}}
+    {{/form-group-control}}
+  {{/form-group}}
+  {{#> form-group form-group--modifier="pf-m-action"}}
+    {{#> form-group-control}}
+      {{#> form-actions}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+          Submit form
+        {{/button}}
+        {{#> button button--modifier="pf-m-link"}}
+          Cancel
+        {{/button}}
+      {{/form-actions}}
+    {{/form-group-control}}
+  {{/form-group}}
+{{/form}}
+```
+
+### Radio group
+```hbs
+{{#> form form--id="radio-group-example"}}
+  {{#> form-group form-group--id="-name"}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}{{/form-control}}
+      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Please provide your full name{{/form-helper-text}}
+    {{/form-group-control}}
+  {{/form-group}}
+  {{#> form-group form-group--IsCheckGroup="true" form-group--IsRadioGroup="true" form-group--id="-contact"}}
+    {{#> form-group-label}}
+      {{#> form-label}}Time zone{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
+      {{#> check}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '1" name="' form--id form-group--id '-radio"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Eastern{{/check-label}}
+      {{/check}}
+      {{#> check}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '2" name="' form--id form-group--id '-radio"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Central{{/check-label}}
+      {{/check}}
+      {{#> check}}
+        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '-radio"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Pacific{{/check-label}}
       {{/check}}
     {{/form-group-control}}
   {{/form-group}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -39,17 +39,36 @@ section: components
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '1" name="' form--id form-group--id '1"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Email{{/check-label}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '-check-1" name="' form--id form-group--id '-check-1"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '-check-1"')}}Email{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '2" name="' form--id form-group--id '2"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Phone{{/check-label}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '-check-2" name="' form--id form-group--id '-check-2"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '-check-2"')}}Phone{{/check-label}}
       {{/check}}
       {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '3" name="' form--id form-group--id '3"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Mail{{/check-label}}
+        {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '-check-3" name="' form--id form-group--id '-check-3"')}}{{/check-input}}
+        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '-check-3"')}}Mail{{/check-label}}
       {{/check}}
+    {{/form-group-control}}
+  {{/form-group}}
+  {{#> form-group form-group--IsCheckGroup="true" form-group--IsRadioGroup="true" form-group--id="-time-zone"}}
+    {{#> form-group-label}}
+      {{#> form-label}}Time zone{{/form-label}}
+    {{/form-group-label}}
+    {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
+      {{#> radio}}
+        {{#> radio-input radio-input--attribute=(concat 'id="' form--id form-group--id '-radio-1" name="' form--id form-group--id '-radio"')}}{{/radio-input}}
+        {{#> radio-label radio-label--attribute=(concat 'for="' form--id form-group--id '-radio-1"')}}Eastern{{/radio-label}}
+      {{/radio}}
+      {{#> radio}}
+        {{#> radio-input radio-input--attribute=(concat 'id="' form--id form-group--id '-radio-2" name="' form--id form-group--id '-radio"')}}{{/radio-input}}
+        {{#> radio-label radio-label--attribute=(concat 'for="' form--id form-group--id '-radio-2"')}}Central{{/radio-label}}
+      {{/radio}}
+      {{#> radio}}
+        {{#> radio-input radio-input--attribute=(concat 'id="' form--id form-group--id '-radio-3" name="' form--id form-group--id '-radio"')}}{{/radio-input}}
+        {{#> radio-label radio-label--attribute=(concat 'for="' form--id form-group--id '-radio-3"')}}Pacific{{/radio-label}}
+      {{/radio}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -152,52 +152,6 @@ section: components
 {{/form}}
 ```
 
-### Radio group
-```hbs
-{{#> form form--id="radio-group-example"}}
-  {{#> form-group form-group--id="-name"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}{{/form-control}}
-      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Please provide your full name{{/form-helper-text}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--IsCheckGroup="true" form-group--IsRadioGroup="true" form-group--id="-contact"}}
-    {{#> form-group-label}}
-      {{#> form-label}}Time zone{{/form-label}}
-    {{/form-group-label}}
-    {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
-      {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '1" name="' form--id form-group--id '-radio"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '1"')}}Eastern{{/check-label}}
-      {{/check}}
-      {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '2" name="' form--id form-group--id '-radio"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '2"')}}Central{{/check-label}}
-      {{/check}}
-      {{#> check}}
-        {{#> check-input check-input--attribute=(concat 'type="radio" id="' form--id form-group--id '3" name="' form--id form-group--id '-radio"')}}{{/check-input}}
-        {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '3"')}}Pacific{{/check-label}}
-      {{/check}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--modifier="pf-m-action"}}
-    {{#> form-group-control}}
-      {{#> form-actions}}
-        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-          Submit form
-        {{/button}}
-        {{#> button button--modifier="pf-m-link"}}
-          Cancel
-        {{/button}}
-      {{/form-actions}}
-    {{/form-group-control}}
-  {{/form-group}}
-{{/form}}
-```
-
 ### Grid
 ```hbs
 {{#> form form--id="form-demo-grid"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -33,7 +33,7 @@ section: components
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="tel" placeholder="Example, (555) 555-5555" id="' form--id form-group--id '" name="' form--id form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
-  {{#> form-group form-group--id="-contact"}}
+  {{#> form-group form-group--IsCheckGroup="true" form-group--id="-contact"}}
     {{#> form-group-label}}
       {{#> form-label}}How can we contact you?{{/form-label}}
     {{/form-group-label}}
@@ -98,7 +98,7 @@ section: components
       {{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
-   {{#> form-group form-group--id="-contact"}}
+   {{#> form-group form-group--IsCheckGroup="true" form-group--id="-contact"}}
     {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
       {{#> form-label }}How can we contact you?{{/form-label}}
       {{> form-group-label-help}}


### PR DESCRIPTION
fixes #4124 

Fix based on the guidance provided here: [associating-related-controls-with-wai-aria](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria)

Using the `<fieldset>` element with grid worked for formatting, although I'm not sure if it loses semantic value in doing so. It looks like, based on [this description](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#styling_with_css), that it's acceptable to use. What didn't work well was the `<legend>` element, which is only display block. Using this breaks the `required` and/or `helper` concept layouts.  