### PR TITLE
fix(form-select): match padding with select

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -148,7 +148,8 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   --pf-c-form-control--m-clock--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--m-clock--Coordinates, $svg-color: $pf-c-form-control--m-clock--Color)};
 
   // Select -- rename __select to --select in a breaking change release
-  --pf-c-form-control__select--PaddingRight: var(--pf-global--spacer--lg);
+  --pf-c-form-control__select--PaddingRight: calc(var(--pf-global--spacer--lg) + var(--pf-c-form-control--BorderWidth) + var(--pf-c-form-control--BorderWidth));
+  --pf-c-form-control__select--PaddingLeft: calc(var(--pf-global--spacer--sm) - var(--pf-c-form-control--BorderWidth));
   --pf-c-form-control__select--BackgroundUrl: #{pf-bg-svg($pf-c-form-control__select--Coordinates, $pf-c-form-control__select--ViewBox)};
   --pf-c-form-control__select--BackgroundSize: .625em; // Calculated from react-icon SVG viewbox
   --pf-c-form-control__select--BackgroundPositionX: calc(100% - var(--pf-global--spacer--md) + 1px);
@@ -333,10 +334,18 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
 
   @at-root select#{&} {
     --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--PaddingRight);
+    --pf-c-form-control--PaddingLeft: var(--pf-c-form-control__select--PaddingLeft);
 
     background-image: var(--pf-c-form-control__select--BackgroundUrl);
     background-position: var(--pf-c-form-control__select--BackgroundPosition);
     background-size: var(--pf-c-form-control__select--BackgroundSize);
+
+    // Firefox's select text has additional padding
+    // stylelint-disable-next-line
+    @-moz-document url-prefix() {
+      --pf-c-form-control--PaddingRight: calc(var(--pf-c-form-control__select--PaddingRight) - 1px);
+      --pf-c-form-control--PaddingLeft: calc(var(--pf-c-form-control__select--PaddingLeft) - 4px);
+    }
 
     &[aria-invalid="true"] {
       --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--invalid--PaddingRight);


### PR DESCRIPTION
This adjusts the padding on the form component select so that it matches the PatternFly select component.
Screen shot of Chrome, FF, and Safari below. @garrett I didn't find that the same values you provided gave me the correct alignment (but the selector was very helpful), so if you could check this out that would be great. 

To see this, you'll need to inspect and put width:auto on the select form elements.

![image](https://user-images.githubusercontent.com/19825616/140411610-2c637251-2fc8-4c7b-9149-a32e4cd6d854.png)

One other note: the placeholder text doesn't seem to respect the padding when using width: auto. If you put `&nbsp;` in the placeholder you can fake it... 😬

fixes #4387 