### PR TITLE
feat(tooltip): diagonal positioning

### DIFF
--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -41,6 +41,36 @@ cssPrefix: pf-c-tooltip
 {{/tooltip}}
 ```
 
+### Left with top and bottom positions
+```hbs
+{{#> tooltip tooltip--modifier="pf-m-left-top"}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+  {{/tooltip-content}}
+{{/tooltip}}
+<br />
+{{#> tooltip tooltip--modifier="pf-m-left-bottom"}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+  {{/tooltip-content}}
+{{/tooltip}}
+```
+
+### Bottom with left and right positions
+```hbs
+{{#> tooltip tooltip--modifier="pf-m-bottom-left"}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+  {{/tooltip-content}}
+{{/tooltip}}
+<br />
+{{#> tooltip tooltip--modifier="pf-m-bottom-right"}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+  {{/tooltip-content}}
+{{/tooltip}}
+```
+
 ### Left aligned text
 ```hbs
 {{#> tooltip tooltip--modifier="pf-m-top"}}
@@ -66,8 +96,8 @@ A tooltip is used to provide contextual information for another component on hov
 | `.pf-c-tooltip` | `<div>` |  Creates a tooltip. Always use with a modifier class that positions the tooltip relative to the element it describes. **Required**|
 | `.pf-c-tooltip__arrow` | `<div>` |  Creates an arrow pointing towards the element the tooltip describes. **Required** |
 | `.pf-c-tooltip__content` | `<div>` |  Creates the body of the tooltip. **Required** |
-| `.pf-m-left` | `.pf-c-tooltip` | Positions the tooltip to the left of the element. |
-| `.pf-m-right` | `.pf-c-tooltip` | Positions the tooltip to the right of the element. |
-| `.pf-m-top` | `.pf-c-tooltip` | Positions the tooltip to the top of the element. |
-| `.pf-m-bottom` | `.pf-c-tooltip` | Positions the tooltip to the bottom of the element. |
+| `.pf-m-left{-top/bottom}` | `.pf-c-tooltip` | Positions the tooltip to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}` | `.pf-c-tooltip` | Positions the tooltip to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}` | `.pf-c-tooltip` | Positions the tooltip to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}` | `.pf-c-tooltip` | Positions the tooltip to the bottom (or bottom left/bottom right) of the element. |
 | `.pf-m-text-align-left` | `.pf-c-tooltip__content` | Modifies tooltip content to text align left. |

--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -44,13 +44,13 @@ cssPrefix: pf-c-tooltip
 ### Left with top and bottom positions
 ```hbs
 {{#> tooltip tooltip--modifier="pf-m-left-top"}}
-  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-top-content"'}}
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
   {{/tooltip-content}}
 {{/tooltip}}
 <br />
 {{#> tooltip tooltip--modifier="pf-m-left-bottom"}}
-  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-bottom-content"'}}
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
   {{/tooltip-content}}
 {{/tooltip}}
@@ -59,13 +59,13 @@ cssPrefix: pf-c-tooltip
 ### Bottom with left and right positions
 ```hbs
 {{#> tooltip tooltip--modifier="pf-m-bottom-left"}}
-  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-bottom-left-content"'}}
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
   {{/tooltip-content}}
 {{/tooltip}}
 <br />
 {{#> tooltip tooltip--modifier="pf-m-bottom-right"}}
-  {{#> tooltip-content tooltip-content--attribute='id="tooltip-left-content"'}}
+  {{#> tooltip-content tooltip-content--attribute='id="tooltip-bottom-right-content"'}}
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
   {{/tooltip-content}}
 {{/tooltip}}

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -32,7 +32,9 @@
   max-width: var(--pf-c-tooltip--MaxWidth);
   box-shadow: var(--pf-c-tooltip--BoxShadow);
 
-  &.pf-m-top {
+  &.pf-m-top,
+  &.pf-m-top-left,
+  &.pf-m-top-right {
     .pf-c-tooltip__arrow {
       bottom: 0;
       left: 50%;
@@ -40,7 +42,9 @@
     }
   }
 
-  &.pf-m-bottom {
+  &.pf-m-bottom,
+  &.pf-m-bottom-left,
+  &.pf-m-bottom-right {
     .pf-c-tooltip__arrow {
       top: 0;
       left: 50%;
@@ -48,7 +52,9 @@
     }
   }
 
-  &.pf-m-left {
+  &.pf-m-left,
+  &.pf-m-left-top,
+  &.pf-m-left-bottom {
     .pf-c-tooltip__arrow {
       top: 50%;
       right: 0;
@@ -56,11 +62,43 @@
     }
   }
 
-  &.pf-m-right {
+  &.pf-m-right,
+  &.pf-m-right-top,
+  &.pf-m-right-bottom {
     .pf-c-tooltip__arrow {
       top: 50%;
       left: 0;
       transform: translateX(var(--pf-c-tooltip__arrow--m-right--TranslateX)) translateY(var(--pf-c-tooltip__arrow--m-right--TranslateY)) rotate(var(--pf-c-tooltip__arrow--m-right--Rotate));
+    }
+  }
+
+  &.pf-m-left-top,
+  &.pf-m-right-top {
+    .pf-c-tooltip__arrow {
+      top: var(--pf-c-tooltip__arrow--Height);
+    }
+  }
+
+  &.pf-m-left-bottom,
+  &.pf-m-right-bottom {
+    .pf-c-tooltip__arrow {
+      top: auto;
+      bottom: 0;
+    }
+  }
+
+  &.pf-m-top-left,
+  &.pf-m-bottom-left {
+    .pf-c-tooltip__arrow {
+      left: var(--pf-c-tooltip__arrow--Width);
+    }
+  }
+
+  &.pf-m-top-right,
+  &.pf-m-bottom-right {
+    .pf-c-tooltip__arrow {
+      right: 0;
+      left: auto;
     }
   }
 }


### PR DESCRIPTION
Fixes #4382 

Adds diagonal positioning with the same modifiers currently used in the popover.