### PR TITLE
fix(truncate): resolved spacing issues

### DIFF
--- a/src/patternfly/components/Truncate/examples/Truncate.css
+++ b/src/patternfly/components/Truncate/examples/Truncate.css
@@ -1,0 +1,9 @@
+.pf-c-truncate--example {
+  width: 320px;
+  resize: horizontal;
+  overflow: auto;
+  min-width: 161px;
+  max-width: 100%;
+  padding: var(--pf-global--spacer--md);
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+}

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -5,6 +5,8 @@ section: components
 cssPrefix: pf-c-truncate
 ---
 
+import './Truncate.css'
+
 ## Examples
 
 ### Notes
@@ -12,7 +14,7 @@ The truncate component contains two child elements, `.pf-c-truncate__start` and 
 
 ### Default
 ```hbs
-<div style="width: 220px; resize: horizontal; overflow: auto;">
+<div class="pf-c-truncate--example">
   {{#> truncate truncate--id="default-truncation-example"}}
     {{> truncate-start truncate-start--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan."}}
   {{/truncate}}
@@ -21,17 +23,17 @@ The truncate component contains two child elements, `.pf-c-truncate__start` and 
 
 ### Middle
 ```hbs
-<div style="width: 226px; resize: horizontal; overflow: auto;">
+<div class="pf-c-truncate--example">
   {{#> truncate truncate--id="middle-of-line-truncation-example"}}
-    {{> truncate-start truncate-start--text="redhat_logo_black_and_white_reversed_"}}
-    {{> truncate-end truncate-end--text="simple_with_fedora_container.zip"}}
+    {{> truncate-start truncate-start--text="redhat_logo_black_and_white_reversed_simple_with_fedora_con"}}
+    {{> truncate-end truncate-end--text="tainer.zip"}}
   {{/truncate}}
 </div>
 ```
 
 ### Start
 ```hbs
-<div style="width: 220px; resize: horizontal; overflow: auto;">
+<div class="pf-c-truncate--example">
   {{#> truncate truncate--id="start-truncation-example"}}
     {{> truncate-end truncate-end--text="Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.&lrm;"}}
   {{/truncate}}
@@ -47,4 +49,3 @@ The truncate component contains two child elements, `.pf-c-truncate__start` and 
 | `.pf-c-truncate` | `<span>` | Initiates the truncate component. |
 | `.pf-c-truncate__start` | `<span>` | Defines the truncate component starting text. |
 | `.pf-c-truncate__end` | `<span>` | Defines the truncate component ending text. |
-| `.pf-c-truncate__text` | `<span>` | Defines the truncate component text. |

--- a/src/patternfly/components/Truncate/truncate-end.hbs
+++ b/src/patternfly/components/Truncate/truncate-end.hbs
@@ -2,12 +2,10 @@
   {{#if truncate-end--attribute}}
     {{{truncate-end--attribute}}}
   {{/if}}>
-  {{#> truncate-text truncate-text--attribute='style="--pf-c-truncate--FontSize: 1rem"'}}
-    {{#if truncate-end--text}}
-      {{{truncate-end--text}}}
-    {{/if}}
-    {{#if @partial-block}}
-      {{> @partial-block}}
-    {{/if}}
-  {{/truncate-text}}
+  {{#if truncate-end--text}}
+    {{{truncate-end--text}}}
+  {{/if}}
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
 </span>

--- a/src/patternfly/components/Truncate/truncate-start.hbs
+++ b/src/patternfly/components/Truncate/truncate-start.hbs
@@ -2,12 +2,10 @@
   {{#if truncate-start--attribute}}
     {{{truncate-start--attribute}}}
   {{/if}}>
-  {{#> truncate-text}}
-    {{#if truncate-start--text}}
-      {{{truncate-start--text}}}
-    {{/if}}
-    {{#if @partial-block}}
-      {{> @partial-block}}
-    {{/if}}
-  {{/truncate-text}}
+  {{#if truncate-start--text}}
+    {{{truncate-start--text}}}
+  {{/if}}
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
 </span>

--- a/src/patternfly/components/Truncate/truncate-text.hbs
+++ b/src/patternfly/components/Truncate/truncate-text.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-truncate__text{{#if truncate-text--modifier}} {{truncate-text--modifier}}{{/if}}"
-  {{#if truncate-text--attribute}}
-    {{{truncate-text--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,55 +1,36 @@
 .pf-c-truncate {
-  --pf-c-truncate--FontSize: 1rem;
+  --pf-c-truncate--MinWidth: 12ch;
+  --pf-c-truncate__start--MinWidth: 6ch;
 
-  display: inline-flex;
-  flex-wrap: nowrap;
-  max-width: 100%;
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: baseline;
+  min-width: var(--pf-c-truncate--MinWidth);
 }
 
-// Start, end
 .pf-c-truncate__start,
 .pf-c-truncate__end {
-  flex-shrink: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.pf-c-truncate__start {
+  min-width: var(--pf-c-truncate__start--MinWidth);
+}
+
 // End
 .pf-c-truncate__end {
   direction: rtl;
-  text-align: left;
 }
 
-// text-overflow: <string>
-@supports (text-overflow: "") {
-  .pf-c-truncate__start + .pf-c-truncate__end {
-    text-overflow: "";
-  }
-}
-
-// text-overflow: ellipsis
-@supports not (text-overflow: "") {
-  // Start + end = middle truncation
-  .pf-c-truncate__start + .pf-c-truncate__end {
-    font-size: 0; // shrink ellipsis size to zero
-
-    .pf-c-truncate__text {
-      font-size: var(--pf-c-truncate--FontSize);
-    }
-  }
+.pf-c-truncate__start + .pf-c-truncate__end {
+  overflow: visible;
+  direction: ltr;
 }
 
 // safari not supported
 @supports (-webkit-hyphens: none) {
-  .pf-c-truncate {
-    display: inline-block;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   .pf-c-truncate__end {
     direction: ltr;
   }


### PR DESCRIPTION
[React issue 6713](https://github.com/patternfly/patternfly-react/pull/6713) raises several questions about the truncate component. There is only one way to truncate with CSS per character, and that is with `text-overflow: ellipsis` or `text-overflow: {string}` (currently only supported in FF). Calculating string widths per non-monospace font character is a heavy JS lift alone, and the truncate component will appear multiple times in tables, data lists, etc those browser calcs will be exponential and lead to performance issues. 

The current implementation takes advantage of `text-overflow: ellipsis` by setting the font size of the duplicate ellipsis to `0` which essentially hides it. `display: flex` doesn't respond to truncated text when it occurs at the beginning of a string and something in the `text-overflow` functionality considers individual character width resulting in: 

> @mattnolting @mcarrano It looks like when the truncation is in the middle, there is sometimes a noticeable large space to the right of the ellipses. On the left, the ellipses are always right next to last character before them. Is this intentional? ![image](https://user-images.githubusercontent.com/39532947/148457759-f313cbc0-cfdd-4bf5-b06e-a01980a2fbe0.png)

## This update changes the way middle truncation is presented

Instead of cutting a string in half and adding the ellipsis the exact middle of that string, we cut the last 5-10 characters off the string and present them as the second piece of truncated text.

![trim](https://user-images.githubusercontent.com/5385435/148836103-4ab5dd63-9aa1-4602-8e6c-22e1fbc1804a.gif)

After further contextual testing I learned a couple of things: 
* `display: inline-flex` does not function well in (at least) table and data-list, which makes in an inviable solution. Updating to `display: inline-grid` works very well and is more stable within other components and standard block level elements.
* Passing `font-size` from parent to child is fragile and will lead to unforeseen issues.

With this updated solution we can:
* Mimic the middle truncation functionality by slicing the last 5-10 characters off the string and passing to `pf-c-truncate__end`. This allows `pf-c-truncate__start` to handle truncation alone.
* We no longer need much of the conditional CSS in the current implementation.
* We eliminate or limit (to no more than one space) the gapping that occurs in the current implementation.
* We can remove the `pf-c-truncate__text` wrapper and avoid passing parent text `font-size` to child text. Which eliminates the need for additional JS logic. 

Outline of what will need to be updated in React implementation:
* Remove `pf-c-truncate__text` wrapper.
* For middle truncated text, slice the last 5-10 characters off the string and add to `pf-c-truncate__end`, rather than slicing the string equally into parts `__start` and `__end`. 

Example CSS has also been updated.
