### PR TITLE
fix: enable dart-sass compilation

### DIFF
--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -2,6 +2,7 @@
 // PatternFly functions
 // --------------------------------------------------
 @import "./div";
+@import "./scss-variables.scss";
 
 // Transform px to rems
 @function pf-strip-unit($num) {

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -2,6 +2,8 @@
 // All variables should have a valid css value,
 // and use !default so they can be overwritten.
 
+@import "./colors.scss";
+
 // `$pf-global--concept--PropiertyCamelCase--modifier--state`
 
 // Patternfly options


### PR DESCRIPTION
[patternfly-elements is moving to dart-sass](https://github.com/patternfly/patternfly-elements/pull/1804) (`npm i sass`). We were only able to build our sass files by making this patch to upstream.

Please take a look and let me know.