### PR TITLE
fix(app launcher, menu, select): fixed favorite colors

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -45,13 +45,15 @@
   --pf-c-app-launcher__menu-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-app-launcher__menu-item--m-link--PaddingRight: 0;
   --pf-c-app-launcher__menu-item--m-link--hover--BackgroundColor: transparent;
-  --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
+  --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-global--Color--200);
   --pf-c-app-launcher__menu-item--m-action--Width: auto;
   --pf-c-app-launcher__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
   --pf-c-app-launcher__menu-item--m-action--hover--BackgroundColor: transparent;
-  --pf-c-app-launcher__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200);
+  --pf-c-app-launcher__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200); // remove at breaking change
   --pf-c-app-launcher__menu-item--m-action--hover--Color: var(--pf-global--Color--100);
+  --pf-c-app-launcher__menu-item--m-action--disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-app-launcher__menu-item--m-favorite__menu-item--m-action--Color: var(--pf-global--palette--gold-400);
+  --pf-c-app-launcher__menu-item--m-favorite__menu-item--m-action--hover--Color: var(--pf-global--palette--gold-500);
 
   // Menu item icon
   --pf-c-app-launcher__menu-item-icon--MarginRight: var(--pf-global--spacer--sm);
@@ -157,6 +159,7 @@
 
   &.pf-m-favorite {
     --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-c-app-launcher__menu-item--m-favorite__menu-item--m-action--Color);
+    --pf-c-app-launcher__menu-item--m-action--hover--Color: var(--pf-c-app-launcher__menu-item--m-favorite__menu-item--m-action--hover--Color);
   }
 }
 
@@ -172,7 +175,7 @@
 
   &:hover,
   &:focus {
-    --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-c-app-launcher__menu-item--hover__menu-item--m-action--Color);
+    --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-c-app-launcher__menu-item--hover__menu-item--m-action--Color); // remove at breaking change
 
     text-decoration: none;
   }
@@ -188,6 +191,7 @@
   &:disabled,
   &.pf-m-disabled {
     --pf-c-app-launcher__menu-item--Color: var(--pf-c-app-launcher__menu-item--disabled--Color);
+    --pf-c-app-launcher__menu-item--m-action--Color: var(--pf-c-app-launcher__menu-item--m-action--disabled--Color);
 
     pointer-events: none;
   }

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -136,9 +136,9 @@
   --pf-c-menu__item-action--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu__item-action--Color: var(--pf-global--Color--200);
   --pf-c-menu__item-action--hover--Color: var(--pf-global--Color--100);
+  --pf-c-menu__item-action--disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-menu__item-action--m-favorited--Color: var(--pf-global--palette--gold-400);
   --pf-c-menu__item-action--m-favorited--hover--Color: var(--pf-global--palette--gold-500);
-  --pf-c-menu__list-item--m-disabled__item-action--Color: var(--pf-global--disabled-color--200);
 
   // Action icon
   --pf-c-menu__item-action-icon--Height: calc(var(--pf-c-menu__item--FontSize) * var(--pf-c-menu__item--LineHeight));
@@ -431,7 +431,6 @@
     --pf-c-menu__list-item--hover--BackgroundColor: transparent;
     --pf-c-menu__list-item--focus-within--BackgroundColor: transparent;
     --pf-c-menu__item--Color: var(--pf-c-menu__list-item--m-disabled__item--Color);
-    --pf-c-menu__item-action--Color: var(--pf-c-menu__list-item--m-disabled__item-action--Color);
     --pf-c-menu__item-toggle-icon: var(--pf-c-menu__list-item--m-disabled__item-toggle-icon--Color);
 
     pointer-events: none;
@@ -581,6 +580,10 @@
   &:hover,
   &:focus {
     --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--hover--Color);
+  }
+
+  &:disabled {
+    --pf-c-menu__item-action--Color: var(--pf-c-menu__item-action--disabled--Color);
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -124,23 +124,29 @@
   --pf-c-select__menu-item--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-select__menu-item--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-select__menu-item--Color: var(--pf-global--Color--dark-100);
-  --pf-c-select__menu-item--Width: 100%;
   --pf-c-select__menu-item--disabled--Color: var(--pf-global--Color--dark-200);
+  --pf-c-select__menu-item--Width: 100%;
   --pf-c-select__menu-item--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-select__menu-item--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-300);
   --pf-c-select__menu-item--disabled--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-link--Width: auto;
   --pf-c-select__menu-item--m-link--hover--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-link--focus--BackgroundColor: transparent;
-  --pf-c-select__menu-item--m-action--Color: var(--pf-global--disabled-color--200);
+  --pf-c-select__menu-item--m-action--Color: var(--pf-global--Color--200);
+  --pf-c-select__menu-item--m-action--hover--Color: var(--pf-global--Color--100);
+  --pf-c-select__menu-item--m-action--focus--Color: var(--pf-global--Color--100);
+  --pf-c-select__menu-item--m-action--disabled--Color: var(--pf-global--disabled-color--200);
   --pf-c-select__menu-item--m-action--Width: auto;
   --pf-c-select__menu-item--m-action--FontSize: var(--pf-global--icon--FontSize--sm);
   --pf-c-select__menu-item--m-action--hover--BackgroundColor: transparent;
   --pf-c-select__menu-item--m-action--focus--BackgroundColor: transparent;
-  --pf-c-select__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200);
-  --pf-c-select__menu-item--m-action--hover--Color: var(--pf-global--Color--100);
-  --pf-c-select__menu-item--m-action--focus--Color: var(--pf-global--Color--100);
+  --pf-c-select__menu-item--hover__menu-item--m-action--Color: var(--pf-global--Color--200); // remove at breaking change
+  --pf-c-select__menu-item--m-favorite-action--Color: var(--pf-global--Color--200);
+  --pf-c-select__menu-item--m-favorite-action--hover--Color: var(--pf-global--Color--100);
+  --pf-c-select__menu-item--m-favorite-action--focus--Color: var(--pf-global--Color--100);
   --pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--Color: var(--pf-global--palette--gold-400);
+  --pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--hover--Color: var(--pf-global--palette--gold-500);
+  --pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--focus--Color: var(--pf-global--palette--gold-500);
   --pf-c-select__menu-item--m-load--Color: var(--pf-global--link--Color);
 
   // Menu item icon
@@ -469,7 +475,9 @@
   display: flex;
 
   &.pf-m-favorite .pf-c-select__menu-item.pf-m-favorite-action {
-    --pf-c-select__menu-item--Color: var(--pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--Color);
+    --pf-c-select__menu-item--m-favorite-action--Color: var(--pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--Color);
+    --pf-c-select__menu-item--m-favorite-action--hover--Color: var(--pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--hover--Color);
+    --pf-c-select__menu-item--m-favorite-action--focus--Color: var(--pf-c-select__menu-wrapper--m-favorite__menu-item--m-favorite-action--focus--Color);
   }
 }
 
@@ -489,7 +497,7 @@
   &:hover,
   &:focus,
   &.pf-m-focus {
-    --pf-c-select__menu-item--m-action--Color: var(--pf-c-select__menu-item--hover__menu-item--m-action--Color);
+    --pf-c-select__menu-item--m-action--Color: var(--pf-c-select__menu-item--hover__menu-item--m-action--Color); // remove at breaking change
 
     text-decoration: none;
   }
@@ -537,6 +545,16 @@
     &:focus {
       --pf-c-select__menu-item--m-action--Color: var(--pf-c-select__menu-item--m-action--focus--Color);
     }
+
+    &:disabled {
+      --pf-c-select__menu-item--disabled--Color: var(--pf-c-select__menu-item--m-action--disabled--Color);
+    }
+  }
+
+  &.pf-m-favorite-action {
+    --pf-c-select__menu-item--m-action--Color: var(--pf-c-select__menu-item--m-favorite-action--Color);
+    --pf-c-select__menu-item--m-action--hover--Color: var(--pf-c-select__menu-item--m-favorite-action--hover--Color);
+    --pf-c-select__menu-item--m-action--focus--Color: var(--pf-c-select__menu-item--m-favorite-action--focus--Color);
   }
 
   &.pf-m-selected {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3674

All of the menu item actions now match the default button styling (color--200 default, color--100 hover/focus, disabled-color--200 disabled), a favorited item is gold-400 and a hovered/focused favorited item is gold-500.