### PR TITLE
fix(menu toggle): fixed plain menu toggle state

### DIFF
--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -79,10 +79,7 @@
   --pf-c-menu-toggle--m-plain--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-menu-toggle--m-plain--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu-toggle--m-plain--hover--Color: var(--pf-global--Color--100);
-  --pf-c-menu-toggle--m-plain--focus--Color: var(--pf-global--Color--100);
-  --pf-c-menu-toggle--m-plain--active--Color: var(--pf-global--Color--100);
   --pf-c-menu-toggle--m-plain--disabled--Color: var(--pf-global--disabled-color--200);
-  --pf-c-menu-toggle--m-plain--m-expanded--Color: var(--pf-global--Color--100);
 
   // Icon
   --pf-c-menu-toggle__icon--MarginRight: var(--pf-global--spacer--sm);
@@ -212,7 +209,6 @@
       --pf-c-menu-toggle--PaddingRight: var(--pf-c-menu-toggle--m-plain--PaddingRight);
       --pf-c-menu-toggle--PaddingLeft: var(--pf-c-menu-toggle--m-plain--PaddingLeft);
       --pf-c-menu-toggle--disabled--BackgroundColor: transparent;
-      --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
 
       display: inline-block;
 
@@ -225,7 +221,7 @@
       }
 
       &:disabled {
-        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--disabled--Color);
+        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
       }
     }
   }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -217,6 +217,7 @@
       --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
 
       display: inline-block;
+      color: var(--pf-c-menu-toggle__toggle-icon--Color);
     }
   }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -208,8 +208,6 @@
     &:not(.pf-m-text) {
       --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--Color);
       --pf-c-menu-toggle--hover--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-      --pf-c-menu-toggle--focus--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-      --pf-c-menu-toggle--active--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
       --pf-c-menu-toggle--disabled--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
       --pf-c-menu-toggle--PaddingRight: var(--pf-c-menu-toggle--m-plain--PaddingRight);
       --pf-c-menu-toggle--PaddingLeft: var(--pf-c-menu-toggle--m-plain--PaddingLeft);
@@ -217,7 +215,18 @@
       --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
 
       display: inline-block;
-      color: var(--pf-c-menu-toggle__toggle-icon--Color);
+
+      &:hover,
+      &:focus,
+      &:active,
+      &.pf-m-active,
+      &.pf-m-expanded {
+        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
+      }
+
+      &:disabled {
+        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--disabled--Color);
+      }
     }
   }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -79,7 +79,11 @@
   --pf-c-menu-toggle--m-plain--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-menu-toggle--m-plain--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu-toggle--m-plain--hover--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--focus--Color: var(--pf-global--Color--100);
+  --pf-c-menu-toggle--m-plain--active--Color: var(--pf-global--Color--100);
   --pf-c-menu-toggle--m-plain--disabled--Color: var(--pf-global--disabled-color--200);
+  --pf-c-menu-toggle--m-plain--m-expanded--Color: var(--pf-global--Color--100);
+
 
   // Icon
   --pf-c-menu-toggle__icon--MarginRight: var(--pf-global--spacer--sm);
@@ -203,26 +207,12 @@
     --pf-c-menu-toggle__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain__toggle-icon--Color);
 
     &:not(.pf-m-text) {
-      --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--Color);
-      --pf-c-menu-toggle--hover--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-      --pf-c-menu-toggle--disabled--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
       --pf-c-menu-toggle--PaddingRight: var(--pf-c-menu-toggle--m-plain--PaddingRight);
       --pf-c-menu-toggle--PaddingLeft: var(--pf-c-menu-toggle--m-plain--PaddingLeft);
       --pf-c-menu-toggle--disabled--BackgroundColor: transparent;
 
       display: inline-block;
-
-      &:hover,
-      &:focus,
-      &:active,
-      &.pf-m-active,
-      &.pf-m-expanded {
-        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
-      }
-
-      &:disabled {
-        --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
-      }
+      color: var(--pf-c-menu-toggle--m-plain--Color);
     }
   }
 
@@ -231,6 +221,7 @@
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--hover--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--hover--after--BorderBottomColor);
     --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--hover__toggle-icon--Color);
+    --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--hover--Color);
   }
 
   &:focus {
@@ -238,6 +229,7 @@
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--focus--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--focus--after--BorderBottomColor);
     --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--focus__toggle-icon--Color);
+    --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--focus--Color);
   }
 
   &:active {
@@ -245,6 +237,7 @@
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--active--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--active--after--BorderBottomColor);
     --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--active__toggle-icon--Color);
+    --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--active--Color);
   }
 
   &.pf-m-expanded {
@@ -253,11 +246,13 @@
     --pf-c-menu-toggle--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomWidth);
     --pf-c-menu-toggle--after--BorderBottomColor: var(--pf-c-menu-toggle--m-expanded--after--BorderBottomColor);
     --pf-c-menu-toggle--m-plain__toggle-icon--Color: var(--pf-c-menu-toggle--m-plain--m-expanded__toggle-icon--Color);
+    --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
   }
 
   &:disabled {
     --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--disabled--Color);
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--disabled--BackgroundColor);
+    --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
 
     pointer-events: none;
   }


### PR DESCRIPTION
Closes #4630 

This PR fixes the active/hover/focus/expanded/disabled states of the plain menu toggle:
- Declare these styles within the `.pf-c-menu-toggle.pf-m-plain:not(.pf-m-text)` scope to resolve specificity issues.
- Removed three unused variables (which all match `--pf-c-menu-toggle--m-plain--hover--Color`:
  - `--pf-c-menu-toggle--m-plain--focus--Color`
  - `--pf-c-menu-toggle--m-plain--active--Color`
  - `--pf-c-menu-toggle--m-plain--m-expanded--Color`