### PR TITLE
fix(check, radio): increased size, added accent color

### DIFF
--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -6,7 +6,11 @@
   --pf-c-check__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-check__label--LineHeight: var(--pf-global--LineHeight--sm);
   --pf-c-check__input--Height: var(--pf-c-check__label--FontSize);
+  --pf-c-check__input--Width: var(--pf-c-check__input--Height);
   --pf-c-check__input--MarginTop: calc(((var(--pf-c-check__label--FontSize) * var(--pf-c-check__label--LineHeight)) - var(--pf-c-check__input--Height)) / 2);
+  --pf-c-check__input--AccentColor: var(--pf-global--primary-color--100);
+  --pf-c-check__input--TranslateY: 0;
+  --pf-c-check--m-standalone__input--TranslateY: .15em;
   --pf-c-check__description--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-check__description--Color: var(--pf-global--Color--200);
   --pf-c-check__body--MarginTop: var(--pf-global--spacer--sm);
@@ -19,8 +23,8 @@
 
   &.pf-m-standalone {
     --pf-c-check--GridGap: 0;
-    --pf-c-check__input--Height: auto;
     --pf-c-check__input--MarginTop: 0;
+    --pf-c-check__input--TranslateY: var(--pf-c-check--m-standalone__input--TranslateY);
 
     display: inline-grid;
     line-height: 1;
@@ -35,8 +39,11 @@
 }
 
 .pf-c-check__input {
+  width: var(--pf-c-check__input--Width);
   height: var(--pf-c-check__input--Height);
   margin-top: var(--pf-c-check__input--MarginTop);
+  accent-color: var(--pf-c-check__input--AccentColor);
+  transform: translateY(var(--pf-c-check__input--TranslateY));
 }
 
 .pf-c-check__description {

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -6,7 +6,11 @@
   --pf-c-radio__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-radio__label--LineHeight: var(--pf-global--LineHeight--sm);
   --pf-c-radio__input--Height: var(--pf-c-radio__label--FontSize);
+  --pf-c-radio__input--Width: var(--pf-c-radio__input--Height);
   --pf-c-radio__input--MarginTop: calc(((var(--pf-c-radio__label--FontSize) * var(--pf-c-radio__label--LineHeight)) - var(--pf-c-radio__input--Height)) / 2);
+  --pf-c-radio__input--AccentColor: var(--pf-global--primary-color--100);
+  --pf-c-radio__input--TranslateY: 0;
+  --pf-c-radio--m-standalone__input--TranslateY: .15em;
   --pf-c-radio__input--first-child--MarginLeft: #{pf-size-prem(1px)};
   --pf-c-radio__input--last-child--MarginRight: #{pf-size-prem(1px)};
   --pf-c-radio__description--FontSize: var(--pf-global--FontSize--sm);
@@ -21,8 +25,8 @@
 
   &.pf-m-standalone {
     --pf-c-radio--GridGap: 0;
-    --pf-c-radio__input--Height: auto;
     --pf-c-radio__input--MarginTop: 0;
+    --pf-c-radio__input--TranslateY: var(--pf-c-radio--m-standalone__input--TranslateY);
 
     display: inline-grid;
     line-height: 1;
@@ -37,8 +41,11 @@
 }
 
 .pf-c-radio__input {
+  width: var(--pf-c-radio__input--Width);
   height: var(--pf-c-radio__input--Height);
   margin-top: var(--pf-c-radio__input--MarginTop);
+  accent-color: var(--pf-c-radio__input--AccentColor);
+  transform: translateY(var(--pf-c-radio__input--TranslateY));
 
   // fixes a chrome issue where the left edge is cut off in a container with overflow hidden
   &:first-child {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4322

----

Looking at what I think are the best ways to do this, we can:

1. Use radios/checks as they are, just increase their size and apply `accent-color` set to our primary color. That's the change in this PR, and I created a codepen demo here - https://codepen.io/mcoker/pen/JjrzgEv
  * Pros:
    * Retains the browser default shape and interactive behavior.
    * Inputs are larger (a11y++) and IMO look better.
    * CSS is super simple. Only a few lines per component. I feel a lot more comfortable making this a global change for all checkboxes/radios - not just our checkbox/radio component. Meaning if someone includes a random input that doesn't use our component, it will look like the component.
  * Cons:
    * `accent-color` isn't supported in Safari (yet), though the default isn't far off from our primary blue so I don't think it's a big deal. Seems like a good opportunity for a progressive enhancement.
    * The right side of radio inputs seems to be cut off in Safari. Should be fixable though, didn't spend much time on it.

2. Use pseudo elements to recreate/draw the inputs. The basic idea here is to hide the default input, and attach a style to it that lets us create our own "element" that represents the input. Here's a codepen with that - https://codepen.io/mcoker/pen/rNGREgj.
  * Pros:
    * Gives us and users significantly more flexibility over how to draw/animate/customize the inputs. 
    * It's probably easier to align these elements with labels/text across browsers since they don't include the default input CSS per browser which is kind of a pain to work with with to get the element to align properly. Though I'd want to work on the alignment between the approaches a little more to get a better idea.
  * Cons:
    * We lose the default browser shape/interactive behavior. This would probably make it a breaking visual change since these inputs look different across browsers.
    * CSS is quite a bit more complex. Definitely a code breaking change.
    * There may be a11y implications with this since it's a bit more intrusive on the styling side by hiding the default input. But that may not be a factor given we're able to hide the default input in a browser friendly way.

In both cases, the increased width does push the text beside the input over by a couple of pixels. The horizontal layout shift could potentially cause an input + label (or an inline row of multiple input + labels) to break to a new line when it didn't previously. Likely an edge case, and seems acceptable to me.

IMO the first solution is the preferred approach, at least for the short term. Seems like something we could do now. The other approach, given proper time to work on may be better in the long term since it allows for way more customization and would make the inputs consistent across browsers.


