### PR TITLE
feat(pagination): remove number input arrow visibility

### DIFF
--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -6,7 +6,7 @@
   --pf-c-number-input__icon--FontSize: var(--pf-global--FontSize--xs);
 
   // form control
-  --pf-c-number-input--c-form-control--width-base: calc(var(--pf-global--spacer--sm) * 2); // element's padding
+  --pf-c-number-input--c-form-control--width-base: calc(var(--pf-global--spacer--sm) * 2 + var(--pf-global--BorderWidth--sm) * 2); // element's padding
   --pf-c-number-input--c-form-control--width-chars: 4;
   --pf-c-number-input--c-form-control--Width: calc(var(--pf-c-number-input--c-form-control--width-base) + var(--pf-c-number-input--c-form-control--width-chars) * 1ch);
 

--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -18,15 +18,7 @@
     width: var(--pf-c-number-input--c-form-control--Width);
     text-align: right;
 
-    // disable default number increment arrows
-    // stylelint-disable
-    -moz-appearance: textfield;
-    &::-webkit-outer-spin-button,
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-    // stylelint-enable
+    @extend %pf-remove-num-arrows;
   }
 }
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -37,7 +37,7 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   --pf-c-pagination__nav-page-select--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-pagination__nav-page-select--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-pagination__nav-page-select--child--MarginRight: var(--pf-global--spacer--xs);
-  --pf-c-pagination__nav-page-select--c-form-control--width-base: calc(var(--pf-global--spacer--sm) * 2);
+  --pf-c-pagination__nav-page-select--c-form-control--width-base: calc(var(--pf-global--spacer--sm) * 2 + var(--pf-global--BorderWidth--sm) * 2);
   --pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;
   --pf-c-pagination__nav-page-select--c-form-control--Width: calc(var(--pf-c-pagination__nav-page-select--c-form-control--width-base) + (var(--pf-c-pagination__nav-page-select--c-form-control--width-chars) * 1ch));
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -37,7 +37,7 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
   --pf-c-pagination__nav-page-select--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-pagination__nav-page-select--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-pagination__nav-page-select--child--MarginRight: var(--pf-global--spacer--xs);
-  --pf-c-pagination__nav-page-select--c-form-control--width-base: 3.5ch;
+  --pf-c-pagination__nav-page-select--c-form-control--width-base: calc(var(--pf-global--spacer--sm) * 2);
   --pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;
   --pf-c-pagination__nav-page-select--c-form-control--Width: calc(var(--pf-c-pagination__nav-page-select--c-form-control--width-base) + (var(--pf-c-pagination__nav-page-select--c-form-control--width-chars) * 1ch));
 
@@ -255,21 +255,10 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
     }
   }
 
-  // hide number input up/down arrow buttons
-  input[type="number"] {
-    // stylelint-disable
-    &::-webkit-inner-spin-button,
-    &::-webkit-outer-spin-button {
-    // stylelint-enable
-      appearance: none;
-      margin: 0;
-    }
-
-    appearance: textfield;
-  }
-
   .pf-c-form-control {
     width: var(--pf-c-pagination__nav-page-select--c-form-control--Width);
+
+    @extend %pf-remove-num-arrows;
   }
 }
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -255,6 +255,19 @@ $pf-c-pagination--breakpoint-map: build-breakpoint-map();
     }
   }
 
+  // hide number input up/down arrow buttons
+  input[type="number"] {
+    // stylelint-disable
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+    // stylelint-enable
+      appearance: none;
+      margin: 0;
+    }
+
+    appearance: textfield;
+  }
+
   .pf-c-form-control {
     width: var(--pf-c-pagination__nav-page-select--c-form-control--Width);
   }

--- a/src/patternfly/sass-utilities/placeholders.scss
+++ b/src/patternfly/sass-utilities/placeholders.scss
@@ -80,3 +80,15 @@
   }
 }
 // stylelint-enable
+
+%pf-remove-num-arrows {
+  appearance: textfield;
+
+  // stylelint-disable
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+  // stylelint-enable
+    appearance: none;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Closes: #4224

To test, navigate to the Pagination examples and verify when focusing on any page select input box that up/down arrows are not visible and you are still able to use keyboard up/down arrows to increment/decrement the count.