### PR TITLE
fix(documentation): fix broken links

### DIFF
--- a/src/patternfly/components/AboutModalBox/examples/AboutModalBox.md
+++ b/src/patternfly/components/AboutModalBox/examples/AboutModalBox.md
@@ -45,7 +45,7 @@ cssPrefix: pf-c-about-modal-box
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-about-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required** |
 | `aria-label="Close Dialog"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required** |
-| `aria-hidden="true"` | Parent element containing the page contents when the modal is open. | Hides main contents of the page from screen readers. The element with `.pf-c-modal-box` must not be a descendent of the element with `aria-hidden="true"`. For more info see [trapping focus](https://pf4.patternfly.org/accessibility-guide#trapping-focus) **Required** |
+| `aria-hidden="true"` | Parent element containing the page contents when the modal is open. | Hides main contents of the page from screen readers. The element with `.pf-c-modal-box` must not be a descendent of the element with `aria-hidden="true"`. For more info, see [trapping focus](/accessibility/product-development-guide#trapping-focus). **Required** |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/ChipGroup/examples/ChipGroup.md
+++ b/src/patternfly/components/ChipGroup/examples/ChipGroup.md
@@ -548,7 +548,7 @@ A chip group is constrained to the width of its container and will wrap when it 
 
 If you want to create sub-groupings of chips to represent multiple values applied against the same category, chips can be grouped by category. This can be useful in filtering use cases, for example, where you want all items that match more than one value of the same attribute, e.g., ‘status = down OR needs maintenance’.
 
-The chip group requires the [chip component](/documentation/core/components/chip).
+The chip group requires the [chip component](/components/chip).
 
 ### Accessibility
 

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -1087,7 +1087,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ## Documentation
 ### Overview
-The DataList component provides a flexible alternative to the Table component, wherein individual data points may or may not exist within each row. DataList relies upon PatternFly layouts to achieve desired presentation within `pf-c-data-list__cell`s. DataLists do not have headers. If headers are required, use the [table component](/documentation/core/components/table).
+The DataList component provides a flexible alternative to the Table component, wherein individual data points may or may not exist within each row. DataList relies upon PatternFly layouts to achieve desired presentation within `pf-c-data-list__cell`s. DataLists do not have headers. If headers are required, use the [table component](/components/table).
 
 
 ### Grid

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -137,7 +137,7 @@ Resizes horizontally
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [check component](/documentation/core/components/check). **Required**  |
+| `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
 | `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. |

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -114,7 +114,7 @@ cssPrefix: pf-c-input-group
 Use the input group to extend form controls by adding text, buttons, selects, etc.
 
 ### Accessibility
-When using the `.pf-c-input-group` always ensure labels are used outside the input group with the `.pf-screen-reader` class applied. You can also make use of the `aria-describedby`, `aria-label`, or `aria-labelledby` attributues. For more information on accessibility and forms see the [form component](/documentation/core/components/form).
+When using the `.pf-c-input-group` always ensure labels are used outside the input group with the `.pf-screen-reader` class applied. You can also make use of the `aria-describedby`, `aria-label`, or `aria-labelledby` attributes. For more information on accessibility and forms see the [form component](/components/form).
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-describedby` | `.pf-c-form-control` |  When using `.pf-c-input-group__text` or `.pf-c-input-group__action` make use of this on the input field. |

--- a/src/patternfly/components/LabelGroup/examples/LabelGroup.md
+++ b/src/patternfly/components/LabelGroup/examples/LabelGroup.md
@@ -429,9 +429,8 @@ cssPrefix: pf-c-label-group
 {{/label-group}}
 ```
 
-In addition to [label documentation](../label#editable), dynamic label groups should be managed with JavaScript
-* `.pf-c-label-group.pf-m-editable` onClick event should (excluding labels within):
-  * Set focus on `.pf-c-label-group__textarea`
+In addition to the JavaScript management of [editable labels](/components/label#editable), dynamic label groups also need:
+* `.pf-c-label-group.pf-m-editable` onClick event should (excluding labels within) set focus on `.pf-c-label-group__textarea`
 
 ### Editable labels, dynamic label group
 ``` hbs

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -329,7 +329,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
 | `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
-| `aria-hidden="true"` | Parent element containing the page contents when modal is open | Hides main contents of the page from screen readers. The element with `.pf-c-modal-box` must not be a descendent of the element with `aria-hidden="true"`. For more info see [trapping focus](https://pf4.patternfly.org/accessibility-guide#trapping-focus). **Required** |
+| `aria-hidden="true"` | Parent element containing the page contents when modal is open | Hides main contents of the page from screen readers. The element with `.pf-c-modal-box` must not be a descendent of the element with `aria-hidden="true"`. For more info see [trapping focus](/accessibility/product-development-guide#trapping-focus). **Required** |
 
 ### Usage
 | Class | Applied | Outcome |

--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -219,7 +219,7 @@ A popover is used to provide contextual information for another component on cli
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-popover` | Gives the popover an accessible description by referring to the popover content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the popover. |
 | `aria-modal="true"` | `.pf-c-popover` | Tells assistive technologies that the windows underneath the current popover are not available for interaction. **Required**|
 | `aria-label="Close"` | `.pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
-| `aria-hidden="true"` | Parent element containing the page contents when the popover is open. | Hides main contents of the page from screen readers. The element with `.pf-c-popover` must not be a descendent of the element with `aria-hidden="true"`. For more info see [trapping focus](https://pf4.patternfly.org/accessibility-guide#trapping-focus). **Required** |
+| `aria-hidden="true"` | Parent element containing the page contents when the popover is open. | Hides main contents of the page from screen readers. The element with `.pf-c-popover` must not be a descendent of the element with `aria-hidden="true"`. For more info, see [trapping focus](/accessibility/product-development-guide#trapping-focus). **Required** |
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -228,7 +228,7 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-c-popover__arrow` | `<div>` |  Creates an arrow pointing towards the element the popover describes. **Required** |
 | `.pf-c-popover__content` | `<div>` |  Creates the content area of the popover. **Required** |
 | `.pf-c-button` | `<button>` |  Positions the close icon in the top-right corner of the popover. **Required** |
-| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. See [title component](/documentation/core/components/title) for more info.|
+| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. See the [title component](/components/title) for more info.|
 | `.pf-c-popover__body` | `<div>` |  The popover's body text. **Required** |
 | `.pf-c-popover__footer` | `<footer>` | Initiates a popover footer. |
 | `.pf-m-left{-top/bottom}` | `.pf-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |

--- a/src/patternfly/components/Select/examples/Select.md
+++ b/src/patternfly/components/Select/examples/Select.md
@@ -180,7 +180,7 @@ The Dropdown Multi Select should be used when the user is selecting multiple ite
 | `.pf-c-select` | `<div>` |  Initiates the select component. |
 | `.pf-c-select__toggle` | `<div>` |  Initiates the select toggle. |
 | `.pf-c-select__toggle-wrapper` | `<div>` |  Initiates the select toggle wrapper so that chips and input field can wrap together. |
-| `.pf-c-chip` | `<div>` |  Initiates a chip. (See [chip component](/documentation/core/components/check) for more details) |
+| `.pf-c-chip` | `<div>` |  Initiates a chip. (See [chip component](/components/chip) for more details) |
 | `.pf-c-select__toggle-typeahead` | `input.pf-c-form-control` |  Initiates the input field for typeahead. |
 | `.pf-c-select__toggle-clear` | `button.pf-m-plain` |  Initiates a clear button in the toggle. |
 | `.pf-c-select__toggle-button` | `<button>` | Initiates a toggle button. |
@@ -240,7 +240,7 @@ The checkbox select can select multiple items using checkboxes. The number of it
 | `.pf-c-select` | `<div>` | Initiates the select component. |
 | `.pf-c-select__toggle` | `<button>` | Initiates the select toggle. |
 | `.pf-c-select__toggle-wrapper` | `<div>` | Initiates the select toggle wrapper so that chips and input field can wrap together. |
-| `.pf-c-chip` | `<div>` | Initiates a chip. (See [chip component](/documentation/core/components/chip) for more details) |
+| `.pf-c-chip` | `<div>` | Initiates a chip. (See [chip component](/components/chip) for more details) |
 | `.pf-c-select__toggle-typeahead` | `input.pf-c-form-control` |  Initiates the input field for typeahead. |
 | `.pf-c-select__toggle-badge` | `<div>` | Initiates a container for a badge to indicate the number of items checked. * note: This should contain an unread badge * |
 | `.pf-c-select__toggle-clear` | `button.pf-m-plain` | Initiates a clear button in the toggle. |

--- a/src/patternfly/components/SkipToContent/examples/SkipToContent.md
+++ b/src/patternfly/components/SkipToContent/examples/SkipToContent.md
@@ -108,7 +108,7 @@ Press tab to skip to content at the bottom of the page.
 ### Overview
 Skip to content allows screen reader and keyboard users to bypass navigation rather than tabbing through it.
 
-When using `.pf-c-skip-to-content` you must provide an `href` attribute whose value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](/documentation/core/demos/page), and note the use of `tabindex="-1"` which allows the element to receive focus programmatically.
+When using `.pf-c-skip-to-content` you must provide an `href` attribute whose value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](/components/page/html-demos), and note the use of `tabindex="-1"` which allows the element to receive focus programmatically.
 
 ### Accessibility
 | Attribute | Applied to | Outcome |

--- a/src/patternfly/components/TabContent/examples/TabContent.md
+++ b/src/patternfly/components/TabContent/examples/TabContent.md
@@ -55,7 +55,7 @@ cssPrefix: pf-c-tab-content
 
 ## Documentation
 ### Overview
-Tab content should be used with the [tabs component](/documentation/core/components/tabs).
+Tab content should be used with the [tabs component](/components/tabs).
 
 ### Accessibility
 | Attribute | Applied to | Outcome |

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -218,9 +218,9 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-The tabs component should only be used to change content views within a page. The similar-looking but semantically different [horizontal nav component](/documentation/core/components/nav) is available for general navigation use cases.
+The tabs component should only be used to change content views within a page. The similar-looking but semantically different [horizontal nav component](/components/page/html/#horizontal-nav) is available for general navigation use cases.
 
-Tabs should be used with the [tab content component](/documentation/core/components/tabcontent).
+Tabs should be used with the [tab content component](/components/tab-content).
 
 Whenever a list of tabs is unique on the current page, it can be used in a `<nav>` element. Cases where the same set of tabs are duplicated in multiple regions on a page (e.g. cards on a dashboard) are less likely to benefit from using the `<nav>` element.
 

--- a/src/site/pages/contribution.md
+++ b/src/site/pages/contribution.md
@@ -23,7 +23,7 @@ The main handlebars file for a block should be named using kebab case. For examp
 ## Documentation
 For each example you should provide the relevant accessibility and usage guidance as well as any additional notes that could be helpful. Any information that is not specific to an example should be included at the bottom of the page.
 
-A good example of this approach is the [table component](/documentation/core/components/table).
+A good example of this approach is the [table component](/components/table).
 
 ## Modifiers
 ### Modifier parameter


### PR DESCRIPTION
Fixes #4293 

Updates links to use  `/components/component-id` and `/accessibility/product-development-guide`

Updates the list given in the issue, with the following exceptions:
- Spinner, Breadcrumb, and AlertGroup were ok as is
- Added a fix in contribution.md pointing to the table component