### PR TITLE
feat(progress-stepper): added help text for popover

### DIFF
--- a/src/patternfly/components/ProgressStepper/examples/ProgressStepper.md
+++ b/src/patternfly/components/ProgressStepper/examples/ProgressStepper.md
@@ -39,7 +39,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Basic with descriptions
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper }}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -79,7 +78,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Center aligned with descriptions
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper  progress-stepper--IsCenter="true"}}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -119,7 +117,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Vertical with descriptions
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper progress-stepper--IsVertical="true"}}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -159,7 +156,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Compact
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper progress-stepper--IsCompact="true"}}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -199,7 +195,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Basic with an issue
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper }}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -247,7 +242,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Basic with a failure
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper }}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -295,7 +289,6 @@ cssPrefix: pf-c-progress-stepper
 
 ### Basic with Patternfly icons
 ```hbs
-<!-- progress-stepper--IsVertical="true" progress-stepper--IsCenter="true" progress-stepper--IsCompact="true" -->
 {{#> progress-stepper }}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
     {{> progress-stepper-step-icon}}
@@ -323,6 +316,44 @@ cssPrefix: pf-c-progress-stepper
   {{/progress-stepper-step}}
 {{/progress-stepper}}
 ```
+### With popovers
+```hbs
+{{#> progress-stepper }}
+  {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
+    {{> progress-stepper-step-icon}}
+    {{#> progress-stepper-step-main}}
+      {{#> progress-stepper-step-title progress-stepper-step-title--type="span" progress-stepper-step-title--IsHelp="true"}}
+        First step
+      {{/progress-stepper-step-title}}
+    {{/progress-stepper-step-main}}
+  {{/progress-stepper-step}}
+  {{#> progress-stepper-step progress-stepper-step--IsFailure="true"}}
+    {{> progress-stepper-step-icon}}
+    {{#> progress-stepper-step-main}}
+      {{#> progress-stepper-step-title progress-stepper-step-title--type="span" progress-stepper-step-title--IsHelp="true"}}
+        Second step
+      {{/progress-stepper-step-title}}
+    {{/progress-stepper-step-main}}
+  {{/progress-stepper-step}}
+  {{#> progress-stepper-step progress-stepper-step--IsInProgress="true" progress-stepper-step--IsCurrent="true"}}
+    {{> progress-stepper-step-icon}}
+    {{#> progress-stepper-step-main}}
+      {{#> progress-stepper-step-title progress-stepper-step-title--type="span" progress-stepper-step-title--IsHelp="true"}}
+        Third step
+      {{/progress-stepper-step-title}}
+    {{/progress-stepper-step-main}}
+  {{/progress-stepper-step}}
+  {{#> progress-stepper-step progress-stepper-step--IsPending="true"}}
+    {{> progress-stepper-step-icon}}
+    {{#> progress-stepper-step-main}}
+      {{#> progress-stepper-step-title}}
+        Fourth step
+      {{/progress-stepper-step-title}}
+    {{/progress-stepper-step-main}}
+  {{/progress-stepper-step}}
+{{/progress-stepper}}
+```
+
 
 
 ## Documentation
@@ -358,3 +389,5 @@ Steps can be modified with `.pf-m-success`, `.pf-m-warning`, `.pf-m-danger`, and
 | `.pf-m-info`| `.pf-c-progress-stepper__step` | Modifies for info styling. |
 | `.pf-m-current`| `.pf-c-progress-stepper__step` | Modifies styling for the current step. |
 | `.pf-m-pending`| `.pf-c-progress-stepper__step` | Modifies styling for pending steps. |
+| `.pf-m-help-text`| `.pf-c-progress-stepper__step-title` | Modifies styling for steps that have a popover. |
+ 

--- a/src/patternfly/components/ProgressStepper/examples/ProgressStepper.md
+++ b/src/patternfly/components/ProgressStepper/examples/ProgressStepper.md
@@ -316,7 +316,7 @@ cssPrefix: pf-c-progress-stepper
   {{/progress-stepper-step}}
 {{/progress-stepper}}
 ```
-### With popovers
+### With help text
 ```hbs
 {{#> progress-stepper }}
   {{#> progress-stepper-step progress-stepper-step--IsComplete="true"}}
@@ -389,5 +389,5 @@ Steps can be modified with `.pf-m-success`, `.pf-m-warning`, `.pf-m-danger`, and
 | `.pf-m-info`| `.pf-c-progress-stepper__step` | Modifies for info styling. |
 | `.pf-m-current`| `.pf-c-progress-stepper__step` | Modifies styling for the current step. |
 | `.pf-m-pending`| `.pf-c-progress-stepper__step` | Modifies styling for pending steps. |
-| `.pf-m-help-text`| `.pf-c-progress-stepper__step-title` | Modifies styling for steps that have a popover. |
+| `.pf-m-help-text`| `.pf-c-progress-stepper__step-title` | Modifies styling for steps that have help text. |
  

--- a/src/patternfly/components/ProgressStepper/progress-stepper-step-title.hbs
+++ b/src/patternfly/components/ProgressStepper/progress-stepper-step-title.hbs
@@ -1,6 +1,11 @@
-<div class="pf-c-progress-stepper__step-title{{#if progress-stepper-step-title--modifier}} {{progress-stepper-step-title--modifier}}{{/if}}"
+<{{#if progress-stepper-step-title--type}}{{progress-stepper-step-title--type}}{{else}}div{{/if}} class="pf-c-progress-stepper__step-title{{#if progress-stepper-step-title--IsHelp}} pf-m-help-text{{/if}}{{#if progress-stepper-step-title--modifier}} {{progress-stepper-step-title--modifier}}{{/if}}"
+  {{#if progress-stepper-step-title--IsHelp}}
+    role="button"
+    type="button"
+    tabindex="0"
+  {{/if}}
   {{#if progress-stepper-step-title--attribute}}
     {{{progress-stepper-step-title--attribute}}}
   {{/if}}>
   {{>@partial-block}}
-</div>
+</{{#if progress-stepper-step-title--type}}{{progress-stepper-step-title--type}}{{else}}div{{/if}}>

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -76,7 +76,6 @@
   --pf-c-progress-stepper__step--m-current__step-title--Color: var(--pf-global--Color--100);
   --pf-c-progress-stepper__step--m-pending__step-title--Color: var(--pf-global--Color--200);
   --pf-c-progress-stepper__step--m-danger__step-title--Color: var(--pf-global--danger-color--100);
-  --pf-c-progress-stepper__step--m-danger__step-description--Color: var(--pf-global--danger-color--100);
   --pf-c-progress-stepper--m-center__step-title--TextAlign: center;
   --pf-c-progress-stepper--m-compact__step-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-progress-stepper--m-compact__step-title--FontWeight: var(--pf-global--FontWeight--normal);

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -10,7 +10,7 @@
 
   // Step variables
 
-  // Ste -connector variables
+  // Step connector variables
   --pf-c-progress-stepper__step-connector--JustifyContent: start;
   --pf-c-progress-stepper--m-center__step-connector--JustifyContent: center;
 
@@ -75,10 +75,27 @@
   --pf-c-progress-stepper__step--m-current__step-title--FontWeight: var(--pf-global--FontWeight--bold);
   --pf-c-progress-stepper__step--m-current__step-title--Color: var(--pf-global--Color--100);
   --pf-c-progress-stepper__step--m-pending__step-title--Color: var(--pf-global--Color--200);
+  --pf-c-progress-stepper__step--m-danger__step-title--Color: var(--pf-global--danger-color--100);
   --pf-c-progress-stepper__step--m-danger__step-description--Color: var(--pf-global--danger-color--100);
   --pf-c-progress-stepper--m-center__step-title--TextAlign: center;
   --pf-c-progress-stepper--m-compact__step-title--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-progress-stepper--m-compact__step-title--FontWeight: var(--pf-global--FontWeight--normal);
+
+  // Help text variables for the step title
+  --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-global--BorderColor--200);
+  --pf-c-progress-stepper__step-title--m-help-text--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
+  --pf-c-progress-stepper__step-title--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --pf-c-progress-stepper__step-title--m-help-text--hover--TextDecorationColor: var(--pf-global--Color--100);
+  --pf-c-progress-stepper__step-title--m-help-text--focus--TextDecorationColor: var(--pf-global--Color--100);
+  --pf-c-progress-stepper__step-title--m-help-text--hover--Color: var(--pf-global--Color--100);
+  --pf-c-progress-stepper__step-title--m-help-text--focus--Color: var(--pf-global--Color--100);
+
+  // Help text variables the step title for failure state
+  --pf-c-progress-stepper__step--m-danger__step-title--m-help-text--hover--Color: var(--pf-global--danger-color--200);
+  --pf-c-progress-stepper__step--m-danger__step-title--m-help-text--focus--Color: var(--pf-global--danger-color--200);
+  --pf-c-progress-stepper__step--m-danger__step-title--m-help-text--TextDecorationColor: var(--pf-global--danger-color--100);
+  --pf-c-progress-stepper__step--m-danger__step-title--m-help-text--hover--TextDecorationColor: var(--pf-global--danger-color--200);
+  --pf-c-progress-stepper__step--m-danger__step-title--m-help-text--focus--TextDecorationColor: var(--pf-global--danger-color--200);
 
   // Step Description variables
   --pf-c-progress-stepper__step-description--MarginTop: var(--pf-global--spacer--xs);
@@ -173,7 +190,14 @@
 
   &.pf-m-danger {
     --pf-c-progress-stepper__step-icon--Color: var(--pf-global--danger-color--100);
-    --pf-c-progress-stepper__step-title--Color: var(--pf-c-progress-stepper__step--m-danger__step-description--Color);
+    --pf-c-progress-stepper__step-title--Color: var(--pf-c-progress-stepper__step--m-danger__step-title--Color);
+
+    // Help text variables for failure state
+    --pf-c-progress-stepper__step-title--m-help-text--hover--Color: var(--pf-c-progress-stepper__step--m-danger__step-title--m-help-text--hover--Color);
+    --pf-c-progress-stepper__step-title--m-help-text--focus--Color: var(--pf-c-progress-stepper__step--m-danger__step-title--m-help-text--focus--Color);
+    --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-c-progress-stepper__step--m-danger__step-title--m-help-text--TextDecorationColor);
+    --pf-c-progress-stepper__step-title--m-help-text--hover--TextDecorationColor: var(--pf-c-progress-stepper__step--m-danger__step-title--m-help-text--hover--TextDecorationColor);
+    --pf-c-progress-stepper__step-title--m-help-text--focus--TextDecorationColor: var(--pf-c-progress-stepper__step--m-danger__step-title--m-help-text--focus--TextDecorationColor);
   }
 
   &.pf-m-warning {
@@ -243,6 +267,25 @@
   font-weight: var(--pf-c-progress-stepper__step-title--FontWeight);
   color: var(--pf-c-progress-stepper__step-title--Color);
   text-align: var(--pf-c-progress-stepper__step-title--TextAlign);
+
+  &.pf-m-help-text {
+    text-decoration: underline;
+    cursor: pointer;
+    text-decoration-style: dashed;
+    text-decoration-color: var(--pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor);
+    text-decoration-thickness: var(--pf-c-progress-stepper__step-title--m-help-text--TextDecorationThickness);
+    text-underline-offset: var(--pf-c-progress-stepper__step-title--m-help-text--TextUnderlineOffset);
+
+    &:hover {
+      --pf-c-progress-stepper__step-title--Color: var(--pf-c-progress-stepper__step-title--m-help-text--hover--Color);
+      --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-c-progress-stepper__step-title--m-help-text--hover--TextDecorationColor);
+    }
+
+    &:focus {
+      --pf-c-progress-stepper__step-title--Color: var(--pf-c-progress-stepper__step-title--m-help-text--focus--Color);
+      --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-c-description-list__text--m-help-text--focus--TextDecorationColor);
+    }
+  }
 }
 
 // Step description

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -283,7 +283,7 @@
 
     &:focus {
       --pf-c-progress-stepper__step-title--Color: var(--pf-c-progress-stepper__step-title--m-help-text--focus--Color);
-      --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-c-description-list__text--m-help-text--focus--TextDecorationColor);
+      --pf-c-progress-stepper__step-title--m-help-text--TextDecorationColor: var(--pf-c-progress-stepper__step-title--m-help-text--focus--TextDecorationColor);
     }
   }
 }


### PR DESCRIPTION
This adds in styling for the `.pf-m-help-text` to be added to the step title so that it can be used for initiating a popover.

Fixes #4372 