### PR TITLE
fix(TableDemo): remove bulk selector from header

### DIFF
--- a/src/patternfly/demos/DataList/data-list-expandable-compact-table.hbs
+++ b/src/patternfly/demos/DataList/data-list-expandable-compact-table.hbs
@@ -22,8 +22,8 @@
       {{#> table-th table-th--attribute='scope="col"' table-th--icon="true"}}
         Icons
       {{/table-th}}
-      {{#> table-th}}{{/table-th}}
-      {{#> table-th}}{{/table-th}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
   {{#> table-tbody}}

--- a/src/patternfly/demos/Table/table-compact-table.hbs
+++ b/src/patternfly/demos/Table/table-compact-table.hbs
@@ -1,9 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-compact pf-m-grid-lg" table--attribute='aria-label="This is a compact table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
-        <input type="checkbox" name="check-all" aria-label="Select all rows">
-      {{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Contributor
       {{/table-th}}
@@ -22,8 +20,8 @@
       {{#> table-th table-th--attribute='scope="col"' table-th--icon="true"}}
         Icons
       {{/table-th}}
-      {{#> table-th}}{{/table-th}}
-      {{#> table-th}}{{/table-th}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 

--- a/src/patternfly/demos/Table/table-expandable-table.hbs
+++ b/src/patternfly/demos/Table/table-expandable-table.hbs
@@ -2,9 +2,7 @@
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
       {{> table--toggle-all}}
-      {{#> table-td table-td--check="true"}}
-        <input type="checkbox" name="check-all" aria-label="Select all rows">
-      {{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-width-30"}}
         Repositories
       {{/table-th}}
@@ -20,8 +18,8 @@
       {{#> table-th table-th--attribute='scope="col"'}}
         Last commit
       {{/table-th}}
-      {{#> table-td}}{{/table-td}}
-      {{#> table-td}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -1,9 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
-        <input type="checkbox" name="check-all" aria-label="Select all rows">
-      {{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}
@@ -19,8 +17,8 @@
       {{#> table-th table-th--attribute='scope="col"'}}
         Last commit
       {{/table-th}}
-      {{#> table-td}}{{/table-td}}
-      {{#> table-td}}{{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 

--- a/src/patternfly/demos/Table/table-sortable-table.hbs
+++ b/src/patternfly/demos/Table/table-sortable-table.hbs
@@ -1,9 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a sortable table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
-        <input type="checkbox" name="check-all" aria-label="Select all rows">
-      {{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true" table-th--selected="true" table-th--asc="true"}}
         Repositories
       {{/table-th}}
@@ -19,10 +17,8 @@
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}
         Last commit
       {{/table-th}}
-      {{#> table-td}}
-      {{/table-td}}
-      {{#> table-td}}
-      {{/table-td}}
+      {{> table-td table-td--IsEmpty="true"}}
+      {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
 


### PR DESCRIPTION
Fixes #4598 

This also replaces a couple of empty THs with TDs to fix an accessibility error (empty THs are not allowed).

https://patternfly-pr-4640.surge.sh/components/table/html-demos#basic
Bulk selector removed from the header of  the basic, sortable, expandable, compact, static bottom pagination, column management modal, and sticky header demos.
The data list example just changes the empty TH to a TD for a11y, but I believe should still have the bulk selector in the table header since it's a selector for the secondary table. https://patternfly-pr-4640.surge.sh/components/data-list/html-demos#expandable-demo