### PR TITLE
chore(docs): promote beta components

### DIFF
--- a/src/patternfly/components/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/components/BackToTop/examples/BackToTop.md
@@ -1,6 +1,5 @@
 ---
 id: 'Back to top'
-beta: true
 section: components
 cssPrefix: pf-c-back-to-top
 ---

--- a/src/patternfly/components/JumpLinks/examples/JumpLinks.md
+++ b/src/patternfly/components/JumpLinks/examples/JumpLinks.md
@@ -2,7 +2,6 @@
 id: Jump links
 section: components
 cssPrefix: pf-c-jump-links
-beta: true
 ---
 
 ## Examples

--- a/src/patternfly/demos/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/demos/BackToTop/examples/BackToTop.md
@@ -1,6 +1,5 @@
 ---
 id: 'Back to top'
-beta: true
 section: components
 cssPrefix: pf-d-back-to-top
 ---

--- a/src/patternfly/demos/JumpLinks/examples/JumpLinks.md
+++ b/src/patternfly/demos/JumpLinks/examples/JumpLinks.md
@@ -1,6 +1,5 @@
 ---
 id: Jump links
-beta: true
 section: components
 ---
 


### PR DESCRIPTION
Closes: #4604

For reference:
The only open issues for jumplinks are to build a new demo: [jump links issues](https://github.com/orgs/patternfly/projects/7/views/5?filterQuery=is%3Aopen+jump+links+)
The only issues open for Back to top are the typescript conversion and design guidelines: [back to top issues](https://github.com/orgs/patternfly/projects/7/views/5?filterQuery=is%3Aopen+back+to+top+
)