### PR TITLE
feat(Text input group): added autocomplete ghosting

### DIFF
--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -78,3 +78,15 @@ cssPrefix: pf-c-text-input-group
   {{/text-input-group-utilities}}
 {{/text-input-group}}
 ```
+
+### Autocomplete last option hint
+```hbs
+{{#> text-input-group text-input-group--id="basic" text-input-group--value="apples"}}
+  {{#> text-input-group-main}}
+    {{#> text-input-group-text}}
+      {{> text-input-group-text-input text-input-group-text-input--hint-text="appleseed" }}
+      {{> text-input-group-text-input}}
+    {{/text-input-group-text}}
+  {{/text-input-group-main}}
+{{/text-input-group}}
+```

--- a/src/patternfly/components/TextInputGroup/text-input-group-text-input.hbs
+++ b/src/patternfly/components/TextInputGroup/text-input-group-text-input.hbs
@@ -6,16 +6,16 @@
   type="text"
   {{#if text-input-group--IsDisabled}}
     value="Disabled"
+    disabled
+    aria-label="Disabled text input group example input"
   {{else if text-input-group-text-input--hint-text}}
     value="{{text-input-group-text-input--hint-text}}"
   {{else}}
     value="{{text-input-group--value}}"
   {{/if}}
-  aria-label="Type to filter"
-  {{#if text-input-group--IsDisabled}}
-    disabled
-    aria-label="Disabled text input group example input"
-  {{/if}}
+  {{#unless text-input-group-text-input--hint-text}}
+    aria-label="Type to filter"
+  {{/unless}}
   {{#if text-input-group-text-input--hint-text }}
     disabled
     aria-hidden="true"

--- a/src/patternfly/components/TextInputGroup/text-input-group-text-input.hbs
+++ b/src/patternfly/components/TextInputGroup/text-input-group-text-input.hbs
@@ -1,10 +1,24 @@
-<input class="pf-c-text-input-group__text-input{{~#if text-input-group-text-input--modifier}} {{text-input-group-text-input--modifier}}{{/if}}"
+<input class="pf-c-text-input-group__text-input
+  {{~#if text-input-group-text-input--hint-text}} pf-m-hint{{/if}}
+  {{~#if text-input-group-text-input--modifier}}
+    {{text-input-group-text-input--modifier}}
+  {{/if}}"
   type="text"
-  value="{{#if text-input-group--IsDisabled}}Disabled{{else}}{{text-input-group--value}}{{/if}}"
+  {{#if text-input-group--IsDisabled}}
+    value="Disabled"
+  {{else if text-input-group-text-input--hint-text}}
+    value="{{text-input-group-text-input--hint-text}}"
+  {{else}}
+    value="{{text-input-group--value}}"
+  {{/if}}
   aria-label="Type to filter"
   {{#if text-input-group--IsDisabled}}
     disabled
     aria-label="Disabled text input group example input"
+  {{/if}}
+  {{#if text-input-group-text-input--hint-text }}
+    disabled
+    aria-hidden="true"
   {{/if}}
   {{#if text-input-group-text-input--attribute}}
     {{text-input-group-text-input--attribute}}


### PR DESCRIPTION
Closes #4558 

This PR adds a new example for text input group using the existing `--pf-c-text-input-group__text-input--m-hint--Color` variable to show ghosting for autocomplete suggestion.