### PR TITLE
fix(table): removed cursor pointer on disabled checkboxes

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -902,7 +902,7 @@
 .pf-c-table__check {
   --pf-c-table--cell--FontSize: var(--pf-c-table__check--input--FontSize);
 
-  > input {
+  > input:not([disabled]) {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
Closes #4475 

Updated selector to no longer apply `cursor: pointer` to checkboxes with `disabled` attribute.