### PR TITLE
feat(data-list): updated drag/drop styles for draggable component

### DIFF
--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -82,6 +82,15 @@
   --pf-c-data-list__toggle-icon--Rotate: 0;
   --pf-c-data-list__item--m-expanded__toggle-icon--Rotate: 90deg;
 
+  // draggable
+  --pf-c-data-list--m-drag-over--before--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-data-list--m-drag-over--before--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-data-list--m-drag-over--before--Opacity: .6;
+  --pf-c-data-list--m-drag-over--after--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-data-list--m-drag-over--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-data-list--m-drag-over--after--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-data-list--m-drag-outside--after--BorderColor: var(--pf-global--danger-color--100);
+
   // draggable button/icon
   --pf-c-data-list__item-draggable-button--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-data-list__item-draggable-button--PaddingRight: var(--pf-global--spacer--md);
@@ -94,8 +103,14 @@
   --pf-c-data-list__item-draggable-button--m-disabled__draggable-icon--Color: var(--pf-global--disabled-color--200);
   --pf-c-data-list__item-draggable-button--hover__draggable-icon--Color: var(--pf-global--icon--Color--dark);
   --pf-c-data-list__item-draggable-button--focus__draggable-icon--Color: var(--pf-global--icon--Color--dark);
-  --pf-c-data-list__item--m-ghost-row--after--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-data-list__item--m-ghost-row--after--Opacity: .6;
+  --pf-c-data-list__item--m-ghost-row--BoxShadow: var(--pf-global--BoxShadow--md);
+  --pf-c-data-list__item--m-ghost-row--active--Cursor: grabbing;
+  --pf-c-data-list--m-drag-outside__item--m-ghost-row--active--Cursor: not-allowed;
+  --pf-c-data-list__item--m-ghost-row--after--BackgroundColor: transparent; // remove at breaking change
+  --pf-c-data-list__item--m-ghost-row--after--Opacity: 1; // remove at breaking change
+  --pf-c-data-list__item--m-ghost-row--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-data-list__item--m-ghost-row--after--BorderColor: var(--pf-global--active-color--100);
+  --pf-c-data-list--m-drag-outside__item--m-ghost-row--after--BorderColor: var(--pf-global--danger-color--100);
 
   // controls
   --pf-c-data-list__item-control--PaddingTop: var(--pf-global--spacer--lg);
@@ -107,7 +122,6 @@
   // check
   --pf-c-data-list__check--Height: calc(var(--pf-c-data-list--FontSize) * var(--pf-c-data-list--LineHeight));
   --pf-c-data-list__check--MarginTop: #{pf-size-prem(-1px)}; // slightly offset input
-
 
   // actions
   --pf-c-data-list__item-action--Display: flex;
@@ -204,7 +218,36 @@
   }
 
   &.pf-m-drag-over {
+    position: relative;
     overflow-anchor: none;
+
+    &::before,
+    &::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      content: "";
+    }
+
+    &::before {
+      z-index: var(--pf-c-data-list--m-drag-over--before--ZIndex);
+      background-color: var(--pf-c-data-list--m-drag-over--before--BackgroundColor);
+      opacity: var(--pf-c-data-list--m-drag-over--before--Opacity);
+    }
+
+    &::after {
+      z-index: var(--pf-c-data-list--m-drag-over--after--ZIndex);
+      background: #{rgba(var(--pf-c-data-list--m-drag-over--before--BackgroundColor), .5)};
+      border: var(--pf-c-data-list--m-drag-over--after--BorderWidth) solid var(--pf-c-data-list--m-drag-over--after--BorderColor);
+    }
+  }
+
+  &.pf-m-drag-outside {
+    --pf-c-data-list--m-drag-over--after--BorderColor: var(--pf-c-data-list--m-drag-outside--after--BorderColor);
+    --pf-c-data-list__item--m-ghost-row--after--BorderColor: var(--pf-c-data-list--m-drag-outside__item--m-ghost-row--after--BorderColor);
+    --pf-c-data-list__item--m-ghost-row--active--Cursor: var(--pf-c-data-list--m-drag-outside__item--m-ghost-row--active--Cursor);
   }
 }
 
@@ -289,6 +332,12 @@
   }
 
   &.pf-m-ghost-row {
+    box-shadow: var(--pf-c-data-list__item--m-ghost-row--BoxShadow);
+
+    &:active {
+      cursor: var(--pf-c-data-list__item--m-ghost-row--active--Cursor);
+    }
+
     &::after {
       position: absolute;
       top: 0;
@@ -297,6 +346,7 @@
       left: 0;
       content: "";
       background-color: var(--pf-c-data-list__item--m-ghost-row--after--BackgroundColor);
+      border: var(--pf-c-data-list__item--m-ghost-row--after--BorderWidth) solid var(--pf-c-data-list__item--m-ghost-row--after--BorderColor);
       opacity: var(--pf-c-data-list__item--m-ghost-row--after--Opacity);
     }
   }

--- a/src/patternfly/components/DataList/examples/DataList.css
+++ b/src/patternfly/components/DataList/examples/DataList.css
@@ -1,0 +1,17 @@
+#ws-core-c-data-list-draggable {
+  --ws-core-c-data-list-draggable--ghost-row--Top: 50%;
+}
+
+[id^="ws-core-c-data-list-draggable"] .pf-m-ghost-row {
+  position: absolute;
+  top: var(--ws-core-c-data-list-draggable--ghost-row--Top);
+  left: 1em;
+  z-index: 9999;
+  width: 100%;
+}
+
+#ws-core-c-data-list-draggable-drag-outside {
+  --ws-core-c-data-list-draggable--ghost-row--Top: calc(100% + .5em);
+
+  padding-bottom: 60px;
+}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -4,6 +4,8 @@ section: components
 cssPrefix: pf-c-data-list
 ---
 
+import './DataList.css'
+
 ## Examples
 
 ### Basic
@@ -881,7 +883,7 @@ When a list item includes more than one block of content, it can be difficult fo
 <div id="draggable-help">
   Activate the reorder button and use the arrow keys to reorder the list or use your mouse to drag/reorder. Press escape to cancel the reordering.
 </div>
-{{#> data-list data-list--modifier="pf-m-compact" data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
+{{#> data-list data-list--modifier="pf-m-compact pf-m-drag-over" data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
@@ -914,10 +916,26 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-3" data-list-item--modifier="pf-m-ghost-row"}}
+  {{#> data-list-item data-list-item--id="item-3"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-         {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-3" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-3 ' data-list--id '-item-3" disabled')}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-3" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-3 ' data-list--id '-item-3"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-4" data-list-item--modifier="pf-m-ghost-row"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+         {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-4" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-4 ' data-list--id '-item-4" disabled')}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -930,10 +948,133 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-4"}}
+  {{#> data-list-item data-list-item--id="item-5"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-4" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-4 ' data-list--id '-item-4"')}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-5" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-5 ' data-list--id '-item-5"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-6"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-6" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-6 ' data-list--id '-item-6"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+{{/data-list}}
+<div class="pf-screen-reader" aria-live="assertive">
+  This is the aria-live section that provides real-time feedback to the user.
+</div>
+```
+
+### Draggable drag outside
+```hbs
+<div id="draggable-help">
+  Activate the reorder button and use the arrow keys to reorder the list or use your mouse to drag/reorder. Press escape to cancel the reordering.
+</div>
+{{#> data-list data-list--modifier="pf-m-compact pf-m-drag-over pf-m-drag-outside" data-list--id="data-list-draggable-drag-outside" data-list--attribute='aria-label="Draggable data list rows"'}}
+  {{#> data-list-item data-list-item--id="item-1"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--modifier="pf-m-disabled" data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-1" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-1 ' data-list--id '-item-1" disabled')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            Draggable icon disabled
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-2"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-2" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-2 ' data-list--id '-item-2"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-3"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-3" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-3 ' data-list--id '-item-3"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-4" data-list-item--modifier="pf-m-ghost-row"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+         {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-4" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-4 ' data-list--id '-item-4" disabled')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            Ghost row
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-5"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-5" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-5 ' data-list--id '-item-5"')}}
+        {{> data-list-check}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          {{#> data-list-cell-text data-list-cell-text--attribute=(concat 'id="' data-list--id '-' data-list-item--id '"')}}
+            List item
+          {{/data-list-cell-text}}
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--id="item-6"}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-6" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-6 ' data-list--id '-item-6"')}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -969,6 +1110,7 @@ When a list item includes more than one block of content, it can be difficult fo
 | `.pf-m-ghost-row` | `.pf-c-data-list__item.pf-m-draggable` | Modifies a draggable data list item to be the ghost row. |
 | `.pf-m-disabled` | `.pf-c-data-list__item.pf-m-draggable` | Modifies a data list draggable item for the disabled state. |
 | `.pf-m-drag-over` | `.pf-c-data-list` | Modifies the data list to indicate that a draggable item is being dragged over the data list. |
+| `.pf-m-drag-outside` | `.pf-c-data-list` | Modifies the data list to indicate that a draggable item is being dragged outside of the allowed drop zone. |
 
 ### Text modifiers
 ```hbs


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4376

@redallen this leaves the existing style API in place:

* add `.pf-m-ghost-row` to the `.pf-c-data-list__item` being dragged
* add `.pf-m-drag-over` to the `.pf-c-data-list` being dragged over
* add `.pf-m-drag-outside` to the `.pf-c-data-list` if the draggable item is out of bounds