### PR TITLE
fix(global): removed custom firefox focus styles

### DIFF
--- a/src/patternfly/base/_globals.scss
+++ b/src/patternfly/base/_globals.scss
@@ -127,22 +127,6 @@
     cursor: pointer;
   }
 
-  button,
-  [type="button"],
-  [type="reset"],
-  [type="submit"] {
-    // Remove the inner border and padding in Firefox.
-    &::-moz-focus-inner {
-      padding: 0;
-      border-style: none;
-    }
-
-    // Restore the focus styles unset by the previous rule.
-    &:-moz-focusring {
-      outline: 1px dotted ButtonText;
-    }
-  }
-
   @include pf-m-overpass-font {
     a {
       font-weight: var(--pf-global--FontWeight--semi-bold);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4524

These custom focus styles were to fix a problem with buttons being different sizes in firefox, however that has since been fixed. This restores the default focus styles for buttons. @mcarrano @mceledonia do you see this as a breaking change? It's definitely a bug fix as far as I'm concerned, but it will change the default focus style for buttons in FF so it could result in an unexpected visual change for FF users.