### PR TITLE
feat(truncate): added truncate component

### DIFF
--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -38,28 +38,6 @@ The truncate component contains to child elements, `.pf-c-truncate__start` and `
 </div>
 ```
 
-### In text
-```hbs
-<div style="width: 420px">
-  {{#> content}}
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras at lacus quis urna auctor sagittis sed vitae tellus. Morbi fringilla purus leo, molestie eleifend enim convallis in. Nam justo justo, interdum at efficitur a, posuere at mauris.
-      {{#> truncate truncate--id="basic-middle-of-line-truncation-example" truncate--modifier="pf-u-default-color-200"}}
-        {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim"}}
-        {{> truncate-end truncate-end--text="faucibus, sit amet molestie est accumsan.&lrm;"}}
-      {{/truncate}} Cras tincidunt rhoncus massa, ac consectetur purus luctus nec. Vestibulum imperdiet turpis sed elit facilisis, at ultrices eros tempor. Curabitur porta dolor malesuada accumsan varius. Quisque ut accumsan nulla. Curabitur ac libero est.
-    </p>
-    <p>
-      Vestibulum efficitur et leo in mollis. Nullam quis enim est. Sed blandit libero et viverra varius. Nulla placerat, nisl vitae interdum aliquam, sem mauris sagittis tellus, varius consectetur ligula sapien id nulla. Donec ultrices sed purus nec interdum. Duis egestas dui quam, nec rutrum nisl varius eu. Integer tempus sem orci, ut mollis leo consequat vel. Mauris euismod nisi nunc, a aliquet ipsum imperdiet at. Ut et nunc dignissim, pulvinar metus nec, volutpat velit. Proin eu ante cursus, blandit ipsum in, cursus erat. Maecenas ornare commodo condimentum. Pellentesque est libero, pulvinar iaculis efficitur quis, cursus et felis. Aliquam erat volutpat. Nulla eu dolor vel dui congue vulputate. Maecenas in ex dui. Nulla in erat pulvinar metus ullamcorper aliquam id non quam.
-    </p>
-
-    <p>
-      Donec bibendum volutpat ex, non ultrices enim tempor ut. Aliquam at metus at lacus sodales pretium interdum quis est. Donec tincidunt elit at cursus finibus. Aenean suscipit cursus justo, id facilisis ex ultrices sit amet. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec a orci odio. Nam pharetra felis at ligula ornare, vel pretium elit volutpat. Pellentesque lacinia nisi sit amet ex finibus efficitur. Cras interdum rutrum sem non eleifend. Proin velit nunc, aliquam id nisl vitae, malesuada gravida ante. Vivamus placerat libero sed porttitor consectetur.
-    </p>
-  {{/content}}
-</div>
-```
-
 ## Documentation
 
 ### Usage

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -8,7 +8,7 @@ cssPrefix: pf-c-truncate
 ## Examples
 
 ### Notes
-The truncate component contains to child elements, `.pf-c-truncate__start` and `.pf-c-truncate__end`. If both `start` and `end` are present within `.pf-c-truncate`, trucation will occur in the middle of the string. If only `.pf-c-truncate__start` is present, truncation will occur at the end of the string. If only `.pf-c-truncate__end` is present, truncation will occur at the beginning of the string. A `.pf-c-popover` will be automatically applied to the PatternFly React implementation. `&lrm;` must be included at the end of string to denote the ending punctuation mark. Otherwise it will occur and the beggining of truncation for a `pf-c-truncate__end` element.
+The truncate component contains two child elements, `.pf-c-truncate__start` and `.pf-c-truncate__end`. If both `start` and `end` are present within `.pf-c-truncate`, trucation will occur in the middle of the string. If only `.pf-c-truncate__start` is present, truncation will occur at the end of the string. If only `.pf-c-truncate__end` is present, truncation will occur at the beginning of the string. A `.pf-c-popover` will be automatically applied to the PatternFly React implementation. `&lrm;` must be included at the end of string to denote the ending punctuation mark. Otherwise it will occur and the beggining of truncation for a `pf-c-truncate__end` element.
 
 ### Default
 ```hbs

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -12,7 +12,7 @@ The truncate component contains to child elements, `.pf-c-truncate__start` and `
 
 ### Default
 ```hbs
-<div style="width: 120px">
+<div style="width: 220px; resize: horizontal; overflow: auto;">
   {{#> truncate truncate--id="default-truncation-example"}}
     {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan."}}
   {{/truncate}}
@@ -21,17 +21,17 @@ The truncate component contains to child elements, `.pf-c-truncate__start` and `
 
 ### Middle
 ```hbs
-<div style="width: 220px">
+<div style="width: 226px; resize: horizontal; overflow: auto;">
   {{#> truncate truncate--id="middle-of-line-truncation-example"}}
-    {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim"}}
-    {{> truncate-end truncate-end--text="faucibus, sit amet molestie est accumsan.&lrm;"}}
+    {{> truncate-start truncate-start--text="redhat_logo_black_and_white_reversed_"}}
+    {{> truncate-end truncate-end--text="simple_with_fedora_container.zip"}}
   {{/truncate}}
 </div>
 ```
 
 ### Start
 ```hbs
-<div style="width: 120px">
+<div style="width: 220px; resize: horizontal; overflow: auto;">
   {{#> truncate truncate--id="start-truncation-example"}}
     {{> truncate-end truncate-end--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.&lrm;"}}
   {{/truncate}}
@@ -47,3 +47,4 @@ The truncate component contains to child elements, `.pf-c-truncate__start` and `
 | `.pf-c-truncate` | `<span>` | Initiates the truncate component. |
 | `.pf-c-truncate__start` | `<span>` | Defines the truncate component starting text. |
 | `.pf-c-truncate__end` | `<span>` | Defines the truncate component ending text. |
+| `.pf-c-truncate__text` | `<span>` | Defines the truncate component text. |

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -1,0 +1,71 @@
+---
+id: 'Truncate'
+beta: true
+section: components
+cssPrefix: pf-c-truncate
+---
+
+## Examples
+
+### Notes
+The truncate component contains to child elements, `.pf-c-truncate__start` and `.pf-c-truncate__end`. If both `start` and `end` are present within `.pf-c-truncate`, trucation will occur in the middle of the string. If only `.pf-c-truncate__start` is present, truncation will occur at the end of the string. If only `.pf-c-truncate__end` is present, truncation will occur at the beginning of the string. A `.pf-c-popover` will be automatically applied to the PatternFly React implementation. `&lrm;` must be included at the end of string to denote the ending punctuation mark. Otherwise it will occur and the beggining of truncation for a `pf-c-truncate__end` element.
+
+### Default
+```hbs
+<div style="width: 120px">
+  {{#> truncate truncate--id="default-truncation-example"}}
+    {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan."}}
+  {{/truncate}}
+</div>
+```
+
+### Middle
+```hbs
+<div style="width: 220px">
+  {{#> truncate truncate--id="middle-of-line-truncation-example"}}
+    {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim"}}
+    {{> truncate-end truncate-end--text="faucibus, sit amet molestie est accumsan.&lrm;"}}
+  {{/truncate}}
+</div>
+```
+
+### Start
+```hbs
+<div style="width: 120px">
+  {{#> truncate truncate--id="start-truncation-example"}}
+    {{> truncate-end truncate-end--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.&lrm;"}}
+  {{/truncate}}
+</div>
+```
+
+### In text
+```hbs
+<div style="width: 420px">
+  {{#> content}}
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras at lacus quis urna auctor sagittis sed vitae tellus. Morbi fringilla purus leo, molestie eleifend enim convallis in. Nam justo justo, interdum at efficitur a, posuere at mauris.
+      {{#> truncate truncate--id="basic-middle-of-line-truncation-example" truncate--modifier="pf-u-default-color-200"}}
+        {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim"}}
+        {{> truncate-end truncate-end--text="faucibus, sit amet molestie est accumsan.&lrm;"}}
+      {{/truncate}} Cras tincidunt rhoncus massa, ac consectetur purus luctus nec. Vestibulum imperdiet turpis sed elit facilisis, at ultrices eros tempor. Curabitur porta dolor malesuada accumsan varius. Quisque ut accumsan nulla. Curabitur ac libero est.
+    </p>
+    <p>
+      Vestibulum efficitur et leo in mollis. Nullam quis enim est. Sed blandit libero et viverra varius. Nulla placerat, nisl vitae interdum aliquam, sem mauris sagittis tellus, varius consectetur ligula sapien id nulla. Donec ultrices sed purus nec interdum. Duis egestas dui quam, nec rutrum nisl varius eu. Integer tempus sem orci, ut mollis leo consequat vel. Mauris euismod nisi nunc, a aliquet ipsum imperdiet at. Ut et nunc dignissim, pulvinar metus nec, volutpat velit. Proin eu ante cursus, blandit ipsum in, cursus erat. Maecenas ornare commodo condimentum. Pellentesque est libero, pulvinar iaculis efficitur quis, cursus et felis. Aliquam erat volutpat. Nulla eu dolor vel dui congue vulputate. Maecenas in ex dui. Nulla in erat pulvinar metus ullamcorper aliquam id non quam.
+    </p>
+
+    <p>
+      Donec bibendum volutpat ex, non ultrices enim tempor ut. Aliquam at metus at lacus sodales pretium interdum quis est. Donec tincidunt elit at cursus finibus. Aenean suscipit cursus justo, id facilisis ex ultrices sit amet. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec a orci odio. Nam pharetra felis at ligula ornare, vel pretium elit volutpat. Pellentesque lacinia nisi sit amet ex finibus efficitur. Cras interdum rutrum sem non eleifend. Proin velit nunc, aliquam id nisl vitae, malesuada gravida ante. Vivamus placerat libero sed porttitor consectetur.
+    </p>
+  {{/content}}
+</div>
+```
+
+## Documentation
+
+### Usage
+
+| Class | Applied | Outcome |
+| -- | -- | -- |
+| `.pf-c-truncate` | `<span>` | Initiates the truncate component. |
+| `.pf-c-truncate__start` | `<span>` | Defines the truncate component starting text. |
+| `.pf-c-truncate__end` | `<span>` | Defines the truncate component ending text. |

--- a/src/patternfly/components/Truncate/truncate-end.hbs
+++ b/src/patternfly/components/Truncate/truncate-end.hbs
@@ -1,0 +1,11 @@
+<span class="pf-c-truncate__end{{#if truncate-end--modifier}} {{truncate-end--modifier}}{{/if}}"
+  {{#if truncate-end--attribute}}
+    {{{truncate-end--attribute}}}
+  {{/if}}>
+  {{#if truncate-end--text}}
+    {{{truncate-end--text}}}
+  {{/if}}
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
+</span>

--- a/src/patternfly/components/Truncate/truncate-end.hbs
+++ b/src/patternfly/components/Truncate/truncate-end.hbs
@@ -2,10 +2,12 @@
   {{#if truncate-end--attribute}}
     {{{truncate-end--attribute}}}
   {{/if}}>
-  {{#if truncate-end--text}}
-    {{{truncate-end--text}}}
-  {{/if}}
-  {{#if @partial-block}}
-    {{> @partial-block}}
-  {{/if}}
+  {{#> truncate-text truncate-text--attribute='style="--pf-c-truncate--FontSize: 1rem"'}}
+    {{#if truncate-end--text}}
+      {{{truncate-end--text}}}
+    {{/if}}
+    {{#if @partial-block}}
+      {{> @partial-block}}
+    {{/if}}
+  {{/truncate-text}}
 </span>

--- a/src/patternfly/components/Truncate/truncate-start.hbs
+++ b/src/patternfly/components/Truncate/truncate-start.hbs
@@ -1,0 +1,11 @@
+<span class="pf-c-truncate__start{{#if truncate-start--modifier}} {{truncate-start--modifier}}{{/if}}"
+  {{#if truncate-start--attribute}}
+    {{{truncate-start--attribute}}}
+  {{/if}}>
+  {{#if truncate-start--text}}
+    {{{truncate-start--text}}}
+  {{/if}}
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
+</span>

--- a/src/patternfly/components/Truncate/truncate-start.hbs
+++ b/src/patternfly/components/Truncate/truncate-start.hbs
@@ -2,10 +2,12 @@
   {{#if truncate-start--attribute}}
     {{{truncate-start--attribute}}}
   {{/if}}>
-  {{#if truncate-start--text}}
-    {{{truncate-start--text}}}
-  {{/if}}
-  {{#if @partial-block}}
-    {{> @partial-block}}
-  {{/if}}
+  {{#> truncate-text}}
+    {{#if truncate-start--text}}
+      {{{truncate-start--text}}}
+    {{/if}}
+    {{#if @partial-block}}
+      {{> @partial-block}}
+    {{/if}}
+  {{/truncate-text}}
 </span>

--- a/src/patternfly/components/Truncate/truncate-text.hbs
+++ b/src/patternfly/components/Truncate/truncate-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-truncate__text{{#if truncate-text--modifier}} {{truncate-text--modifier}}{{/if}}"
+  {{#if truncate-text--attribute}}
+    {{{truncate-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Truncate/truncate.hbs
+++ b/src/patternfly/components/Truncate/truncate.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-truncate{{#if truncate--modifier}} {{truncate--modifier}}{{/if}}"
+  {{#if truncate--attribute}}
+    {{{truncate--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,5 +1,6 @@
-// Truncate
 .pf-c-truncate {
+  --pf-c-truncate--FontSize: var(--pf-c-truncate--FontSize, 1rem);
+
   display: inline-flex;
   flex-wrap: nowrap;
   max-width: 100%;
@@ -10,18 +11,8 @@
 .pf-c-truncate__end {
   flex-shrink: 1;
   overflow: hidden;
-  white-space: nowrap;
-}
-
-// Start
-.pf-c-truncate__start {
   text-overflow: ellipsis;
-}
-
-// Start + end
-.pf-c-truncate__start + .pf-c-truncate__end {
-  text-overflow: clip;
-  text-overflow: "";
+  white-space: nowrap;
 }
 
 // End
@@ -30,6 +21,21 @@
   text-align: left;
 }
 
-.pf-c-truncate__end:first-child {
-  text-overflow: ellipsis;
+// text-overflow: <string>
+@supports (text-overflow: "") {
+  .pf-c-truncate__start + .pf-c-truncate__end {
+    text-overflow: "";
+  }
+}
+
+// text-overflow: ellipsis
+@supports not (text-overflow: "") {
+  // Start + end = middle truncation
+  .pf-c-truncate__start + .pf-c-truncate__end {
+    font-size: 0; // shrink ellipsis size to zero
+
+    .pf-c-truncate__text {
+      font-size: var(--pf-c-truncate--FontSize);
+    }
+  }
 }

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,0 +1,35 @@
+// Truncate
+.pf-c-truncate {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  max-width: 100%;
+}
+
+// Start, end
+.pf-c-truncate__start,
+.pf-c-truncate__end {
+  flex-shrink: 1;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+// Start
+.pf-c-truncate__start {
+  text-overflow: ellipsis;
+}
+
+// Start + end
+.pf-c-truncate__start + .pf-c-truncate__end {
+  text-overflow: clip;
+  text-overflow: "";
+}
+
+// End
+.pf-c-truncate__end {
+  direction: rtl;
+  text-align: left;
+}
+
+.pf-c-truncate__end:first-child {
+  text-overflow: ellipsis;
+}

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -39,3 +39,18 @@
     }
   }
 }
+
+// safari not supported
+@supports (-webkit-hyphens: none) {
+  .pf-c-truncate {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pf-c-truncate__end {
+    direction: ltr;
+  }
+}

--- a/src/patternfly/components/_all.scss
+++ b/src/patternfly/components/_all.scss
@@ -83,6 +83,7 @@
 @import "./Title/title";
 @import "./ToggleGroup/toggle-group";
 @import "./Tooltip/tooltip";
+@import "./Truncate/truncate";
 @import "./NumberInput/number-input";
 @import "./TreeView/tree-view";
 @import "./Wizard/wizard";


### PR DESCRIPTION
closes #4129 

A couple of notes: 
- Only firefox currently supports `text-overflow: <string>`, all other browser hide overflow text regardless of character placement (characters could be hidden in the middle). We could control this programmatically, but could result in performance issues. 
- No modifiers are needed, the css recognizes `start` and `end` elements and logically controls where truncation occurs. 
- Text strings are scalable ie there's no `width` control other than that included by container. 