### PR TITLE
feat(nav): added variation to fix section spacing

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -2,6 +2,7 @@
 #ws-core-c-navigation-basic,
 #ws-core-c-navigation-grouped,
 #ws-core-c-navigation-grouped-nav,
+#ws-core-c-navigation-grouped-nav-no-titles,
 #ws-core-c-navigation-expanded,
 #ws-core-c-navigation-expanded-with-subnav-titles,
 #ws-core-c-navigation-mixed,

--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -14,7 +14,8 @@
 #ws-core-c-navigation-nav-with-drilldown-menu .pf-c-nav,
 #ws-core-c-navigation-level-2-drilldown,
 #ws-core-c-navigation-level-3-drilldown,
-#ws-core-c-navigation-nav-with-flyout .pf-c-nav {
+#ws-core-c-navigation-nav-with-flyout .pf-c-nav,
+#ws-core-c-navigation-grouped-nav-no-titles-no-margin-top {
   padding: 0;
   background-color: var(--pf-global--BackgroundColor--dark-300);
 }

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -153,7 +153,7 @@ import './Navigation.css'
       {{/nav-item}}
     {{/nav-list}}
   {{/nav-section}}
-  {{#> nav-section nav-section--modifier="pf-m-no-margin-top" nav-section--attribute='aria-label="Section two"'}}
+  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section two"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -785,7 +785,7 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon wrapper. |
 | `.pf-c-nav__scroll-button` | `<button>` | Initiates a nav scroll button. **Required for horizontal navs** |
 | `.pf-m-horizontal` | `.pf-c-nav` | Modifies nav for the horizontal variation. |
-| `.pf-m-no-margin-top` | `.pf-c-nav__section` | Modifies nav section margin top to 0. |
+| `.pf-m-no-title` | `.pf-c-nav__section` | Modifies nav section margin top to 0. |
 | `.pf-m-horizontal-subnav` | `.pf-c-nav` | Modifies nav for the horizontal subnav variation. |
 | `.pf-m-tertiary` | `.pf-c-nav` | Modifies nav for the tertiary variation. |
 | `.pf-m-light` | `.pf-c-nav` | Modifies nav for the light variation. **Note: only for use with vertical navs, and requires `.pf-m-light` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -89,7 +89,7 @@ import './Navigation.css'
 ### Grouped nav, no titles
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
-  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
+  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section one"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -109,7 +109,7 @@ import './Navigation.css'
     {{/nav-list}}
   {{/nav-section}}
   {{> divider}}
-  {{#> nav-section nav-section--attribute='aria-label="Section two"'}}
+  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section two"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -134,7 +134,7 @@ import './Navigation.css'
 ### Grouped nav, no titles, no margin top
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
-  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
+  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section one"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -86,6 +86,51 @@ import './Navigation.css'
 {{/nav}}
 ```
 
+### Grouped nav, no titles
+```hbs
+{{#> nav nav--attribute='aria-label="Global"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
+    {{#> nav-list}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 1
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 2
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 3
+        {{/nav-link}}
+      {{/nav-item}}
+    {{/nav-list}}
+  {{/nav-section}}
+  {{> divider}}
+  {{#> nav-section nav-section--attribute='aria-label="Section two"'}}
+    {{#> nav-list}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Section 2, link 1
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+          Current link
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 3
+        {{/nav-link}}
+      {{/nav-item}}
+    {{/nav-list}}
+  {{/nav-section}}
+{{/nav}}
+```
+
 ### Expanded
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
@@ -671,6 +716,7 @@ The navigation system relies on several different sub-components:
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `aria-label="[landmark description]"` | `.pf-c-nav` |  Describes `<nav>` landmark. |
+| `aria-label="[section title]"` | `.pf-c-nav__section` |  Describes a nav `<section>`, where a `.pf-c-nav__section-title` is not present. |
 | `aria-labelledby="[id value of link describing subnav]"` | `.pf-c-nav__subnav` |  Gives the subnav `<section>` landmark an accessible name by referring to the element that provides the subnav `<section>` landmark title. |
 | `aria-expanded="false"` | `.pf-c-nav__link` |  Indicates that subnav section is hidden. |
 | `aria-expanded="true"` | `.pf-c-nav__link` |  Indicates that subnav section is visible. |

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -131,6 +131,50 @@ import './Navigation.css'
 {{/nav}}
 ```
 
+### Grouped nav, no titles, no margin top
+```hbs
+{{#> nav nav--attribute='aria-label="Global"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
+    {{#> nav-list}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 1
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 2
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 3
+        {{/nav-link}}
+      {{/nav-item}}
+    {{/nav-list}}
+  {{/nav-section}}
+  {{#> nav-section nav-section--modifier="pf-m-no-margin-top" nav-section--attribute='aria-label="Section two"'}}
+    {{#> nav-list}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Section 2, link 1
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+          Current link
+        {{/nav-link}}
+      {{/nav-item}}
+      {{#> nav-item}}
+        {{#> nav-link nav-link--href="#"}}
+          Link 3
+        {{/nav-link}}
+      {{/nav-item}}
+    {{/nav-list}}
+  {{/nav-section}}
+{{/nav}}
+```
+
 ### Expanded
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
@@ -741,6 +785,7 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon wrapper. |
 | `.pf-c-nav__scroll-button` | `<button>` | Initiates a nav scroll button. **Required for horizontal navs** |
 | `.pf-m-horizontal` | `.pf-c-nav` | Modifies nav for the horizontal variation. |
+| `.pf-m-no-margin-top` | `.pf-c-nav__section` | Modifies nav section margin top to 0. |
 | `.pf-m-horizontal-subnav` | `.pf-c-nav` | Modifies nav for the horizontal subnav variation. |
 | `.pf-m-tertiary` | `.pf-c-nav` | Modifies nav for the tertiary variation. |
 | `.pf-m-light` | `.pf-c-nav` | Modifies nav for the light variation. **Note: only for use with vertical navs, and requires `.pf-m-light` on the page component's sidebar element (`.pf-c-page__sidebar`)**. |

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1078,7 +1078,7 @@
     --pf-c-nav__section--MarginTop: var(--pf-c-nav__section--section--MarginTop);
   }
 
-  &.pf-m-no-margin-top {
+  &.pf-m-no-title {
     --pf-c-nav__section--MarginTop: 0;
   }
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1074,8 +1074,8 @@
   // Divider
   --pf-c-nav--c-divider--MarginBottom: 0;
 
-  & + & {
-    --pf-c-nav__section--MarginTop: var(--pf-c-nav__section--section--MarginTop);
+  & + & .pf-c-nav__section-title {
+    margin-top: var(--pf-c-nav__section--section--MarginTop); // update at breaking change
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1074,8 +1074,12 @@
   // Divider
   --pf-c-nav--c-divider--MarginBottom: 0;
 
-  & + & .pf-c-nav__section-title {
-    margin-top: var(--pf-c-nav__section--section--MarginTop); // update at breaking change
+  & + & {
+    --pf-c-nav__section--MarginTop: var(--pf-c-nav__section--section--MarginTop);
+  }
+
+  &.pf-m-no-margin-top {
+    --pf-c-nav__section--MarginTop: 0;
   }
 }
 


### PR DESCRIPTION
fixes #4602 

@mcarrano @mceledonia I added a divider between sections to separate them and an `aria-label` to sections without titles. Lmk if you this presentation is what you expect. 