### PR TITLE
fix(masthead): added content wrapper to demo

### DIFF
--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -59,7 +59,7 @@ wrapperTag: div
               {{> masthead-demo--context-selector}}
             {{/toolbar-item}}
             {{#> toolbar-item toolbar-item--modifier="pf-m-hidden pf-m-visible-on-lg"}}
-              {{> dropdown dropdown--modifier="pf-m-full-height" dropdown--id="dropdown-expanded" dropdown--IsExpandedqqq="true" dropdown-toggle--text="Expanded dropdown"}}
+              {{> dropdown dropdown--modifier="pf-m-full-height" dropdown--id="dropdown-expanded" dropdown-toggle--text="Dropdown"}}
             {{/toolbar-item}}
           {{/toolbar-group}}
           {{#> toolbar-item toolbar-item--modifier="pf-m-align-right"}}

--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -22,13 +22,15 @@ wrapperTag: div
   {{/masthead-main}}
   {{#> masthead-content}}
     {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}
-      {{#> toolbar-content-section}}
-        {{#> toolbar-group toolbar-group--modifier="pf-m-align-right"}}
-          {{#> toolbar-item}}
-            {{> dropdown dropdown--id=(concat masthead--id "-header-action") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-          {{/toolbar-item}}
-        {{/toolbar-group}}
-      {{/toolbar-content-section}}
+      {{#> toolbar-content}}
+        {{#> toolbar-content-section}}
+          {{#> toolbar-group toolbar-group--modifier="pf-m-align-right"}}
+            {{#> toolbar-item}}
+              {{> dropdown dropdown--id=(concat masthead--id "-header-action") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
+            {{/toolbar-item}}
+          {{/toolbar-group}}
+        {{/toolbar-content-section}}
+      {{/toolbar-content}}
     {{/toolbar}}
   {{/masthead-content}}
 {{/masthead}}


### PR DESCRIPTION
closes #4303

Adds `.pf-c-toolbar__content` to basic masthead example.