### PR TITLE
feat(demos): adds a password generator demo

### DIFF
--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -30,7 +30,7 @@ section: demos
           {{#> menu-content}}
               {{#> menu-list}}
                 {{#> menu-list-item}}
-                  {{#> menu-item menu-item--modifier="pf-m-selected"}}
+                  {{#> menu-item}}
                     {{#> menu-item-main}}
                       {{#> menu-item-text}}
                         Use suggested password: fqu9kKe676JmKt2

--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -1,6 +1,5 @@
 ---
 id: 'Password generator'
-beta: false
 section: demos
 ---
 
@@ -21,15 +20,14 @@ section: demos
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> input-group}}
-            {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
+            {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="password" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
           {{/form-control}}
-          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
-            <i class="fas fa-eye-slash" aria-hidden="true"></i>
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
+            <i class="fas fa-eye" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
         {{#> menu}}
           {{#> menu-content}}
-            {{#> menu-group}}
               {{#> menu-list}}
                 {{#> menu-list-item}}
                   {{#> menu-item menu-item--modifier="pf-m-selected"}}
@@ -44,7 +42,6 @@ section: demos
                   {{/menu-item-action}}
                 {{/menu-list-item}}
               {{/menu-list}}
-            {{/menu-group}}
           {{/menu-content}}
         {{/menu}}
       {{/form-group-control}}

--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -1,0 +1,57 @@
+---
+id: 'Password generator'
+beta: false
+section: demos
+---
+
+## Examples
+
+### Provide a generated password
+
+```hbs
+  {{#> form form--id="password-generator-demo--initial"}}
+    {{#> form-group}}
+      {{#> form-group-label form-group-label-info="true"}}
+        {{#> form-group-label-main}}
+              {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
+          {{> form-group-label-help}}
+        {{/form-group-label-main}}
+        {{#> form-group-label-info}}
+        {{/form-group-label-info}}
+      {{/form-group-label}}
+      {{#> form-group-control}}
+        {{#> input-group}}
+            {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
+          {{/form-control}}
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
+            <i class="fas fa-eye-slash" aria-hidden="true"></i>
+          {{/button}}
+        {{/input-group}}
+        {{#> menu}}
+          {{#> menu-content}}
+            {{#> menu-group}}
+              {{#> menu-list}}
+                {{#> menu-list-item}}
+                  {{#> menu-item menu-item--modifier="pf-m-selected"}}
+                    {{#> menu-item-main}}
+                      {{#> menu-item-text}}
+                        Use suggested password: fqu9kKe676JmKt2
+                      {{/menu-item-text}}
+                    {{/menu-item-main}}
+                  {{/menu-item}}
+                  {{#> menu-item-action menu-item-action--attribute='aria-label="Generate a new suggested password"'}}
+                    <i class="fas fa-fw fa-redo" aria-hidden="true"></i>
+                  {{/menu-item-action}}
+                {{/menu-list-item}}
+              {{/menu-list}}
+            {{/menu-group}}
+          {{/menu-content}}
+        {{/menu}}
+      {{/form-group-control}}
+    {{/form-group}}
+  {{/form}}
+```
+
+## Documentation
+
+This demo shows how to use a menu in conjunction with a form input to provide a generated password and an associated button for refresh.

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -22,7 +22,7 @@ section: demos
         {{#> input-group}}
             {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
           {{/form-control}}
-          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
             <i class="fas fa-eye-slash" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
@@ -63,7 +63,7 @@ section: demos
         {{#> input-group}}
           {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$RedHat78" placeholder="Password"')}}
           {{/form-control}}
-          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
             <i class="fas fa-eye-slash" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
@@ -110,7 +110,7 @@ section: demos
         {{#> input-group}}
           {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$Can3Read" placeholder="Password"')}}
           {{/form-control}}
-          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
             <i class="fas fa-eye-slash" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}
@@ -157,7 +157,7 @@ section: demos
         {{#> input-group}}
           {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$Can8Read3Pass@Word" placeholder="Password"')}}
           {{/form-control}}
-          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password button for password input"'}}
+          {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
             <i class="fas fa-eye-slash" aria-hidden="true"></i>
           {{/button}}
         {{/input-group}}


### PR DESCRIPTION
This adds a new demo showing a form input field in combination with a menu to show a suggested password and button to regenerate a new password.

Mockup here: https://marvelapp.com/prototype/c7j2b6b/screen/79266406

Fixes #4340 
