### PR TITLE
feat(card): added non-selectable card, updated card view demo

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -61,6 +61,10 @@
   --pf-c-card--m-selectable-raised--m-selected-raised--before--Transition: transform .25s linear;
   --pf-c-card--m-selectable-raised--m-selected-raised--before--TranslateY: calc(var(--pf-c-card--m-selectable-raised--m-selected-raised--TranslateY) * -1);
   --pf-c-card--m-selectable-raised--m-selected-raised--before--ScaleY: 2;
+  --pf-c-card--m-non-selectable-raised--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-card--m-non-selectable-raised--before--BackgroundColor: var(--pf-global--disabled-color--200);
+  --pf-c-card--m-non-selectable-raised--before--ScaleY: 2;
+  --pf-c-card--m-flat--m-non-selectable-raised--before--BorderColor: var(--pf-global--disabled-color--200);
 
   // Compact
   --pf-c-card--m-compact__body--FontSize: var(--pf-global--FontSize--sm);
@@ -143,7 +147,8 @@
   }
 
   &.pf-m-hoverable-raised,
-  &.pf-m-selectable-raised {
+  &.pf-m-selectable-raised,
+  &.pf-m-non-selectable-raised {
     position: relative;
 
     &::before {
@@ -180,15 +185,12 @@
       --pf-c-card--m-selectable-raised--before--BackgroundColor: var(--pf-c-card--m-selectable-raised--focus--before--BackgroundColor);
     }
 
-    /*
     &:active {
       --pf-c-card--BoxShadow: var(--pf-c-card--m-selectable-raised--active--BoxShadow);
       --pf-c-card--m-selectable-raised--before--BackgroundColor: var(--pf-c-card--m-selectable-raised--active--before--BackgroundColor);
     }
-    */
 
-    &.pf-m-selected-raised,
-    &:active {
+    &.pf-m-selected-raised {
       --pf-c-card--m-selectable-raised--before--BackgroundColor: var(--pf-c-card--m-selectable-raised--m-selected-raised--before--BackgroundColor);
       --pf-c-card--m-selectable-raised--before--Transition: var(--pf-c-card--m-selectable-raised--m-selected-raised--before--Transition);
       --pf-c-card--m-selectable-raised--before--TranslateY: var(--pf-c-card--m-selectable-raised--m-selected-raised--before--TranslateY); // moves before down when selected - same amount and speed as the selected card moves up
@@ -198,6 +200,14 @@
       transition: var(--pf-c-card--m-selectable-raised--m-selected-raised--Transition);
       transform: translateY(var(--pf-c-card--m-selectable-raised--m-selected-raised--TranslateY)); // moves card up when selected
     }
+  }
+
+  &.pf-m-non-selectable-raised {
+    --pf-c-card--BackgroundColor: var(--pf-c-card--m-non-selectable-raised--BackgroundColor);
+    --pf-c-card--BoxShadow: none;
+    --pf-c-card--m-flat--BorderColor: var(--pf-c-card--m-flat--m-non-selectable-raised--before--BorderColor);
+    --pf-c-card--m-selectable-raised--before--BackgroundColor: var(--pf-c-card--m-non-selectable-raised--before--BackgroundColor);
+    --pf-c-card--m-selectable-raised--before--ScaleY: var(--pf-c-card--m-non-selectable-raised--before--ScaleY);
   }
 
   &.pf-m-compact {

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -270,6 +270,21 @@ import './Card.css'
 {{/card}}
 ```
 
+### Non selectable
+```hbs
+{{#> card card--id="card-non-selectable-example" card--modifier="pf-m-non-selectable-raised"}}
+  {{#> card-title}}
+    Title
+  {{/card-title}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+```
+
 ### Hoverable (legacy)
 ```hbs
 {{#> card card--id="card-hoverable-legacy-example" card--modifier="pf-m-hoverable"}}
@@ -500,6 +515,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-m-hoverable-raised` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |
 | `.pf-m-selectable-raised` | `.pf-c-card` | Modifies a selectable card so that it is selectable. |
 | `.pf-m-selected-raised` | `.pf-c-card.pf-m-selectable-raised` | Modifies a selectable card for the selected state. |
+| `.pf-m-non-selectable-raised` | `.pf-c-card` | Modifies a selectable card so that it is not selectable. |
 | `.pf-m-flat` | `.pf-c-card` | Modifies the card to have a border instead of a shadow. `.pf-m-flat` is for use in layouts where cards are against a white background. |
 | `.pf-m-rounded` | `.pf-c-card` | Modifies the card to have rounded corners. |
 | `.pf-m-plain` | `.pf-c-card` | Modifies the card to have no box shadow and no background color. |

--- a/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
@@ -1,5 +1,5 @@
 {{#> gallery gallery--modifier="pf-m-gutter"}}
-    {{#> card card--id="card-empty-state" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-empty-state" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> bullseye}}
         {{#> empty-state empty-state--modifier="pf-m-xs"}}
           <i class="fas fa-plus-circle pf-c-empty-state__icon"></i>
@@ -14,7 +14,7 @@
         {{/empty-state}}
       {{/bullseye}}
     {{/card}}
-    {{#> card card--id="card-1" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-1" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo">
         {{#> card-actions}}
@@ -34,7 +34,7 @@
           PatternFly is a community project that promotes design commonality and improves user experience.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-2" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-2" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -54,7 +54,7 @@
         The ActiveMQ component allows messages to be sent to a JMS Queue or Topic; or messages to be consumed from a JMS Queue or Topic using Apache ActiveMQ.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-3" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-3" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -74,7 +74,7 @@
         This documentation page covers the Apache Spark component for the Apache Camel.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-4" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-4" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -94,7 +94,7 @@
         This component provides a dataformat for avro, which allows serialization and deserialization of messages using Apache Avro’s binary dataformat. Moreover, it provides support for Apache Avro’s rpc, by providing producers and consumers endpoint for using avro over netty or http.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-5" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-5" card--modifier="pf-m-selectable-raised pf-m-selected-raised pf-m-compact"}}
     {{#> card-header}}
       <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
       {{#> card-actions}}
@@ -114,13 +114,13 @@
       The Camel Components for Windows Azure Services provide connectivity to Azure services from Camel.
     {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-6" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-6" card--modifier="pf-m-non-selectable-raised pf-m-compact"}}
     {{#> card-header}}
         <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
           {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
           {{#> check check--modifier="pf-m-standalone"}}
-            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
+            {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" disabled aria-labelledby="' card--id '-check-label"')}}{{/check-input}}
           {{/check}}
         {{/card-actions}}
       {{/card-header}}
@@ -134,7 +134,7 @@
       For providing flexible endpoints to sign and verify exchanges using the Signature Service of the Java Cryptographic Extension.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-7" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-7" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/camel-dropbox_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -154,7 +154,7 @@
         The dropbox: component allows you to treat Dropbox remote folders as a producer or consumer of messages.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-8" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-8" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/camel-infinispan_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -174,7 +174,7 @@
         Read or write to a fully-supported distributed cache and data grid for faster integration services.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-9" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-9" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/FuseConnector_Icons_REST.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -195,7 +195,7 @@
         From Camel 2.18 onwards the rest component can also be used as a client (producer) to call REST services.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-10" card--modifier="pf-m-hoverable pf-m-compact"}}
+    {{#> card card--id="card-10" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> card-header}}
         <img src="/assets/images/camel-swagger-java_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4359

* Adds a `pf-m-non-selectable-raised` variant
* Updates the card view demo to use the new selectable-raised variant instead of the old hoverable variant, and add a selected and non selectable card

example - https://patternfly-pr-4500.surge.sh/components/card#non-selectable
card view demo - https://patternfly-pr-4500.surge.sh/demos/card-view/html-demos/card-view/

FYI, here is what the card view demo looks like with flat cards:
<img width="1703" alt="Screen Shot 2021-11-08 at 3 45 41 PM" src="https://user-images.githubusercontent.com/35148959/140823303-40f0d501-829e-4bb6-903c-a4943946b7a0.png">


