### PR TITLE
Add note and example about required css files for spacing classes

### DIFF
--- a/src/patternfly/utilities/Spacing/examples/Spacing.md
+++ b/src/patternfly/utilities/Spacing/examples/Spacing.md
@@ -151,7 +151,17 @@ import './Spacing.css'
 ```
 
 ## Documentation
+
 ### Overview
+Allow setting standard size margin and padding on elements.
+
+Note to use these classes you will need to import `spacing.css` from
+`react-styles`; e.g.
+
+```
+import '@patternfly/react-styles/css/utilities/Spacing/spacing.css'
+```
+
 Breakpoint is optional. Breakpoints: base (no breakpoint value), -on-sm, -on-md, -on-lg, -on-xl. **Example .pf-u-m-sm-on-lg**
 
 ### Margin properties


### PR DESCRIPTION
It wasn't clear to me that the `spacing.css` is required to be explicitly imported to use these classes.  Add a note on that.