### PR TITLE
fix(table): fix pf-m-truncate alignment

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -552,6 +552,14 @@
     --pf-c-table--cell--Overflow: hidden;
     --pf-c-table--cell--TextOverflow: ellipsis;
     --pf-c-table--cell--WhiteSpace: nowrap;
+
+    // stylelint-disable selector-class-pattern
+    // align icon middle when truncated
+    > .pficon,
+    > .fas {
+      vertical-align: middle;
+    }
+    // stylelint-enable
   }
 
   .pf-m-wrap {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -552,14 +552,6 @@
     --pf-c-table--cell--Overflow: hidden;
     --pf-c-table--cell--TextOverflow: ellipsis;
     --pf-c-table--cell--WhiteSpace: nowrap;
-
-    // stylelint-disable selector-class-pattern
-    // align icon middle when truncated
-    > .pficon,
-    > .fas {
-      vertical-align: middle;
-    }
-    // stylelint-enable
   }
 
   .pf-m-wrap {

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -5,7 +5,7 @@
     {{> table--scrollable--td table--scrollable--td--content=cell-1--content}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"'}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"' table--scrollable--th--HasIcon="true"}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -1,11 +1,11 @@
 {{#> table-tr}}
   {{#if table--scrollable--Column1IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 100px;"' table--scrollable--NoIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-1--content}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"' table--scrollable--th--HasIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--td.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--td.hbs
@@ -1,6 +1,8 @@
 {{#> table-td table-td--data-label="Example td"}}
   {{#if table--scrollable--td--content}}
     {{{table--scrollable--td--content}}}
+  {{else if @partial-block}}
+    {{> @partial-block}}
   {{else}}
     Cell
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--th.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--th.hbs
@@ -1,10 +1,8 @@
 {{#> table-th table-th--modifier=(concat table--scrollable--th--modifier ' pf-m-truncate') table-th--attribute=(concat 'scope="col" ' table-th--attribute) table-th--data-label="Example th"}}
-  {{#if table--scrollable--th--HasIcon}}
-    <i class="pficon fas fa-fw {{#if table--scrollable--th--icon}}{{table--scrollable--th--icon}}{{else}}pf-icon-blueprint{{/if}}" aria-hidden="true"></i>
-    &nbsp;
-  {{/if}}
   {{#if table--scrollable--th--content}}
     {{{table--scrollable--th--content}}}
+  {{else if @partial-block}}
+    {{> @partial-block}}
   {{else}}
     Header cell
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--th.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--th.hbs
@@ -1,16 +1,11 @@
-{{#> table-th table-th--modifier=(concat 'pf-m-nowrap ' table--scrollable--th--modifier) table-th--attribute=(concat 'scope="col" ' table-th--attribute) table-th--data-label="Example th"}}
-  {{#> table-text}}
-    {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
-      {{#unless table--scrollable--NoIcon}}
-        <i class="pficon fas {{#if table--scrollable--th--icon}}{{table--scrollable--th--icon}}{{else}}pf-icon-blueprint{{/if}}" aria-hidden="true"></i>
-      {{/unless}}
-      <span>
-        {{#if table--scrollable--th--content}}
-          {{{table--scrollable--th--content}}}
-        {{else}}
-          Header cell
-        {{/if}}
-      </span>
-    {{/l-flex}}
-  {{/table-text}}
+{{#> table-th table-th--modifier=(concat table--scrollable--th--modifier ' pf-m-truncate') table-th--attribute=(concat 'scope="col" ' table-th--attribute) table-th--data-label="Example th"}}
+  {{#if table--scrollable--th--HasIcon}}
+    <i class="pficon fas fa-fw {{#if table--scrollable--th--icon}}{{table--scrollable--th--icon}}{{else}}pf-icon-blueprint{{/if}}" aria-hidden="true"></i>
+    &nbsp;
+  {{/if}}
+  {{#if table--scrollable--th--content}}
+    {{{table--scrollable--th--content}}}
+  {{else}}
+    Header cell
+  {{/if}}
 {{/table-th}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -1,13 +1,13 @@
 {{#> table-tr}}
   {{#if table--scrollable--Column1IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true" table--scrollable--NoIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true"}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-1--content table--scrollable--th--icon=cell-1--icon table-th--sortable="true" table--scrollable--NoIcon="true"}}
+    {{#> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--sortable="true"}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 120px; --pf-c-table__sticky-column--Left: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true" table--scrollable--NoIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 120px; --pf-c-table__sticky-column--Left: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true"}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable="true" table--scrollable--NoIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable="true"}}
   {{/if}}
   {{> table--scrollable--th table--scrollable--th--content=cell-3--content table--scrollable--th--icon=cell-3--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-4--content table--scrollable--th--icon=cell-4--icon}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -5,7 +5,7 @@
     {{> table--scrollable--th table--scrollable--th--content=cell-1--content table--scrollable--th--icon=cell-1--icon table-th--sortable="true" table--scrollable--NoIcon="true"}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true" table--scrollable--NoIcon="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 120px; --pf-c-table__sticky-column--Left: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true" table--scrollable--NoIcon="true"}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable="true" table--scrollable--NoIcon="true"}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable.hbs
@@ -3,7 +3,7 @@
     {{> table--scrollable--thead--tr table--tr--modifier="pf-m-nowrap" cell-1--content="Fact" cell-2--content="State" cell-3--content="Header 3" cell-4--content="Header 4" cell-5--content="Header 5" cell-6--content="Header 6" cell-7--content="Header 7" cell-8--content="Header 8" cell-9--content="Header 9"}}
   {{/table-thead}}
 
-  {{#> table-tbody}}
+  {{#> table-tbody table-td--modifier="pf-m-nowrap"}}
     {{> table--scrollable--tbody--tr cell-1--content="Fact 1" cell-2--content="State 1" cell-3--content="Test cell 1-3" cell-4--content="Test cell 1-4" cell-5--content="Test cell 1-5" cell-6--content="Test cell 1-6" cell-7--content="Test cell 1-7" cell-8--content="Test cell 1-8" cell-9--content="Test cell 1-9"}}
     {{> table--scrollable--tbody--tr cell-1--content="Fact 2" cell-2--content="State 2" cell-3--content="Test cell 2-3" cell-4--content="Test cell 2-4" cell-5--content="Test cell 2-5" cell-6--content="Test cell 2-6" cell-7--content="Test cell 2-7" cell-8--content="Test cell 2-8" cell-9--content="Test cell 2-9"}}
     {{> table--scrollable--tbody--tr cell-1--content="Fact 3" cell-2--content="State 3" cell-3--content="Test cell 3-3" cell-4--content="Test cell 3-4" cell-5--content="Test cell 3-5" cell-6--content="Test cell 3-6" cell-7--content="Test cell 3-7" cell-8--content="Test cell 3-8" cell-9--content="Test cell 3-9"}}


### PR DESCRIPTION
closes #4488 

Using `pf-l-flex` as a child of table cells, in conjunction with `.pf-m-truncate` and icons prohibits the cell from restricting width. This PR

- Removes `pf-l-flex` 
- Add support for vertical alignment of icons in `pf-m-truncate`
- Allows for text to truncate when width is set