### PR TITLE
chore(tabs): update tabs demos to use secondary tabs and standard styles

### DIFF
--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -285,7 +285,7 @@ section: components
 ```hbs isFullscreen
 {{#> tabs--page-wrapper tabs--page-wrapper--id="nested-tabs-example"}}
   {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier="pf-m-light"}}
-    {{#> title title--modifier="pf-m-2xl pf-u-mt-md"}}
+    {{#> title title--modifier="pf-m-2xl"}}
       Overview
     {{/title}}
   {{/page-main-section}}
@@ -481,7 +481,7 @@ section: components
           {{#> modal-box-body modal-box-body--attribute=(concat 'id="' example-wrapper--id '-modal-description"')}}
             {{#> grid grid--modifier="pf-m-gutter"}}
               {{#> grid-item}}
-                {{#> tabs tabs--id=(concat example-wrapper--id '-tabs') tabs--modifier="pf-m-no-border-bottom pf-m-inset-none pf-m-secondary"}}
+                {{#> tabs tabs--id=(concat example-wrapper--id '-tabs') tabs--modifier="pf-m-inset-none pf-m-secondary"}}
                   {{#> tabs-list}}
                     {{> __tabs-item
                       __tabs-item--current="true"
@@ -546,7 +546,7 @@ section: components
 ```hbs isFullscreen
 {{#> tabs--page-wrapper tabs--page-wrapper--id="gray-tabs-example"}}
   {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier="pf-m-light"}}
-    {{#> title title--modifier="pf-m-2xl pf-u-mt-md"}}
+    {{#> title title--modifier="pf-m-2xl"}}
       Overview
     {{/title}}
   {{/page-main-section}}

--- a/src/patternfly/demos/Tabs/templates/tabs--page-grid-view.hbs
+++ b/src/patternfly/demos/Tabs/templates/tabs--page-grid-view.hbs
@@ -2,7 +2,7 @@
   {{#> grid-item grid-item--modifier="pf-m-6-col-on-md pf-m-8-col-on-xl"}}
     {{#> card card--modifier="pf-m-full-height"}}
       {{#> card-header}}
-        {{#> title titleType="h2" title--modifier="pf-m-lg pf-u-font-weight-light"}}
+        {{#> title titleType="h2" title--modifier="pf-m-lg"}}
           Status
         {{/title}}
       {{/card-header}}
@@ -10,7 +10,7 @@
         {{#> wrapper newcontext tabs--page-grid-view--id=(concat tabs--page-grid-view--id "-subtabs")}}
           {{#> l-flex l-flex--modifier="pf-m-column"}}
             {{#> l-flex-item}}
-              {{#> tabs tabs--id=tabs--page-grid-view--id tabs--modifier="pf-m-no-border-bottom"}}
+              {{#> tabs tabs--IsSecondary="true" tabs--id=tabs--page-grid-view--id}}
                 {{#> tabs-list}}
                   {{> __tabs-item
                     __tabs-item--current="true"
@@ -64,7 +64,7 @@
       {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
         {{#> card card--modifier="pf-m-full-height"}}
           {{#> card-header}}
-            {{#> title titleType="h3" title--modifier="pf-m-lg pf-u-font-weight-light"}}
+            {{#> title titleType="h3" title--modifier="pf-m-lg"}}
               Title of card
             {{/title}}
           {{/card-header}}
@@ -73,7 +73,7 @@
       {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
         {{#> card card--modifier="pf-m-full-height"}}
           {{#> card-header}}
-            {{#> title titleType="h3" title--modifier="pf-m-lg pf-u-font-weight-light"}}
+            {{#> title titleType="h3" title--modifier="pf-m-lg"}}
               Title of card
             {{/title}}
           {{/card-header}}


### PR DESCRIPTION
Closes #4615 

This PR:
- Replaces `.pf-m-no-border-bottom` with secondary tabs in the Grey tabs demo
- Removes unncessary `.pf-m-no-border-bottom` class from secondary tabs in Modal tabs demo
- Removes the `.pf-u-font-weight-light` class from the body card headers in the Gray tabs demo
- Removes the `.pf-u-mt-md` manual margin-top from the main h1 in the Nested tabs & Gray tabs demos