### PR TITLE
feat(DescriptionList): add icon variant

### DIFF
--- a/src/patternfly/components/DescriptionList/description-list-icon.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-icon.hbs
@@ -1,0 +1,6 @@
+<{{#if description-list-icon--type}}{{description-list-icon--type}}{{else}}span{{/if}} class="pf-c-description-list__term-icon{{#if description-list-icon--modifier}} {{description-list-icon--modifier}}{{/if}}"
+  {{#if description-list-icon--attribute}}
+    {{{description-list-icon--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{#if description-list-icon--type}}{{description-list-icon--type}}{{else}}span{{/if}}>

--- a/src/patternfly/components/DescriptionList/description-list-term.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-term.hbs
@@ -3,7 +3,6 @@
     {{#if description-list-term--attribute}}
       {{{description-list-term--attribute}}}
     {{/if}}>
-
       {{> @partial-block}}
   </dt>
 {{/wrapper}}

--- a/src/patternfly/components/DescriptionList/description-list-term.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-term.hbs
@@ -2,7 +2,6 @@
   {{#if description-list-term--attribute}}
     {{{description-list-term--attribute}}}
   {{/if}}>
-  {{#> description-list-text description-list-text--type="span" description-list-text--IsHelp=description-list-term--TextIsHelp}}
+
     {{> @partial-block}}
-  {{/description-list-text}}
 </dt>

--- a/src/patternfly/components/DescriptionList/description-list-term.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-term.hbs
@@ -1,7 +1,9 @@
-<dt class="pf-c-description-list__term{{#if description-list-term--modifier}} {{description-list-term--modifier}}{{/if}}"
-  {{#if description-list-term--attribute}}
-    {{{description-list-term--attribute}}}
-  {{/if}}>
+{{#> wrapper description-list-text--type="span"}}{{!-- in a term, always make the text a span --}}
+  <dt class="pf-c-description-list__term{{#if description-list-term--modifier}} {{description-list-term--modifier}}{{/if}}"
+    {{#if description-list-term--attribute}}
+      {{{description-list-term--attribute}}}
+    {{/if}}>
 
-    {{> @partial-block}}
-</dt>
+      {{> @partial-block}}
+  </dt>
+{{/wrapper}}

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -19,23 +19,20 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
   --pf-c-description-list--m-compact--ColumnGap: var(--pf-global--spacer--sm);
 
   // term
+  --pf-c-description-list__term--Display: inline;
+  --pf-c-description-list__term--sm--Display: flex;
   --pf-c-description-list__term--FontWeight: var(--pf-global--FontWeight--bold);
   --pf-c-description-list__term--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-description-list__term--LineHeight: var(--pf-global--LineHeight--sm);
 
+  @media screen and (min-width: $pf-global--breakpoint--sm) {
+    --pf-c-description-list__term--Display: var(--pf-c-description-list__term--sm--Display);
+  }
+
   // icon
   --pf-c-description-list__term-icon--MinWidth: var(--pf-global--icon--FontSize--sm);
   --pf-c-description-list__term-icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-description-list__term-icon--FontSize: var(--pf-global--icon--FontSize--sm);
   --pf-c-description-list__term-icon--Color: var(--pf-global--icon--Color--light);
-
-  // term text
-  --pf-c-description-list__term-text--Display: inline;
-  --pf-c-description-list__term-text--sm--Display: flex;
-
-  @media screen and (min-width: $pf-global--breakpoint--sm) {
-    --pf-c-description-list__term-text--Display: var(--pf-c-description-list__term-text--sm--Display);
-  }
 
   // vertical
   --pf-c-description-list--m-vertical__group--GridTemplateColumns: repeat(var(--pf-c-description-list--GridTemplateColumns--count));
@@ -129,13 +126,13 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
 }
 
 .pf-c-description-list__term {
+  display: var(--pf-c-description-list__term--Display);
   font-size: var(--pf-c-description-list__term--FontSize);
   font-weight: var(--pf-c-description-list__term--FontWeight);
   line-height: var(--pf-c-description-list__term--LineHeight);
 
   .pf-c-description-list__text {
-    display: var(--pf-c-description-list__term-text--Display);
-    align-items: baseline;
+    display: inline;
   }
 }
 
@@ -143,7 +140,6 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
   flex-shrink: 0;
   min-width: var(--pf-c-description-list__term-icon--MinWidth);
   margin-right: var(--pf-c-description-list__term-icon--MarginRight);
-  font-size: var(--pf-c-description-list__term-icon--FontSize);
   color: var(--pf-c-description-list__term-icon--Color);
 }
 

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -23,6 +23,20 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
   --pf-c-description-list__term--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-description-list__term--LineHeight: var(--pf-global--LineHeight--sm);
 
+  // icon
+  --pf-c-description-list__term-icon--MinWidth: var(--pf-global--icon--FontSize--sm);
+  --pf-c-description-list__term-icon--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-description-list__term-icon--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-description-list__term-icon--Color: var(--pf-global--icon--Color--light);
+
+  // term text
+  --pf-c-description-list__term-text--Display: inline;
+  --pf-c-description-list__term-text--sm--Display: flex;
+
+  @media screen and (min-width: $pf-global--breakpoint--sm) {
+    --pf-c-description-list__term-text--Display: var(--pf-c-description-list__term-text--sm--Display);
+  }
+
   // vertical
   --pf-c-description-list--m-vertical__group--GridTemplateColumns: repeat(var(--pf-c-description-list--GridTemplateColumns--count));
 
@@ -120,8 +134,17 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
   line-height: var(--pf-c-description-list__term--LineHeight);
 
   .pf-c-description-list__text {
-    display: inline;
+    display: var(--pf-c-description-list__term-text--Display);
+    align-items: baseline;
   }
+}
+
+.pf-c-description-list__term-icon {
+  flex-shrink: 0;
+  min-width: var(--pf-c-description-list__term-icon--MinWidth);
+  margin-right: var(--pf-c-description-list__term-icon--MarginRight);
+  font-size: var(--pf-c-description-list__term-icon--FontSize);
+  color: var(--pf-c-description-list__term-icon--Color);
 }
 
 .pf-c-description-list__text {

--- a/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
+++ b/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
@@ -3,8 +3,10 @@
     {{#> description-list-term}}
       {{#> description-list-icon}}
         <i class="fas fa-cube" aria-hidden="true"></i>
-      {{/description-list-icon}}
-      Name Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/description-list-icon}} 
+      {{#> description-list-text description-list-text--type="span"}}
+        This is a long description that should wrap to multiple lines in cases where the viewport is quite narrow.
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       example
@@ -15,7 +17,9 @@
       {{#> description-list-icon}}
         <i class="fas fa-book" aria-hidden="true"></i>
       {{/description-list-icon}}
-      Namespace
+      {{#> description-list-text description-list-text--type="span"}}
+        Namespace
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       <a href="#">mary-test</a>
@@ -26,7 +30,9 @@
       {{#> description-list-icon}}
         <i class="fas fa-key" aria-hidden="true"></i>
       {{/description-list-icon}}
-      Labels
+      {{#> description-list-text description-list-text--type="span"}}
+        Labels
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       example
@@ -37,7 +43,9 @@
       {{#> description-list-icon}}
         <i class="fas fa-globe" aria-hidden="true"></i>
       {{/description-list-icon}}
-      Pod selector
+      {{#> description-list-text description-list-text--type="span"}}
+        Pod selector
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       {{#> button button--modifier="pf-m-link pf-m-inline"}}
@@ -53,7 +61,9 @@
       {{#> description-list-icon}}
         <i class="fas fa-flag" aria-hidden="true"></i>
       {{/description-list-icon}}
-      Annotation
+      {{#> description-list-text description-list-text--type="span"}}
+        Annotation
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       2 Annotations

--- a/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
+++ b/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
@@ -4,7 +4,7 @@
       {{#> description-list-icon}}
         <i class="fas fa-cube" aria-hidden="true"></i>
       {{/description-list-icon}} 
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         This is a long description that should wrap to multiple lines in cases where the viewport is quite narrow.
       {{/description-list-text}}
     {{/description-list-term}}
@@ -17,7 +17,7 @@
       {{#> description-list-icon}}
         <i class="fas fa-book" aria-hidden="true"></i>
       {{/description-list-icon}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Namespace
       {{/description-list-text}}
     {{/description-list-term}}
@@ -30,7 +30,7 @@
       {{#> description-list-icon}}
         <i class="fas fa-key" aria-hidden="true"></i>
       {{/description-list-icon}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Labels
       {{/description-list-text}}
     {{/description-list-term}}
@@ -43,7 +43,7 @@
       {{#> description-list-icon}}
         <i class="fas fa-globe" aria-hidden="true"></i>
       {{/description-list-icon}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Pod selector
       {{/description-list-text}}
     {{/description-list-term}}
@@ -61,7 +61,7 @@
       {{#> description-list-icon}}
         <i class="fas fa-flag" aria-hidden="true"></i>
       {{/description-list-icon}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Annotation
       {{/description-list-text}}
     {{/description-list-term}}

--- a/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
+++ b/src/patternfly/components/DescriptionList/description-list__example-with-icons.hbs
@@ -1,0 +1,62 @@
+{{#> description-list}}
+  {{#> description-list-group}}
+    {{#> description-list-term}}
+      {{#> description-list-icon}}
+        <i class="fas fa-cube" aria-hidden="true"></i>
+      {{/description-list-icon}}
+      Name Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    {{/description-list-term}}
+    {{#> description-list-description}}
+      example
+    {{/description-list-description}}
+  {{/description-list-group}}
+  {{#> description-list-group}}
+    {{#> description-list-term}}
+      {{#> description-list-icon}}
+        <i class="fas fa-book" aria-hidden="true"></i>
+      {{/description-list-icon}}
+      Namespace
+    {{/description-list-term}}
+    {{#> description-list-description}}
+      <a href="#">mary-test</a>
+    {{/description-list-description}}
+  {{/description-list-group}}
+  {{#> description-list-group}}
+    {{#> description-list-term}}
+      {{#> description-list-icon}}
+        <i class="fas fa-key" aria-hidden="true"></i>
+      {{/description-list-icon}}
+      Labels
+    {{/description-list-term}}
+    {{#> description-list-description}}
+      example
+    {{/description-list-description}}
+  {{/description-list-group}}
+  {{#> description-list-group}}
+    {{#> description-list-term}}
+      {{#> description-list-icon}}
+        <i class="fas fa-globe" aria-hidden="true"></i>
+      {{/description-list-icon}}
+      Pod selector
+    {{/description-list-term}}
+    {{#> description-list-description}}
+      {{#> button button--modifier="pf-m-link pf-m-inline"}}
+        {{#> button-icon button-icon--modifier="pf-m-start"}}
+          <i class="fas fa-plus-circle" aria-hidden="true"></i>
+        {{/button-icon}}
+        app=MyApp
+      {{/button}}
+    {{/description-list-description}}
+  {{/description-list-group}}
+  {{#> description-list-group}}
+    {{#> description-list-term}}
+      {{#> description-list-icon}}
+        <i class="fas fa-flag" aria-hidden="true"></i>
+      {{/description-list-icon}}
+      Annotation
+    {{/description-list-term}}
+    {{#> description-list-description}}
+      2 Annotations
+    {{/description-list-description}}
+  {{/description-list-group}}
+{{/description-list}}

--- a/src/patternfly/components/DescriptionList/description-list__example.hbs
+++ b/src/patternfly/components/DescriptionList/description-list__example.hbs
@@ -1,7 +1,7 @@
 {{#> description-list}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Name
       {{/description-list-text}}
     {{/description-list-term}}
@@ -15,7 +15,7 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Namespace
       {{/description-list-text}}
     {{/description-list-term}}
@@ -25,7 +25,7 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Labels
       {{/description-list-text}}
     {{/description-list-term}}
@@ -35,7 +35,7 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Pod selector
       {{/description-list-text}}
     {{/description-list-term}}
@@ -50,7 +50,7 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      {{#> description-list-text description-list-text--type="span"}}
+      {{#> description-list-text}}
         Annotation
       {{/description-list-text}}
     {{/description-list-term}}

--- a/src/patternfly/components/DescriptionList/description-list__example.hbs
+++ b/src/patternfly/components/DescriptionList/description-list__example.hbs
@@ -1,7 +1,9 @@
 {{#> description-list}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      Name
+      {{#> description-list-text description-list-text--type="span"}}
+        Name
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       {{#if description-list--IsLongDescription}}
@@ -13,7 +15,9 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      Namespace
+      {{#> description-list-text description-list-text--type="span"}}
+        Namespace
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       <a href="#">mary-test</a>
@@ -21,7 +25,9 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      Labels
+      {{#> description-list-text description-list-text--type="span"}}
+        Labels
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       example
@@ -29,7 +35,9 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      Pod selector
+      {{#> description-list-text description-list-text--type="span"}}
+        Pod selector
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       {{#> button button--modifier="pf-m-link pf-m-inline"}}
@@ -42,7 +50,9 @@
   {{/description-list-group}}
   {{#> description-list-group}}
     {{#> description-list-term}}
-      Annotation
+      {{#> description-list-text description-list-text--type="span"}}
+        Annotation
+      {{/description-list-text}}
     {{/description-list-term}}
     {{#> description-list-description}}
       2 Annotations

--- a/src/patternfly/components/DescriptionList/examples/DescriptionList.md
+++ b/src/patternfly/components/DescriptionList/examples/DescriptionList.md
@@ -124,6 +124,13 @@ Column fill will modify the default placement of description list groups to fill
 {{> description-list__example description-list--title="Horizontal 2 column DL" description-list--modifier="pf-m-horizontal pf-m-auto-term-widths pf-m-2-col"}}
 ``` -->
 
+## With icons
+
+### Icons on terms
+```hbs
+{{> description-list__example-with-icons description-list--title="With icon"}}
+```
+
 ## Documentation
 
 ### Accessibility
@@ -142,6 +149,7 @@ Column fill will modify the default placement of description list groups to fill
 | `.pf-c-description-list__term` | `<dt>` | Initiates a description list component term. **Required** |
 | `.pf-c-description-list__description` | `<dd>` | Initiates a description list component description. **Required** |
 | `.pf-c-description-list__text` | `<span>`, `<div>` | Initiates a description list component text element. Use a `<span>` when a child of `.pf-c-description-list__term`. **Required** |
+| `.pf-c-description-list__term-icon` | `<span>` | Initiates a description list component term icon element. |
 | `.pf-m-compact` | `.pf-c-description-list` | Modifies the description list for compact horizontal and vertical spacing. |
 | `.pf-m-fluid` | `.pf-c-description-list.pf-m-horizontal` | Modifies the description list term width to be fluid. |
 | `.pf-m-help-text` | `.pf-c-description-list__text` | Indicates there is more information available for the description list component term text. |


### PR DESCRIPTION
This adds support for an icon in the term of a description list. 
Note that per design, at the smallest width, the text wraps under the icon, but at the small breakpoint the text changes to be indented past the icon.

Fixes #4353 