### PR TITLE
chore(wizard): update docs/hbs for description to allow div

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -494,7 +494,7 @@ import './Wizard.css'
 | `.pf-c-wizard__header` | `<header>` | Initiates the header. **Required** when the wizard is in a modal. Not recommended to use when the wizard is placed on a page. |
 | `.pf-c-wizard__close` | `.pf-c-button.pf-m-plain` | Initiates the close button. **Required** |
 | `.pf-c-wizard__title` | `.pf-c-title.pf-m-3xl` | Initiates the title. **Required** |
-| `.pf-c-wizard__description` | `<p>` | Initiates the description. |
+| `.pf-c-wizard__description` | `<div>`, `<p>` | Initiates the description. |
 | `.pf-c-wizard__toggle` | `<button>` | Initiates the mobile steps menu toggle button. **Required** |
 | `.pf-c-wizard__toggle-list` | `<span>` | Initiates the toggle list. **Required** |
 | `.pf-c-wizard__toggle-list-item` | `<span>` | Initiates a toggle list item. **Required** |

--- a/src/patternfly/components/Wizard/wizard-description.hbs
+++ b/src/patternfly/components/Wizard/wizard-description.hbs
@@ -1,6 +1,6 @@
-<p class="pf-c-wizard__description{{#if wizard-description--modifier}} {{wizard-description--modifier}}{{/if}}"
+<div class="pf-c-wizard__description{{#if wizard-description--modifier}} {{wizard-description--modifier}}{{/if}}"
   {{#if wizard-description--attribute}}
     {{{wizard-description--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</p>
+</div>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4688

The plan is to add a `component` prop in the react component that will let it be either a `<p>` (default) or a `<div>` - then update it to be a `<div>` by default in our next breaking change.