### PR TITLE
fix(form-control): removed extra space under textarea

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -180,9 +180,11 @@ cssPrefix: pf-c-form
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="info"}}
-    {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
-      Information
-    {{/form-label}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
+        Information
+      {{/form-label}}
+    {{/form-group-label}}
     {{#> form-control controlType="textarea" form-control--attribute=(concat 'id="' form--id form-group--id '" name="' form--id form-group--id '" aria-invalid="true" aria-describedby="' form--id form-group--id '-helper"')}}
     {{/form-control}}
     {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -376,6 +376,7 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
 
     width: var(--pf-c-form-control--textarea--Width);
     height: var(--pf-c-form-control--textarea--Height);
+    vertical-align: bottom;
   }
 
   &.pf-m-resize-vertical {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4288

Not sure if I want to make this change now or in a breaking change. It seems like a safe enough change, I just wonder if it could cause some unexpected issue - and the form control elements are commonly used. Beyond fixing the extra space from the original issue, it fixes this inconsistency that currently exists under the element between firefox and either chrome or safari.

wdyt @mattnolting @srambach 

chrome
<img width="355" alt="Screen Shot 2021-08-24 at 5 47 11 PM" src="https://user-images.githubusercontent.com/35148959/130699872-04c94a68-96e2-4764-b6d9-d1cd57a2524d.png">

safari
<img width="354" alt="Screen Shot 2021-08-24 at 5 47 20 PM" src="https://user-images.githubusercontent.com/35148959/130699882-019907f7-1ed4-4369-b707-c175dcb4c3ef.png">

firefox
<img width="349" alt="Screen Shot 2021-08-24 at 5 47 31 PM" src="https://user-images.githubusercontent.com/35148959/130699890-87e47eea-32a8-4df2-98b8-4abf0f8ed472.png">
