### PR TITLE
fix(dual-list-selector): align a11y to react

### DIFF
--- a/patternfly-a11y.config.js
+++ b/patternfly-a11y.config.js
@@ -9,6 +9,6 @@ module.exports = {
   waitFor,
   crawl: false,
   urls: Object.keys(fullscreenRoutes),
-  ignoreRules: ['color-contrast', 'page-has-heading-one', 'scrollable-region-focusable', 'bypass'].join(','),
+  ignoreRules: ['color-contrast', 'page-has-heading-one', 'scrollable-region-focusable', 'bypass', 'nested-interactive'].join(','),
   ignoreIncomplete: true
 };

--- a/src/patternfly/components/DualListSelector/dual-list-selector-item.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-item.hbs
@@ -1,17 +1,9 @@
 {{#> dual-list-selector-list-item-row}}
-  <{{#if dual-list-selector-item--type}}{{dual-list-selector-item--type}}{{else}}button{{/if}} class="pf-c-dual-list-selector__item{{#if dual-list-selector-item--modifier}} {{dual-list-selector-item--modifier}}{{/if}}"
+  <{{#if dual-list-selector-item--type}}{{dual-list-selector-item--type}}{{else}}span{{/if}} class="pf-c-dual-list-selector__item{{#if dual-list-selector-item--modifier}} {{dual-list-selector-item--modifier}}{{/if}}"
     {{#unless dual-list-selector-list-item--IsDisabled}}
       {{#if dual-list-selector-item--type}}
         tabindex="0"
       {{/if}}
-    {{/unless}}
-    {{#if dual-list-selector-list-item--IsDisabled}}
-      {{#unless dual-list-selector-item--type}}
-        disabled
-      {{/unless}}
-    {{/if}}
-    {{#unless dual-list-selector-item--type}}
-      type="button"
     {{/unless}}
     {{#if dual-list-selector-item--attribute}}
       {{{dual-list-selector-item--attribute}}}
@@ -36,5 +28,5 @@
         {{/badge}}
       {{/dual-list-selector-item-count}}
     {{/dual-list-selector-item--count}}
-  </{{#if dual-list-selector-item--type}}{{dual-list-selector-item--type}}{{else}}button{{/if}}>
+  </{{#if dual-list-selector-item--type}}{{dual-list-selector-item--type}}{{else}}span{{/if}}>
 {{/dual-list-selector-list-item-row}}

--- a/src/patternfly/components/DualListSelector/dual-list-selector-list-item.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-list-item.hbs
@@ -12,6 +12,7 @@
   {{/if}}
   {{#if dual-list-selector-list-item--attribute}}
     {{{dual-list-selector-list-item--attribute}}}
-  {{/if}}>
+  {{/if}}
+  role="option">
   {{>@partial-block}}
 </li>

--- a/src/patternfly/components/DualListSelector/dual-list-selector-list-item.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-list-item.hbs
@@ -8,11 +8,17 @@
   {{/if}}
   {{~#if dual-list-selector-list-item--modifier}} {{dual-list-selector-list-item--modifier}}{{/if}}"
   {{#if dual-list-selector-list-item--IsExpandable}}
-    aria-expanded="{{#if dual-list-selector-list-item--IsExpanded}}true{{else}}false{{/if}}"
+    aria-expanded="true"
   {{/if}}
   {{#if dual-list-selector-list-item--attribute}}
     {{{dual-list-selector-list-item--attribute}}}
   {{/if}}
-  role="option">
+  {{#if dual-list-selector-list--IsTree}}
+    role="treeitem"
+  {{else if dual-list-selector-list--IsSublist}}
+    role="treeitem"
+  {{else}}
+    role="option"
+  {{/if}}>
   {{>@partial-block}}
 </li>

--- a/src/patternfly/components/DualListSelector/dual-list-selector-list.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-list.hbs
@@ -9,7 +9,7 @@
   {{else}}
     role="listbox"
   {{/if}}
-  aria-labelledby="{{dual-list-selector-list--LabelledBy}}"
+  aria-labelledby="{{dual-list-selector-pane--id}}-status-text"
   {{#unless dual-list-selector-list--IsSublist}}
     aria-multiselectable="true"
     aria-activedescendant=""

--- a/src/patternfly/components/DualListSelector/dual-list-selector-list.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-list.hbs
@@ -1,6 +1,18 @@
 <ul class="pf-c-dual-list-selector__list{{#if dual-list-selector-list--modifier}} {{dual-list-selector-list--modifier}}{{/if}}"
   {{#if dual-list-selector-list--attribute}}
     {{{dual-list-selector-list--attribute}}}
-  {{/if}}>
+  {{/if}}
+  {{#if dual-list-selector-list--IsTree}}
+    role="tree"
+  {{else if dual-list-selector-list--IsSublist}}
+    role="group"
+  {{else}}
+    role="listbox"
+  {{/if}}
+  aria-labelledby="{{dual-list-selector-list--LabelledBy}}"
+  {{#unless dual-list-selector-list--IsSublist}}
+    aria-multiselectable="true"
+    aria-activedescendant=""
+  {{/unless}}>
   {{>@partial-block}}
 </ul>

--- a/src/patternfly/components/DualListSelector/dual-list-selector-status-text.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-status-text.hbs
@@ -2,8 +2,6 @@
   {{#if dual-list-selector-status-text--attribute}}
     {{{dual-list-selector-status-text--attribute}}}
   {{/if}}
-  {{#if dual-list-selector-status-text--id}}
-    id="{{{dual-list-selector-status-text--id}}}"
-  {{/if}}>
+  id="{{dual-list-selector-pane--id}}-status-text">
   {{>@partial-block}}
 </span>

--- a/src/patternfly/components/DualListSelector/dual-list-selector-status-text.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-status-text.hbs
@@ -1,6 +1,9 @@
 <span class="pf-c-dual-list-selector__status-text{{#if dual-list-selector-status-text--modifier}} {{dual-list-selector-status-text--modifier}}{{/if}}"
   {{#if dual-list-selector-status-text--attribute}}
     {{{dual-list-selector-status-text--attribute}}}
+  {{/if}}
+  {{#if dual-list-selector-status-text--id}}
+    id="{{{dual-list-selector-status-text--id}}}"
   {{/if}}>
   {{>@partial-block}}
 </span>

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -265,9 +265,7 @@ $pf-c-dual-list-selector__item--MaxNesting: 10;
   position: relative;
   width: 100%;
   padding: var(--pf-c-dual-list-selector__item--PaddingTop) var(--pf-c-dual-list-selector__item--PaddingRight) var(--pf-c-dual-list-selector__item--PaddingBottom) var(--pf-c-dual-list-selector__item--PaddingLeft);
-  text-align: left;
   cursor: pointer;
-  border: 0;
 }
 
 .pf-c-dual-list-selector__item-count {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -183,6 +183,10 @@ $pf-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 .pf-c-dual-list-selector__list-item {
+  &:focus {
+    --pf-c-dual-list-selector__list-item-row--BackgroundColor: var(--pf-c-dual-list-selector__list-item-row--focus-within--BackgroundColor);
+  }
+
   &.pf-m-expandable {
     --pf-c-dual-list-selector__item--PaddingLeft: var(--pf-c-dual-list-selector__item--m-expandable--PaddingLeft);
   }
@@ -206,10 +210,6 @@ $pf-c-dual-list-selector__item--MaxNesting: 10;
 
   &:hover {
     --pf-c-dual-list-selector__list-item-row--BackgroundColor: var(--pf-c-dual-list-selector__list-item-row--hover--BackgroundColor);
-  }
-
-  &:focus-within {
-    --pf-c-dual-list-selector__list-item-row--BackgroundColor: var(--pf-c-dual-list-selector__list-item-row--focus-within--BackgroundColor);
   }
 
   &.pf-m-selected {

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -38,7 +38,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -108,7 +108,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -147,7 +147,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -217,7 +217,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -256,7 +256,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -326,7 +326,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -365,7 +365,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -435,7 +435,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -477,7 +477,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -547,7 +547,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item-row--IsSelected="true"}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item5"}}
         {{/dual-list-selector-list-item}}
@@ -590,7 +590,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true"}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--id="0" dual-list-selector-item--count="6" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
             {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true" dual-list-selector-list--IsSublist="true"}}
@@ -686,7 +686,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -725,7 +725,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true"}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--count="6" dual-list-selector-item--id="11" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
             {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}
@@ -809,12 +809,13 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text
+      }}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true"}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--id="21" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
             {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}
@@ -865,7 +866,7 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}
       {{#> dual-list-selector-menu}}
-        {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+        {{#> dual-list-selector-list}}
           {{#> dual-list-selector-list-item}}
             {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
           {{/dual-list-selector-list-item}}
@@ -929,7 +930,7 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}
       {{#> dual-list-selector-menu}}
-        {{#> dual-list-selector-list dual-list-selector-list-item--IsDraggable="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+        {{#> dual-list-selector-list dual-list-selector-list-item--IsDraggable="true"}}
           {{#> dual-list-selector-list-item dual-list-selector-list-item--id=(concat dual-list-selector--id '-list-item-2') dual-list-selector-draggable-button--IsDisabled="true"}}
             {{> dual-list-selector-item dual-list-selector-item--text="Item2 - draggable icon disabled"}}
           {{/dual-list-selector-list-item}}

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -962,7 +962,7 @@ cssPrefix: pf-c-dual-list-selector
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-dual-list-selector__draggable .pf-c-button` | Gives the draggable button an accessible description by referring to the textual content that describes how to use the button to drag elements. **Highly recommended** |
 | `aria-labelledby="[id of .pf-c-dual-list-selector__draggable .pf-c-button] [id of item text]"` | `.pf-c-table__dual-list-selector .pf-c-button` | Provides an accessible name for the draggable button. |
 | `id="[]"` | `.pf-c-dual-list-selector__draggable .pf-c-button`, `[item text]` | Gives the button and the text element accessible IDs. |
-| `disabled` | `.pf-c-dual-list-selector__item [button, check]` | Disables interactive elements in a disabled item. **Required** when an item is disabled. |
+| `role="option"` | `.pf-c-dual-list-selector__list-item [li]` | not sure |
 
 ### Usage
 
@@ -984,7 +984,7 @@ cssPrefix: pf-c-dual-list-selector
 | `.pf-c-dual-list-selector__list-item` | `<li>` | Initiates a dual list selector pane menu list item. **Required** |
 | `.pf-c-dual-list-selector__list-item-row` | `<div>` | Initiates a dual list selector pane menu list item row. **Required** |
 | `.pf-c-dual-list-selector__draggable` | `<div>` | Initiates a dual list selector pane draggable element. |
-| `.pf-c-dual-list-selector__item` | `<button>`, `<div>` | Initiates a dual list selector pane menu item. **Required** |
+| `.pf-c-dual-list-selector__item` | `<span>`, `<div>` | Initiates a dual list selector pane menu item. **Required** |
 | `.pf-c-dual-list-selector__item-main` | `<span>` | Initiates a dual list selector pane menu item main container. **Required** |
 | `.pf-c-dual-list-selector__item-check` | `<span>` | Initiates the dual list selector item check. |
 | `.pf-c-dual-list-selector__item-count` | `<span>` | Initiates the dual list selector item count. |

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -33,7 +33,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -103,7 +103,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -142,7 +142,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         1 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -212,7 +212,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -251,7 +251,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         1 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -321,7 +321,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -360,7 +360,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 4 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -430,7 +430,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 1 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -472,7 +472,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 4 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -542,7 +542,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         1 of 1 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -585,7 +585,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         1 of 11 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -681,7 +681,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -720,7 +720,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 10 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -809,7 +809,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-status-text}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
@@ -860,7 +860,7 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-tools-actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
-        {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+        {{#> dual-list-selector-status-text}}
           0 of 5 items selected
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}
@@ -924,7 +924,7 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-tools-actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
-        {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
+        {{#> dual-list-selector-status-text}}
           0 of 0 items selected
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -33,12 +33,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -103,12 +103,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -142,12 +142,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         1 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -212,12 +212,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -251,12 +251,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         1 of 5 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -321,12 +321,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -360,12 +360,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 4 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -430,12 +430,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 1 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -472,12 +472,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 4 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
         {{/dual-list-selector-list-item}}
@@ -542,12 +542,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         1 of 1 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item-row--IsSelected="true"}}
           {{> dual-list-selector-item dual-list-selector-item--text="Item5"}}
         {{/dual-list-selector-list-item}}
@@ -560,7 +560,7 @@ cssPrefix: pf-c-dual-list-selector
 
 ### Tree view
 ```hbs
-{{#> dual-list-selector dual-list-selector--id="basic"}}
+{{#> dual-list-selector dual-list-selector--id="tree"}}
   {{#> dual-list-selector-pane dual-list-selector-pane--id=(concat dual-list-selector--id '-available') dual-list-selector-pane--modifier="pf-m-available"}}
     {{#> dual-list-selector-header}}
       {{#> dual-list-selector-title}}
@@ -585,15 +585,15 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         1 of 11 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--id="0" dual-list-selector-item--count="6" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
-            {{#> dual-list-selector-list newcontext}}
+            {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true" dual-list-selector-list--IsSublist="true"}}
               {{#> dual-list-selector-list-item dual-list-selector-list-item-row--HasCheck="true"}}
                 {{#> dual-list-selector-item dual-list-selector-item--text="Red" dual-list-selector-item--id="1" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
               {{/dual-list-selector-list-item}}
@@ -605,7 +605,7 @@ cssPrefix: pf-c-dual-list-selector
               {{/dual-list-selector-list-item}}
               {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
                 {{#> dual-list-selector-item dual-list-selector-item--text="Green" dual-list-selector-item--id="4" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
-                {{#> dual-list-selector-list newcontext}}
+                {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}
                   {{#> dual-list-selector-list-item dual-list-selector-list-item-row--HasCheck="true"}}
                     {{#> dual-list-selector-item dual-list-selector-item--text="Light green" dual-list-selector-item--id="5" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
                   {{/dual-list-selector-list-item}}
@@ -681,12 +681,12 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
       {{/dual-list-selector-list}}
     {{/dual-list-selector-menu}}
   {{/dual-list-selector-pane}}
@@ -695,7 +695,7 @@ cssPrefix: pf-c-dual-list-selector
 
 ### Tree view with chosen and disabled options
 ```hbs
-{{#> dual-list-selector dual-list-selector--id="basic"}}
+{{#> dual-list-selector dual-list-selector--id="tree-options"}}
   {{#> dual-list-selector-pane dual-list-selector-pane--id=(concat dual-list-selector--id '-available') dual-list-selector-pane--modifier="pf-m-available"}}
     {{#> dual-list-selector-header}}
       {{#> dual-list-selector-title}}
@@ -720,15 +720,15 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 10 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--count="6" dual-list-selector-item--id="11" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
-            {{#> dual-list-selector-list newcontext}}
+            {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}
               {{#> dual-list-selector-list-item dual-list-selector-list-item-row--IsSelected="true" dual-list-selector-list-item-row--HasCheck="true"}}
                 {{#> dual-list-selector-item dual-list-selector-item--text="Orange" dual-list-selector-item--id="12" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
               {{/dual-list-selector-list-item}}
@@ -737,7 +737,7 @@ cssPrefix: pf-c-dual-list-selector
               {{/dual-list-selector-list-item}}
               {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item--IsDisabled="true" dual-list-selector-list-item-row--HasCheck="true"}}
                 {{#> dual-list-selector-item dual-list-selector-item--text="Green (disabled)" dual-list-selector-item--id="14" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
-                {{#> dual-list-selector-list newcontext dual-list-selector-list-item--IsTopLevelDisabled="true" dual-list-selector-list-item--IsDisabled="true"}}
+                {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true" dual-list-selector-list-item--IsTopLevelDisabled="true" dual-list-selector-list-item--IsDisabled="true"}}
                   {{#> dual-list-selector-list-item dual-list-selector-list-item-row--HasCheck="true"}}
                     {{#> dual-list-selector-item dual-list-selector-item--text="Light green" dual-list-selector-item--id="15" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
                   {{/dual-list-selector-list-item}}
@@ -809,15 +809,15 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-tools-actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
-      {{#> dual-list-selector-status-text}}
+      {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
         0 of 0 items selected
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list}}
+      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--id="21" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
-            {{#> dual-list-selector-list newcontext}}
+            {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}
               {{#> dual-list-selector-list-item dual-list-selector-list-item-row--IsSelected="true" dual-list-selector-list-item-row--HasCheck="true"}}
                 {{#> dual-list-selector-item dual-list-selector-item--text="Orange" dual-list-selector-item--id="22" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
               {{/dual-list-selector-list-item}}
@@ -860,12 +860,12 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-tools-actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
-        {{#> dual-list-selector-status-text}}
+        {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
           0 of 5 items selected
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}
       {{#> dual-list-selector-menu}}
-        {{#> dual-list-selector-list}}
+        {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
           {{#> dual-list-selector-list-item}}
             {{> dual-list-selector-item dual-list-selector-item--text="Item1"}}
           {{/dual-list-selector-list-item}}
@@ -924,12 +924,12 @@ cssPrefix: pf-c-dual-list-selector
         {{/dual-list-selector-tools-actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
-        {{#> dual-list-selector-status-text}}
+        {{#> dual-list-selector-status-text dual-list-selector-status-text--id=(concat dual-list-selector-pane--id '-status-text')}}
           0 of 0 items selected
         {{/dual-list-selector-status-text}}
       {{/dual-list-selector-status}}
       {{#> dual-list-selector-menu}}
-        {{#> dual-list-selector-list dual-list-selector-list-item--IsDraggable="true"}}
+        {{#> dual-list-selector-list dual-list-selector-list-item--IsDraggable="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
           {{#> dual-list-selector-list-item dual-list-selector-list-item--id=(concat dual-list-selector--id '-list-item-2') dual-list-selector-draggable-button--IsDisabled="true"}}
             {{> dual-list-selector-item dual-list-selector-item--text="Item2 - draggable icon disabled"}}
           {{/dual-list-selector-list-item}}
@@ -961,8 +961,13 @@ cssPrefix: pf-c-dual-list-selector
 | `aria-live` | `[element with live text]` | To give screen reader users live feedback about what's happening during interaction with the dual list selector, both during drag and drop interactions and keyboard interactions. **Highly Recommended** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-dual-list-selector__draggable .pf-c-button` | Gives the draggable button an accessible description by referring to the textual content that describes how to use the button to drag elements. **Highly recommended** |
 | `aria-labelledby="[id of .pf-c-dual-list-selector__draggable .pf-c-button] [id of item text]"` | `.pf-c-table__dual-list-selector .pf-c-button` | Provides an accessible name for the draggable button. |
-| `id="[]"` | `.pf-c-dual-list-selector__draggable .pf-c-button`, `[item text]` | Gives the button and the text element accessible IDs. |
-| `role="option"` | `.pf-c-dual-list-selector__list-item [li]` | not sure |
+| `id="[]"` | `.pf-c-dual-list-selector__draggable .pf-c-button`, `[item text]`, `.pf-c-dual-list-selector__status-text` | Gives the button and the text element accessible IDs. |
+| `aria-labelledby="[id of .pf-c-dual-list-selector__status-text]` | `.pf-c-dual-list-selector__list [ul]` | Gives the list an accessible name. |
+| `role="listbox or tree or group"` | `.pf-c-dual-list-selector__list [ul]` | Indicates the list is single, a tree, or a subgroup within the tree. |
+| `aria-multiselectable="true"` | `.pf-c-dual-list-selector__list [ul]` | Indicates the list is multiselectable. |
+| `aria-activedescendant=""` | `.pf-c-dual-list-selector__list [ul]` | Indicates the list has clickable children. |
+| `role="option or treeitem"` | `.pf-c-dual-list-selector__list-item [li]` | Indicates whether the item is part of a tree. |
+| `aria-expanded="true"`      | `.pf-c-dual-list-selector__list-item [li]` | Indicates a treeitem is expanded. |
 
 ### Usage
 

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -814,7 +814,7 @@ cssPrefix: pf-c-dual-list-selector
       {{/dual-list-selector-status-text}}
     {{/dual-list-selector-status}}
     {{#> dual-list-selector-menu}}
-      {{#> dual-list-selector-list dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
+      {{#> dual-list-selector-list dual-list-selector-list--IsTree="true" dual-list-selector-list--LabelledBy=(concat dual-list-selector-pane--id '-status-text')}}
         {{#> dual-list-selector-list-item dual-list-selector-list-item--IsExpandable="true" dual-list-selector-list-item--IsExpanded="true" dual-list-selector-list-item-row--HasCheck="true"}}
           {{#> dual-list-selector-item dual-list-selector-item--text="Colors" dual-list-selector-item--id="21" dual-list-selector-item--type="div"}}{{/dual-list-selector-item}}
             {{#> dual-list-selector-list newcontext dual-list-selector-list--IsSublist="true"}}


### PR DESCRIPTION
Fixes #4413 and also a few more inconsistencies not mentioned in the issue. 

Important notes:
This PR is currently failing A11y checks due to a nested interactive component where it's not allowed in the draggable version. 
The React component currently has a span there instead of a button for the drag handle - but this was a stop gap measure and the plan is to put it back. I could remove the button temporarily here, but changing it to a span (as the React component has) means that other a11y issues arise such as `aria-label` and `aria-labeledby` is not allowed on a span.