### PR TITLE
[WIP] Text and background color utilities

### DIFF
--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -73,8 +73,12 @@
   --pf-c-alert--m-inline--m-info--BackgroundColor: var(--pf-global--palette--blue-50);
 
   // Inline plain
-  --pf-c-alert--m-inline--m-plain--BorderTopColor: transparent;
+  --pf-c-alert--m-inline--m-plain--BorderTopWidth: 0;
   --pf-c-alert--m-inline--m-plain--BackgroundColor: transparent;
+  --pf-c-alert--m-inline--m-plain--PaddingTop: 0;
+  --pf-c-alert--m-inline--m-plain--PaddingRight: 0;
+  --pf-c-alert--m-inline--m-plain--PaddingBottom: 0;
+  --pf-c-alert--m-inline--m-plain--PaddingLeft: 0;
 
   @include pf-t-light; // This component always needs to be light
 
@@ -125,8 +129,13 @@
   }
 
   &.pf-m-plain {
-    --pf-c-alert--BorderTopColor: var(--pf-c-alert--m-inline--m-plain--BorderTopColor);
+    border-top-width: var(--pf-c-alert--m-inline--m-plain--BorderTopWidth);
+
     --pf-c-alert--BackgroundColor: var(--pf-c-alert--m-inline--m-plain--BackgroundColor);
+    --pf-c-alert--PaddingTop: var(--pf-c-alert--m-inline--m-plain--PaddingTop);
+    --pf-c-alert--PaddingRight: var(--pf-c-alert--m-inline--m-plain--PaddingRight);
+    --pf-c-alert--PaddingBottom: var(--pf-c-alert--m-inline--m-plain--PaddingBottom);
+    --pf-c-alert--PaddingLeft: var(--pf-c-alert--m-inline--m-plain--PaddingLeft);
   }
 }
 

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -73,12 +73,8 @@
   --pf-c-alert--m-inline--m-info--BackgroundColor: var(--pf-global--palette--blue-50);
 
   // Inline plain
-  --pf-c-alert--m-inline--m-plain--BorderTopWidth: 0;
+  --pf-c-alert--m-inline--m-plain--BorderTopColor: transparent;
   --pf-c-alert--m-inline--m-plain--BackgroundColor: transparent;
-  --pf-c-alert--m-inline--m-plain--PaddingTop: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingRight: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingBottom: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingLeft: 0;
 
   @include pf-t-light; // This component always needs to be light
 
@@ -129,12 +125,8 @@
   }
 
   &.pf-m-plain {
-    --pf-c-alert--BorderTopWidth: var(--pf-c-alert--m-inline--m-plain--BorderTopWidth);
+    --pf-c-alert--BorderTopColor: var(--pf-c-alert--m-inline--m-plain--BorderTopColor);
     --pf-c-alert--BackgroundColor: var(--pf-c-alert--m-inline--m-plain--BackgroundColor);
-    --pf-c-alert--PaddingTop: var(--pf-c-alert--m-inline--m-plain--PaddingTop);
-    --pf-c-alert--PaddingRight: var(--pf-c-alert--m-inline--m-plain--PaddingRight);
-    --pf-c-alert--PaddingBottom: var(--pf-c-alert--m-inline--m-plain--PaddingBottom);
-    --pf-c-alert--PaddingLeft: var(--pf-c-alert--m-inline--m-plain--PaddingLeft);
   }
 }
 

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -129,8 +129,7 @@
   }
 
   &.pf-m-plain {
-    border-top-width: var(--pf-c-alert--m-inline--m-plain--BorderTopWidth);
-
+    --pf-c-alert--BorderTopWidth: var(--pf-c-alert--m-inline--m-plain--BorderTopWidth);
     --pf-c-alert--BackgroundColor: var(--pf-c-alert--m-inline--m-plain--BackgroundColor);
     --pf-c-alert--PaddingTop: var(--pf-c-alert--m-inline--m-plain--PaddingTop);
     --pf-c-alert--PaddingRight: var(--pf-c-alert--m-inline--m-plain--PaddingRight);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -72,14 +72,6 @@
   // Inline info
   --pf-c-alert--m-inline--m-info--BackgroundColor: var(--pf-global--palette--blue-50);
 
-  // Inline plain
-  --pf-c-alert--m-inline--m-plain--BorderTopWidth: 0;
-  --pf-c-alert--m-inline--m-plain--BackgroundColor: transparent;
-  --pf-c-alert--m-inline--m-plain--PaddingTop: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingRight: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingBottom: 0;
-  --pf-c-alert--m-inline--m-plain--PaddingLeft: 0;
-
   @include pf-t-light; // This component always needs to be light
 
   position: relative;
@@ -126,15 +118,6 @@
   &.pf-m-inline {
     --pf-c-alert--BoxShadow: var(--pf-c-alert--m-inline--BoxShadow);
     --pf-c-alert--BackgroundColor: var(--pf-c-alert--m-inline--BackgroundColor);
-  }
-
-  &.pf-m-plain {
-    --pf-c-alert--BorderTopWidth: var(--pf-c-alert--m-inline--m-plain--BorderTopWidth);
-    --pf-c-alert--BackgroundColor: var(--pf-c-alert--m-inline--m-plain--BackgroundColor);
-    --pf-c-alert--PaddingTop: var(--pf-c-alert--m-inline--m-plain--PaddingTop);
-    --pf-c-alert--PaddingRight: var(--pf-c-alert--m-inline--m-plain--PaddingRight);
-    --pf-c-alert--PaddingBottom: var(--pf-c-alert--m-inline--m-plain--PaddingBottom);
-    --pf-c-alert--PaddingLeft: var(--pf-c-alert--m-inline--m-plain--PaddingLeft);
   }
 }
 

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -213,6 +213,15 @@ cssPrefix: pf-c-alert
     Danger inline alert title
   {{/alert-title}}
 {{/alert}}
+<br>
+{{#> alert alert--modifier="pf-m-info pf-m-plain pf-m-inline" alert--attribute='aria-label="Inline plain alert"'}}
+  {{#> alert-icon alert-icon--type="info-circle"}}
+  {{/alert-icon}}
+  {{#> alert-title}}
+    {{#> screen-reader}}Info alert:{{/screen-reader}}
+    Plain inline info alert title
+  {{/alert-title}}
+{{/alert}}
 ```
 
 ### Inline variations

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -312,18 +312,6 @@ cssPrefix: pf-c-alert
 {{/alert}}
 ```
 
-### Inline plain
-```hbs
-{{#> alert alert--modifier="pf-m-success pf-m-plain pf-m-inline" alert--attribute='aria-label="Success alert"'}}
-  {{#> alert-icon alert-icon--type="check-circle"}}
-  {{/alert-icon}}
-  {{#> alert-title}}
-    {{#> screen-reader}}Success alert:{{/screen-reader}}
-    Success alert title
-  {{/alert-title}}
-{{/alert}}
-```
-
 ## Documentation
 ### Overview
 Add a modifier class to the default alert to change the color: `.pf-m-success`, `.pf-m-danger`, `.pf-m-warning`, or `.pf-m-info`.
@@ -357,5 +345,4 @@ Add a modifier class to the default alert to change the color: `.pf-m-success`, 
 | `.pf-m-warning` | `.pf-c-alert` |  Applies warning styling. |
 | `.pf-m-info` | `.pf-c-alert` |  Applies info styling. |
 | `.pf-m-inline` | `.pf-c-alert` |  Applies inline styling. |
-| `.pf-m-plain` | `.pf-c-alert.pf-m-inline` |  Applies plain styling to an inline alert. |
 | `.pf-m-truncate` | `.pf-c-alert__title` |  Modifies the title to display a single line and truncate any overflow text with ellipses. **Note:** you can specify the max number of lines to show by setting the `--pf-c-alert__title--max-lines` (the default value is `1`). |

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -213,15 +213,6 @@ cssPrefix: pf-c-alert
     Danger inline alert title
   {{/alert-title}}
 {{/alert}}
-<br>
-{{#> alert alert--modifier="pf-m-info pf-m-plain pf-m-inline" alert--attribute='aria-label="Inline plain alert"'}}
-  {{#> alert-icon alert-icon--type="info-circle"}}
-  {{/alert-icon}}
-  {{#> alert-title}}
-    {{#> screen-reader}}Info alert:{{/screen-reader}}
-    Plain inline info alert title
-  {{/alert-title}}
-{{/alert}}
 ```
 
 ### Inline variations

--- a/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
+++ b/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
@@ -19,9 +19,25 @@ $pf-u-background-color-options: (
   ),
   background-color-dark-400: (
     background-color var(--pf-global--BackgroundColor--dark-400)
+  ),
+  background-color-danger: (
+    background-color var(--pf-global--palette--red-50)
+  ),
+  background-color-default: (
+    background-color var(--pf-global--palette--cyan-50)
+  ),
+  background-color-info: (
+    background-color var(--pf-global--palette--blue-50)
+  ),
+  background-color-success: (
+    background-color var(--pf-global--palette--green-50)
+  ),
+  background-color-warning: (
+    background-color var(--pf-global--palette--gold-50)
   )
 );
 
 @include pf-utility-builder($pf-u-background-color-options, $pf-global--breakpoint-list);
 
 // stylelint-enable
+

--- a/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
+++ b/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
@@ -8,6 +8,15 @@ $pf-u-background-color-options: (
   background-color-200: (
     background-color var(--pf-global--BackgroundColor--200)
   ),
+  background-color-active-color-100: (
+    background-color var(--pf-global--active-color--100)
+  ),
+  background-color-active-color-300: (
+    background-color var(--pf-global--active-color--300)
+  ),
+  background-color-primary-color-200: (
+    background-color var(--pf-global--primary-color--100)
+  ),
   background-color-dark-100: (
     background-color var(--pf-global--BackgroundColor--dark-100)
   ),
@@ -19,6 +28,12 @@ $pf-u-background-color-options: (
   ),
   background-color-dark-400: (
     background-color var(--pf-global--BackgroundColor--dark-400)
+  ),
+  background-color-disabled-200: (
+    background-color var(--pf-global--disabled-color--200)
+  ),
+  background-color-disabled-300: (
+    background-color var(--pf-global--disabled-color--300)
   ),
   background-color-danger: (
     background-color var(--pf-global--palette--red-50)

--- a/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
+++ b/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
@@ -6,7 +6,7 @@ beta: true
 
 ## Examples
 
-### White
+### Standard background colors
 
 ```hbs
 <div class="pf-u-background-color-100">
@@ -14,11 +14,7 @@ beta: true
     Background Color 100
   {{/background-color}}
 </div>
-```
-
-### Gray
-
-```hbs
+<br/>
 <div class="pf-u-background-color-200">
 {{#> background-color}}
   Background Color 200
@@ -26,50 +22,72 @@ beta: true
 </div>
 ```
 
-### Dark 100
+### Inverse background colors
 
 ```hbs
 <div class="pf-u-background-color-dark-100">
   {{#> background-color }}
-    {{#> text text--modifier="pf-u-color-400" }}
+    {{#> text text--modifier="pf-u-color-light-200" }}
     Background Color Dark 100
     {{/text}}
   {{/background-color}}
 </div>
-```
-
-### Dark 200
-
-```hbs
+<br/>
 <div class="pf-u-background-color-dark-200">
   {{#> background-color }}
-    {{#> text text--modifier="pf-u-color-400" }}
+    {{#> text text--modifier="pf-u-color-light-200" }}
     Background Color Dark 200
     {{/text}}
   {{/background-color}}
 </div>
-```
-
-### Dark 300
-
-```hbs
+<br/>
 <div class="pf-u-background-color-dark-300">
   {{#> background-color}}
-    {{#> text text--modifier="pf-u-color-400" }}
+    {{#> text text--modifier="pf-u-color-light-200" }}
     Background Color Dark 300
+    {{/text}}
+  {{/background-color}}
+</div>
+<br/>
+
+<div class="pf-u-background-color-dark-400">
+  {{#> background-color}}
+    {{#> text text--modifier="pf-u-color-light-200" }}
+    Background Color Dark 400
     {{/text}}
   {{/background-color}}
 </div>
 ```
 
-### Dark 400
-
+### Status and state background colors
 ```hbs
-<div class="pf-u-background-color-dark-400">
+<div class="pf-u-background-color-default">
   {{#> background-color}}
-    {{#> text text--modifier="pf-u-color-400" }}
-    Background Color Dark 400
-    {{/text}}
+    Background Color Default
+  {{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-success">
+  {{#> background-color}}
+    Background Color Success
+  {{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-info">
+  {{#> background-color}}
+    Background Color Info
+  {{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-warning">
+  {{#> background-color}}
+    Background Color Warning
+  {{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-danger">
+  {{#> background-color}}
+    Background Color Danger
   {{/background-color}}
 </div>
 ```
@@ -80,6 +98,9 @@ beta: true
 
 Background color utility
 
+Care should be taken especially when applying text colors, as this can have a negative affect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+
+Note that "inverse" background colors are labelled as such to indicate that they are best used with the ["inverse" text colors](http://localhost:8001/utilities/text#inverse-colors). 
 ### Usage
 
 | Class                             | Applied to | Outcome                            |
@@ -90,3 +111,8 @@ Background color utility
 | `.pf-u-background-color-dark-200` | `*`        | Applies background-color-dark 200. |
 | `.pf-u-background-color-dark-300` | `*`        | Applies background-color-dark 300. |
 | `.pf-u-background-color-dark-400` | `*`        | Applies background-color-dark 200. |
+| `.pf-u-background-color-default`  | `*`        | Applies background-color-default.  |
+| `.pf-u-background-color-success`  | `*`        | Applies background-color-success.  |
+| `.pf-u-background-color-info`     | `*`        | Applies background-color-info.     |
+| `.pf-u-background-color-warning`  | `*`        | Applies background-color-warning.  |
+| `.pf-u-background-color-danger`   | `*`        | Applies background-color-danger.   |

--- a/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
+++ b/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
@@ -20,6 +20,30 @@ beta: true
   Background Color 200
 {{/background-color}}
 </div>
+<br/>
+<div class="pf-u-background-color-active-color-100">
+{{#> background-color}}
+  {{#> text text--modifier="pf-u-color-light-200" }}
+    Active Color 100
+  {{/text}}
+{{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-active-color-300">
+{{#> background-color}}
+  {{#> text text--modifier="pf-u-color-light-200" }}
+    Active Color 300
+  {{/text}}
+{{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-primary-color-200">
+{{#> background-color}}
+  {{#> text text--modifier="pf-u-color-light-200" }}
+    Primary Color 200
+  {{/text}}
+{{/background-color}}
+</div>
 ```
 
 ### Inverse background colors
@@ -55,6 +79,22 @@ beta: true
     {{#> text text--modifier="pf-u-color-light-200" }}
     Background Color Dark 400
     {{/text}}
+  {{/background-color}}
+</div>
+```
+
+### Disabled background colors
+
+```hbs
+<div class="pf-u-background-color-disabled-200">
+  {{#> background-color }}
+    Background Color Disabled 200
+  {{/background-color}}
+</div>
+<br/>
+<div class="pf-u-background-color-disabled-300">
+  {{#> background-color}}
+    Background Color Disabled 300
   {{/background-color}}
 </div>
 ```
@@ -96,23 +136,25 @@ beta: true
 
 ### Overview
 
-Background color utility
+These background color utilities can be used to modify the background color of an element. In most cases, using the components with available modifiers should be sufficient to implement most designs, and should be preferred over customizations using these utilities.
 
-Care should be taken especially when applying text colors, as this can have a negative affect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+Care should be taken especially when applying background colors, as this can have a negative effect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
 
-Note that "inverse" background colors are labelled as such to indicate that they are best used with the ["inverse" text colors](http://localhost:8001/utilities/text#inverse-colors). 
+Note that "inverse" background colors are labeled as such to indicate that they are best used with the ["inverse" text colors](http://localhost:8001/utilities/text#inverse-colors). 
 ### Usage
 
 | Class                             | Applied to | Outcome                            |
 | --------------------------------- | ---------- | ---------------------------------- |
-| `.pf-u-background-color-100`      | `*`        | Applies background-color 100.      |
-| `.pf-u-background-color-200`      | `*`        | Applies background-color 200.      |
-| `.pf-u-background-color-dark-100` | `*`        | Applies background-color-dark 100. |
-| `.pf-u-background-color-dark-200` | `*`        | Applies background-color-dark 200. |
-| `.pf-u-background-color-dark-300` | `*`        | Applies background-color-dark 300. |
-| `.pf-u-background-color-dark-400` | `*`        | Applies background-color-dark 200. |
-| `.pf-u-background-color-default`  | `*`        | Applies background-color-default.  |
-| `.pf-u-background-color-success`  | `*`        | Applies background-color-success.  |
-| `.pf-u-background-color-info`     | `*`        | Applies background-color-info.     |
-| `.pf-u-background-color-warning`  | `*`        | Applies background-color-warning.  |
-| `.pf-u-background-color-danger`   | `*`        | Applies background-color-danger.   |
+| `.pf-u-background-color-100`      | `*`        | Applies background color 100.      |
+| `.pf-u-background-color-200`      | `*`        | Applies background color 200.      |
+| `.pf-u-background-color-dark-100` | `*`        | Applies background color dark 100. |
+| `.pf-u-background-color-dark-200` | `*`        | Applies background color dark 200. |
+| `.pf-u-background-color-dark-300` | `*`        | Applies background color dark 300. |
+| `.pf-u-background-color-dark-400` | `*`        | Applies background color dark 200. |
+| `.pf-u-background-color-disabled-200` | `*`        | Applies background color disabled 200. |
+| `.pf-u-background-color-disabled-300` | `*`        | Applies background color disabled 300. |
+| `.pf-u-background-color-default`  | `*`        | Applies the background color for the default state.  |
+| `.pf-u-background-color-success`  | `*`        | Applies the background color for the success state.  |
+| `.pf-u-background-color-info`     | `*`        | Applies the background color for the info state.     |
+| `.pf-u-background-color-warning`  | `*`        | Applies the background color for the warning state.  |
+| `.pf-u-background-color-danger`   | `*`        | Applies the background color for the danger state.   |

--- a/src/patternfly/utilities/Text/examples/Text.md
+++ b/src/patternfly/utilities/Text/examples/Text.md
@@ -64,9 +64,15 @@ import './Text.css'
 {{#> text text--modifier="pf-u-color-400"}}
   Font color 400
 {{/text}}
-<!-- {{#> text text--modifier="pf-u-color-link"}}
-  Link color
-{{/text}} -->
+{{#> text text--modifier="pf-u-active-color-100"}}
+  Active color 100
+{{/text}}
+{{#> text text--modifier="pf-u-active-color-400"}}
+  Active color 400
+{{/text}}
+{{#> text text--modifier="pf-u-primary-color-100"}}
+  Primary color 100
+{{/text}}
 ```
 ### Inverse colors
 ```hbs
@@ -79,7 +85,33 @@ import './Text.css'
   {{/text}}
 </div>
 ```
-### State/status text colors
+### Link colors
+```hbs
+  {{#> text text--modifier="pf-u-link-color"}}
+    Link color
+  {{/text}}
+  {{#> text text--modifier="pf-u-link-color-hover"}}
+    Hover link color
+  {{/text}}
+<div class="pf-u-background-color-dark-400">
+  {{#> text text--modifier="pf-u-link-color-light"}}
+    Light link color
+  {{/text}}
+  {{#> text text--modifier="pf-u-link-color-light-hover"}}
+    Light, hover link color
+  {{/text}}
+</div>
+  {{#> text text--modifier="pf-u-link-color-dark"}}
+    Dark link color
+  {{/text}}
+  {{#> text text--modifier="pf-u-link-color-dark-hover"}}
+    Dark, hover link color
+  {{/text}}
+  {{#> text text--modifier="pf-u-link-color-visited"}}
+    Visited link color
+  {{/text}}
+```
+### Status and state text colors
 ```hbs
 {{#> text text--modifier="pf-u-default-color-100"}}
   Font color default 100
@@ -125,9 +157,6 @@ import './Text.css'
 {{/text}}
 {{#> text text--modifier="pf-u-disabled-color-200"}}
   Font color disabled 200
-{{/text}}
-{{#> text text--modifier="pf-u-disabled-color-300"}}
-  Font color disabled 300
 {{/text}}
 ```
 
@@ -177,9 +206,9 @@ import './Text.css'
 
 These text utilities can be used to modify text within the PatternFly framework. In most cases, using the components with available modifiers should be sufficient to implement most designs, and should be preferred over customizations using these utilities.
 
-Care should be taken especially when applying text colors, as this can have a negative affect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+Care should be taken especially when applying text colors, as this can have a negative effect on the readability and accessibility of text. Refer to the information on [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
 
-Note that "inverse" colors are labeled as such to indicate that they best used with the "inverse" background colors. 
+Note that "inverse" text colors are labeled as such to indicate that they best used with the ["inverse" background colors](http://localhost:8001/utilities/background-color). 
 
 ### Usage
 
@@ -200,19 +229,18 @@ Note that "inverse" colors are labeled as such to indicate that they best used w
 | `.pf-u-color-200`           | `*`        | Sets font-color to Color 200           |
 | `.pf-u-color-300`           | `*`        | Sets font-color to Color 300           |
 | `.pf-u-color-400`           | `*`        | Sets font-color to Color 400           |
-| `.pf-u-icon-color-light`    | `*`        | Sets font-color to Icon Color Light    |
-| `.pf-u-icon-color-dark`     | `*`        | Sets font-color to Icon Color Dark     |
-| `.pf-u-link-color`          | `*`        | Sets font-color to Link Color          |
 | `.pf-u-active-color-100`    | `*`        | Sets font-color to Active Color 100    |
-| `.pf-u-active-color-200`    | `*`        | Sets font-color to Active Color 200    |
-| `.pf-u-active-color-300`    | `*`        | Sets font-color to Active Color 300    |
 | `.pf-u-active-color-400`    | `*`        | Sets font-color to Active Color 400    |
-| `.pf-u-disabled-color-100`  | `*`        | Sets font-color to Disabled Color 100  |
-| `.pf-u-disabled-color-200`  | `*`        | Sets font-color to Disabled Color 200  |
-| `.pf-u-disabled-color-300`  | `*`        | Sets font-color to Disabled Color 300  |
 | `.pf-u-primary-color-100`   | `*`        | Sets font-color to Primary Color 100   |
-| `.pf-u-primary-color-200`   | `*`        | Sets font-color to Primary Color 200   |
-| `.pf-u-secondary-color-100` | `*`        | Sets font-color to Secondary Color 100 |
+| `.pf-u-color-light-100`     | `*`        | Sets font-color to Light Color 100     |
+| `.pf-u-color-light-200`     | `*`        | Sets font-color to Light Color 200     |
+| `.pf-u-link-color`          | `*`        | Sets font-color to Link Color          |
+| `.pf-u-link-color-hover`    | `*`        | Sets font-color to Hover Link Color    |
+| `.pf-u-link-color-light`    | `*`        | Sets font-color to Light Link Color    |
+| `.pf-u-link-color-light-hover`| `*`      | Sets font-color to Light Hover Link Color|
+| `.pf-u-link-color-dark`     | `*`        | Sets font-color to Dark Link Color     |
+| `.pf-u-link-color-dark-hover`| `*`       | Sets font-color to Dark Hover Link Color|
+| `.pf-u-link-color-visited`  | `*`        | Sets font-color to Visited Link Color  |
 | `.pf-u-default-color-100`   | `*`        | Sets font-color to Default Color 100   |
 | `.pf-u-default-color-200`   | `*`        | Sets font-color to Default Color 200   |
 | `.pf-u-default-color-300`   | `*`        | Sets font-color to Default Color 300   |
@@ -225,6 +253,10 @@ Note that "inverse" colors are labeled as such to indicate that they best used w
 | `.pf-u-danger-color-100`    | `*`        | Sets font-color to Danger Color 100    |
 | `.pf-u-danger-color-200`    | `*`        | Sets font-color to Danger Color 200    |
 | `.pf-u-danger-color-300`    | `*`        | Sets font-color to Danger Color 300    |
+| `.pf-u-disabled-color-100`  | `*`        | Sets font-color to Disabled Color 100  |
+| `.pf-u-disabled-color-200`  | `*`        | Sets font-color to Disabled Color 200  |
+| `.pf-u-icon-color-light`    | `*`        | Sets font-color to Icon Color Light    |
+| `.pf-u-icon-color-dark`     | `*`        | Sets font-color to Icon Color Dark     |
 | `.pf-u-text-break-word`     | `*`        | Sets word-break to break-word          |
 | `.pf-u-text-nowrap`         | `*`        | Sets white-space to nowrap             |
 | `.pf-u-text-wrap`           | `*`        | Sets white-space to normal             |

--- a/src/patternfly/utilities/Text/examples/Text.md
+++ b/src/patternfly/utilities/Text/examples/Text.md
@@ -50,9 +50,7 @@ import './Text.css'
   Bold
 {{/text}}
 ```
-
-### Color
-
+### Standard colors
 ```hbs
 {{#> text text--modifier="pf-u-color-100"}}
   Font color 100
@@ -65,6 +63,81 @@ import './Text.css'
 {{/text}}
 {{#> text text--modifier="pf-u-color-400"}}
   Font color 400
+{{/text}}
+<!-- {{#> text text--modifier="pf-u-color-link"}}
+  Link color
+{{/text}} -->
+```
+### Inverse colors
+```hbs
+<div class="pf-u-background-color-dark-400">
+  {{#> text text--modifier="pf-u-color-light-100"}}
+    Font color light 100
+  {{/text}}
+  {{#> text text--modifier="pf-u-color-light-200"}}
+    Font color light 200
+  {{/text}}
+</div>
+```
+### State/status text colors
+```hbs
+{{#> text text--modifier="pf-u-default-color-100"}}
+  Font color default 100
+{{/text}}
+{{#> text text--modifier="pf-u-default-color-200"}}
+  Font color default 200
+{{/text}}
+{{#> text text--modifier="pf-u-default-color-300"}}
+  Font color default 300
+{{/text}}
+{{#> text text--modifier="pf-u-success-color-100"}}
+  Font color success 100
+{{/text}}
+{{#> text text--modifier="pf-u-success-color-200"}}
+  Font color success 200
+{{/text}}
+{{#> text text--modifier="pf-u-info-color-100"}}
+  Font color info 100
+{{/text}}
+{{#> text text--modifier="pf-u-info-color-200"}}
+  Font color info 200
+{{/text}}
+{{#> text text--modifier="pf-u-warning-color-100"}}
+  Font color warning 100
+{{/text}}
+{{#> text text--modifier="pf-u-warning-color-200"}}
+  Font color warning 200
+{{/text}}
+{{#> text text--modifier="pf-u-danger-color-100"}}
+  Font color danger 100
+{{/text}}
+{{#> text text--modifier="pf-u-danger-color-200"}}
+  Font color danger 200
+{{/text}}
+{{#> text text--modifier="pf-u-danger-color-300"}}
+  Font color danger 300
+{{/text}}
+```
+### Disabled text colors
+```hbs
+{{#> text text--modifier="pf-u-disabled-color-100"}}
+  Font color disabled 100
+{{/text}}
+{{#> text text--modifier="pf-u-disabled-color-200"}}
+  Font color disabled 200
+{{/text}}
+{{#> text text--modifier="pf-u-disabled-color-300"}}
+  Font color disabled 300
+{{/text}}
+```
+
+### Icon colors
+```hbs
+{{#> text text--modifier="pf-u-icon-color-dark"}}
+  <i class="fas fa-thumbtack" aria-hidden="true"></i>
+{{/text}}
+{{#> text text--modifier="pf-u-icon-color-light"}}
+  <i class="fas fa-thumbtack" aria-hidden="true"></i> 
 {{/text}}
 ```
 
@@ -102,7 +175,11 @@ import './Text.css'
 
 ### Overview
 
-Text utility
+These text utilities can be used to modify text within the PatternFly framework. In most cases, using the components with available modifiers should be sufficient to implement most designs, and should be preferred over customizations using these utilities.
+
+Care should be taken especially when applying text colors, as this can have a negative affect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+
+Note that "inverse" colors are labeled as such to indicate that they best used with the "inverse" background colors. 
 
 ### Usage
 
@@ -132,7 +209,7 @@ Text utility
 | `.pf-u-active-color-400`    | `*`        | Sets font-color to Active Color 400    |
 | `.pf-u-disabled-color-100`  | `*`        | Sets font-color to Disabled Color 100  |
 | `.pf-u-disabled-color-200`  | `*`        | Sets font-color to Disabled Color 200  |
-| `.pf-u-disabled-color-300`  | `*`        | Sets font-color to Disabled Color 200  |
+| `.pf-u-disabled-color-300`  | `*`        | Sets font-color to Disabled Color 300  |
 | `.pf-u-primary-color-100`   | `*`        | Sets font-color to Primary Color 100   |
 | `.pf-u-primary-color-200`   | `*`        | Sets font-color to Primary Color 200   |
 | `.pf-u-secondary-color-100` | `*`        | Sets font-color to Secondary Color 100 |

--- a/src/patternfly/utilities/Text/text.scss
+++ b/src/patternfly/utilities/Text/text.scss
@@ -59,14 +59,20 @@ $pf-u-font-color-options: (
   color-400: (
     color var(--pf-global--Color--400)
   ),
+  color-light-100: (
+    color var(--pf-global--Color--light-100)
+  ),
+  color-light-200: (
+    color var(--pf-global--Color--light-200)
+  ),
+  color-link: (
+    color var(--pf-global--link--Color)
+  ),
   icon-color-light: (
     color var(--pf-global--icon--Color--light)
   ),
   icon-color-dark: (
     color var(--pf-global--icon--Color--dark)
-  ),
-  link-color: (
-    color var(--pf-global--link--Color)
   ),
   active-color-100: (
     color var(--pf-global--active-color--100)

--- a/src/patternfly/utilities/Text/text.scss
+++ b/src/patternfly/utilities/Text/text.scss
@@ -65,8 +65,26 @@ $pf-u-font-color-options: (
   color-light-200: (
     color var(--pf-global--Color--light-200)
   ),
-  color-link: (
+  link-color: (
     color var(--pf-global--link--Color)
+  ),
+  link-color-hover: (
+    color var(--pf-global--link--Color--hover)
+  ),
+  link-color-light: (
+    color var(--pf-global--link--Color--light)
+  ),
+  link-color-light-hover: (
+    color var(--pf-global--link--Color--light--hover)
+  ),
+  link-color-dark: (
+    color var(--pf-global--link--Color--dark)
+  ),
+  link-color-dark-hover: (
+    color var(--pf-global--link--Color--dark-hover)
+  ),
+  link-color-visited: (
+    color var(--pf-global--link--Color--visited)
   ),
   icon-color-light: (
     color var(--pf-global--icon--Color--light)
@@ -91,9 +109,6 @@ $pf-u-font-color-options: (
   ),
   disabled-color-200: (
     color var(--pf-global--disabled-color--200)
-  ),
-  disabled-color-300: (
-    color var(--pf-global--disabled-color--300)
   ),
   primary-color-100: (
     color var(--pf-global--primary-color--100)


### PR DESCRIPTION
This adds in some text color and background color utilities. There are a few issues and questions to work out.
- Link, Active, and Primary text colors were already listed in the documentation and implemented, but not in any examples. Do we want to show them?
- Icons use the same colors as text, but there is also a variable for a light and dark icon. These were implemented but I've added an example for these.
- I've put light text/dark backgrounds into examples marked "inverse" and pointed to them from the documentation. 
- I've added some additional documentation that we could use to address the purpose and caveats of using these as customizations.

Note this is WIP. I'm sending it out so that we can discuss direction. @mcarrano @mcoker @mceledonia 
#3642 