### PR TITLE
Fix hover state for all plain variant icons

### DIFF
--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -35,6 +35,9 @@
   // Toggle icon arrow
   --pf-c-context-selector__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-context-selector__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
+  --pf-c-context-selector__toggle-icon--Color: var(--pf-c-context-selector__toggle--Color);
+  --pf-c-context-selector--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-context-selector--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
   // Menu
   --pf-c-context-selector__menu--Top: calc(100% + var(--pf-global--spacer--xs));
@@ -240,6 +243,7 @@
   &.pf-m-plain {
     --pf-c-context-selector__toggle--PaddingRight: var(--pf-c-context-selector__toggle--m-plain--PaddingRight);
     --pf-c-context-selector__toggle--PaddingLeft: var(--pf-c-context-selector__toggle--m-plain--PaddingLeft);
+    --pf-c-context-selector__toggle-icon--Color: var(--pf-c-context-selector--m-plain__toggle-icon--Color);
 
     &.pf-m-text {
       --pf-c-context-selector__toggle--PaddingRight: var(--pf-c-context-selector__toggle--m-plain--m-text--PaddingRight);
@@ -250,19 +254,20 @@
       display: inline-block;
       width: auto;
       color: var(--pf-c-context-selector__toggle--m-plain--Color);
+    }
 
-      &.pf-m-disabled,
-      &:disabled {
-        --pf-c-context-selector__toggle--m-plain--Color: var(--pf-c-context-selector__toggle--m-plain--disabled--Color);
-      }
+    &.pf-m-disabled,
+    &:disabled {
+      --pf-c-context-selector__toggle--m-plain--Color: var(--pf-c-context-selector__toggle--m-plain--disabled--Color);
+    }
 
-      &:hover,
-      &:active,
-      &.pf-m-active,
-      &:focus,
-      .pf-c-context-selector.pf-m-expanded > & {
-        --pf-c-context-selector__toggle--m-plain--Color: var(--pf-c-context-selector__toggle--m-plain--hover--Color);
-      }
+    &:hover,
+    &:active,
+    &.pf-m-active,
+    &:focus,
+    .pf-c-context-selector.pf-m-expanded > & {
+      --pf-c-context-selector__toggle--m-plain--Color: var(--pf-c-context-selector__toggle--m-plain--hover--Color);
+      --pf-c-context-selector--m-plain__toggle-icon--Color: var(--pf-c-context-selector--m-plain--hover__toggle-icon--Color);
     }
 
     &::before {
@@ -282,6 +287,7 @@
 .pf-c-context-selector__toggle-icon {
   margin-right: var(--pf-c-context-selector__toggle-icon--MarginRight);
   margin-left: var(--pf-c-context-selector__toggle-icon--MarginLeft);
+  color: var(--pf-c-context-selector__toggle-icon--Color);
 }
 
 .pf-c-context-selector__menu {

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -35,7 +35,6 @@
   // Toggle icon arrow
   --pf-c-context-selector__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-context-selector__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
-  --pf-c-context-selector__toggle-icon--Color: var(--pf-c-context-selector__toggle--Color);
   --pf-c-context-selector--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
   --pf-c-context-selector--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
@@ -287,7 +286,7 @@
 .pf-c-context-selector__toggle-icon {
   margin-right: var(--pf-c-context-selector__toggle-icon--MarginRight);
   margin-left: var(--pf-c-context-selector__toggle-icon--MarginLeft);
-  color: var(--pf-c-context-selector__toggle-icon--Color);
+  color: var(--pf-c-context-selector__toggle-icon--Color, inherit);
 }
 
 .pf-c-context-selector__menu {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -92,6 +92,9 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-dropdown__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-dropdown--m-top--m-expanded__toggle-icon--Rotate: 180deg;
+  --pf-c-dropdown__toggle-icon--Color: var(--pf-c-dropdown__toggle-button--Color);
+  --pf-c-dropdown--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-dropdown--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
   // Menu
   --pf-c-dropdown__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
@@ -407,6 +410,8 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   }
 
   &.pf-m-plain {
+    --pf-c-dropdown__toggle-icon--Color: var(--pf-c-dropdown--m-plain__toggle-icon--Color);
+
     &:not(.pf-m-text) {
       --pf-c-dropdown__toggle--PaddingRight: var(--pf-c-dropdown__toggle--m-plain--PaddingRight);
       --pf-c-dropdown__toggle--PaddingLeft: var(--pf-c-dropdown__toggle--m-plain--PaddingLeft);
@@ -430,6 +435,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
     &.pf-m-active,
     .pf-m-expanded > & {
       --pf-c-dropdown__toggle--m-plain--Color: var(--pf-c-dropdown__toggle--m-plain--hover--Color);
+      --pf-c-dropdown--m-plain__toggle-icon--Color: var(--pf-c-dropdown--m-plain--hover__toggle-icon--Color);
     }
 
     &.pf-m-disabled,
@@ -515,6 +521,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   margin-right: var(--pf-c-dropdown__toggle-icon--MarginRight);
   margin-left: var(--pf-c-dropdown__toggle-icon--MarginLeft);
   line-height: var(--pf-c-dropdown__toggle-icon--LineHeight);
+  color: var(--pf-c-dropdown__toggle-icon--Color);
 
   // stylelint-disable-next-line
   .pf-c-dropdown.pf-m-top.pf-m-expanded & {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -92,7 +92,6 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-dropdown__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-dropdown--m-top--m-expanded__toggle-icon--Rotate: 180deg;
-  --pf-c-dropdown__toggle-icon--Color: var(--pf-c-dropdown__toggle-button--Color);
   --pf-c-dropdown--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
   --pf-c-dropdown--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
@@ -521,7 +520,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   margin-right: var(--pf-c-dropdown__toggle-icon--MarginRight);
   margin-left: var(--pf-c-dropdown__toggle-icon--MarginLeft);
   line-height: var(--pf-c-dropdown__toggle-icon--LineHeight);
-  color: var(--pf-c-dropdown__toggle-icon--Color);
+  color: var(--pf-c-dropdown__toggle-icon--Color, inherit);
 
   // stylelint-disable-next-line
   .pf-c-dropdown.pf-m-top.pf-m-expanded & {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -103,7 +103,7 @@
   --pf-c-menu-toggle--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-menu-toggle--m-plain--active__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-menu-toggle--m-plain--focus__toggle-icon--Color: var(--pf-global--Color--100);
-  --pf-c-menu-toggle--m-plain--expanded__toggle-icon--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--m-expanded__toggle-icon--Color: var(--pf-global--Color--100);
 
   // Full height
   --pf-c-menu-toggle--m-full-height--PaddingRight: var(--pf-global--spacer--lg);
@@ -247,7 +247,7 @@
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--m-expanded--BackgroundColor);
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomColor);
-    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--expanded__toggle-icon--Color);
+    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--m-expanded__toggle-icon--Color);
   }
 
   &:disabled {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -98,7 +98,6 @@
 
   // Toggle icon
   --pf-c-menu-toggle__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-menu-toggle__toggle-icon--Color: var(--pf-c-menu-toggle--Color);
   --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
   --pf-c-menu-toggle--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-menu-toggle--m-plain--active__toggle-icon--Color: var(--pf-global--Color--100);
@@ -302,5 +301,5 @@
 
 .pf-c-menu-toggle__toggle-icon {
   margin-right: var(--pf-c-menu-toggle__toggle-icon--MarginRight);
-  color: var(--pf-c-menu-toggle__toggle-icon--Color);
+  color: var(--pf-c-menu-toggle__toggle-icon--Color, inherit);
 }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -98,6 +98,12 @@
 
   // Toggle icon
   --pf-c-menu-toggle__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__toggle-icon--Color: var(--pf-c-menu-toggle--Color);
+  --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-menu-toggle--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--active__toggle-icon--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--focus__toggle-icon--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--expanded__toggle-icon--Color: var(--pf-global--Color--100);
 
   // Full height
   --pf-c-menu-toggle--m-full-height--PaddingRight: var(--pf-global--spacer--lg);
@@ -197,36 +203,43 @@
     }
   }
 
-  &.pf-m-plain:not(.pf-m-text) {
-    --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--Color);
-    --pf-c-menu-toggle--hover--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-    --pf-c-menu-toggle--focus--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-    --pf-c-menu-toggle--active--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-    --pf-c-menu-toggle--disabled--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
-    --pf-c-menu-toggle--PaddingRight: var(--pf-c-menu-toggle--m-plain--PaddingRight);
-    --pf-c-menu-toggle--PaddingLeft: var(--pf-c-menu-toggle--m-plain--PaddingLeft);
-    --pf-c-menu-toggle--disabled--BackgroundColor: transparent;
-    --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
+  &.pf-m-plain {
+    --pf-c-menu-toggle__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain__toggle-icon--Color);
 
-    display: inline-block;
+    &:not(.pf-m-text) {
+      --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--Color);
+      --pf-c-menu-toggle--hover--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
+      --pf-c-menu-toggle--focus--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
+      --pf-c-menu-toggle--active--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
+      --pf-c-menu-toggle--disabled--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
+      --pf-c-menu-toggle--PaddingRight: var(--pf-c-menu-toggle--m-plain--PaddingRight);
+      --pf-c-menu-toggle--PaddingLeft: var(--pf-c-menu-toggle--m-plain--PaddingLeft);
+      --pf-c-menu-toggle--disabled--BackgroundColor: transparent;
+      --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
+
+      display: inline-block;
+    }
   }
 
   &:hover {
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--hover--BackgroundColor);
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--hover--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--hover--after--BorderBottomColor);
+    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--hover__toggle-icon--Color);
   }
 
   &:focus {
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--focus--BackgroundColor);
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--focus--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--focus--after--BorderBottomColor);
+    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--focus__toggle-icon--Color);
   }
 
   &:active {
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--active--BackgroundColor);
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--active--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--active--after--BorderBottomColor);
+    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--active__toggle-icon--Color);
   }
 
   &.pf-m-expanded {
@@ -234,6 +247,7 @@
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--m-expanded--BackgroundColor);
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomColor);
+    --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--expanded__toggle-icon--Color);
   }
 
   &:disabled {
@@ -288,4 +302,5 @@
 
 .pf-c-menu-toggle__toggle-icon {
   margin-right: var(--pf-c-menu-toggle__toggle-icon--MarginRight);
+  color: var(--pf-c-menu-toggle__toggle-icon--Color);
 }

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -31,7 +31,6 @@
   --pf-c-options-menu__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-options-menu__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-options-menu--m-top--m-expanded__toggle-icon--Rotate: 180deg;
-  --pf-c-options-menu__toggle-icon--Color: var(--pf-c-options-menu__toggle--Color);
   --pf-c-options-menu--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
   --pf-c-options-menu--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
@@ -217,7 +216,7 @@
 
 .pf-c-options-menu__toggle-icon,
 .pf-c-options-menu__toggle-button-icon {
-  color: var(--pf-c-options-menu__toggle-icon--Color);
+  color: var(--pf-c-options-menu__toggle-icon--Color, inherit);
 }
 
 .pf-c-options-menu__toggle-icon {

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -31,6 +31,9 @@
   --pf-c-options-menu__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-options-menu__toggle-icon--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-options-menu--m-top--m-expanded__toggle-icon--Rotate: 180deg;
+  --pf-c-options-menu__toggle-icon--Color: var(--pf-c-options-menu__toggle--Color);
+  --pf-c-options-menu--m-plain__toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-options-menu--m-plain--hover__toggle-icon--Color: var(--pf-global--Color--100);
 
   // Text toggle button
   --pf-c-options-menu__toggle-button--BackgroundColor: transparent;
@@ -153,15 +156,19 @@
     }
   }
 
-  &.pf-m-plain:not(.pf-m-text) {
-    --pf-c-options-menu__toggle--PaddingRight: var(--pf-c-options-menu__toggle--m-plain--PaddingRight);
-    --pf-c-options-menu__toggle--PaddingLeft: var(--pf-c-options-menu__toggle--m-plain--PaddingLeft);
+  &.pf-m-plain {
+    --pf-c-options-menu__toggle-icon--Color: var(--pf-c-options-menu--m-plain__toggle-icon--Color);
 
-    display: inline-block;
-    color: var(--pf-c-options-menu__toggle--m-plain--Color);
+    &:not(.pf-m-text) {
+      --pf-c-options-menu__toggle--PaddingRight: var(--pf-c-options-menu__toggle--m-plain--PaddingRight);
+      --pf-c-options-menu__toggle--PaddingLeft: var(--pf-c-options-menu__toggle--m-plain--PaddingLeft);
 
-    .pf-c-options-menu__toggle-button-icon {
-      line-height: var(--pf-c-options-menu__toggle--LineHeight);
+      display: inline-block;
+      color: var(--pf-c-options-menu__toggle--m-plain--Color);
+
+      .pf-c-options-menu__toggle-button-icon {
+        line-height: var(--pf-c-options-menu__toggle--LineHeight);
+      }
     }
 
     &:hover,
@@ -170,6 +177,7 @@
     &:focus,
     .pf-c-options-menu.pf-m-expanded > & {
       --pf-c-options-menu__toggle--m-plain--Color: var(--pf-c-options-menu__toggle--m-plain--hover--Color);
+      --pf-c-options-menu--m-plain__toggle-icon--Color: var(--pf-c-options-menu--m-plain--hover__toggle-icon--Color);
     }
 
     &.pf-m-disabled,
@@ -205,6 +213,11 @@
 
 .pf-c-options-menu__toggle-text {
   @include pf-text-overflow;
+}
+
+.pf-c-options-menu__toggle-icon,
+.pf-c-options-menu__toggle-button-icon {
+  color: var(--pf-c-options-menu__toggle-icon--Color);
 }
 
 .pf-c-options-menu__toggle-icon {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -95,6 +95,9 @@
   --pf-c-select__toggle-arrow--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-select__toggle-arrow--with-clear--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-select__toggle-arrow--m-top--m-expanded__toggle-arrow--Rotate: 180deg;
+  --pf-c-select__toggle-arrow--Color: var(--pf-c-select__toggle--Color);
+  --pf-c-select--m-plain__toggle-arrow--Color: var(--pf-global--Color--200);
+  --pf-c-select--m-plain--hover__toggle-arrow--Color: var(--pf-global--Color--100);
 
   // Toggle button
   --pf-c-select__toggle-clear--PaddingRight: var(--pf-global--spacer--sm);
@@ -323,8 +326,18 @@
   }
 
   &.pf-m-plain {
+    --pf-c-select__toggle-arrow--Color: var(--pf-c-select--m-plain__toggle-arrow--Color);
+
     &::before {
       border-color: var(--pf-c-select__toggle--m-plain--before--BorderColor);
+    }
+
+    &:hover,
+    &:active,
+    &.pf-m-active,
+    &:focus,
+    .pf-c-select.pf-m-expanded > & {
+      --pf-c-select--m-plain__toggle-arrow--Color: var(--pf-c-select--m-plain--hover__toggle-arrow--Color);
     }
   }
 
@@ -363,6 +376,8 @@
 }
 
 .pf-c-select__toggle-arrow {
+  color: var(--pf-c-select__toggle-arrow--Color);
+
   * + & {
     margin-right: var(--pf-c-select__toggle-arrow--MarginRight);
     margin-left: var(--pf-c-select__toggle-arrow--MarginLeft);

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -95,7 +95,6 @@
   --pf-c-select__toggle-arrow--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-select__toggle-arrow--with-clear--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-select__toggle-arrow--m-top--m-expanded__toggle-arrow--Rotate: 180deg;
-  --pf-c-select__toggle-arrow--Color: var(--pf-c-select__toggle--Color);
   --pf-c-select--m-plain__toggle-arrow--Color: var(--pf-global--Color--200);
   --pf-c-select--m-plain--hover__toggle-arrow--Color: var(--pf-global--Color--100);
 
@@ -376,7 +375,7 @@
 }
 
 .pf-c-select__toggle-arrow {
-  color: var(--pf-c-select__toggle-arrow--Color);
+  color: var(--pf-c-select__toggle-arrow--Color, inherit);
 
   * + & {
     margin-right: var(--pf-c-select__toggle-arrow--MarginRight);


### PR DESCRIPTION
Fixes #4552 

This changed the toggle icon to be darker on hover for dropdown, options menu, select, menu toggle, context selector, and pagination.