### PR TITLE
feat(back-to-top): added back to top component

### DIFF
--- a/src/patternfly/components/BackToTop/back-to-top.hbs
+++ b/src/patternfly/components/BackToTop/back-to-top.hbs
@@ -1,0 +1,11 @@
+<div class="pf-c-back-to-top{{#if back-to-top--modifier}} {{back-to-top--modifier}}{{/if}}"
+  {{#if back-to-top--attribute}}
+    {{{back-to-top--attribute}}}
+  {{/if}}>
+  {{#> button-link button-link--attribute=(concat 'href="#' back-to-top--target '"') button-link--modifier="pf-m-primary"}}
+    Back to top
+    {{#> button-icon button-icon--modifier="pf-m-end"}}
+      <i class="fas fa-angle-up" aria-hidden="true"></i>
+    {{/button-icon}}
+  {{/button-link}}
+</div>

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -17,6 +17,11 @@
   position: absolute;
   right: var(--pf-c-back-to-top--Right);
   bottom: var(--pf-c-back-to-top--Bottom);
+  display: none;
+
+  &.pf-m-visible {
+    display: block;
+  }
 
   .pf-c-button {
     --pf-c-button--FontSize: var(--pf-c-back-to-top--c-button--FontSize);

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -17,10 +17,9 @@
   position: absolute;
   right: var(--pf-c-back-to-top--Right);
   bottom: var(--pf-c-back-to-top--Bottom);
-  display: none;
 
-  &.pf-m-visible {
-    display: block;
+  &.pf-m-hidden {
+    display: none;
   }
 
   .pf-c-button {

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -1,0 +1,31 @@
+.pf-c-back-to-top {
+  --pf-c-back-to-top--Right: var(--pf-global--spacer--2xl);
+  --pf-c-back-to-top--Bottom: var(--pf-global--spacer--lg);
+  --pf-c-back-to-top--md--Bottom: var(--pf-global--spacer--2xl);
+  --pf-c-back-to-top--c-button--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-back-to-top--c-button--BorderRadius: var(--pf-global--BorderRadius--lg);
+  --pf-c-back-to-top--c-button--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-back-to-top--c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-back-to-top--c-button--PaddingBottom: var(--pf-global--spacer--xs);
+  --pf-c-back-to-top--c-button--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-back-to-top--c-button--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
+
+  @media (min-width: $pf-global--breakpoint--md) {
+    --pf-c-back-to-top--Bottom: var(--pf-c-back-to-top--md--Bottom);
+  }
+
+  .pf-c-button {
+    --pf-c-button--FontSize: var(--pf-c-back-to-top--c-button--FontSize);
+    --pf-c-button--BorderRadius: var(--pf-c-back-to-top--c-button--BorderRadius);
+    --pf-c-button--PaddingTop: var(--pf-c-back-to-top--c-button--PaddingTop);
+    --pf-c-button--PaddingRight: var(--pf-c-back-to-top--c-button--PaddingRight);
+    --pf-c-button--PaddingBottom: var(--pf-c-back-to-top--c-button--PaddingBottom);
+    --pf-c-button--PaddingLeft: var(--pf-c-back-to-top--c-button--PaddingLeft);
+
+    box-shadow: var(--pf-c-back-to-top--c-button--BoxShadow);
+  }
+
+  position: absolute;
+  right: var(--pf-c-back-to-top--Right);
+  bottom: var(--pf-c-back-to-top--Bottom);
+}

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -8,11 +8,15 @@
   --pf-c-back-to-top--c-button--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-back-to-top--c-button--PaddingBottom: var(--pf-global--spacer--xs);
   --pf-c-back-to-top--c-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-back-to-top--c-button--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
+  --pf-c-back-to-top--c-button--BoxShadow: var(--pf-global--BoxShadow--lg-bottom);
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-back-to-top--Bottom: var(--pf-c-back-to-top--md--Bottom);
   }
+
+  position: absolute;
+  right: var(--pf-c-back-to-top--Right);
+  bottom: var(--pf-c-back-to-top--Bottom);
 
   .pf-c-button {
     --pf-c-button--FontSize: var(--pf-c-back-to-top--c-button--FontSize);
@@ -24,8 +28,4 @@
 
     box-shadow: var(--pf-c-back-to-top--c-button--BoxShadow);
   }
-
-  position: absolute;
-  right: var(--pf-c-back-to-top--Right);
-  bottom: var(--pf-c-back-to-top--Bottom);
 }

--- a/src/patternfly/components/BackToTop/examples/BackToTop.css
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.css
@@ -1,0 +1,4 @@
+#ws-core-c-back-to-top-basic {
+  height: 300px;
+  position: relative;
+}

--- a/src/patternfly/components/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.md
@@ -10,9 +10,7 @@ import './BackToTop.css'
 ## Examples
 ### Basic
 ```hbs
-{{#> back-to-top}}
-  Basic example content
-{{/back-to-top}}
+{{> back-to-top}}
 ```
 
 ## Documentation

--- a/src/patternfly/components/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.md
@@ -10,7 +10,7 @@ import './BackToTop.css'
 ## Examples
 ### Basic
 ```hbs
-{{> back-to-top}}
+{{> back-to-top back-to-top--modifier="pf-m-visible"}}
 ```
 
 ## Documentation
@@ -18,3 +18,4 @@ import './BackToTop.css'
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-back-to-top` | `<div>` | Initiates the back to top component. **Required** |
+| `.pf-m-visible` | `.pf-c-back-to-top` | Modifies the component to be visible. |

--- a/src/patternfly/components/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.md
@@ -1,0 +1,22 @@
+---
+id: 'Back to top'
+beta: true
+section: components
+cssPrefix: pf-c-back-to-top
+---
+
+import './BackToTop.css'
+
+## Examples
+### Basic
+```hbs
+{{#> back-to-top}}
+  Basic example content
+{{/back-to-top}}
+```
+
+## Documentation
+### Usage
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-back-to-top` | `<div>` | Initiates the back to top component. **Required** |

--- a/src/patternfly/components/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.md
@@ -10,7 +10,7 @@ import './BackToTop.css'
 ## Examples
 ### Basic
 ```hbs
-{{> back-to-top back-to-top--modifier="pf-m-visible"}}
+{{> back-to-top}}
 ```
 
 ## Documentation
@@ -18,4 +18,4 @@ import './BackToTop.css'
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-back-to-top` | `<div>` | Initiates the back to top component. **Required** |
-| `.pf-m-visible` | `.pf-c-back-to-top` | Modifies the component to be visible. |
+| `.pf-m-hidden` | `.pf-c-back-to-top` | Modifies the component to be hidden. |

--- a/src/patternfly/components/_all.scss
+++ b/src/patternfly/components/_all.scss
@@ -7,6 +7,7 @@
 @import "./Avatar/avatar.scss";
 @import "./Backdrop/backdrop.scss";
 @import "./BackgroundImage/background-image.scss";
+@import "./BackToTop/back-to-top.scss";
 @import "./Badge/badge.scss";
 @import "./Banner/banner.scss";
 @import "./Brand/brand.scss";

--- a/src/patternfly/demos/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/demos/BackToTop/examples/BackToTop.md
@@ -1,0 +1,15 @@
+---
+id: 'Back to top'
+beta: true
+section: components
+cssPrefix: pf-d-back-to-top
+---
+
+## Examples
+### Basic
+```hbs isFullscreen
+{{#> page-demo-default page-demo-default--id="back-to-top-basic"}}
+  {{> page-template-gallery page-template--gallery--IsLongGallery="true"}}
+  {{> back-to-top back-to-top--target="main-content-back-to-top-basic"}}
+{{/page-demo-default}}
+```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4255

example: https://patternfly-pr-4291.surge.sh/components/back-to-top
demo: https://patternfly-pr-4291.surge.sh/components/back-to-top/html-demos/basic/
  * The demo just shows the button placement in context of the page. Doesn't show any sort of interaction, which will all likely be handled via JS in the react component. 

Some questions:

* Will there be some kind of show/hide fade animation?
* It's easy to add this to a simple page that has a single scrollbar for the main content area with a bunch of content on it that scrolls - the button is just positioned at the bottom/right of the main content area. It's more difficult to add it to these types of pages:
  * [overflow scroll](https://www.patternfly.org/v4/components/page/html-demos/overflow-scroll/)
    * In this scenario, would the button be in the scrollable page section, and clicking would scroll that page section back to the top?
    * We'll likely need to introduce a new scroll wrapper. 
    * There is this technique, though it's a bit hacky... I'd want to test it more - https://codesandbox.io/s/fervent-stonebraker-txoy3?file=/style.css
  * [sticky bottom section](https://www.patternfly.org/v4/components/page/html-demos/sticky-section-bottom/)
    * By default, since the button is at the bottom/right of the main content area, it's probably going to overlap the sticky section at the bottom. 
    * JS could detect the height of any sticky sections like that and try to offset the button. That can get really tricky though because there may be a page section that's sticky, but may not always be sticky to the bottom if, for example, it isn't the last section on the page. That may also be more parsing and making assumptions about the children to the page than we're comfortable doing.

Do we want to try and support those use cases? Or would we just support a basic page that scrolls? We can also just start out with a super basic implementation and change it as needed.

cc @mcarrano @mceledonia @bgliwa01