### PR TITLE
fix(table): fixed sort/fit-content width

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -579,7 +579,7 @@
   .pf-c-table__icon,
   .pf-m-fit-content {
     --pf-c-table--cell--MinWidth: fit-content;
-    --pf-c-table--cell--MaxWidth: fit-content;
+    --pf-c-table--cell--MaxWidth: none;
     --pf-c-table--cell--Width: 1%;
     --pf-c-table--cell--Overflow: visible;
     --pf-c-table--cell--TextOverflow: clip;


### PR DESCRIPTION
closes #4535 

@mcarrano Looks like this issue applies to all sortable table `th`s, not just nested `th`s. `max-width` should be `none` rather than `fit-content`. Update tested in FF, Chrome and Safari. 