### PR TITLE
fix(login page): aligned login box to top

### DIFF
--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -165,6 +165,7 @@
 }
 
 .pf-c-login__main {
+  align-self: start;
   margin-bottom: var(--pf-c-login__main--MarginBottom);
   background-color: var(--pf-c-login__main--BackgroundColor);
   grid-area: main;


### PR DESCRIPTION
Closes #4540 

This PR sets `align-self: start` on `.pf-c-login__main` to avoid it stretching to fill height if the content beside it is taller than it is.