### PR TITLE
fix(focus): fixed focus styles for interactable elems

### DIFF
--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -1,4 +1,11 @@
 .pf-c-context-selector {
+  --pf-c-context-selector__toggle--before--base--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-context-selector__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
+
+  // access variables for :focus-visible + mouseout
+  --pf-c-context-selector__toggle--before--reset--BorderBottomWidth: var(--pf-c-context-selector__toggle--before--base--BorderBottomWidth);
+  --pf-c-context-selector__toggle--before--reset--BorderBottomColor: var(--pf-c-context-selector__toggle--before--base--BorderBottomColor);
+
   // Context selector
   --pf-c-context-selector--Width: #{pf-size-prem(250px)};
 
@@ -7,10 +14,10 @@
   --pf-c-context-selector__toggle--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-context-selector__toggle--PaddingBottom: var(--pf-global--spacer--form-element);
   --pf-c-context-selector__toggle--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-context-selector__toggle--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-context-selector__toggle--BorderWidth: var(--pf-c-context-selector__toggle--before--base--BorderBottomWidth);
   --pf-c-context-selector__toggle--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-context-selector__toggle--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--base--BorderBottomColor);
   --pf-c-context-selector__toggle--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-context-selector__toggle--Color: var(--pf-global--Color--100);
   --pf-c-context-selector__toggle--hover--BorderBottomWidth: var(--pf-c-context-selector__toggle--BorderWidth);
@@ -186,6 +193,12 @@
     --pf-c-context-selector__toggle--m-plain--m-text--PaddingRight: var(--pf-c-context-selector--m-page-insets__toggle--m-plain--m-text--PaddingRight);
     --pf-c-context-selector__toggle--m-plain--m-text--PaddingLeft: var(--pf-c-context-selector--m-page-insets__toggle--m-plain--m-text--PaddingLeft);
   }
+}
+
+// reset :focus-visible + mouseout accent
+@include pf-reset-accent-focus-border("pf-c-context-selector", $before: true, $root: false) {
+  --pf-c-context-selector__toggle--active--BorderBottomWidth: var(--pf-c-context-selector__toggle--before--reset--BorderBottomWidth);
+  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--reset--BorderBottomColor);
 }
 
 .pf-c-context-selector__toggle {

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -1,10 +1,10 @@
 .pf-c-context-selector {
-  --pf-c-context-selector__toggle--before--base--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-context-selector__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-context-selector__toggle--before--BorderBottomWidth--base: var(--pf-global--BorderWidth--sm);
+  --pf-c-context-selector__toggle--before--BorderBottomColor--base: var(--pf-global--BorderColor--200);
 
   // access variables for :focus-visible + mouseout
-  --pf-c-context-selector__toggle--before--reset--BorderBottomWidth: var(--pf-c-context-selector__toggle--before--base--BorderBottomWidth);
-  --pf-c-context-selector__toggle--before--reset--BorderBottomColor: var(--pf-c-context-selector__toggle--before--base--BorderBottomColor);
+  --pf-c-context-selector__toggle--before--BorderBottomWidth--reset: var(--pf-c-context-selector__toggle--before--BorderBottomWidth--base);
+  --pf-c-context-selector__toggle--before--BorderBottomColor--reset: var(--pf-c-context-selector__toggle--before--BorderBottomColor--base);
 
   // Context selector
   --pf-c-context-selector--Width: #{pf-size-prem(250px)};
@@ -14,10 +14,10 @@
   --pf-c-context-selector__toggle--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-context-selector__toggle--PaddingBottom: var(--pf-global--spacer--form-element);
   --pf-c-context-selector__toggle--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-context-selector__toggle--BorderWidth: var(--pf-c-context-selector__toggle--before--base--BorderBottomWidth);
+  --pf-c-context-selector__toggle--BorderWidth: var(--pf-c-context-selector__toggle--before--BorderBottomWidth--base);
   --pf-c-context-selector__toggle--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-context-selector__toggle--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--base--BorderBottomColor);
+  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--BorderBottomColor--base);
   --pf-c-context-selector__toggle--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-context-selector__toggle--Color: var(--pf-global--Color--100);
   --pf-c-context-selector__toggle--hover--BorderBottomWidth: var(--pf-c-context-selector__toggle--BorderWidth);
@@ -197,8 +197,8 @@
 
 // reset :focus-visible + mouseout accent
 @include pf-reset-accent-focus-border("pf-c-context-selector", $before: true, $root: false) {
-  --pf-c-context-selector__toggle--active--BorderBottomWidth: var(--pf-c-context-selector__toggle--before--reset--BorderBottomWidth);
-  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--reset--BorderBottomColor);
+  --pf-c-context-selector__toggle--active--BorderBottomWidth: var(--pf-c-context-selector__toggle--before--BorderBottomWidth--reset);
+  --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-context-selector__toggle--before--BorderBottomColor--reset);
 }
 
 .pf-c-context-selector__toggle {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,12 +1,12 @@
 $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-dropdown {
-  --pf-c-dropdown__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
-  --pf-c-dropdown__toggle--before--base--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-dropdown__toggle--before--BorderBottomColor--base: var(--pf-global--BorderColor--200);
+  --pf-c-dropdown__toggle--before--BorderWidth--base: var(--pf-global--BorderWidth--sm);
 
   // access variables for :focus-visible + mouseout
-  --pf-c-dropdown__toggle--before--reset--BorderBottomWidth: var(--pf-c-dropdown__toggle--before--base--BorderBottomWidth);
-  --pf-c-dropdown__toggle--before--reset--BorderBottomColor: var(--pf-c-dropdown__toggle--before--base--BorderBottomColor);
+  --pf-c-dropdown__toggle--before--BorderBottomWidth--reset: var(--pf-c-dropdown__toggle--before--BorderBottomWidth--base);
+  --pf-c-dropdown__toggle--before--BorderBottomColor--reset: var(--pf-c-dropdown__toggle--before--BorderBottomColor--base);
 
   // Toggle
   --pf-c-dropdown__toggle--PaddingTop: var(--pf-global--spacer--form-element);
@@ -19,10 +19,10 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__toggle--Color: var(--pf-global--Color--100);
   --pf-c-dropdown__toggle--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-dropdown__toggle--BackgroundColor: transparent;
-  --pf-c-dropdown__toggle--before--BorderWidth: var(--pf-c-dropdown__toggle--before--base--BorderWidth);
+  --pf-c-dropdown__toggle--before--BorderWidth: var(--pf-c-dropdown__toggle--before--BorderWidth--base);
   --pf-c-dropdown__toggle--before--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--base--BorderBottomColor);
+  --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--BorderBottomColor--base);
   --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-dropdown__toggle--hover--before--BorderBottomColor: var(--pf-global--active-color--100);
   --pf-c-dropdown__toggle--focus--before--BorderBottomWidth: var(--pf-global--BorderWidth--md);
@@ -227,8 +227,8 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 
 // reset :focus-visible + mouseout accent
 @include pf-reset-accent-focus-border("pf-c-dropdown", $before: true, $root: false) {
-  --pf-c-dropdown__toggle--focus--before--BorderBottomWidth: var(--pf-c-dropdown__toggle--before--reset--BorderBottomWidth);
-  --pf-c-dropdown__toggle--focus--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--reset--BorderBottomColor);
+  --pf-c-dropdown__toggle--focus--before--BorderBottomWidth: var(--pf-c-dropdown__toggle--before--BorderBottomWidth--reset);
+  --pf-c-dropdown__toggle--focus--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--BorderBottomColor--reset);
 }
 
 .pf-c-dropdown__toggle {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,6 +1,13 @@
 $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-dropdown {
+  --pf-c-dropdown__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-dropdown__toggle--before--base--BorderWidth: var(--pf-global--BorderWidth--sm);
+
+  // access variables for :focus-visible + mouseout
+  --pf-c-dropdown__toggle--before--reset--BorderBottomWidth: var(--pf-c-dropdown__toggle--before--base--BorderBottomWidth);
+  --pf-c-dropdown__toggle--before--reset--BorderBottomColor: var(--pf-c-dropdown__toggle--before--base--BorderBottomColor);
+
   // Toggle
   --pf-c-dropdown__toggle--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-dropdown__toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -12,10 +19,10 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__toggle--Color: var(--pf-global--Color--100);
   --pf-c-dropdown__toggle--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-dropdown__toggle--BackgroundColor: transparent;
-  --pf-c-dropdown__toggle--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-dropdown__toggle--before--BorderWidth: var(--pf-c-dropdown__toggle--before--base--BorderWidth);
   --pf-c-dropdown__toggle--before--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--base--BorderBottomColor);
   --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-dropdown__toggle--hover--before--BorderBottomColor: var(--pf-global--active-color--100);
   --pf-c-dropdown__toggle--focus--before--BorderBottomWidth: var(--pf-global--BorderWidth--md);
@@ -216,6 +223,12 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   &.pf-m-expanded {
     --pf-c-dropdown__toggle--m-split-button--m-primary--child--BackgroundColor: var(--pf-c-dropdown__toggle--m-split-button--m-primary--child--m-expanded--BackgroundColor);
   }
+}
+
+// reset :focus-visible + mouseout accent
+@include pf-reset-accent-focus-border("pf-c-dropdown", $before: true, $root: false) {
+  --pf-c-dropdown__toggle--focus--before--BorderBottomWidth: var(--pf-c-dropdown__toggle--before--reset--BorderBottomWidth);
+  --pf-c-dropdown__toggle--focus--before--BorderBottomColor: var(--pf-c-dropdown__toggle--before--reset--BorderBottomColor);
 }
 
 .pf-c-dropdown__toggle {

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -121,7 +121,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-context-selector__toggle--BorderRightColor: transparent;
   --pf-c-masthead--c-context-selector__toggle--BorderBottomColor: transparent;
   --pf-c-masthead--c-context-selector__toggle--BorderLeftColor: transparent;
-  --pf-c-masthead--c-context-selector__toggle--before--reset--BorderBottomColor: transparent;
+  --pf-c-masthead--c-context-selector__toggle--before--BorderBottomColor--reset: transparent;
   --pf-c-masthead--c-context-selector--m-full-height__toggle--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-context-selector--m-full-height__toggle--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
 
@@ -130,7 +130,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-dropdown__toggle--before--BorderRightColor: transparent;
   --pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor: transparent;
   --pf-c-masthead--c-dropdown__toggle--before--BorderLeftColor: transparent;
-  --pf-c-masthead--c-dropdown__toggle--before--reset--BorderBottomColor: transparent;
+  --pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor--reset: transparent;
   --pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
 
@@ -140,7 +140,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-menu-toggle--before--BorderBottomColor: transparent;
   --pf-c-masthead--c-menu-toggle--before--BorderLeftColor: transparent;
   --pf-c-masthead--c-menu-toggle--after--BorderColor: transparent;
-  --pf-c-masthead--c-menu-toggle--after--reset--BorderColor: transparent;
+  --pf-c-masthead--c-menu-toggle--after--BorderColor--reset: transparent;
   --pf-c-masthead--c-menu-toggle--m-full-height--before--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-menu-toggle--m-full-height--before--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
 
@@ -217,7 +217,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-menu-toggle--before--BorderBottomColor: var(--pf-c-masthead--c-menu-toggle--before--BorderBottomColor);
     --pf-c-menu-toggle--before--BorderLeftColor: var(--pf-c-masthead--c-menu-toggle--before--BorderLeftColor);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-masthead--c-menu-toggle--after--BorderBottomColor);
-    --pf-c-menu-toggle--after--reset--BorderColor: var(--pf-c-masthead--c-menu-toggle--after--reset--BorderColor);
+    --pf-c-menu-toggle--after--BorderColor--reset: var(--pf-c-masthead--c-menu-toggle--after--BorderColor--reset);
 
     &.pf-m-full-height {
       --pf-c-menu-toggle--before--BorderRightColor: var(--pf-c-masthead--c-menu-toggle--m-full-height--before--BorderRightColor);
@@ -231,7 +231,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-context-selector__toggle--BorderRightColor: var(--pf-c-masthead--c-context-selector__toggle--BorderRightColor);
     --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-masthead--c-context-selector__toggle--BorderBottomColor);
     --pf-c-context-selector__toggle--BorderLeftColor: var(--pf-c-masthead--c-context-selector__toggle--BorderLeftColor);
-    --pf-c-context-selector__toggle--before--reset--BorderBottomColor: var(--pf-c-masthead--c-context-selector__toggle--before--reset--BorderBottomColor);
+    --pf-c-context-selector__toggle--before--BorderBottomColor--reset: var(--pf-c-masthead--c-context-selector__toggle--before--BorderBottomColor--reset);
 
     &.pf-m-full-height {
       --pf-c-context-selector__toggle--BorderRightColor: var(--pf-c-masthead--c-context-selector--m-full-height__toggle--BorderRightColor);
@@ -244,7 +244,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderRightColor);
     --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor);
     --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderLeftColor);
-    --pf-c-dropdown__toggle--before--reset--BorderBottomColor: var(--pf-c-masthead--c-dropdown__toggle--before--reset--BorderBottomColor);
+    --pf-c-dropdown__toggle--before--BorderBottomColor--reset: var(--pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor--reset);
 
     &.pf-m-full-height {
       --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderRightColor);

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -121,6 +121,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-context-selector__toggle--BorderRightColor: transparent;
   --pf-c-masthead--c-context-selector__toggle--BorderBottomColor: transparent;
   --pf-c-masthead--c-context-selector__toggle--BorderLeftColor: transparent;
+  --pf-c-masthead--c-context-selector__toggle--before--reset--BorderBottomColor: transparent;
   --pf-c-masthead--c-context-selector--m-full-height__toggle--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-context-selector--m-full-height__toggle--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
 
@@ -129,6 +130,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-dropdown__toggle--before--BorderRightColor: transparent;
   --pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor: transparent;
   --pf-c-masthead--c-dropdown__toggle--before--BorderLeftColor: transparent;
+  --pf-c-masthead--c-dropdown__toggle--before--reset--BorderBottomColor: transparent;
   --pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
 
@@ -137,8 +139,11 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead--c-menu-toggle--before--BorderRightColor: transparent;
   --pf-c-masthead--c-menu-toggle--before--BorderBottomColor: transparent;
   --pf-c-masthead--c-menu-toggle--before--BorderLeftColor: transparent;
+  --pf-c-masthead--c-menu-toggle--after--BorderColor: transparent;
+  --pf-c-masthead--c-menu-toggle--after--reset--BorderColor: transparent;
   --pf-c-masthead--c-menu-toggle--m-full-height--before--BorderRightColor: var(--pf-c-masthead--item-border-color--base);
   --pf-c-masthead--c-menu-toggle--m-full-height--before--BorderLeftColor: var(--pf-c-masthead--item-border-color--base);
+
 
   // Toolbar
   --pf-c-masthead--c-toolbar__content--PaddingRight: 0;
@@ -211,6 +216,8 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-menu-toggle--before--BorderRightColor: var(--pf-c-masthead--c-menu-toggle--before--BorderRightColor);
     --pf-c-menu-toggle--before--BorderBottomColor: var(--pf-c-masthead--c-menu-toggle--before--BorderBottomColor);
     --pf-c-menu-toggle--before--BorderLeftColor: var(--pf-c-masthead--c-menu-toggle--before--BorderLeftColor);
+    --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-masthead--c-menu-toggle--after--BorderBottomColor);
+    --pf-c-menu-toggle--after--reset--BorderColor: var(--pf-c-masthead--c-menu-toggle--after--reset--BorderColor);
 
     &.pf-m-full-height {
       --pf-c-menu-toggle--before--BorderRightColor: var(--pf-c-masthead--c-menu-toggle--m-full-height--before--BorderRightColor);
@@ -224,6 +231,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-context-selector__toggle--BorderRightColor: var(--pf-c-masthead--c-context-selector__toggle--BorderRightColor);
     --pf-c-context-selector__toggle--BorderBottomColor: var(--pf-c-masthead--c-context-selector__toggle--BorderBottomColor);
     --pf-c-context-selector__toggle--BorderLeftColor: var(--pf-c-masthead--c-context-selector__toggle--BorderLeftColor);
+    --pf-c-context-selector__toggle--before--reset--BorderBottomColor: var(--pf-c-masthead--c-context-selector__toggle--before--reset--BorderBottomColor);
 
     &.pf-m-full-height {
       --pf-c-context-selector__toggle--BorderRightColor: var(--pf-c-masthead--c-context-selector--m-full-height__toggle--BorderRightColor);
@@ -236,6 +244,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderRightColor);
     --pf-c-dropdown__toggle--before--BorderBottomColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderBottomColor);
     --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-c-masthead--c-dropdown__toggle--before--BorderLeftColor);
+    --pf-c-dropdown__toggle--before--reset--BorderBottomColor: var(--pf-c-masthead--c-dropdown__toggle--before--reset--BorderBottomColor);
 
     &.pf-m-full-height {
       --pf-c-dropdown__toggle--before--BorderRightColor: var(--pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderRightColor);

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -1,10 +1,10 @@
 .pf-c-menu-toggle {
-  --pf-c-menu-toggle--after--base--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-menu-toggle--after--base--BorderColor: var(--pf-global--BorderColor--200);
+  --pf-c-menu-toggle--after--BorderWidth--base: var(--pf-global--BorderWidth--sm);
+  --pf-c-menu-toggle--after--BorderColor--base: var(--pf-global--BorderColor--200);
 
   // access variables for :focus-visible + mouseout
-  --pf-c-menu-toggle--after--reset--BorderWidth: var(--pf-c-menu-toggle--after--base--BorderWidth);
-  --pf-c-menu-toggle--after--reset--BorderColor: var(--pf-c-menu-toggle--after--base--BorderColor);
+  --pf-c-menu-toggle--after--BorderWidth--reset: var(--pf-c-menu-toggle--after--BorderWidth--base);
+  --pf-c-menu-toggle--after--BorderColor--reset: var(--pf-c-menu-toggle--after--BorderColor--base);
 
   // toggle
   --pf-c-menu-toggle--BorderRadius: 0;
@@ -28,8 +28,8 @@
   --pf-c-menu-toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
 
   // Border accent
-  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--base--BorderWidth);
-  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--base--BorderColor);
+  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--BorderWidth--base);
+  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--BorderColor--base);
 
   // Hover
   --pf-c-menu-toggle--hover--BackgroundColor: transparent;
@@ -275,8 +275,8 @@
 
 // reset :focus-visible + mouseout accent
 @include pf-reset-accent-focus-border("pf-c-menu-toggle") {
-  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--reset--BorderWidth);
-  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--reset--BorderColor);
+  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--BorderWidth--reset);
+  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--BorderColor--reset);
 }
 
 .pf-c-menu-toggle__icon {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -1,4 +1,12 @@
 .pf-c-menu-toggle {
+  --pf-c-menu-toggle--after--base--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-menu-toggle--after--base--BorderColor: var(--pf-global--BorderColor--200);
+
+  // access variables for :focus-visible + mouseout
+  --pf-c-menu-toggle--after--reset--BorderWidth: var(--pf-c-menu-toggle--after--base--BorderWidth);
+  --pf-c-menu-toggle--after--reset--BorderColor: var(--pf-c-menu-toggle--after--base--BorderColor);
+
+  // toggle
   --pf-c-menu-toggle--BorderRadius: 0;
   --pf-c-menu-toggle--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-menu-toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -20,8 +28,8 @@
   --pf-c-menu-toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
 
   // Border accent
-  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--base--BorderWidth);
+  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--base--BorderColor);
 
   // Hover
   --pf-c-menu-toggle--hover--BackgroundColor: transparent;
@@ -263,6 +271,12 @@
 
     height: 100%;
   }
+}
+
+// reset :focus-visible + mouseout accent
+@include pf-reset-accent-focus-border("pf-c-menu-toggle") {
+  --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--after--reset--BorderWidth);
+  --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--after--reset--BorderColor);
 }
 
 .pf-c-menu-toggle__icon {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -1,6 +1,13 @@
 .pf-c-select {
   @include pf-t-light; // force the container follow the light theme
 
+  --pf-c-select__toggle--before--base--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-select__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
+
+  // access variables for :focus-visible + mouseout
+  --pf-c-select__toggle--before--reset--BorderBottomWidth: var(--pf-c-select__toggle--before--base--BorderBottomWidth);
+  --pf-c-select__toggle--before--reset--BorderBottomColor: var(--pf-c-select__toggle--before--base--BorderBottomColor);
+
   // Toggle
   --pf-c-select__toggle--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-select__toggle--PaddingRight: var(--pf-global--spacer--sm);
@@ -13,12 +20,12 @@
   --pf-c-select__toggle--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-select__toggle--before--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-select__toggle--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--base--BorderBottomWidth);
   --pf-c-select__toggle--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-select__toggle--before--BorderWidth: var(--pf-c-select__toggle--before--BorderTopWidth) var(--pf-c-select__toggle--before--BorderRightWidth) var(--pf-c-select__toggle--before--BorderBottomWidth) var(--pf-c-select__toggle--before--BorderLeftWidth); // remove at breaking change
   --pf-c-select__toggle--before--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-select__toggle--before--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--base--BorderBottomColor);
   --pf-c-select__toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-select__toggle--Color: var(--pf-global--Color--100);
   --pf-c-select__toggle--hover--before--BorderBottomColor: var(--pf-global--active-color--100);
@@ -255,6 +262,12 @@
     --pf-c-select__toggle--m-expanded--before--BorderBottomColor: var(--pf-c-select--m-warning__toggle--m-expanded--before--BorderBottomColor);
     --pf-c-select__toggle-status-icon--Color: var(--pf-c-select--m-warning__toggle-status-icon--Color);
   }
+}
+
+// reset :focus-visible + mouseout accent
+@include pf-reset-accent-focus-border("pf-c-select", $before: true, $root: false) {
+  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--reset--BorderBottomWidth);
+  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--reset--BorderBottomColor);
 }
 
 .pf-c-select__menu-search + .pf-c-divider {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -1,12 +1,12 @@
 .pf-c-select {
   @include pf-t-light; // force the container follow the light theme
 
-  --pf-c-select__toggle--before--base--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-select__toggle--before--base--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-select__toggle--before--BorderBottomWidth--base: var(--pf-global--BorderWidth--sm);
+  --pf-c-select__toggle--before--BorderBottomColor--base: var(--pf-global--BorderColor--200);
 
   // access variables for :focus-visible + mouseout
-  --pf-c-select__toggle--before--reset--BorderBottomWidth: var(--pf-c-select__toggle--before--base--BorderBottomWidth);
-  --pf-c-select__toggle--before--reset--BorderBottomColor: var(--pf-c-select__toggle--before--base--BorderBottomColor);
+  --pf-c-select__toggle--before--BorderBottomWidth--reset: var(--pf-c-select__toggle--before--BorderBottomWidth--base);
+  --pf-c-select__toggle--before--BorderBottomColor--reset: var(--pf-c-select__toggle--before--BorderBottomColor--base);
 
   // Toggle
   --pf-c-select__toggle--PaddingTop: var(--pf-global--spacer--form-element);
@@ -20,12 +20,12 @@
   --pf-c-select__toggle--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-select__toggle--before--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-select__toggle--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--base--BorderBottomWidth);
+  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--BorderBottomWidth--base);
   --pf-c-select__toggle--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-select__toggle--before--BorderWidth: var(--pf-c-select__toggle--before--BorderTopWidth) var(--pf-c-select__toggle--before--BorderRightWidth) var(--pf-c-select__toggle--before--BorderBottomWidth) var(--pf-c-select__toggle--before--BorderLeftWidth); // remove at breaking change
   --pf-c-select__toggle--before--BorderTopColor: var(--pf-global--BorderColor--300);
   --pf-c-select__toggle--before--BorderRightColor: var(--pf-global--BorderColor--300);
-  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--base--BorderBottomColor);
+  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--BorderBottomColor--base);
   --pf-c-select__toggle--before--BorderLeftColor: var(--pf-global--BorderColor--300);
   --pf-c-select__toggle--Color: var(--pf-global--Color--100);
   --pf-c-select__toggle--hover--before--BorderBottomColor: var(--pf-global--active-color--100);
@@ -266,8 +266,8 @@
 
 // reset :focus-visible + mouseout accent
 @include pf-reset-accent-focus-border("pf-c-select", $before: true, $root: false) {
-  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--reset--BorderBottomWidth);
-  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--reset--BorderBottomColor);
+  --pf-c-select__toggle--before--BorderBottomWidth: var(--pf-c-select__toggle--before--BorderBottomWidth--reset);
+  --pf-c-select__toggle--before--BorderBottomColor: var(--pf-c-select__toggle--before--BorderBottomColor--reset);
 }
 
 .pf-c-select__menu-search + .pf-c-divider {

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -267,8 +267,6 @@
     $namespace: #{$namespace} + ":not(.pf-m-expanded):focus:not(:focus-visible):not(:hover):not(:active)::" + #{$position};
   }
 
-  @debug #{$namespace};
-
   .#{$namespace} {
     @content;
   }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -254,3 +254,22 @@
     }
   }
 }
+
+@mixin pf-reset-accent-focus-border($namespace, $toggle: $namespace + "__toggle", $root: true, $before: false, $position: "after") {
+  @if $before == true {
+    $position: "before";
+  }
+
+  // construct selector
+  @if $root == false {
+    $namespace: #{$namespace} + ":not(.pf-m-expanded) > ." + #{$toggle} + ":focus:not(:focus-visible):not(:hover):not(:active)::" + #{$position};
+  } @else {
+    $namespace: #{$namespace} + ":not(.pf-m-expanded):focus:not(:focus-visible):not(:hover):not(:active)::" + #{$position};
+  }
+
+  @debug #{$namespace};
+
+  .#{$namespace} {
+    @content;
+  }
+}

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -260,11 +260,13 @@
     $position: "before";
   }
 
+  $focus-root: ":focus:where(:not(:focus-visible):not(:hover):not(:active))::";
+
   // construct selector
   @if $root == false {
-    $namespace: #{$namespace} + ":not(.pf-m-expanded) > ." + #{$toggle} + ":focus:not(:focus-visible):not(:hover):not(:active)::" + #{$position};
+    $namespace: #{$namespace} + ":not(.pf-m-expanded) > ." + #{$toggle} + #{$focus-root} + #{$position};
   } @else {
-    $namespace: #{$namespace} + ":not(.pf-m-expanded):focus:not(:focus-visible):not(:hover):not(:active)::" + #{$position};
+    $namespace: #{$namespace} + ":not(.pf-m-expanded)" #{$focus-root} + #{$position};
   }
 
   .#{$namespace} {


### PR DESCRIPTION
fixes #4534 

This PR changes the default behavior of dropdown, context-selector, menu toggle and select. If element `:focus` + `mouseout`, focus/active/hover styles are reverted to default state. 

