### PR TITLE
4675 search inputs in demos

### DIFF
--- a/src/patternfly/components/AppLauncher/examples/application-launcher.md
+++ b/src/patternfly/components/AppLauncher/examples/application-launcher.md
@@ -210,8 +210,7 @@ import './application-launcher.css'
 {{#> app-launcher app-launcher--id="app-launcher-favorites" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-menu-search}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" aria-label="Type to filter" placeholder="Filter by name..." id="' app-launcher--id '-text-input" name="textInput1"')}}
-        {{/form-control}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/app-launcher-menu-search}}
     {{#> app-launcher-group}}
       {{#> app-launcher-group-title}}

--- a/src/patternfly/components/ContextSelector/examples/context-selector.md
+++ b/src/patternfly/components/ContextSelector/examples/context-selector.md
@@ -18,13 +18,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
   {{/context-selector-menu}}
@@ -40,13 +34,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" placeholder="Search" id="textInput2" name="textInput2" aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
   {{/context-selector-menu}}
@@ -65,13 +53,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
   {{/context-selector-menu}}
@@ -87,13 +69,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" placeholder="Search" id="textInput2" name="textInput2" aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
   {{/context-selector-menu}}
@@ -112,13 +88,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" placeholder="Search" id="' context-selector--id '-textInput3" name="textInput3" aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
     {{#> context-selector-menu-footer}}
@@ -139,13 +109,7 @@ import './context-selector.css'
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" placeholder="Search" id="' context-selector--id '-textInput3" name="textInput3" aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
     {{#> context-selector-menu-footer}}

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -25,8 +25,6 @@ import './FormControl.css'
 <br><br>
 {{> form-control controlType="input" input="true" form-control--IsExpanded="true" form-control--attribute='type="text" value="Expanded" id="input-expanded" aria-label="Expanded input example"'}}
 <br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute='type="search" value="Search" id="input-search" name="search-input" aria-label="Search input example"'}}
-<br><br>
 {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute='type="text" value="Calendar" id="input-calendar" name="input-calendar" aria-label="Calendar input example"'}}
 <br><br>
 {{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-clock" form-control--attribute='type="text" value="Clock" id="input-clock" name="input-clock" aria-label="Clock input example"'}}

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -83,7 +83,7 @@ cssPrefix: pf-c-input-group
 {{/input-group}}
 <br>
 {{#> input-group}}
-  {{#> form-control controlType="input" input="true" form-control--attribute='type="search" id="textInput12" name="textInput12" aria-label="Input example with popover"'}}
+  {{#> form-control controlType="input" input="true" form-control--attribute='type="text" id="textInput12" name="textInput12" aria-label="Input example with popover"'}}
   {{/form-control}}
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Popover for input"'}}
     <i class="fas fa-question-circle" aria-hidden="true"></i>
@@ -91,7 +91,7 @@ cssPrefix: pf-c-input-group
 {{/input-group}}
 <br>
 {{#> input-group}}
-  {{#> form-control controlType="input" input="true" form-control--attribute='type="search" id="textInput14" name="textInput14" aria-label="Input example with plain unit"'}}
+  {{#> form-control controlType="input" input="true" form-control--attribute='type="number" id="textInput14" name="textInput14" aria-label="Input example with plain unit"'}}
   {{/form-control}}
   {{#> input-group-text input-group-text--modifier="pf-m-plain"}}
    %

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -75,14 +75,6 @@ cssPrefix: pf-c-input-group
 {{/input-group}}
 <br>
 {{#> input-group}}
-  {{#> form-control controlType="input" input="true" form-control--attribute='type="search" id="textInput11" name="textInput11" aria-label="Search input example"'}}
-  {{/form-control}}
-  {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}
-    <i class="fas fa-search" aria-hidden="true"></i>
-  {{/button}}
-{{/input-group}}
-<br>
-{{#> input-group}}
   {{#> form-control controlType="input" input="true" form-control--attribute='type="text" id="textInput13" name="textInput13" aria-label="Input example with popover"'}}
   {{/form-control}}
   {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Popover for input"'}}

--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -952,7 +952,7 @@ import './Menu.css'
 {{#> menu menu--id="scrollable-menu-search-footer-example" menu--modifier="pf-m-scrollable"}}
   {{#> menu-search}}
     {{#> menu-search-input}}
-      {{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/menu-search-input}}
   {{/menu-search}}
   {{> divider}}
@@ -972,7 +972,7 @@ import './Menu.css'
 {{#> menu}}
   {{#> menu-search}}
     {{#> menu-search-input}}
-      {{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/menu-search-input}}
   {{/menu-search}}
   {{> divider}}
@@ -1671,7 +1671,7 @@ import './Menu.css'
 {{#> menu menu--id="plain-with-search-and-footer-example" menu--modifier="pf-m-plain"}}
   {{#> menu-search}}
     {{#> menu-search-input}}
-      {{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/menu-search-input}}
   {{/menu-search}}
   {{> divider}}
@@ -1691,7 +1691,7 @@ import './Menu.css'
 {{#> menu menu--id="plain-scrollable-with-search-and-footer-example" menu--modifier="pf-m-plain pf-m-scrollable"}}
   {{#> menu-search}}
     {{#> menu-search-input}}
-      {{> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/menu-search-input}}
   {{/menu-search}}
   {{> divider}}

--- a/src/patternfly/components/Page/page-sidebar.hbs
+++ b/src/patternfly/components/Page/page-sidebar.hbs
@@ -14,13 +14,7 @@
         {{/context-selector-toggle}}
         {{#> context-selector-menu}}
           {{#> context-selector-menu-search}}
-            {{#> input-group}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-              {{/form-control}}
-              {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-                <i class="fas fa-search" aria-hidden="true"></i>
-              {{/button}}
-            {{/input-group}}
+            {{#> search-input search-input--placeholder="Search"}}{{/search-input}}
           {{/context-selector-menu-search}}
           {{> __context-selector-menu-menu}}
         {{/context-selector-menu}}

--- a/src/patternfly/components/SearchInput/search-input.hbs
+++ b/src/patternfly/components/SearchInput/search-input.hbs
@@ -1,6 +1,6 @@
 <div class="pf-c-search-input{{#if search-input--modifier}} {{search-input--modifier}}{{/if}}"
   {{#if search-input--attribute}}
-    {{search-input--attribute}}
+    {{{search-input--attribute}}}
   {{/if}}>
   {{#if search-input--IsAdvancedSearch}}
     {{#> input-group}}

--- a/src/patternfly/components/Select/__select-checkbox-checked.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-checked.hbs
@@ -5,7 +5,7 @@
   {{/if}}>
   {{#if select--IsFilterable}}
     {{#> select-menu-search}}
-      {{> select-menu-search-input}}
+      {{#> search-input search-input--placeholder="Search"}}{{/search-input}}
     {{/select-menu-search}}
     {{> divider}}
   {{/if}}

--- a/src/patternfly/components/Select/__select-checkbox-groups-checked.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-groups-checked.hbs
@@ -5,7 +5,7 @@
   {{/if}}>
   {{#if select--IsFilterable}}
     {{#> select-menu-search}}
-      {{> select-menu-search-input}}
+      {{#> search-input search-input--placeholder="Search"}}{{/search-input}}
     {{/select-menu-search}}
     {{> divider}}
   {{/if}}

--- a/src/patternfly/components/Select/__select-menu-favorites.hbs
+++ b/src/patternfly/components/Select/__select-menu-favorites.hbs
@@ -5,7 +5,7 @@
     {{{select--attribute}}}
   {{/if}}>
   {{#> select-menu-search}}
-    {{> select-menu-search-input}}
+    {{#> search-input search-input--placeholder="Search"}}{{/search-input}}
   {{/select-menu-search}}
   {{> divider}}
   {{#> select-menu-group}}

--- a/src/patternfly/components/Select/select-menu-search-input.hbs
+++ b/src/patternfly/components/Select/select-menu-search-input.hbs
@@ -1,2 +1,0 @@
-{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute=(concat 'type="search" id="' id '-search-input" name="' id '-search-input" aria-label="Search"')}}
-{{/form-control}}

--- a/src/patternfly/components/Toolbar/toolbar-item-context-selector.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-context-selector.hbs
@@ -8,13 +8,7 @@
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{#> context-selector-menu-menu}}
       <li>

--- a/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
@@ -1,7 +1,6 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-search-filter ' toolbar-item-search-filter--modifier)}}
   {{#> input-group input-group--attribute=(concat 'aria-label="search filter" role="group"')}}
     {{> dropdown dropdown--id=(concat toolbar--id '-' button--id) dropdown-toggle--text="Name"}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" id="' toolbar--id '-' button--id '-search-filter-input" name="' toolbar--id '-search-filter-input" aria-label="input with dropdown and button" aria-describedby="' toolbar--id '-' button--id '-button"')}}
-    {{/form-control}}
+    {{> search-input search-input--placeholder="Find by name"}}
   {{/input-group}}
 {{/toolbar-item}}

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -103,8 +103,7 @@ beta: true
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-search}}
-    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-search" form-control--attribute='type="search" id="input-search" name="search-input" aria-label="Search input example"'}}
-    {{/form-control}}
+    {{> search-input search-input--placeholder="Search"}}
   {{/tree-view-search}}
   {{> divider}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}

--- a/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
@@ -52,13 +52,7 @@ section: components
               {{/context-selector-toggle}}
               {{#> context-selector-menu}}
                 {{#> context-selector-menu-search}}
-                  {{#> input-group}}
-                    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="textInput1"' 'name="textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-                    {{/form-control}}
-                    {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-                      <i class="fas fa-search" aria-hidden="true"></i>
-                    {{/button}}
-                  {{/input-group}}
+                  {{> search-input search-input--placeholder="Search"}}
                 {{/context-selector-menu-search}}
                 {{> __context-selector-menu-menu}}
               {{/context-selector-menu}}

--- a/src/patternfly/demos/Masthead/templates/masthead-demo--drilldown.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-demo--drilldown.hbs
@@ -1,4 +1,4 @@
-{{#> menu menu--modifier="pf-m-drilldown pf-m-align-right" menu--IsHidden="true"}}
+{{#> menu menu--modifier="pf-m-drilldown pf-m-align-right"}}
   {{#> menu-content menu-content--attribute=reset}}
     {{#> menu-group menu-group--modifier="pf-m-hidden-on-sm"}}
       {{#> menu-list}}

--- a/src/patternfly/demos/Masthead/templates/masthead-template-application-launcher.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-template-application-launcher.hbs
@@ -1,8 +1,7 @@
 {{#> app-launcher app-launcher--id=(concat masthead--id '-application-launcher') app-launcher--attribute=(concat 'id="' app-launcher--id '"') app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu app-launcher-menu--modifier="pf-m-align-right"}}
     {{#> app-launcher-menu-search}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search" aria-label="Type to filter" placeholder="Filter by name..." id="' app-launcher--id '-text-input" name="textInput1"')}}
-        {{/form-control}}
+      {{> search-input search-input--placeholder="Filter by name"}}
     {{/app-launcher-menu-search}}
     {{#> app-launcher-group}}
       {{#> app-launcher-group-title}}

--- a/src/patternfly/demos/Masthead/templates/masthead-template-context-selector.hbs
+++ b/src/patternfly/demos/Masthead/templates/masthead-template-context-selector.hbs
@@ -7,13 +7,7 @@
   {{/context-selector-toggle}}
   {{#> context-selector-menu}}
     {{#> context-selector-menu-search}}
-      {{#> input-group}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="search"' 'placeholder="Search"' 'id="' context-selector--id 'textInput1"' 'name="' context-selector--id 'textInput1"' 'aria-labelledby="' context-selector--id '-search-button"')}}
-        {{/form-control}}
-        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' context-selector--id '-search-button"' 'aria-label="Search menu items"')}}
-          <i class="fas fa-search" aria-hidden="true"></i>
-        {{/button}}
-      {{/input-group}}
+      {{> search-input search-input--placeholder="Search"}}
     {{/context-selector-menu-search}}
     {{> __context-selector-menu-menu}}
   {{/context-selector-menu}}

--- a/src/patternfly/demos/Skeleton/table-skeleton-toolbar.hbs
+++ b/src/patternfly/demos/Skeleton/table-skeleton-toolbar.hbs
@@ -9,11 +9,7 @@
               {{#> select select--attribute="style='width: 150px'" id=(concat toolbar--id '-select-name') select-toggle--icon="fas fa-filter"}}
                 Name
               {{/select}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'id="' toolbar--id '-textInput11" name="textInput11" type="search" placeholder="Filter by name..." aria-label="Search input example"')}}
-              {{/form-control}}
-              {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}
-                <i class="fas fa-search" aria-hidden="true"></i>
-              {{/button}}
+              {{#> search-input search-input--placeholder="Find by name"}}{{/search-input}}
             {{/input-group}}
           {{/toolbar-item}}
         {{/toolbar-group}}

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -20,11 +20,7 @@ import './Toolbar.css'
               {{#> select select--attribute="style='width: 150px'" id=(concat toolbar--id '-select-name') select-toggle--icon="fas fa-filter"}}
                 Name
               {{/select}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'id="' toolbar--id '-textInput11" name="textInput11" type="search" placeholder="Filter by name..." aria-label="Search input example"')}}
-              {{/form-control}}
-              {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}
-                <i class="fas fa-search" aria-hidden="true"></i>
-              {{/button}}
+              {{> search-input search-input--placeholder="Find by name"}}
             {{/input-group}}
           {{/toolbar-item}}
         {{/toolbar-group}}
@@ -66,14 +62,10 @@ import './Toolbar.css'
       {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
         {{#> toolbar-item}}
           {{#> input-group}}
-            {{#> select select--attribute="style='width: 150px'" id=(concat toolbar--id '-select-name-expanded') select-toggle--icon="fas fa-filter"}}
+            {{#> select select--attribute='style="width: 150px"' id=(concat toolbar--id '-select-name-expanded') select-toggle--icon="fas fa-filter"}}
               Name
             {{/select}}
-            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'id="' toolbar--id '-textInput12" name="textInput11" type="search" placeholder="Filter by name..." aria-label="Search input example"')}}
-            {{/form-control}}
-            {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}
-              <i class="fas fa-search" aria-hidden="true"></i>
-            {{/button}}
+            {{> search-input search-input--placeholder="Find by name" search-input--attribute='style="width: 100%"'}}
           {{/input-group}}
         {{/toolbar-item}}
       {{/toolbar-group}}
@@ -325,11 +317,7 @@ import './Toolbar.css'
                   {{#> select select--attribute="style='width: 150px'" id=(concat toolbar--id '-select-name') select-toggle--icon="fas fa-filter"}}
                     Name
                   {{/select}}
-                  {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'id="' toolbar--id '-textInput11" name="textInput11" type="search" placeholder="Filter by name..." aria-label="Search input example"')}}
-                  {{/form-control}}
-                  {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Search button for search input"'}}
-                    <i class="fas fa-search" aria-hidden="true"></i>
-                  {{/button}}
+                  {{> search-input search-input--placeholder="Find by name"}}
                 {{/input-group}}
               {{/toolbar-item}}
             {{/toolbar-group}}


### PR DESCRIPTION
Fixes #4609 

Replaces form elements used to create a search input with the search input component.
There were additional instances not evident (search input might not have been visible) so there are additional replacements beyond the original list [here](https://docs.google.com/spreadsheets/d/1VXHUw2gfn9lodhie_I8C0nfJUy9j4tf_yRTIxhdmjzc/edit#gid=2024512193). I've added to the bottom of the sheet, but review for corresponding patternfy-react changes is necessary. 