### PR TITLE
fix(text input group): updated to only apply margin if utilities not empty

### DIFF
--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -162,10 +162,12 @@
 .pf-c-text-input-group__utilities {
   display: flex;
   align-items: center;
+  margin-right: var(--pf-c-text-input-group__utilities--MarginRight);
+  margin-left: var(--pf-c-text-input-group__utilities--MarginLeft);
 
-  &:not(:empty) {
-    margin-right: var(--pf-c-text-input-group__utilities--MarginRight);
-    margin-left: var(--pf-c-text-input-group__utilities--MarginLeft);
+  &:empty {
+    --pf-c-text-input-group__utilities--MarginRight: 0;
+    --pf-c-text-input-group__utilities--MarginLeft: 0;
   }
 
   > * + * {

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -162,8 +162,11 @@
 .pf-c-text-input-group__utilities {
   display: flex;
   align-items: center;
-  margin-right: var(--pf-c-text-input-group__utilities--MarginRight);
-  margin-left: var(--pf-c-text-input-group__utilities--MarginLeft);
+
+  &:not(:empty) {
+    margin-right: var(--pf-c-text-input-group__utilities--MarginRight);
+    margin-left: var(--pf-c-text-input-group__utilities--MarginLeft);
+  }
 
   > * + * {
     margin-left: var(--pf-c-text-input-group__utilities--child--MarginLeft);


### PR DESCRIPTION
closes #4514 

Updated `.pf-c-text-input-group__utilities` margins to only apply if element is not empty.