### PR TITLE
Update some documentation links to be relative

### DIFF
--- a/src/patternfly/components/SkipToContent/examples/SkipToContent.md
+++ b/src/patternfly/components/SkipToContent/examples/SkipToContent.md
@@ -108,7 +108,7 @@ Press tab to skip to content at the bottom of the page.
 ### Overview
 Skip to content allows screen reader and keyboard users to bypass navigation rather than tabbing through it.
 
-When using `.pf-c-skip-to-content` you must provide an `href` attribute whose value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](/components/page/html-demos), and note the use of `tabindex="-1"` which allows the element to receive focus programmatically.
+When using `.pf-c-skip-to-content` you must provide an `href` attribute whose value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this, navigate to a [page demo](/components/page/html-demos) and note the use of `tabindex="-1"`, which allows the element to receive focus programmatically.
 
 ### Accessibility
 | Attribute | Applied to | Outcome |

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -218,7 +218,7 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-The tabs component should only be used to change content views within a page. The similar-looking but semantically different [horizontal nav component](/components/page/html/#horizontal-nav) is available for general navigation use cases.
+The tabs component should only be used to change content views within a page. The similar-looking but semantically different [horizontal nav component](/components/navigation/#horizontal) is available for general navigation use cases.
 
 Tabs should be used with the [tab content component](/components/tab-content).
 

--- a/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
+++ b/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
@@ -136,9 +136,9 @@ section: utilities
 
 These background color utilities can be used to modify the background color of an element. In most cases, using the components with available modifiers should be sufficient to implement most designs, and should be preferred over customizations using these utilities.
 
-Care should be taken especially when applying background colors, as this can have a negative effect on the readability and accessibility of text. Refer to [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+Care should be taken especially when applying background colors, as this can have a negative effect on the readability and accessibility of text. Refer to [contrast ratios](/guidelines/colors/#contrast-ratios) for more information.
 
-Note that "inverse" background colors are labeled as such to indicate that they are best used with the ["inverse" text colors](https://www.patternfly.org/v4/utilities/text#inverse-colors). 
+Note that "inverse" background colors are labeled as such to indicate that they are best used with the ["inverse" text colors](/utilities/text#inverse-colors). 
 ### Usage
 
 | Class                             | Applied to | Outcome                            |

--- a/src/patternfly/utilities/Text/examples/Text.md
+++ b/src/patternfly/utilities/Text/examples/Text.md
@@ -205,9 +205,9 @@ import './Text.css'
 
 These text utilities can be used to modify text within the PatternFly framework. In most cases, using the components with available modifiers should be sufficient to implement most designs, and should be preferred over customizations using these utilities.
 
-Care should be taken especially when applying text colors, as this can have a negative effect on the readability and accessibility of text. Refer to the information on [contrast ratios](https://www.patternfly.org/v4/guidelines/colors/#contrast-ratios) for more information.
+Care should be taken especially when applying text colors, as this can have a negative effect on the readability and accessibility of text. Refer to the information on [contrast ratios](/guidelines/colors/#contrast-ratios) for more information.
 
-Note that "inverse" text colors are labeled as such to indicate that they best used with the ["inverse" background colors](https://www.patternfly.org/v4/utilities/background-color). 
+Note that "inverse" text colors are labeled as such to indicate that they best used with the ["inverse" background colors](/utilities/background-color). 
 
 ### Usage
 

--- a/src/patternfly/utilities/Text/examples/Text.md
+++ b/src/patternfly/utilities/Text/examples/Text.md
@@ -207,7 +207,7 @@ These text utilities can be used to modify text within the PatternFly framework.
 
 Care should be taken especially when applying text colors, as this can have a negative effect on the readability and accessibility of text. Refer to the information on [contrast ratios](/guidelines/colors/#contrast-ratios) for more information.
 
-Note that "inverse" text colors are labeled as such to indicate that they best used with the ["inverse" background colors](/utilities/background-color). 
+Note that "inverse" text colors are labeled as such to indicate that they best used with the ["inverse" background colors](/utilities/background-color#inverse-background-colors). 
 
 ### Usage
 


### PR DESCRIPTION
Fixes #4345 

Note that in the core workspace, the `/guidelines` links won't point to the right thing, but they will in patternfly.org.