### PR TITLE
chore(menu): added panel example

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -1563,6 +1563,15 @@ import './Menu.css'
 {{/menu}}
 ```
 
+### Panel
+```hbs
+{{#> menu menu--id="panel-example"}}
+  {{#> menu-content}}
+    [Content goes here]
+  {{/menu-content}}
+{{/menu}}
+```
+
 ## Documentation
 
 ### Accessibility


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4378

@nicolethoen any reason this couldn't just be the menu with none of the structural stuff in it? You could add the search, footer, make this scrollable, etc - just include the `pf-c-menu__content` element and put the other content in that instead of the `pf-c-menu__list` and `pf-c-menu__list-item` elements.

https://patternfly-pr-4440.surge.sh/components/menu#panel