### PR TITLE
chore(docs): added version details to upgrade guide

### DIFF
--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -3,7 +3,7 @@ id: Upgrade guide
 section: developer-resources
 ---
 
-Note: this guide details upgrading from PatternFly V3 to V4, and references [major release 2020.07](/v4/developer-resources/release-notes/html#2020.07-release-notes-2020-06-05) from 2020-06-05.
+**Note:** this guide details upgrading from PatternFly v3 to v4, and references [major release 2020.07](/developer-resources/release-notes/html/#2020.07-release-notes-2020-06-05) from 2020-06-05.
 <hr/>
 
 Hey, Flyers! We've been busy for the past 12 weeks working on significant changes to PatternFly's HTML and CSS. We made our components mobile-first and changed colors and the default font. This upgrade guide details **what** was broken and **how** to fix it. To learn **why** a change was made, check out the linked pull requests.

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -3,6 +3,9 @@ id: Upgrade guide
 section: developer-resources
 ---
 
+Note: this guide details upgrading from PatternFly V3 to V4, and references [major release 2020.07](/v4/developer-resources/release-notes/html#2020.07-release-notes-2020-06-05) from 2020-06-05.
+<hr/>
+
 Hey, Flyers! We've been busy for the past 12 weeks working on significant changes to PatternFly's HTML and CSS. We made our components mobile-first and changed colors and the default font. This upgrade guide details **what** was broken and **how** to fix it. To learn **why** a change was made, check out the linked pull requests.
 
 ## Global


### PR DESCRIPTION
Closes #4677 

This PR adds additional context to the upgrade guide, clarifying that it details upgrading from V3 to V4 and linking to the relevant release notes.