### PR TITLE
fix(number-input): adjust alignment

### DIFF
--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -36,5 +36,6 @@
 }
 
 .pf-c-number-input__icon {
+  display: flex;
   font-size: var(--pf-c-number-input__icon--FontSize);
 }


### PR DESCRIPTION
This adjusts the vertical alignment of the number input. Screen shot shows old and new alignment in Chrome and Firefox.

![image](https://user-images.githubusercontent.com/19825616/127921400-13043aac-1ade-4063-a530-94b685d708b7.png)

@KKoukiou does this look better to you?

Fixes #4189 