### PR TITLE
docs(examples): updated example/demo microcopy

### DIFF
--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -77,7 +77,7 @@ import './Card.css'
     {{/card-actions}}
   {{/card-header}}
   {{#> card-body card-body--attribute=(concat 'id="' card--id '-check-label"')}}
-    This is the card body, there are only actions in the card head.
+    This is the card body. There are only actions in the card head.
   {{/card-body}}
 {{/card}}
 ```

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -36,14 +36,14 @@ cssPrefix: pf-c-clipboard-copy
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
     {{/button}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
-    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br>
@@ -52,14 +52,14 @@ cssPrefix: pf-c-clipboard-copy
     {{#> button button--modifier="pf-m-control pf-m-expanded" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
     {{/button}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'contenteditable="true" id="' clipboard-copy--id '-content"')}}
-    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br />
@@ -69,14 +69,14 @@ cssPrefix: pf-c-clipboard-copy
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
     {{/button}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
-    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br>
@@ -85,14 +85,14 @@ cssPrefix: pf-c-clipboard-copy
     {{#> button button--modifier="pf-m-control pf-m-expanded" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
     {{/button}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
-    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 ```

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -35,7 +35,7 @@ import './DatePicker.css'
 
 ### Invalid
 ```hbs
-{{#> date-picker date-picker--id="invalid" date-picker-helper-text--text="Invalid date selected." date-picker-helper-text--IsError="true"}}
+{{#> date-picker date-picker--id="invalid" date-picker-helper-text--text="Invalid date" date-picker-helper-text--IsError="true"}}
   {{#> input-group}}
     {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
     {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}

--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -12,11 +12,11 @@ cssPrefix: pf-c-file-upload
   {{#> file-upload-file-select}}
     {{#> input-group}}
       {{> file-upload-text-input
-        file-upload-text-input--aria-label="Drag a file here or browse to upload"
-        file-upload-text-input--attribute=(concat 'readonly placeholder="Drag a file here or browse to upload" aria-describedby="' file-upload--id '-browse"')
+        file-upload-text-input--aria-label="Drag and drop a file or upload one"
+        file-upload-text-input--attribute=(concat 'readonly placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')
         }}
       {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-        Browse...
+        Upload
       {{/button}}
       {{#> button button--modifier="pf-m-control" button--attribute="disabled"}}
         Clear
@@ -38,7 +38,7 @@ cssPrefix: pf-c-file-upload
         file-upload-text-input--attribute=(concat 'readonly value="Read only filename" aria-describedby="' file-upload--id '-browse"')
         }}
       {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-        Browse...
+        Upload
       {{/button}}
       {{#> button button--modifier="pf-m-control"}}
         Clear
@@ -60,7 +60,7 @@ cssPrefix: pf-c-file-upload
         file-upload-text-input--attribute=(concat 'readonly value="Sample.txt" aria-describedby="' file-upload--id '-browse"')
         }}
       {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-        Browse...
+        Upload
       {{/button}}
       {{#> button button--modifier="pf-m-control"}}
         Clear
@@ -77,9 +77,9 @@ cssPrefix: pf-c-file-upload
 {{#> file-upload file-upload--id="drag-file-hover-component" file-upload--modifier="pf-m-drag-hover"}}
   {{#> file-upload-file-select}}
     {{#> input-group}}
-      {{> file-upload-text-input file-upload-text-input--aria-label="Drag a file here or browse to upload" file-upload-text-input--attribute=(concat 'readonly placeholder="Drag a file here or browse to upload" aria-describedby="' file-upload--id '-browse"')}}
+      {{> file-upload-text-input file-upload-text-input--aria-label="Drag and drop a file or upload one" file-upload-text-input--attribute=(concat 'readonly placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')}}
       {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-        Browse...
+        Upload
       {{/button}}
       {{#> button button--modifier="pf-m-control" button--attribute="disabled"}}
         Clear
@@ -103,7 +103,7 @@ cssPrefix: pf-c-file-upload
             file-upload-text-input--attribute=(concat 'required value="Sample.png"  aria-describedby="' file-upload--id '-browse"')
             }}
           {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-            Browse...
+            Upload
           {{/button}}
           {{#> button button--modifier="pf-m-control"}}
             Clear
@@ -129,7 +129,7 @@ cssPrefix: pf-c-file-upload
         file-upload-text-input--attribute=(concat 'readonly name="file-upload-loading" value="Sample.png" aria-describedby="' file-upload--id '-browse"')
       }}
       {{#> button button--modifier="pf-m-control" button--attribute=(concat 'disabled id="' file-upload--id '-browse"')}}
-        Browse...
+        Upload
       {{/button}}
       {{#> button button--modifier="pf-m-control"}}
         Clear

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -133,7 +133,7 @@ cssPrefix: pf-c-form
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}
       {{/form-control}}
       {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
-        This is helper text
+        This is helper text.
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
@@ -147,7 +147,7 @@ cssPrefix: pf-c-form
       {{#> form-control form-control--modifier="pf-m-warning" controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}
       {{/form-control}}
       {{#> form-helper-text  form-helper-text--modifier="pf-m-warning" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
-        This is helper text for a warning input
+        This is helper text for a warning input.
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
@@ -161,7 +161,7 @@ cssPrefix: pf-c-form
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-invalid="true" aria-describedby="' form--id form-group--id '-helper"')}}
       {{/form-control}}
       {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
-        This is helper text for an invalid input
+        This is helper text for an invalid input.
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
@@ -175,7 +175,7 @@ cssPrefix: pf-c-form
       {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}
       {{/form-control}}
       {{#> form-helper-text form-helper-text--modifier="pf-m-success" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
-        This is helper text for success input
+        This is helper text for success input.
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -77,13 +77,6 @@ cssPrefix: pf-c-input-group
 {{/input-group}}
 <br>
 {{#> input-group}}
- {{#> input-group-text input-group-text--type="label" input-group-text--HasCalendarIcon="true" input-group-text--attribute='for="textInput9"'}}
- {{/input-group-text}}
- {{#> form-control controlType="input" input="true" form-control--attribute='type="date" id="textInput9" name="textInput9" aria-label="Date input example"'}}
-{{/form-control}}
-{{/input-group}}
-<br>
-{{#> input-group}}
   {{#> form-control controlType="input" input="true" form-control--attribute='type="search" id="textInput11" name="textInput11" aria-label="Search input example"'}}
   {{/form-control}}
   {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}

--- a/src/patternfly/components/Select/__select-menu-footer.hbs
+++ b/src/patternfly/components/Select/__select-menu-footer.hbs
@@ -17,7 +17,7 @@
       {{#> select-menu-item}}Degraded{{/select-menu-item}}
     </li>
     <li role="presentation">
-      {{#> select-menu-item}}Needs Maintenance{{/select-menu-item}}
+      {{#> select-menu-item}}Needs maintenance{{/select-menu-item}}
     </li>
   {{/select-menu-list}}
   {{#> select-menu-footer}}

--- a/src/patternfly/components/Select/__select-single.hbs
+++ b/src/patternfly/components/Select/__select-single.hbs
@@ -23,7 +23,7 @@
       {{#> select-menu-item}}Degraded{{/select-menu-item}}
     </li>
     <li role="presentation">
-      {{#> select-menu-item}}Needs Maintenance{{/select-menu-item}}
+      {{#> select-menu-item}}Needs maintenance{{/select-menu-item}}
     </li>
     {{#if select--IsLoad}}
       <li role="presentation">

--- a/src/patternfly/components/Select/select-menu.hbs
+++ b/src/patternfly/components/Select/select-menu.hbs
@@ -27,7 +27,7 @@
         {{#> select-menu-item}}Degraded{{/select-menu-item}}
       </li>
       <li role="presentation">
-        {{#> select-menu-item}}Needs Maintenance{{/select-menu-item}}
+        {{#> select-menu-item}}Needs maintenance{{/select-menu-item}}
       </li>
       {{#if select--IsLoad}}
         <li role="presentation">

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -437,13 +437,13 @@ import './Wizard.css'
           {{#> empty-state empty-state--modifier="pf-m-lg"}}
             {{#> empty-state-icon empty-state-icon--type="cogs"}}{{/empty-state-icon}}
             {{#> title titleType="h1" title--modifier="pf-m-lg"}}
-              Configuration in progress
+              Validating credentials
             {{/title}}
             {{#> empty-state-body}}
               {{#> progress progress__value="33" progress--modifier="pf-m-singleline" progress__id="progress-singleline-example"}}{{/progress}}
             {{/empty-state-body}}
             {{#> empty-state-body}}
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec non pulvinar tortor. Maecenas sit amet pellentesque velit, eu eleifend mauris.
+              Description can be used to further elaborate on the validation step, or give the user a better idea of how long the process will take.
             {{/empty-state-body}}
             {{#> empty-state-secondary}}
               {{#> button button--modifier="pf-m-link"}}

--- a/src/patternfly/demos/Alert/examples/horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/examples/horizontal-form.hbs
@@ -14,7 +14,7 @@
         {{/alert-icon}}
         {{#> alert-title}}
           {{#> screen-reader}}Danger alert:{{/screen-reader}}
-          You must fill out all required fields before you can proceed.
+          Fill out all required fields before continuing.
         {{/alert-title}}
       {{/alert}}
     {{/form-alert}}
@@ -28,7 +28,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-name" name="' form--id '-form-name" aria-invalid="true" aria-describedby="' form--id '-form-name-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-name-helper" aria-live="polite"')}}
-          This is a required field.
+          Required field.
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
@@ -52,7 +52,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-phone" name="' form--id '-form-phone" aria-invalid="true" aria-describedby="' form--id '-form-phone-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-phone-helper" aria-live="polite"')}}
-          This is a required field.
+          Required field.
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
@@ -72,11 +72,11 @@
         {{/form-helper-text}}
         {{#> check}}
           {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox1" name="alt-form-checkbox1"'}}{{/check-input}}
-          {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}
+          {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email.{{/check-label}}
         {{/check}}
         {{#> check}}
           {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox2" name="alt-form-checkbox2"'}}{{/check-input}}
-          {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days{{/check-label}}
+          {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days.{{/check-label}}
         {{/check}}
       {{/form-group-control}}
     {{/form-group}}
@@ -84,7 +84,7 @@
       {{#> form-group-control}}
         {{#> form-actions}}
           {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Submit form
+            Submit
           {{/button}}
           {{#> button button--modifier="pf-m-secondary" button--IsReset="true"}}
             Cancel

--- a/src/patternfly/demos/Alert/examples/horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/examples/horizontal-form.hbs
@@ -28,7 +28,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-name" name="' form--id '-form-name" aria-invalid="true" aria-describedby="' form--id '-form-name-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-name-helper" aria-live="polite"')}}
-          Required field.
+          Required field
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
@@ -52,7 +52,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-phone" name="' form--id '-form-phone" aria-invalid="true" aria-describedby="' form--id '-form-phone-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-phone-helper" aria-live="polite"')}}
-          Required field.
+          Required field
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}

--- a/src/patternfly/demos/Alert/examples/stacked-form.hbs
+++ b/src/patternfly/demos/Alert/examples/stacked-form.hbs
@@ -14,7 +14,7 @@
         {{/alert-icon}}
         {{#> alert-title}}
           {{#> screen-reader}}Danger alert:{{/screen-reader}}
-          Please address the errors in your form to proceed
+          Fill out all required fields before continuing.
         {{/alert-title}}
       {{/alert}}
     {{/form-alert}}
@@ -28,7 +28,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-name" name="' form--id '-form-name" aria-invalid="true" aria-describedby="' form--id '-form-name-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-name-helper-name" aria-live="polite"')}}
-          This is a required field.
+          Required field.
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
@@ -42,7 +42,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="patternfly.com" id="' form--id '-form-email" name="' form--id '-form-email" required')}}{{/form-control}}
       {{/form-group-control}}
       {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-email-helper-email" aria-live="polite"')}}
-        Please enter a valid email address: example@email.com
+        Enter a valid email address: example@gmail.com
       {{/form-helper-text}}
     {{/form-group}}
     {{#> form-group}}
@@ -59,7 +59,7 @@
           <option value="Option 4">NY</option>
       {{/form-control}}
       {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-email-helper-state" aria-live="polite"')}}
-        This is a required field
+        Required field.
       {{/form-helper-text}}
     {{/form-group}}
     {{#> form-group form-group--IsCheckGroup="true" form-group--id="-check-group"}}
@@ -93,7 +93,7 @@
       {{#> form-group-control}}
         {{#> form-actions}}
           {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Submit form
+            Submit
           {{/button}}
           {{#> button button--modifier="pf-m-secondary" button--IsReset="true"}}
             Cancel

--- a/src/patternfly/demos/Alert/examples/stacked-form.hbs
+++ b/src/patternfly/demos/Alert/examples/stacked-form.hbs
@@ -28,7 +28,7 @@
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-form-name" name="' form--id '-form-name" aria-invalid="true" aria-describedby="' form--id '-form-name-helper"')}}
         {{/form-control}}
         {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-name-helper-name" aria-live="polite"')}}
-          Required field.
+          Required field
         {{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
@@ -59,7 +59,7 @@
           <option value="Option 4">NY</option>
       {{/form-control}}
       {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-form-email-helper-state" aria-live="polite"')}}
-        Required field.
+        Required field
       {{/form-helper-text}}
     {{/form-group}}
     {{#> form-group form-group--IsCheckGroup="true" form-group--id="-check-group"}}

--- a/src/patternfly/demos/CardView/examples/CardView.md
+++ b/src/patternfly/demos/CardView/examples/CardView.md
@@ -19,7 +19,7 @@ section: demos
         {{/button}}
       {{/page-header-brand-toggle}}
       {{#> page-header-brand-link page-header-brand-link--href="#"}}
-        {{#> brand brand--attribute='src="/assets/images/PF-Masthead-Logo.svg" alt="PatternFly Logo"'}}{{/brand}}
+        {{#> brand brand--attribute='src="/assets/images/PF-Masthead-Logo.svg" alt="PatternFly logo"'}}{{/brand}}
       {{/page-header-brand-link}}
     {{/page-header-brand}}
 

--- a/src/patternfly/demos/CardView/examples/CardView.md
+++ b/src/patternfly/demos/CardView/examples/CardView.md
@@ -19,7 +19,7 @@ section: demos
         {{/button}}
       {{/page-header-brand-toggle}}
       {{#> page-header-brand-link page-header-brand-link--href="#"}}
-        {{#> brand brand--attribute='src="/assets/images/PF-Masthead-Logo.svg" alt="Patternfly Logo"'}}{{/brand}}
+        {{#> brand brand--attribute='src="/assets/images/PF-Masthead-Logo.svg" alt="PatternFly Logo"'}}{{/brand}}
       {{/page-header-brand-link}}
     {{/page-header-brand}}
 
@@ -62,7 +62,7 @@ section: demos
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{#> content}}
         <h1>Projects</h1>
-        <p>This is a demo that showcases Patternfly Cards. </p>
+        <p>This is a demo that showcases PatternFly cards. </p>
       {{/content}}
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-light pf-m-no-padding"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -9,11 +9,11 @@ section: components
 {{#> form form--id="form-demo-basic"}}
   {{#> form-group form-group--id="-name"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Full name{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}{{/form-control}}
-      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Please provide your full name{{/form-helper-text}}
+      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Include your middle name if you have one.{{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-email"}}
@@ -75,7 +75,7 @@ section: components
     {{#> form-group-control}}
       {{#> form-actions}}
         {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-          Submit form
+          Submit
         {{/button}}
         {{#> button button--modifier="pf-m-link"}}
           Cancel
@@ -91,12 +91,12 @@ section: components
 {{#> form form--modifier="pf-m-horizontal" form--id="form-demo-horizontal"}}
   {{#> form-group form-group--modifier="-name"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Full name{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}
       {{/form-control}}
-      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Please provide your full name{{/form-helper-text}}
+      {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Include your middle name if you have one.{{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-email"}}
@@ -141,7 +141,7 @@ section: components
     {{#> form-group-control}}
       {{#> form-actions}}
         {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-          Submit form
+          Submit
         {{/button}}
         {{#> button button--modifier="pf-m-link"}}
           Cancel
@@ -158,11 +158,11 @@ section: components
   {{#> grid grid--modifier="pf-m-all-6-col-on-md pf-m-gutter"}}
     {{#> form-group form-group--id="-name"}}
       {{#> form-group-label}}
-        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Full name{{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-describedby="' form--id form-group--id '-helper"')}}{{/form-control}}
-        {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Please provide your full name{{/form-helper-text}}
+        {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}Include your middle name if you have one.{{/form-helper-text}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group form-group--id="-title"}}
@@ -212,7 +212,7 @@ section: components
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="select" form-control--attribute=(concat 'id="' form--id form-group--id '" name="' form--id form-group--id '"')}}
-            <option value="" selected>Please choose</option>
+            <option value="" selected>Select one</option>
             <option value="AL">Alabama</option>
             <option value="AK">Alaska</option>
             <option value="AZ">Arizona</option>
@@ -271,7 +271,7 @@ section: components
       {{#> form-group-control}}
         {{#> form-actions}}
           {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
-            Submit form
+            Submit
           {{/button}}
           {{#> button button--modifier="pf-m-link"}}
             Cancel
@@ -301,7 +301,7 @@ section: components
     {{/form-group}}
     {{#> form-group form-group--id="-name"}}
       {{#> form-group-label}}
-        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Full name{{/form-label}}
         {{> form-group-label-help}}
       {{/form-group-label}}
       {{#> form-group-control}}

--- a/src/patternfly/demos/Page/page-template-title.hbs
+++ b/src/patternfly/demos/Page/page-template-title.hbs
@@ -1,6 +1,6 @@
 {{#> page-main-section page-main-section--modifier=(concat 'pf-m-light ' page-template-title--modifier) page-main-section--IsLimitWidth="true"}}
   {{#> content}}
     <h1>Main title</h1>
-    <p>This is a demo of the Page component.</p>
+    <p>This is a demo of the page component.</p>
   {{/content}}
 {{/page-main-section}}

--- a/src/patternfly/demos/Skeleton/examples/Skeleton.md
+++ b/src/patternfly/demos/Skeleton/examples/Skeleton.md
@@ -63,7 +63,7 @@ section: components
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{#> content}}
         <h1>Projects</h1>
-        <p>This is a demo that showcases Patternfly Cards. </p>
+        <p>This is a demo that showcases PatternFly cards. </p>
       {{/content}}
     {{/page-main-section}}
     {{#> page-main-section}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -24,7 +24,7 @@ wrapperTag: div
     {{#> page-main-section page-main-section--modifier="pf-m-light" page-main-section--IsLimitWidth="true"}}
       {{#> content}}
         <h1>Table demos</h1>
-        <p>Below is an example of a Table.</p>
+        <p>Below is an example of a table.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum suscipit venenatis enim, ut ultrices metus ornare at. Curabitur vel nibh id leo finibus suscipit. Curabitur eu tellus lectus. Vivamus lacus leo, lobortis ac convallis ac, dapibus vel ligula. Suspendisse vitae felis at augue blandit sollicitudin. Sed erat metus, pellentesque vel accumsan vitae, tincidunt id erat. Mauris et pharetra felis. Duis at nisi leo. Nam blandit dui dui, in euismod est dapibus sed. Vivamus sed dolor ullamcorper, euismod orci efficitur, ornare leo. Sed sit amet sollicitudin nulla. Nunc tristique sem ut est laoreet efficitur. Cras tristique finibus risus, eget fringilla tellus porta vitae. Duis id nunc ultricies, ultrices nibh vel, sollicitudin tellus.</p>
       {{/content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Table/table-main-section-content.hbs
+++ b/src/patternfly/demos/Table/table-main-section-content.hbs
@@ -1,4 +1,4 @@
 {{#> content}}
   <h1>Table demos</h1>
-  <p>Below is an example of a Table.</p>
+  <p>Below is an example of a table.</p>
 {{/content}}


### PR DESCRIPTION
Closes #4023 
Closes #4290 

This PR updates microcopy across many Core examples & demos, per the notes in the original issue (further discussion in [this doc](https://docs.google.com/document/d/1Lqa8turRxmYNn05hDUPykM-q4vQDoWyuVfy3qasXlGU/edit)).

This PR also removes the date variation from the input group examples.