### PR TITLE
fix(truncate): fixed fontsize var value

### DIFF
--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,5 +1,5 @@
 .pf-c-truncate {
-  --pf-c-truncate--FontSize: var(--pf-c-truncate--FontSize, 1rem);
+  --pf-c-truncate--FontSize: 1rem;
 
   display: inline-flex;
   flex-wrap: nowrap;


### PR DESCRIPTION
react build is failing because `--pf-c-truncate--FontSize` is referenced but not defined