### PR TITLE
chore(spinner): rename examples is SVG is default, non-SVG is legacy

### DIFF
--- a/src/patternfly/components/Spinner/examples/Spinner.md
+++ b/src/patternfly/components/Spinner/examples/Spinner.md
@@ -8,30 +8,10 @@ cssPrefix: pf-c-spinner
 
 ### Basic
 ```hbs
-{{#> spinner}}Loading...{{/spinner}}
-```
-
-### Multiple sizes
-```hbs
-{{#> spinner spinner--modifier="pf-m-sm"}}Loading...{{/spinner}}
-
-{{#> spinner spinner--modifier="pf-m-md"}}Loading...{{/spinner}}
-
-{{#> spinner spinner--modifier="pf-m-lg"}}Loading...{{/spinner}}
-
-{{#> spinner spinner--modifier="pf-m-xl"}}Loading...{{/spinner}}
-```
-<br />
-<br />
-<br />
-## SVG spinner
-
-### SVG spinner basic
-```hbs
 {{#> spinner spinner--IsSvg="true"}}Loading...{{/spinner}}
 ```
 
-### SVG spinner, multiple sizes
+### Sizes
 ```hbs
 {{#> spinner spinner--IsSvg="true" spinner--modifier="pf-m-sm"}}Loading...{{/spinner}}
 
@@ -42,10 +22,27 @@ cssPrefix: pf-c-spinner
 {{#> spinner spinner--IsSvg="true" spinner--modifier="pf-m-xl"}}Loading...{{/spinner}}
 ```
 
-### SVG spinner, custom size
+### Custom size
 ```hbs
 {{#> spinner spinner--IsSvg="true" spinner--attribute='style="--pf-c-spinner--diameter: 80px;"'}}Loading...{{/spinner}}
 ```
+
+### Basic (legacy)
+```hbs
+{{#> spinner}}Loading...{{/spinner}}
+```
+
+### Sizes (legacy)
+```hbs
+{{#> spinner spinner--modifier="pf-m-sm"}}Loading...{{/spinner}}
+
+{{#> spinner spinner--modifier="pf-m-md"}}Loading...{{/spinner}}
+
+{{#> spinner spinner--modifier="pf-m-lg"}}Loading...{{/spinner}}
+
+{{#> spinner spinner--modifier="pf-m-xl"}}Loading...{{/spinner}}
+```
+
 
 ## Documentation
 ### Accessibility
@@ -60,20 +57,21 @@ Note: If the spinner is showing that loading of a particular region of a page is
 
 Note: A [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) must be present before changing its status in order for the change to be read.
 
+
 ### Usage
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-spinner` | `<svg>` |  Creates a spinner component. The default is an extra large spinner. **Required**|
+| `.pf-c-spinner__path` | `<circle>` |  Creates a spinner circle component. **Required**|
+| `--pf-c-spinner--diameter` | `.pf-c-spinner` | Modifies the value for `--pf-c-spinner--diameter` declaration. |
+
+### Usage (legacy)
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-spinner` | `<span>` |  Creates a spinner component. The default is an extra large spinner. **Required**|
 | `.pf-c-spinner__clipper` | `<span>` |  Creates the spinning line. **Required**|
 | `.pf-c-spinner__lead-ball` | `<span>` |  Rounds out the beginning of the spinning line. **Required**|
 | `.pf-c-spinner__tail-ball` | `<span>` |  Rounds out the end of the spinning line. **Required**|
-
-### SVG variant
-| Class | Applied to | Outcome |
-| -- | -- | -- |
-| `.pf-c-spinner` | `<svg>` |  Creates a spinner component. The default is an extra large spinner. **Required**|
-| `.pf-c-spinner__path` | `<circle>` |  Creates a spinner circle component. **Required**|
-| `--pf-c-spinner--diameter` | `.pf-c-spinner` | Modifies the value for `--pf-c-spinner--diameter` declaration. |
 
 ### Modifiers
 | Class | Applied to | Outcome |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4679