### PR TITLE
fix(menu): updated flyout button to anchor

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -119,6 +119,150 @@ import './Menu.css'
 {{/menu}}
 ```
 
+### With flyout with link
+```hbs
+{{#> menu menu--modifier="pf-m-flyout"}}
+  {{#> menu-content}}
+    {{#> menu-list menu-item--IsLink="true"}}
+      {{#> menu-list-item}}
+        {{#> menu-item}}
+          {{#> menu-item-main}}
+            {{#> menu-item-text}}
+              Example link 1
+            {{/menu-item-text}}
+          {{/menu-item-main}}
+        {{/menu-item}}
+      {{/menu-list-item}}
+      {{#> menu-list-item}}
+        {{#> menu-item}}
+          {{#> menu-item-main}}
+            {{#> menu-item-text}}
+              Example link 2
+            {{/menu-item-text}}
+          {{/menu-item-main}}
+        {{/menu-item}}
+      {{/menu-list-item}}
+      {{#> menu-list-item menu-list-item--IsFlyoutWithLink="true"}}
+        {{#> menu-item menu-item--url="#with-flyout-with-link"}}
+          {{#> menu-item-main}}
+            {{#> menu-item-text}}
+              Flyout link 1
+            {{/menu-item-text}}
+            {{> menu-item-toggle-icon}}
+          {{/menu-item-main}}
+        {{/menu-item}}
+        {{#> menu menu--attribute="hidden" menu-item--IsLink="true" menu-list-item--IsFlyoutWithLink=reset}}
+          {{#> menu-content}}
+            {{#> menu-list}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Application grouping
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Count
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Labels
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Annotations
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+            {{/menu-list}}
+          {{/menu-content}}
+        {{/menu}}
+      {{/menu-list-item}}
+      {{#> menu-list-item menu-list-item--IsFlyoutWithLink="true" menu-list-item--IsExpanded="true"}}
+        {{#> menu-item}}
+          {{#> menu-item-main}}
+            {{#> menu-item-text menu-item-text--url="#with-flyout-with-link"}}
+              Flyout link 2
+            {{/menu-item-text}}
+            {{> menu-item-toggle-icon}}
+          {{/menu-item-main}}
+          {{#> menu-item-description}}
+            Description
+          {{/menu-item-description}}
+        {{/menu-item}}
+        {{#> menu menu-item--IsLink="true" menu-list-item--IsFlyoutWithLink=reset}}
+          {{#> menu-content}}
+            {{#> menu-list}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Submenu Link 1
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Submenu Link 2
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Submenu Link 3
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Submenu Link 4
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+            {{/menu-list}}
+          {{/menu-content}}
+        {{/menu}}
+      {{/menu-list-item}}
+      {{#> menu-list-item}}
+        {{#> menu-item}}
+          {{#> menu-item-main}}
+            {{#> menu-item-text}}
+              Link 5
+            {{/menu-item-text}}
+          {{/menu-item-main}}
+        {{/menu-item}}
+      {{/menu-list-item}}
+    {{/menu-list}}
+  {{/menu-content}}
+{{/menu}}
+```
+
 ### With flyout
 ```hbs
 {{#> menu menu--modifier="pf-m-flyout"}}
@@ -143,7 +287,7 @@ import './Menu.css'
         {{/menu-item}}
       {{/menu-list-item}}
       {{#> menu-list-item}}
-        {{#> menu-item menu-item--attribute='aria-expanded="false"'}}
+        {{#> menu-item menu-item--attribute='aria-expanded="false"' menu-item--IsFlyout="true"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
               Add storage
@@ -1569,7 +1713,8 @@ import './Menu.css'
 | Attribute | Applied | Outcome |
 | -- | -- | -- |
 | `disabled` | `button.pf-c-menu__item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus. |
-| `aria-disabled="true"` | `a.pf-c-menu__item` | When the menu item uses a link element, removes it from keyboard focus. |
+| `aria-disabled="true"` | `a.pf-c-menu__item` | When the menu item uses a link element (not applicable to flyout), removes it from keyboard focus. |
+| `aria-haspopup="true"` | `a.pf-c-menu__item` | When the menu item is a flyout, indicates that the link has a submenu. |
 | `tabindex="-1"` | `a.pf-c-menu__item` | When the menu item uses a link element, removes it from keyboard focus. |
 | `aria-hidden="true"` | `.pf-c-menu__item-icon`, `.pf-c-menu__item-action-icon`, `.pf-c-menu__item-external-icon`, `.pf-c-menu__item-toggle-icon`, `.pf-c-menu__item-select-icon` | Hides the icon from assistive technologies. |
 | `aria-label="Not starred"` | `.pf-c-menu__item-action-icon.pf-m-favorite` | Provides an accessible label indicating that the favorite action is not selected. |

--- a/src/patternfly/components/Menu/menu-item-text.hbs
+++ b/src/patternfly/components/Menu/menu-item-text.hbs
@@ -1,6 +1,19 @@
-<span class="pf-c-menu__item-text{{#if menu-item-text--modifier}} {{menu-item-text--modifier}}{{/if}}"
+<{{#if menu-list-item--IsFlyoutWithLink}}a{{else}}span{{/if}} class="pf-c-menu__item-text{{#if menu-item-text--modifier}} {{menu-item-text--modifier}}{{/if}}"
+  {{#if menu-list-item--IsFlyoutWithLink}}
+    {{#if menu-item--url}}
+      href="{{menu-item--url}}"
+    {{else}}
+      href="#"
+    {{/if}}
+    aria-haspopup="true"
+    {{#if menu-item--IsExpanded}}
+      aria-expanded="true"
+    {{else}}
+      aria-expanded="false"
+    {{/if}}
+  {{/if}}
   {{#if menu-item-text--attribute}}
     {{{menu-item-text--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</span>
+</{{#if menu-list-item--IsFlyoutWithLink}}a{{else}}span{{/if}}>

--- a/src/patternfly/components/Menu/menu-item-toggle-icon.hbs
+++ b/src/patternfly/components/Menu/menu-item-toggle-icon.hbs
@@ -1,4 +1,4 @@
-<span class="pf-c-menu__item-toggle-icon{{#if menu-item-toggle-icon--modifier}} {{menu-item-toggle-icon--modifier}}{{/if}}"
+<{{#if menu-list-item--IsFlyoutWithLink}}button{{else}}span{{/if}} class="pf-c-menu__item-toggle-icon{{#if menu-item-toggle-icon--modifier}} {{menu-item-toggle-icon--modifier}}{{/if}}"
   {{#if menu-item-toggle-icon--attribute}}
     {{{menu-item-toggle-icon--attribute}}}
   {{/if}}>
@@ -7,4 +7,4 @@
   {{else}}
     <i class="fas fa-angle-right"></i>
   {{/if}}
-</span>
+</{{#if menu-list-item--IsFlyoutWithLink}}button{{else}}span{{/if}}>

--- a/src/patternfly/components/Menu/menu-item.hbs
+++ b/src/patternfly/components/Menu/menu-item.hbs
@@ -1,26 +1,43 @@
-<{{# if menu-item--IsLink}}a{{else if menu-item--type}}{{menu-item--type}}{{else}}button{{/if}} class="pf-c-menu__item{{#if menu-item--modifier}} {{menu-item--modifier}}{{/if}}"
-  {{#if menu-item--IsLink}}
-    href="#"
-    {{#if menu-list-item--IsDisabled}}
-      aria-disabled="true"
-      tabindex="-1"
+{{!-- if the menu list item is a has a flyout with a link, use a div --}}
+<{{#if menu-list-item--IsFlyoutWithLink}}div{{else if menu-item--IsFlyout}}a{{else if menu-item--IsLink}}a{{else if menu-item--type}}{{menu-item--type}}{{else}}button{{/if}} class="pf-c-menu__item{{#if menu-item--modifier}} {{menu-item--modifier}}{{/if}}"
+  
+  {{!-- if the menu list item is a has a flyout with a link, pass these props to text and icon --}}
+  {{#unless menu-list-item--IsFlyoutWithLink}}
+    {{#if menu-item--IsLink}}
+      {{#if menu-item--url}}
+        href="{{menu-item--url}}"
+      {{else}}
+        href="#"
+      {{/if}}
+      {{#if menu-list-item--IsDisabled}}
+        aria-disabled="true"
+        tabindex="-1"
+      {{/if}}
+    {{else if menu-item--IsFlyout}}
+      {{#if menu-item--url}}
+        href="{{menu-item--url}}"
+      {{else}}
+        href="#"
+      {{/if}}
+      aria-haspopup="true"
+    {{else}}
+      type="button"
+      {{#if menu-list-item--IsDisabled}}
+        disabled
+      {{/if}}
     {{/if}}
-  {{else}}
-    type="button"
-    {{#if menu-list-item--IsDisabled}}
-      disabled
+    {{!-- aria-expanded value can still be passed manually --}}
+    {{#if menu-list-item--IsExpandable}}
+      {{#if menu-item--IsExpanded}}
+        aria-expanded="true"
+      {{else}}
+        aria-expanded="false"
+      {{/if}}
     {{/if}}
-  {{/if}}
+  {{/unless}}
+  
   {{#if menu-item--attribute}}
     {{{menu-item--attribute}}}
-  {{/if}}
-  {{!-- aria-expanded value can still be passed manually --}}
-  {{#if menu-list-item--IsExpandable}}
-    {{#if menu-item--IsExpanded}}
-      aria-expanded="true"
-    {{else}}
-      aria-expanded="false"
-    {{/if}}
   {{/if}}>
   {{> @partial-block}}
-</{{# if menu-item--IsLink}}a{{else if menu-item--type}}{{menu-item--type}}{{else}}button{{/if}}>
+</{{#if menu-list-item--IsFlyoutWithLink}}div{{else if menu-item--IsFlyout}}a{{else if menu-item--IsLink}}a{{else if menu-item--type}}{{menu-item--type}}{{else}}button{{/if}}>

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -110,6 +110,7 @@
   // Toggle icon
   --pf-c-menu__item-toggle-icon--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-menu__item-toggle-icon--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu__item-toggle-icon--Border: none;
   --pf-c-menu__list-item--m-disabled__item-toggle-icon--Color: var(--pf-global--disabled-color--200);
 
   // Text + toggle
@@ -468,6 +469,7 @@
   line-height: var(--pf-c-menu__item--LineHeight);
   color: var(--pf-c-menu__item--Color);
   text-align: left;
+  cursor: pointer;
   background-color: var(--pf-c-menu__item--BackgroundColor);
   border: none;
 
@@ -505,6 +507,8 @@
   @include pf-text-overflow;
 
   flex-grow: 1;
+  color: inherit;
+  text-decoration: none;
 }
 
 // Group
@@ -539,6 +543,7 @@
   padding-right: var(--pf-c-menu__item-toggle-icon--PaddingRight);
   padding-left: var(--pf-c-menu__item-toggle-icon--PaddingLeft);
   color: var(--pf-c-menu__item-toggle-icon, inherit);
+  border: var(--pf-c-menu__item-toggle-icon--Border);
 }
 
 .pf-c-menu__item-text + .pf-c-menu__item-toggle-icon {


### PR DESCRIPTION
closes #4306 

Based on the direction provided by [W3.org flyout guidance](https://www.w3.org/WAI/tutorials/menus/flyout/), a flyout parent should be an anchor. If the flyout control should be a link, the icon should control toggle and text should be clickable. 