### PR TITLE
feat(masthead): added horizontal nav demo

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -1,6 +1,6 @@
 <div class="pf-c-dropdown{{#if dropdown--IsExpanded}} pf-m-expanded{{/if}}{{#if dropdown--modifier}} {{dropdown--modifier}}{{/if}}"
   {{#if dropdown--attribute}}
-    {{dropdown--attribute}}
+    {{{dropdown--attribute}}}
   {{/if}}>
 
   {{!-- if content is passed --}}

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -511,6 +511,10 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   }
 }
 
+.pf-c-dropdown__toggle-text {
+  flex: 0 1 auto;
+}
+
 .pf-c-dropdown__toggle-icon {
   margin-right: var(--pf-c-dropdown__toggle-icon--MarginRight);
   margin-left: var(--pf-c-dropdown__toggle-icon--MarginLeft);
@@ -525,6 +529,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 // Toggle image
 .pf-c-dropdown__toggle-image {
   display: inline-flex;
+  flex-shrink: 0;
   margin-top: var(--pf-c-dropdown__toggle-image--MarginTop);
   margin-right: var(--pf-c-dropdown__toggle-image--MarginRight);
   margin-bottom: var(--pf-c-dropdown__toggle-image--MarginBottom);

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -11,7 +11,6 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead__main--PaddingBottom: var(--pf-c-masthead--m-display-stack__main--PaddingBottom);
   --pf-c-masthead__main--MarginRight: var(--pf-c-masthead--m-display-stack__main--MarginRight);
   --pf-c-masthead__main--before--BorderBottom: var(--pf-c-masthead--m-display-stack__main--before--BorderBottom);
-  --pf-c-masthead__main--ColumnGap: var(--pf-global--spacer--md);
   --pf-c-masthead__content--GridColumn: var(--pf-c-masthead--m-display-stack__content--GridColumn);
   --pf-c-masthead__content--MinHeight: var(--pf-c-masthead--m-display-stack__content--MinHeight);
   --pf-c-masthead__content--Order: var(--pf-c-masthead--m-display-stack__content--Order);
@@ -243,6 +242,10 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
       --pf-c-dropdown__toggle--before--BorderLeftColor: var(--pf-c-masthead--c-dropdown--m-full-height__toggle--before--BorderLeftColor);
     }
   }
+
+  .pf-c-nav {
+    align-self: stretch;
+  }
 }
 
 // Main
@@ -258,7 +261,6 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   padding-bottom: var(--pf-c-masthead__main--PaddingBottom);
   margin-right: var(--pf-c-masthead__main--MarginRight);
   grid-column: var(--pf-c-masthead__main--GridColumn);
-  column-gap: var(--pf-c-masthead__main--ColumnGap);
 
   &::before {
     position: absolute;

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -11,6 +11,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --pf-c-masthead__main--PaddingBottom: var(--pf-c-masthead--m-display-stack__main--PaddingBottom);
   --pf-c-masthead__main--MarginRight: var(--pf-c-masthead--m-display-stack__main--MarginRight);
   --pf-c-masthead__main--before--BorderBottom: var(--pf-c-masthead--m-display-stack__main--before--BorderBottom);
+  --pf-c-masthead__main--ColumnGap: var(--pf-global--spacer--md);
   --pf-c-masthead__content--GridColumn: var(--pf-c-masthead--m-display-stack__content--GridColumn);
   --pf-c-masthead__content--MinHeight: var(--pf-c-masthead--m-display-stack__content--MinHeight);
   --pf-c-masthead__content--Order: var(--pf-c-masthead--m-display-stack__content--Order);
@@ -257,6 +258,7 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   padding-bottom: var(--pf-c-masthead__main--PaddingBottom);
   margin-right: var(--pf-c-masthead__main--MarginRight);
   grid-column: var(--pf-c-masthead__main--GridColumn);
+  column-gap: var(--pf-c-masthead__main--ColumnGap);
 
   &::before {
     position: absolute;

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -666,6 +666,7 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional breakpoint. |
 | `.pf-m-label` | `.pf-c-toolbar__item` | Modifies toolbar item to label. |
 | `.pf-m-chip-container` | `.pf-c-toolbar__content`, `.pf-c-toolbar__group` | Modifies the toolbar element for applied filters layout. |
+| `.pf-m-overflow-container` | `.pf-c-toolbar__item`, `.pf-c-toolbar__group` | Modifies the toolbar element to hide overflow and respond to available space. Used for horizontal navigation. |
 | `.pf-m-expanded` | `.pf-c-toolbar__expandable-content`, `.pf-c-toolbar__toggle` | Modifies the component for the expanded state. |
 | `.pf-m-wrap` | `.pf-c-toolbar`, `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies the toolbar element to wrap. |
 | `.pf-m-nowrap` | `.pf-c-toolbar`, `.pf-c-toolbar__group` | Modifies the toolbar element to nowrap. |

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -322,6 +322,15 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   }
 }
 
+.pf-c-toolbar__group,
+.pf-c-toolbar__item {
+  &.pf-m-overflow-container {
+    flex: 1;
+    overflow: hidden;
+  }
+}
+
+
 .pf-c-toolbar__expand-all-icon {
   display: inline-block;
   transition: var(--pf-c-toolbar__expand-all-icon--Transition);

--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -160,77 +160,67 @@ wrapperTag: div
             {{#> toolbar-item toolbar-item--attribute='style="--pf-c-toolbar__item--MinWidth: 140px"'}}
               {{> masthead-demo--context-selector}}
             {{/toolbar-item}}
-            {{#> toolbar-group toolbar-group--modifier="pf-m-icon-button-group pf-m-align-right pf-m-spacer-none pf-m-spacer-md-on-md"}}
-              {{#> toolbar-item}}
-                {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Notifications"'}}
-                  {{#> notification-badge notification-badge--modifier=""}}
-                    <i class="pf-icon-attention-bell" aria-hidden="true"></i>
-                  {{/notification-badge}}
-                {{/button}}
-              {{/toolbar-item}}
-              {{#> toolbar-group toolbar-group--modifier="pf-m-icon-button-group pf-m-hidden pf-m-visible-on-lg"}}
-                {{#> toolbar-item}}
-                  {{> masthead-demo--application-launcher app-launcher--id=(concat masthead-demo--page--id '-app-launcher')}}
-                {{/toolbar-item}}
-                {{#> toolbar-item}}
-                  {{#> dropdown dropdown--id=(concat masthead--id "-settings")}}
-                    {{#> dropdown-toggle dropdown-toggle--modifier="pf-m-plain" dropdown-toggle--HasNoToggleIcon="true" dropdown-toggle--attribute='aria-label="Settings"'}}
-                      <i class="fas fa-cog" aria-hidden="true"></i>
-                    {{/dropdown-toggle}}
-                    {{#> dropdown-menu dropdown-menu--modifier="pf-m-align-right"}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="Settings"}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="Use the beta release"}}
-                    {{/dropdown-menu}}
-                  {{/dropdown}}
-                {{/toolbar-item}}
-                {{#> toolbar-item}}
-                  {{#> dropdown dropdown--id=(concat masthead--id "-help")}}
-                    {{#> dropdown-toggle dropdown-toggle--modifier="pf-m-plain" dropdown-toggle--HasNoToggleIcon="true" dropdown-toggle--attribute='aria-label="Help"'}}
-                      <i class="pf-icon pf-icon-help" aria-hidden="true"></i>
-                    {{/dropdown-toggle}}
-                    {{#> dropdown-menu dropdown-menu--modifier="pf-m-align-right"}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="Support options"}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="Open support case"}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="API documentation"}}
-                    {{/dropdown-menu}}
-                  {{/dropdown}}
-                {{/toolbar-item}}
-              {{/toolbar-group}}
-              {{#> toolbar-item toolbar-item--modifier="pf-m-hidden-on-lg"}}
-                {{#> dropdown dropdown--id=(concat masthead--id "-action") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
-                  {{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsExpanded="true" menu-toggle--attribute='aria-label="Actions"'}}
-                    <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
-                  {{/menu-toggle}}
-                  {{> masthead-demo--drilldown menu--id=(concat masthead--id '-drilldown-menu')}}
-                {{/dropdown}}
-              {{/toolbar-item}}
-            {{/toolbar-group}}
-            {{#> toolbar-item toolbar-item--modifier="pf-m-hidden pf-m-visible-on-sm"}}
-              {{#> dropdown dropdown--id=(concat masthead--id "-profile") dropdown--IsExpanded="true"}}
-                {{#> dropdown-toggle}}
-                  {{#> dropdown-toggle-image}}
-                    {{> avatar avatar--attribute='src="/assets/images/img_avatar.svg" alt="Avatar image"'}}
-                  {{/dropdown-toggle-image}}
-                  {{#> dropdown-toggle-text}}
-                    Ned Username
-                  {{/dropdown-toggle-text}}
-                {{/dropdown-toggle}}
-                {{#> dropdown-menu dropdown-menu--type="div"}}
-                  {{#> dropdown-group}}
-                    {{> dropdown-menu-item dropdown-menu-item--text='<div class="pf-u-font-size-sm">Account number:</div><div>123456789</div>' dropdown-menu-item--type="div" dropdown-menu-item--modifier="pf-m-text"}}
-                    {{> dropdown-menu-item dropdown-menu-item--text='<div class="pf-u-font-size-sm">Username:</div><div>mshaksho@redhat.com</div>' dropdown-menu-item--type="div" dropdown-menu-item--modifier="pf-m-text"}}
-                  {{/dropdown-group}}
-                  {{> divider}}
-                  {{#> dropdown-group}}
-                    {{#> dropdown-menu-list}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="My profile" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="User management" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
-                      {{> dropdown-menu-list-item dropdown-menu-item--text="Logout" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
-                    {{/dropdown-menu-list}}
-                  {{/dropdown-group}}
-                {{/dropdown-menu}}
-              {{/dropdown}}
+            {{> masthead-demo--icon-group masthead-demo--icon-group--profile-dropdown--IsExpanded="true" masthead-demo--icon-group--breakpoint="lg"}}
+          {{/toolbar-content-section}}
+        {{/toolbar-content}}
+      {{/toolbar}}
+    {{/masthead-content}}
+  {{/masthead}}
+{{/masthead-demo--page}}
+```
+
+### Horizontal nav
+```hbs isFullscreen
+{{#> masthead-demo--page masthead-demo--page--id="masthead-horizontal-nav"}}
+  {{#> masthead masthead--id=(concat masthead-demo--page--id '-masthead') masthead--modifier="pf-m-display-stack pf-m-display-inline-on-lg"}}
+    {{> masthead-toggle}}
+    {{#> masthead-main}}
+      {{#> masthead-brand}}
+        {{> brand
+          brand--attribute='style="--pf-c-brand--Width: 180px; --pf-c-brand--Width-on-md: 180px; --pf-c-brand--Width-on-2xl: 220px;"'
+          brand--IsPicture="true"
+          brand--img-url--base='/assets/images/logo__pf--reverse--base.png'
+          brand--img-url='/assets/images/logo__pf--reverse--base.svg'
+          brand--img-url-on-md='/assets/images/logo__pf--reverse-on-md.svg'}}
+      {{/masthead-brand}}
+      {{> masthead-demo--context-selector}}
+    {{/masthead-main}}
+    {{#> masthead-content}}
+      {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}
+        {{#> toolbar-content}}
+          {{#> toolbar-content-section}}
+            {{#> toolbar-item toolbar-item--modifier="pf-m-overflow-container" toolbar-item--attribute='style="--pf-c-toolbar__item--MinWidth: 18ch;"'}}
+              {{#> nav nav--HasScroll="true" nav--IsHorizontal="true" nav--IsScrollable="true" nav--attribute=(concat 'id="' masthead-demo--page--id '-horizontal-nav" aria-label="Global"')}}
+                {{#> nav-list}}
+                  {{#> nav-item}}
+                    {{#> nav-link nav-link--href="#"}}
+                      Horizontal nav item 1
+                    {{/nav-link}}
+                  {{/nav-item}}
+                  {{#> nav-item}}
+                    {{#> nav-link nav-link--href="#"}}
+                      Horizontal nav item 2
+                    {{/nav-link}}
+                  {{/nav-item}}
+                  {{#> nav-item}}
+                    {{#> nav-link nav-link--href="#"}}
+                      Horizontal nav item 3
+                    {{/nav-link}}
+                  {{/nav-item}}
+                  {{#> nav-item}}
+                    {{#> nav-link nav-link--href="#"}}
+                      Horizontal nav item 4
+                    {{/nav-link}}
+                  {{/nav-item}}
+                  {{#> nav-item}}
+                    {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+                      Horizontal nav item 5
+                    {{/nav-link}}
+                  {{/nav-item}}
+                {{/nav-list}}
+              {{/nav}}
             {{/toolbar-item}}
+            {{> masthead-demo--icon-group masthead-demo--icon-group--profile-dropdown--IsExpanded="true" masthead-demo--icon-group--breakpoint="xl"}}
           {{/toolbar-content-section}}
         {{/toolbar-content}}
       {{/toolbar}}

--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -171,9 +171,8 @@ wrapperTag: div
 
 ### Horizontal nav
 ```hbs isFullscreen
-{{#> masthead-demo--page masthead-demo--page--id="masthead-horizontal-nav"}}
+{{#> masthead-demo--page masthead-demo--page--id="masthead-horizontal-nav" isHorizontalNav="true"}}
   {{#> masthead masthead--id=(concat masthead-demo--page--id '-masthead') masthead--modifier="pf-m-display-stack pf-m-display-inline-on-lg"}}
-    {{> masthead-toggle}}
     {{#> masthead-main}}
       {{#> masthead-brand}}
         {{> brand
@@ -183,7 +182,6 @@ wrapperTag: div
           brand--img-url='/assets/images/logo__pf--reverse--base.svg'
           brand--img-url-on-md='/assets/images/logo__pf--reverse-on-md.svg'}}
       {{/masthead-brand}}
-      {{> masthead-demo--context-selector}}
     {{/masthead-main}}
     {{#> masthead-content}}
       {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}

--- a/src/patternfly/demos/Masthead/templates/masthead-demo--drilldown.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-demo--drilldown.hbs
@@ -1,5 +1,5 @@
 {{#> menu menu--modifier="pf-m-drilldown pf-m-align-right"}}
-  {{#> menu-content menu-content--attribute=''}}
+  {{#> menu-content menu-content--attribute=reset}}
     {{#> menu-group menu-group--modifier="pf-m-hidden-on-sm"}}
       {{#> menu-list}}
         {{#> menu-list-item menu-list-item--IsDisabled="true"}}

--- a/src/patternfly/demos/Masthead/templates/masthead-demo--icon-group.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-demo--icon-group.hbs
@@ -1,0 +1,71 @@
+{{#> toolbar-group toolbar-group--modifier="pf-m-icon-button-group pf-m-align-right pf-m-spacer-none pf-m-spacer-md-on-md"}}
+  {{#> toolbar-item}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Notifications"'}}
+      {{#> notification-badge notification-badge--modifier=""}}
+        <i class="pf-icon-attention-bell" aria-hidden="true"></i>
+      {{/notification-badge}}
+    {{/button}}
+  {{/toolbar-item}}
+  {{#> toolbar-group toolbar-group--modifier=(concat 'pf-m-icon-button-group pf-m-hidden pf-m-visible-on-' masthead-demo--icon-group--breakpoint)}}
+    {{#> toolbar-item}}
+      {{> masthead-demo--application-launcher app-launcher--id=(concat masthead-demo--page--id '-app-launcher')}}
+    {{/toolbar-item}}
+    {{#> toolbar-item}}
+      {{#> dropdown dropdown--id=(concat masthead--id "-settings")}}
+        {{#> dropdown-toggle dropdown-toggle--modifier="pf-m-plain" dropdown-toggle--HasNoToggleIcon="true" dropdown-toggle--attribute='aria-label="Settings"'}}
+          <i class="fas fa-cog" aria-hidden="true"></i>
+        {{/dropdown-toggle}}
+        {{#> dropdown-menu dropdown-menu--modifier="pf-m-align-right"}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="Settings"}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="Use the beta release"}}
+        {{/dropdown-menu}}
+      {{/dropdown}}
+    {{/toolbar-item}}
+    {{#> toolbar-item}}
+      {{#> dropdown dropdown--id=(concat masthead--id "-help")}}
+        {{#> dropdown-toggle dropdown-toggle--modifier="pf-m-plain" dropdown-toggle--HasNoToggleIcon="true" dropdown-toggle--attribute='aria-label="Help"'}}
+          <i class="pf-icon pf-icon-help" aria-hidden="true"></i>
+        {{/dropdown-toggle}}
+        {{#> dropdown-menu dropdown-menu--modifier="pf-m-align-right"}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="Support options"}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="Open support case"}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="API documentation"}}
+        {{/dropdown-menu}}
+      {{/dropdown}}
+    {{/toolbar-item}}
+  {{/toolbar-group}}
+  {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-hidden-on-' masthead-demo--icon-group--breakpoint)}}
+    {{#> dropdown dropdown--id=(concat masthead--id "-action") dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--IsPlain="true"}}
+      {{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsExpanded="true" menu-toggle--attribute='aria-label="Actions"'}}
+        <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
+      {{/menu-toggle}}
+      {{> masthead-demo--drilldown menu--id=(concat masthead--id '-drilldown-menu')}}
+    {{/dropdown}}
+  {{/toolbar-item}}
+{{/toolbar-group}}
+{{#> toolbar-item toolbar-item--modifier="pf-m-hidden pf-m-visible-on-sm"}}
+  {{#> dropdown dropdown--id=(concat masthead--id "-profile") dropdown--attribute='style="--pf-c-dropdown--MaxWidth: 20ch;"' dropdown--IsExpanded=masthead-demo--icon-group--profile-dropdown--IsExpanded}}
+    {{#> dropdown-toggle}}
+      {{#> dropdown-toggle-image}}
+        {{> avatar avatar--attribute='src="/assets/images/img_avatar.svg" alt="Avatar image"'}}
+      {{/dropdown-toggle-image}}
+      {{#> dropdown-toggle-text}}
+        Ned Username
+      {{/dropdown-toggle-text}}
+    {{/dropdown-toggle}}
+    {{#> dropdown-menu dropdown-menu--type="div"}}
+      {{#> dropdown-group}}
+        {{> dropdown-menu-item dropdown-menu-item--text='<div class="pf-u-font-size-sm">Account number:</div><div>123456789</div>' dropdown-menu-item--type="div" dropdown-menu-item--modifier="pf-m-text"}}
+        {{> dropdown-menu-item dropdown-menu-item--text='<div class="pf-u-font-size-sm">Username:</div><div>mshaksho@redhat.com</div>' dropdown-menu-item--type="div" dropdown-menu-item--modifier="pf-m-text"}}
+      {{/dropdown-group}}
+      {{> divider}}
+      {{#> dropdown-group}}
+        {{#> dropdown-menu-list}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="My profile" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="User management" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
+          {{> dropdown-menu-list-item dropdown-menu-item--text="Logout" dropdown-menu-item--type="a" dropdown-menu-item--attribute='href="#"'}}
+        {{/dropdown-menu-list}}
+      {{/dropdown-group}}
+    {{/dropdown-menu}}
+  {{/dropdown}}
+{{/toolbar-item}}

--- a/src/patternfly/demos/Masthead/templates/masthead-demo--page.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-demo--page.hbs
@@ -5,37 +5,39 @@
   {{> @partial-block}}
 
   {{!-- Nav --}}
-  {{#> page-sidebar page-sidebar--IsAside="true"}}
-    {{#> nav nav--attribute=(concat 'id="' page--id '-primary-nav" aria-label="Global"')}}
-      {{#> nav-list}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-            System panel
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Policy
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Authentication
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Network services
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Server
-          {{/nav-link}}
-        {{/nav-item}}
-      {{/nav-list}}
-    {{/nav}}
-  {{/page-sidebar}}
+  {{#unless isHorizontalNav}}
+    {{#> page-sidebar page-sidebar--IsAside="true"}}
+      {{#> nav nav--attribute=(concat 'id="' page--id '-primary-nav" aria-label="Global"')}}
+        {{#> nav-list}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+              System panel
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Policy
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Authentication
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Network services
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Server
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav}}
+    {{/page-sidebar}}
+  {{/unless}}
   {{#> page-main page-main--attribute=(concat 'id="' page--id '-main"')}}
     {{#> page-template-breadcrumb}}{{/page-template-breadcrumb}}
     {{#> page-template-title}}{{/page-template-title}}


### PR DESCRIPTION
closes #4522 

@mcarrano @mceledonia can you please review [Masthead with horizontal nav](https://patternfly-pr-4617.surge.sh/components/masthead/html-demos#horizontal-nav)? A couple of things in question, bearing in mind that space becomes much more limited in this iteration. 

* Do we want to show this demo with context selector included? It has to live in the same container as `__brand` to be accommodated. 
* Should the nav be full height?
* Any design details that I've missed...