### PR TITLE
chore(context-selector): fixed broken include paths

### DIFF
--- a/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
@@ -10,17 +10,11 @@ section: components
 {{> page-template page-template--id="context-selector-in-masthead"}}
 
 {{#*inline "masthead-template-content-toolbar-content"}}
-  {{#> masthead-content}}
-    {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}
-      {{#> toolbar-content}}
-        {{#> toolbar-content-section}}
-          {{#> toolbar-item}}
-            {{> masthead-template-context-selector}}
-          {{/toolbar-item}}
-        {{/toolbar-content-section}}
-      {{/toolbar-content}}
-    {{/toolbar}}
-  {{/masthead-content}}
+  {{#> toolbar-content-section}}
+    {{#> toolbar-item}}
+      {{> masthead-template-context-selector}}
+    {{/toolbar-item}}
+  {{/toolbar-content-section}}
 {{/inline}}
 ```
 

--- a/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
@@ -30,8 +30,14 @@ section: components
 
 ### Context selector in page content
 ```hbs isFullscreen
-{{#> page-demo-default page-demo-default--id="context-selector-in-page-content" page-demo-default--HasNoContent="true"}}
-  {{#> page-main-section page-main-section--modifier="pf-m-no-padding" page-main-section--IsLimitWidth="true"}}
+{{> page-template
+  page-template--id="context-selector-in-page-content-demo"
+  page-template--HasNoBreadcrumb="true"
+  page-template--HasNoTitle="true"
+}}
+
+{{#*inline "page-template-section"}}
+  {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier="pf-m-light pf-m-no-padding"}}
     {{#> toolbar toolbar--id="toolbar-simple-example" toolbar--modifier="pf-m-inset-none"}}
       {{#> toolbar-content}}
         {{#> toolbar-content-section}}
@@ -69,5 +75,5 @@ section: components
   {{> page-template-breadcrumb}}
   {{> page-template-title}}
   {{> page-template-gallery}}
-{{/page-demo-default}}
+{{/inline}}
 ```

--- a/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
@@ -7,31 +7,21 @@ section: components
 
 ### Context selector in masthead
 ```hbs isFullscreen
-{{#> masthead-demo--page masthead-demo--page--id="context-selector-in-masthead"}}
-  {{#> masthead masthead--id=(concat masthead-demo--page--id '-masthead')}}  {{> masthead-toggle}}
-    {{#> masthead-main}}
-      {{#> masthead-brand}}
-        {{> brand
-          brand--attribute='style="--pf-c-brand--Width: 180px; --pf-c-brand--Width-on-md: 180px; --pf-c-brand--Width-on-2xl: 220px;"'
-          brand--IsPicture="true"
-          brand--img-url--base='/assets/images/logo__pf--reverse--base.png'
-          brand--img-url='/assets/images/logo__pf--reverse--base.svg'
-          brand--img-url-on-md='/assets/images/logo__pf--reverse-on-md.svg'}}
-      {{/masthead-brand}}
-    {{/masthead-main}}
-    {{#> masthead-content}}
-      {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}
-        {{#> toolbar-content}}
-          {{#> toolbar-content-section}}
-            {{#> toolbar-item}}
-              {{> masthead-demo--context-selector}}
-            {{/toolbar-item}}
-          {{/toolbar-content-section}}
-        {{/toolbar-content}}
-      {{/toolbar}}
-    {{/masthead-content}}
-  {{/masthead}}
-{{/masthead-demo--page}}
+{{> page-template page-template--id="context-selector-in-masthead"}}
+
+{{#*inline "masthead-template-content-toolbar-content"}}
+  {{#> masthead-content}}
+    {{#> toolbar toolbar--modifier="pf-m-full-height pf-m-static" toolbar--id=(concat masthead--id '-toolbar')}}
+      {{#> toolbar-content}}
+        {{#> toolbar-content-section}}
+          {{#> toolbar-item}}
+            {{> masthead-template-context-selector}}
+          {{/toolbar-item}}
+        {{/toolbar-content-section}}
+      {{/toolbar-content}}
+    {{/toolbar}}
+  {{/masthead-content}}
+{{/inline}}
 ```
 
 ### Context selector in sidebar

--- a/src/patternfly/demos/Page/page-demo-masthead-component.hbs
+++ b/src/patternfly/demos/Page/page-demo-masthead-component.hbs
@@ -1,6 +1,6 @@
 {{#> page page--id=page-demo-default--id}}
   {{#> page-header}}
-    {{> page-template-masthead}}
+    {{> masthead-template}}
   {{/page-header}}
   {{> page-template-sidebar}}
   {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}


### PR DESCRIPTION
fixes the context selector demos after an include was removed from https://github.com/patternfly/patternfly/pull/4683/