### PR TITLE
fix(clipboard-copy): allowed gap b/w wrapping lines in inline variation

### DIFF
--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -17,8 +17,8 @@
   --pf-c-clipboard-copy__expandable-content--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
 
   // Inline
-  --pf-c-clipboard-copy--m-inline--PaddingTop: #{pf-size-prem(4px)}; // shorter than bottom padding so it doesn't cut off the bottom of trailing characters on a line above
-  --pf-c-clipboard-copy--m-inline--PaddingBottom: #{pf-size-prem(5px)};
+  --pf-c-clipboard-copy--m-inline--PaddingTop: 0; // remove at breaking change
+  --pf-c-clipboard-copy--m-inline--PaddingBottom: 0; // remove at breaking change
   --pf-c-clipboard-copy--m-inline--PaddingLeft: var(--pf-global--spacer--xs);
   --pf-c-clipboard-copy--m-inline--BackgroundColor: var(--pf-global--BackgroundColor--200);
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3966

examples - https://patternfly-pr-4296.surge.sh/components/clipboard-copy#inline-compact-in-sentence

This only changes the default inline variation with text that wraps inline with other text. It does not change the block variation of inline clipboard copy - that variation looks like it will need a breaking change to rework the html/css to allow for gaps between wrapping lines. Likely something like this:

```
div.pf-c-clipboard-copy.pf-m-inline // set to block
  div.pf-c-clipboard-copy__main // set to inline with styles .pf-c-clipboard-copy.pf-m-inline has now (bgcolor, left/right padding, white-space, etc)
    span.pf-c-clipboard-copy__text
    span.pf-c-clipboard-copy__actions
...
```