### PR TITLE
fix(select): removed double invalid icon on invalid typeahead

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -113,7 +113,7 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   --pf-c-form-control--invalid--BackgroundSize: var(--pf-c-form-control--invalid--BackgroundSizeX) var(--pf-c-form-control--invalid--BackgroundSizeY);
   --pf-c-form-control--invalid--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--invalid--Coordinates, $svg-color: $pf-c-form-control--invalid--Color)};
   --pf-c-form-control--invalid--exclamation--Background: var(--pf-c-form-control--invalid--BackgroundUrl) var(--pf-c-form-control--invalid--BackgroundPosition) / var(--pf-c-form-control--invalid--BackgroundSize) no-repeat;
-  --pf-c-form-control--invalid--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--invalid--exclamation--Background);
+  --pf-c-form-control--invalid--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--invalid--exclamation--Background); // remove in breaking change
 
   // Input m-search
   --pf-c-form-control--m-search--PaddingLeft: var(--pf-global--spacer--xl);

--- a/src/patternfly/components/Select/examples/Select.md
+++ b/src/patternfly/components/Select/examples/Select.md
@@ -126,6 +126,12 @@ The single select should be used when the user is selecting an option from a lis
 {{/select}}
 ```
 
+### Invalid with typeahead
+```hbs
+{{#> select select-toggle--type="div" id="select-single-typeahead-invalid" select--IsTypeahead="true" select-typeahead--Placeholder="Choose a state"  select--IsInvalid="true"}}
+{{/select}}
+```
+
 The single select typeahead should be used when the user is selecting one option from a list of items with the option to narrow the list by typing from the keyboard. Selected items are removed from the list. The user can clear the selection and restore the placeholder text.
 
 ### Accessibility
@@ -165,6 +171,12 @@ The single select typeahead should be used when the user is selecting one option
 ### Multi with typeahead (chip group collapsed)
 ```hbs
 {{#> select select-toggle--type="div" id="select-multi-typeahead-expanded-selected" select--IsMultiSelect="true" select--IsExpanded="true" select--IsTypeahead="true" select--ItemIsSelected="true" select--IsCurrentlyTyping="true" select-typeahead--Placeholder="New"}}
+{{/select}}
+```
+
+### Multi with typeahead invalid
+```hbs
+{{#> select select-toggle--type="div" id="select-multi-typeahead-invalid" select--IsExpandedChips="true" select--IsMultiSelect="true" select--IsExpanded="true" select--IsTypeahead="true" select--ItemIsSelected="true" select--IsInvalid="true" select-typeahead--Placeholder="Choose states"}}
 {{/select}}
 ```
 

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -1,15 +1,15 @@
-{{#if select--ItemIsSelected}}
+{{#if select--IsDisabled}}
   {{#> form-control controlType="input"
     input="true"
     form-control--modifier="pf-c-select__toggle-typeahead"
-    form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" value="' select-typeahead--Placeholder '"')}}
+    form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '" disabled')}}
   {{/form-control}}
 {{else}}
-  {{#if select--IsDisabled}}
+  {{#if select--IsInvalid}}
     {{#> form-control controlType="input"
       input="true"
       form-control--modifier="pf-c-select__toggle-typeahead"
-      form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '" disabled')}}
+      form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
     {{/form-control}}
   {{else}}
     {{#> form-control controlType="input"

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -328,6 +328,8 @@
     .pf-c-form-control {
       @include pf-text-overflow;
 
+      --pf-c-form-control--invalid--BackgroundUrl: none;
+
       position: relative;
       height: auto;
     }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4263

I noticed some differences between core & react's invalid states:

#### Single select
* **Core**: has `aria-invalid` on the toggle `<button>`
* **React**: has `aria-invalid` on the `.pf-c-select` component container

#### Typeahead
* **Core**: now has `aria-invalid` on the text input
* **React*: has `aria-invalid` on the `.pf-c-select` component container

#### Typeahead multi-select
* **Core**: has `aria-invalid` on the text input
* **React**
  * has `aria-invalid` on the `.pf-c-select` component container
  * has `aria-invalid` on the text input

@jessiehuff just wanted to verify any follow up changes needed by core and react after this PR?