### PR TITLE
fix(label): adjust style of editable

### DIFF
--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -574,17 +574,17 @@ This style of label is used to indicate overflow within a label group.
 
 ### Editable
 **Note: Editable label behavior must be handled with JavaScript.**
-* `.pf-c-inline-edit__editable-text` onClick event should:
+* `.pf-c-label__editable-text` onClick event should:
   * Set `.pf-m-editable-active` on `.pf-c-label`
-  * Set `contenteditable="true"` on `.pf-c-inline-edit__editable-text`
+  * Change `.pf-c-label__editable-text`from a button to an input
 * Return keypress, when content is editable, should:
   * Be captured to prevent line wrapping and save updates to label text
   * Remove `.pf-m-editable-active` from `.pf-c-label`
-  * Remove `contenteditable="true"` from `.pf-c-inline-edit__editable-text`
+  * Change `.pf-c-label__editable-text` back from an input to a button and set the `currvalue` of the button to the contents of the input
 * Esc keypress, when content is editable, should:
   * Undo any update to label text
   * Remove `.pf-m-editable-active` from `.pf-c-label`
-  * Remove `contenteditable="true"` from `.pf-c-inline-edit__editable-text`
+  * Change `.pf-c-label__editable-text` back to a button
 
 ``` hbs
 {{#> label label--id="editable-label" label--IsEditable="true" label--isRemovable="true" label--modifier="pf-m-blue"}}Editable label{{/label}}
@@ -605,6 +605,7 @@ This style of label is used to indicate overflow within a label group.
 | `.pf-c-label__content` | `<span>`, `<a>`, `<button>` | Iniates a label content. Use as an `<a>` element if the label serves as a link. Use a `<button>` if the label serves as an action. **Required** |
 | `.pf-c-label__icon` | `<span>` | Initiates a label icon. |
 | `.pf-c-label__text` | `<span>` | Initiates label text. |
+| `.pf-c-label__editable-text` | `<button>`, `<input>` | Initiates editable label text. See the [editable](#editable) example for details about handling behavior in Javascript.|
 | `.pf-m-outline` | `.pf-c-label` | Modifies label for outline styles. |
 | `.pf-m-compact` | `.pf-c-label` | Modifies label for compact styles. |
 | `.pf-m-overflow` | `.pf-c-label` | Modifies label for overflow styles for use in a label group. |

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -564,13 +564,16 @@ import './Label.css'
 ```
 
 ### Overflow
+This style of label is used to indicate overflow within a label group.
 ```hbs
 {{#> label label--id="overflow" label--IsOverflow="true"}}
   Overflow
 {{/label}}
 ```
 
-### Editable label behavior must be handled with JavaScript.
+
+### Editable
+**Note: Editable label behavior must be handled with JavaScript.**
 * `.pf-c-inline-edit__editable-text` onClick event should:
   * Set `.pf-m-editable-active` on `.pf-c-label`
   * Set `contenteditable="true"` on `.pf-c-inline-edit__editable-text`
@@ -583,15 +586,14 @@ import './Label.css'
   * Remove `.pf-m-editable-active` from `.pf-c-label`
   * Remove `contenteditable="true"` from `.pf-c-inline-edit__editable-text`
 
-### Editable
 ``` hbs
-{{#> label label--id="editable-label" label--IsEditable="true" label--isRemovable="true" label--modifier="pf-m-blue"}}
-  Editable label
-{{/label}}
+{{#> label label--id="editable-label" label--IsEditable="true" label--isRemovable="true" label--modifier="pf-m-blue"}}Editable label{{/label}}
 
-{{#> label label--id="editable-label-active" label--IsEditable="true" label--IsEditableActive="true" label--modifier="pf-m-blue"}}
-  Editable active
-{{/label}}
+{{#> label label--id="editable-label-active" label--IsEditable="true" label--IsEditableActive="true" label--modifier="pf-m-blue"}}Editable active{{/label}}
+
+{{#> label label--id="compact-editable-label" label--modifier="pf-m-compact" label--IsEditable="true" label--isRemovable="true" label--modifier="pf-m-blue"}}Compact editable label{{/label}}
+
+{{#> label label--id="compact-editable-label-active" label--modifier="pf-m-compact" label--IsEditable="true" label--IsEditableActive="true" label--modifier="pf-m-blue"}}Compact editable active{{/label}}
 ```
 
 ## Documentation

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -6,12 +6,6 @@
     {{{label-content--attribute}}}
   {{/if}}>
   {{#if label--IsEditable}}
-    {{#> inline-edit}}
-      {{#> inline-edit-editable-text inline-edit-editable-text--IsActive=label--IsEditableActive inline-edit--id=label--id}}
-        {{> @partial-block}}
-      {{/inline-edit-editable-text}}
-    {{/inline-edit}}
-  {{else}}
-    {{> @partial-block}}
-  {{/if}}
+    {{#> label-editable-text}}{{> @partial-block}}{{/label-editable-text}}
+  {{else}}{{~> @partial-block}}{{/if}}
 </{{# if label-content--IsLink}}a{{else}}span{{/if}}>

--- a/src/patternfly/components/Label/label-editable-text.hbs
+++ b/src/patternfly/components/Label/label-editable-text.hbs
@@ -1,8 +1,10 @@
 <{{#if label-editable-text--type}}{{label-editable-text--type}}{{else if label--IsEditableActive}}input{{else}}button{{/if}} class="pf-c-label__editable-text{{#if label-editable-text--modifier}} {{label-editable-text--modifier}}{{/if}}"
-  id="{{label--id}}-editable-text"{{#if label--IsEditableActive}} 
-  type="text" 
-  value="{{~> @partial-block}}"{{else}} 
-  currvalue="{{~> @partial-block}}"{{/if}}
+  id="{{label--id}}-editable-text"
+  {{#if label--IsEditableActive}} 
+    type="text" 
+    value="{{~> @partial-block}}"{{else}} 
+    currvalue="{{~> @partial-block}}"
+  {{/if}}
   {{#if label-editable-text--aria-label}}
     aria-label="{{label-editable-text--aria-label}}"
   {{else}}
@@ -14,5 +16,3 @@
 {{#unless label--IsEditableActive}}
   {{> @partial-block}}
 </{{#if label-editable-text--type}}{{label-editable-text--type}}{{else}}button{{/if}}>{{/unless}}
-
-

--- a/src/patternfly/components/Label/label-editable-text.hbs
+++ b/src/patternfly/components/Label/label-editable-text.hbs
@@ -1,5 +1,8 @@
 <{{#if label-editable-text--type}}{{label-editable-text--type}}{{else if label--IsEditableActive}}input{{else}}button{{/if}} class="pf-c-label__editable-text{{#if label-editable-text--modifier}} {{label-editable-text--modifier}}{{/if}}"
-  id="{{label--id}}-editable-text"{{#if label--IsEditableActive}} type="text" value="{{~> @partial-block}}"{{else}} currvalue="{{~> @partial-block}}"{{/if}}
+  id="{{label--id}}-editable-text"{{#if label--IsEditableActive}} 
+  type="text" 
+  value="{{~> @partial-block}}"{{else}} 
+  currvalue="{{~> @partial-block}}"{{/if}}
   {{#if label-editable-text--aria-label}}
     aria-label="{{label-editable-text--aria-label}}"
   {{else}}

--- a/src/patternfly/components/Label/label-editable-text.hbs
+++ b/src/patternfly/components/Label/label-editable-text.hbs
@@ -1,0 +1,15 @@
+<{{#if label-editable-text--type}}{{label-editable-text--type}}{{else if label--IsEditableActive}}input{{else}}button{{/if}} class="pf-c-label__editable-text{{#if label-editable-text--modifier}} {{label-editable-text--modifier}}{{/if}}"
+  id="{{label--id}}-editable-text"{{#if label--IsEditableActive}} type="text" value="{{~> @partial-block}}"{{else}} currvalue="{{~> @partial-block}}"{{/if}}
+  {{#if label-editable-text--aria-label}}
+    aria-label="{{label-editable-text--aria-label}}"
+  {{else}}
+    aria-label="Editable text"
+  {{/if}}
+  {{#if label-editable-text--attribute}}
+    {{{label-editable-text--attribute}}}
+  {{/if}}{{#if label--IsEditableActive}} /{{/if}}>
+{{#unless label--IsEditableActive}}
+  {{> @partial-block}}
+</{{#if label-editable-text--type}}{{label-editable-text--type}}{{else}}button{{/if}}>{{/unless}}
+
+

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -3,7 +3,7 @@
     {{{label--attribute}}}
   {{/if}}>
   {{#> label-content}}
-    {{> @partial-block}}
+    {{~> @partial-block}}
   {{/label-content}}
   {{#if label--isRemovable}}
     {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' label--id '-button"

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -142,6 +142,17 @@
   --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
 
   // Editable
+  --pf-c-label--m-editable--TextDecoration: underline;
+  --pf-c-label--m-editable--TextDecorationStyle: dashed;
+  --pf-c-label--m-editable--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
+  --pf-c-label--m-editable--TextDecorationOffset: #{pf-size-prem(4px)};
+  --pf-c-label--m-editable--TextDecorationColor: var(--pf-global--BorderColor--200);
+  --pf-c-label--m-editable--hover--TextDecorationColor: var(--pf-global--Color--100);
+  --pf-c-label--m-editable--focus--TextDecorationColor: var(--pf-global--Color--100);
+
+
+  // Editable active
+  --pf-c-label--m-editable--m-editable-active--TextDecoration: none;
   --pf-c-label--m-editable--m-editable-active--BackgroundColor: transparent;
   --pf-c-label--m-editable--m-editable-active__content--before--BorderWidth: 0;
   --pf-c-label--m-editable--m-editable-active__content--before--BorderColor: transparent;
@@ -267,7 +278,25 @@
     }
   }
 
+  &.pf-m-editable {
+    text-decoration: var(--pf-c-label--m-editable--TextDecoration);
+    cursor: pointer;
+    text-decoration-style: var(--pf-c-label--m-editable--TextDecorationStyle);
+    text-decoration-thickness: var(--pf-c-label--m-editable--TextDecorationThickness);
+    text-underline-offset: var(--pf-c-label--m-editable--TextDecorationOffset);
+    text-decoration-color: var(--pf-c-label--m-editable--TextDecorationColor);
+
+    &:hover {
+      --pf-c-label--m-editable--TextDecorationColor: var(--pf-c-label--m-editable--hover--TextDecorationColor);
+    }
+
+    &:focus {
+      --pf-c-label--m-editable--TextDecorationColor: var(--pf-c-label--m-editable--focus--TextDecorationColor);
+    }
+  }
+
   &.pf-m-editable-active {
+    --pf-c-label--m-editable--TextDecoration: var(--pf-c-label--m-editable--m-editable-active--TextDecoration);
     --pf-c-label--BackgroundColor: var(--pf-c-label--m-editable--m-editable-active--BackgroundColor);
     --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderWidth);
     --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderColor);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -118,6 +118,7 @@
   --pf-c-label--m-compact--PaddingBottom: 0;
   --pf-c-label--m-compact--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-label--m-compact--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-label--m-compact--m-editable--TextDecorationOffset: #{pf-size-prem(1px)};
 
   // Content
   --pf-c-label__content--Color: var(--pf-global--Color--100);
@@ -142,6 +143,8 @@
   --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
 
   // Editable
+  --pf-c-label__editable-text--MaxWidth: 16ch;
+  --pf-c-label__editable-text--BorderWidth: 0;
   --pf-c-label--m-editable--Cursor: pointer;
   --pf-c-label--m-editable--TextDecoration: underline;
   --pf-c-label--m-editable--TextDecorationStyle: dashed;
@@ -174,6 +177,7 @@
     --pf-c-label--PaddingBottom: var(--pf-c-label--m-compact--PaddingBottom);
     --pf-c-label--PaddingLeft: var(--pf-c-label--m-compact--PaddingLeft);
     --pf-c-label--FontSize: var(--pf-c-label--m-compact--FontSize);
+    --pf-c-label--m-editable--TextDecorationOffset: var(--pf-c-label--m-compact--m-editable--TextDecorationOffset);
   }
 
   &.pf-m-blue {
@@ -300,14 +304,20 @@
   &.pf-m-editable-active {
     --pf-c-label--m-editable--Cursor: var(--pf-c-label--m-editable--m-editable-active--Cursor);
     --pf-c-label--m-editable--TextDecoration: var(--pf-c-label--m-editable--m-editable-active--TextDecoration);
-
-    // --pf-c-label--BackgroundColor: var(--pf-c-label--m-editable--m-editable-active--BackgroundColor);
-    // --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderWidth);
-    // --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderColor);
+    --pf-c-label--BackgroundColor: var(--pf-c-label--m-editable--m-editable-active--BackgroundColor);
+    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderWidth);
+    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderColor);
 
     .pf-c-button {
       visibility: hidden; // use visibility hidden to retain positioning
     }
+  }
+
+  .pf-c-label__editable-text {
+    @include pf-text-overflow;
+
+    max-width: var(--pf-c-label__editable-text--MaxWidth);
+    border-width: var(--pf-c-label__editable-text--BorderWidth);
   }
 
   .pf-c-button {

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -142,6 +142,7 @@
   --pf-c-label__c-button--PaddingLeft: var(--pf-global--spacer--sm);
 
   // Editable
+  --pf-c-label--m-editable--Cursor: pointer;
   --pf-c-label--m-editable--TextDecoration: underline;
   --pf-c-label--m-editable--TextDecorationStyle: dashed;
   --pf-c-label--m-editable--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
@@ -152,6 +153,7 @@
 
 
   // Editable active
+  --pf-c-label--m-editable--m-editable-active--Cursor: auto;
   --pf-c-label--m-editable--m-editable-active--TextDecoration: none;
   --pf-c-label--m-editable--m-editable-active--BackgroundColor: transparent;
   --pf-c-label--m-editable--m-editable-active__content--before--BorderWidth: 0;
@@ -280,7 +282,7 @@
 
   &.pf-m-editable {
     text-decoration: var(--pf-c-label--m-editable--TextDecoration);
-    cursor: pointer;
+    cursor: var(--pf-c-label--m-editable--Cursor);
     text-decoration-style: var(--pf-c-label--m-editable--TextDecorationStyle);
     text-decoration-thickness: var(--pf-c-label--m-editable--TextDecorationThickness);
     text-underline-offset: var(--pf-c-label--m-editable--TextDecorationOffset);
@@ -296,10 +298,12 @@
   }
 
   &.pf-m-editable-active {
+    --pf-c-label--m-editable--Cursor: var(--pf-c-label--m-editable--m-editable-active--Cursor);
     --pf-c-label--m-editable--TextDecoration: var(--pf-c-label--m-editable--m-editable-active--TextDecoration);
-    --pf-c-label--BackgroundColor: var(--pf-c-label--m-editable--m-editable-active--BackgroundColor);
-    --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderWidth);
-    --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderColor);
+
+    // --pf-c-label--BackgroundColor: var(--pf-c-label--m-editable--m-editable-active--BackgroundColor);
+    // --pf-c-label__content--before--BorderWidth: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderWidth);
+    // --pf-c-label__content--before--BorderColor: var(--pf-c-label--m-editable--m-editable-active__content--before--BorderColor);
 
     .pf-c-button {
       visibility: hidden; // use visibility hidden to retain positioning


### PR DESCRIPTION
This fixes the styling of the editable label, but the structure is in the inline edit component and will be addressed in a future PR.

#4469 

[design](https://docs.google.com/document/d/1ReoW10DzrrWxdAnzwuXbeTMdGXpFfiIAE9JHu-43o4U/edit)

[React PR](https://github.com/patternfly/patternfly-react/pull/6472)