### PR TITLE
fix(log-viewer): preserved white space in log viewer text

### DIFF
--- a/src/patternfly/components/LogViewer/log-viewer-string.hbs
+++ b/src/patternfly/components/LogViewer/log-viewer-string.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-log-viewer__string{{#if log-viewer-string--modifier}} {{log-viewer-string--modifier}}{{/if}}"
-  {{#if log-viewer-string--attribute}}
-    {{{log-viewer-string--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/LogViewer/log-viewer.scss
+++ b/src/patternfly/components/LogViewer/log-viewer.scss
@@ -198,6 +198,7 @@
   font-size: var(--pf-c-log-viewer__text--FontSize);
   color: var(--pf-c-log-viewer__text--Color);
   word-break: break-all;
+  white-space: break-spaces;
 }
 
 // Timestamp

--- a/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
+++ b/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
@@ -1,3 +1,4 @@
+<!--prettyhtml-ignore-start-->
 <div class="pf-c-log-viewer__list" style="height: 301080px;">
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 0px; width: 100%;">
     <span class="pf-c-log-viewer__index">1</span>
@@ -60,3 +61,4 @@
     <span class="pf-c-log-viewer__text">I0223 20:04:25.238819 17 plugins.go:84] Registered admission plugin "scheduling.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/PodNodeConstraints"</span>
   </div>
 </div>
+<!--prettyhtml-ignore-end-->

--- a/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
+++ b/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
@@ -5,58 +5,58 @@
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 21px; width: 100%;">
     <span class="pf-c-log-viewer__index">2</span>
-    <span class="pf-c-log-viewer__text">    Waiting for port :6443 to be released.</span>
+    <span class="pf-c-log-viewer__text">Waiting for port :6443 to be released.</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 42px; width: 100%;">
     <span class="pf-c-log-viewer__index">3</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.084507       1 loader.go:379] Config loaded from file:  /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.084507 1 loader.go:379] Config loaded from file: /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 84px; width: 100%;">
     <span class="pf-c-log-viewer__index">4</span>
-    <span class="pf-c-log-viewer__text">    Copying termination logs to "/var/log/kube-apiserver/termination.log"</span>
+    <span class="pf-c-log-viewer__text">Copying termination logs to "/var/log/kube-apiserver/termination.log"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 105px; width: 100%;">
     <span class="pf-c-log-viewer__index">5</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.087543       1 main.go:124] Touching termination lock file "/var/log/kube-apiserver/.terminating"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.087543 1 main.go:124] Touching termination lock file "/var/log/kube-apiserver/.terminating"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 147px; width: 100%;">
     <span class="pf-c-log-viewer__index">6</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.088797       1 main.go:182] Launching sub-process "/usr/bin/hyperkube kube-apiserver --{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-current"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=10.0.171.12 -v=2"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.088797 1 main.go:182] Launching sub-process "/usr/bin/hyperkube kube-apiserver --{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-current">openshift</span>{{else}}openshift{{/if}}-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=10.0.171.12 -v=2"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 210px; width: 100%;">
     <span class="pf-c-log-viewer__index">7</span>
-    <span class="pf-c-log-viewer__text">    Flag --{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}-config has been deprecated, to be removed</span>
+    <span class="pf-c-log-viewer__text">Flag --{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}-config has been deprecated, to be removed</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 231px; width: 100%;">
     <span class="pf-c-log-viewer__index">8</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238681      17 plugins.go:84] Registered admission plugin "authorization.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/RestrictSubjectBindings"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238681 17 plugins.go:84] Registered admission plugin "authorization.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/RestrictSubjectBindings"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 273px; width: 100%;">
     <span class="pf-c-log-viewer__index">9</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238763      17 plugins.go:84] Registered admission plugin "image.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/ImagePolicy"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238763 17 plugins.go:84] Registered admission plugin "image.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/ImagePolicy"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 315px; width: 100%;">
     <span class="pf-c-log-viewer__index">10</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238775      17 plugins.go:84] Registered admission plugin "route.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/IngressAdmission"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238775 17 plugins.go:84] Registered admission plugin "route.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/IngressAdmission"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 357px; width: 100%;">
     <span class="pf-c-log-viewer__index">11</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238783      17 plugins.go:84] Registered admission plugin "scheduling.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/OriginPodNodeEnvironment"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238783 17 plugins.go:84] Registered admission plugin "scheduling.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/OriginPodNodeEnvironment"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 399px; width: 100%;">
     <span class="pf-c-log-viewer__index">12</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238792      17 plugins.go:84] Registered admission plugin "autoscaling.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/ClusterResourceOverride"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238792 17 plugins.go:84] Registered admission plugin "autoscaling.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/ClusterResourceOverride"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 441px; width: 100%;">
     <span class="pf-c-log-viewer__index">13</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238801      17 plugins.go:84] Registered admission plugin "quota.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/ClusterResourceQuota"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238801 17 plugins.go:84] Registered admission plugin "quota.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/ClusterResourceQuota"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 483px; width: 100%;">
     <span class="pf-c-log-viewer__index">14</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238810      17 plugins.go:84] Registered admission plugin "autoscaling.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/RunOnceDuration"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238810 17 plugins.go:84] Registered admission plugin "autoscaling.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/RunOnceDuration"</span>
   </div>
   <div class="pf-c-log-viewer__list-item" style="position: absolute; left: 0px; top: 525px; width: 100%;">
     <span class="pf-c-log-viewer__index">15</span>
-    <span class="pf-c-log-viewer__text">    I0223 20:04:25.238819      17 plugins.go:84] Registered admission plugin "scheduling.{{#if log-viewer--IsMatch}}{{#> log-viewer-string log-viewer-string--modifier="pf-m-match"}}openshift{{/log-viewer-string}}{{else}}openshift{{/if}}.io/PodNodeConstraints"</span>
+    <span class="pf-c-log-viewer__text">I0223 20:04:25.238819 17 plugins.go:84] Registered admission plugin "scheduling.{{#if log-viewer--IsMatch}}<span class="pf-c-log-viewer__string pf-m-match">openshift</span>{{else}}openshift{{/if}}.io/PodNodeConstraints"</span>
   </div>
 </div>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4396

@redallen when you have an html element in an example block, it renders a new line before the element. Is there a way we can fix that? It's messing up the formatting in some of these examples.
<img width="414" alt="Screen Shot 2021-09-22 at 4 56 54 PM" src="https://user-images.githubusercontent.com/35148959/134427692-23b4aead-fb37-4ed8-89c0-b4a09aabf76f.png">

