### PR TITLE
feat(menu-toggle): added split button

### DIFF
--- a/src/patternfly/components/Check/check-input.hbs
+++ b/src/patternfly/components/Check/check-input.hbs
@@ -2,4 +2,7 @@
   type="checkbox"
   {{#if check-input--attribute}}
     {{{check-input--attribute}}}
+  {{/if}}
+  {{#if check--IsDisabled}}
+    disabled
   {{/if}}>

--- a/src/patternfly/components/Check/check-label.hbs
+++ b/src/patternfly/components/Check/check-label.hbs
@@ -1,6 +1,6 @@
-<{{#if check-label--type}}{{check-label--type}}{{else}}label{{/if}} class="pf-c-check__label{{#if check-label--modifier}} {{check-label--modifier}}{{/if}}"
+<{{#if check-label--type}}{{check-label--type}}{{else}}label{{/if}} class="pf-c-check__label{{#if check-label--IsDisabled}} pf-m-disabled{{/if}}{{#if check-label--modifier}} {{check-label--modifier}}{{/if}}"
   {{#if check-label--attribute}}
     {{{check-label--attribute}}}
   {{/if}}>
-  {{>@partial-block}}
+  {{> @partial-block}}
 </{{#if check-label--type}}{{check-label--type}}{{else}}label{{/if}}>

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -8,6 +8,263 @@ cssPrefix: pf-c-menu-toggle
 import './MenuToggle.css'
 
 ## Examples
+### Split button (checkbox)
+```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-example" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-expanded-example" menu-toggle--IsExpanded="true" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button (checkbox with toggle text)
+```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-example" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+
+### Split button, primary
+```hbs
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-example" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button, secondary
+```hbs
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-example" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button (action)
+```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-action-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-action-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-action-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button, primary (action)
+```hbs
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-with-toggle-action-primary-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-with-toggle-action-primary-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-with-toggle-action-primary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button, secondary (action)
+```hbs
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-with-toggle-action-secondary-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-with-toggle-action-secondary-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-with-toggle-action-secondary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsAction="true" menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-button}}
+    Action
+  {{/menu-toggle-button}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
 ### Collapsed
 ```hbs
 {{#> menu-toggle}}
@@ -273,10 +530,10 @@ import './MenuToggle.css'
 ### Accessibility
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `aria-expanded="true"` | `.pf-c-menu-toggle` | Indicates that the menu toggle component is in the expanded state. |
-| `aria-expanded="false"` | `.pf-c-menu-toggle` | Indicates that the menu toggle component is in the collapsed state. |
+| `aria-expanded="true"` | `.pf-c-menu-toggle`, `.pf-c-menu-toggle__button` | Indicates that the menu toggle component is in the expanded state. |
+| `aria-expanded="false"` | `.pf-c-menu-toggle`, `.pf-c-menu-toggle__button` | Indicates that the menu toggle component is in the collapsed state. |
 | `aria-label="Descriptive text"` | `.pf-c-menu-toggle.pf-m-plain` | Gives the plain menu toggle component an accessible label. |
-| `disabled` | `.pf-c-menu-toggle` | Indicates that the menu toggle component is disabled. |
+| `disabled` | `.pf-c-menu-toggle`, `.pf-c-menu-toggle__button` | Indicates that the menu toggle component is disabled. |
 
 ### Usage
 
@@ -288,6 +545,10 @@ import './MenuToggle.css'
 | `.pf-c-menu-toggle__count` | `<span>` | Defines the menu toggle component count. |
 | `.pf-c-menu-toggle__controls` | `<span>` | Defines the menu toggle component controls. |
 | `.pf-c-menu-toggle__toggle-icon` | `<span>` | Defines the menu toggle component toggle/arrow icon. |
+| `.pf-c-menu-toggle__button` | `<button>` | Initiates the menu toggle button. |
+| `.pf-m-split-button` | `.pf-c-menu-toggle` | Modifies the menu toggle component for the split button variation. |
+| `.pf-m-action` | `.pf-c-menu-toggle.pf-m-split-button` | Modifies the menu toggle component for the action, split button variation. |
+| `.pf-m-disabled` | `.pf-c-menu-toggle` | Modifies the menu toggle component for the disabled variation. |
 | `.pf-m-primary` | `.pf-c-menu-toggle` | Modifies the menu toggle component for the primary variation. |
 | `.pf-m-secondary` | `.pf-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |
 | `.pf-m-text` | `.pf-c-menu-toggle` | Modifies the menu toggle component for the text variation. |

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -8,6 +8,184 @@ cssPrefix: pf-c-menu-toggle
 import './MenuToggle.css'
 
 ## Examples
+
+### Collapsed
+```hbs
+{{#> menu-toggle}}
+  {{#> menu-toggle-text}}
+    Collapsed
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Expanded
+```hbs
+{{#> menu-toggle menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-text}}
+    Expanded
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Disabled
+```hbs
+{{#> menu-toggle menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-text}}
+    Disabled
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Count
+```hbs
+{{#> menu-toggle}}
+  {{#> menu-toggle-text}}
+    Count
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-count}}
+    {{#> badge badge--modifier="pf-m-unread"}}
+      4 selected
+    {{/badge}}
+  {{/menu-toggle-count}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Primary
+```hbs
+{{#> menu-toggle menu-toggle--IsPrimary="true"}}
+  {{#> menu-toggle-text}}
+    Collapsed
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPrimary="true"}}
+  {{#> menu-toggle-icon}}
+    <i class="fas fa-cog" aria-hidden="true"></i>
+  {{/menu-toggle-icon}}
+  {{#> menu-toggle-text}}
+    Icon
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPrimary="true" menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-text}}
+    Expanded
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPrimary="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-text}}
+    Disabled
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Secondary
+```hbs
+{{#> menu-toggle menu-toggle--IsSecondary="true"}}
+  {{#> menu-toggle-text}}
+    Collapsed
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsSecondary="true" menu-toggle--IsExpanded="true"}}
+  {{#> menu-toggle-text}}
+    Expanded
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsSecondary="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-text}}
+    Disabled
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
+### Plain
+```hbs
+{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--attribute='aria-label="Actions"'}}
+  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsExpanded="true" menu-toggle--attribute='aria-label="Actions"'}}
+  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsDisabled="true" menu-toggle--attribute='aria-label="Actions"'}}
+  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
+{{/menu-toggle}}
+```
+
+### Plain with text
+```hbs
+{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true" menu-toggle--IsDisabled="true"}}
+  {{#> menu-toggle-text}}
+    Disabled
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true"}}
+  {{#> menu-toggle-text}}
+    Custom text
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
 ### Split button (checkbox)
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsSplitButton="true"}}
@@ -262,183 +440,6 @@ import './MenuToggle.css'
       {{> menu-toggle-toggle-icon}}
     {{/menu-toggle-controls}}
   {{/menu-toggle-button}}
-{{/menu-toggle}}
-```
-
-### Collapsed
-```hbs
-{{#> menu-toggle}}
-  {{#> menu-toggle-text}}
-    Collapsed
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Expanded
-```hbs
-{{#> menu-toggle menu-toggle--IsExpanded="true"}}
-  {{#> menu-toggle-text}}
-    Expanded
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Disabled
-```hbs
-{{#> menu-toggle menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-text}}
-    Disabled
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Count
-```hbs
-{{#> menu-toggle}}
-  {{#> menu-toggle-text}}
-    Count
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-count}}
-    {{#> badge badge--modifier="pf-m-unread"}}
-      4 selected
-    {{/badge}}
-  {{/menu-toggle-count}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Primary
-```hbs
-{{#> menu-toggle menu-toggle--IsPrimary="true"}}
-  {{#> menu-toggle-text}}
-    Collapsed
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPrimary="true"}}
-  {{#> menu-toggle-icon}}
-    <i class="fas fa-cog" aria-hidden="true"></i>
-  {{/menu-toggle-icon}}
-  {{#> menu-toggle-text}}
-    Icon
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPrimary="true" menu-toggle--IsExpanded="true"}}
-  {{#> menu-toggle-text}}
-    Expanded
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPrimary="true" menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-text}}
-    Disabled
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Secondary
-```hbs
-{{#> menu-toggle menu-toggle--IsSecondary="true"}}
-  {{#> menu-toggle-text}}
-    Collapsed
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsSecondary="true" menu-toggle--IsExpanded="true"}}
-  {{#> menu-toggle-text}}
-    Expanded
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsSecondary="true" menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-text}}
-    Disabled
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-```
-
-### Plain
-```hbs
-{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--attribute='aria-label="Actions"'}}
-  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsExpanded="true" menu-toggle--attribute='aria-label="Actions"'}}
-  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsDisabled="true" menu-toggle--attribute='aria-label="Actions"'}}
-  <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
-{{/menu-toggle}}
-```
-
-### Plain with text
-```hbs
-{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true" menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-text}}
-    Disabled
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-
-&nbsp;
-
-{{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true"}}
-  {{#> menu-toggle-text}}
-    Custom text
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 

--- a/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
@@ -1,0 +1,16 @@
+{{#> id-wrapper menu-toggle--check--id=menu-toggle--id}}
+  {{#if menu-toggle--check--IsStandalone}}
+    {{#> check check--type="label" check--modifier="pf-m-standalone" check--IsDisabled=menu-toggle--IsDisabled}}
+      {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input" aria-label="Standalone input"')}}
+    {{/check}}
+  {{else}}
+    {{#> check check--type="label" check--attribute=(concat 'for="' menu-toggle--check--id '-input"') check--IsDisabled=menu-toggle--IsDisabled}}
+      {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input"')}}
+      {{#if menu-toggle--check--text}}
+        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}{{menu-toggle--check--text}}{{/check-label}}
+      {{else}}
+        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}Label{{/check-label}}
+      {{/if}}
+    {{/check}}
+  {{/if}}
+{{/id-wrapper}}

--- a/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
@@ -1,0 +1,22 @@
+<button class="pf-c-menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}}"
+  type="button"
+  {{#if menu-toggle-button--IsToggle}}
+    aria-expanded="{{#if menu-toggle--IsExpanded}}true{{else}}false{{/if}}"
+    id="{{menu-toggle--id}}-toggle-button"
+    aria-label="Menu toggle"
+  {{/if}}
+  {{#if menu-toggle--IsDisabled}}
+    disabled
+  {{/if}}
+  {{#if menu-toggle-button--IsDisabled}}
+    disabled
+  {{/if}}
+  {{#if menu-toggle-button--attribute}}
+    {{{menu-toggle-button--attribute}}}
+  {{/if}}>
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{else}}
+    <i class="fas fa-caret-down" aria-hidden="true"></i>
+  {{/if}}
+</button>

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -26,9 +26,6 @@
   {{#if menu-toggle--modifier}} {{menu-toggle--modifier}}{{/if}}"
   {{#unless menu-toggle--IsSplitButton}}
     type="button"
-    {{#if menu-toggle--IsDisabled}}
-      disabled
-    {{/if}}
     {{#if menu-toggle--IsExpanded}}
       aria-expanded="true"
     {{else}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -1,4 +1,4 @@
-<button class="pf-c-menu-toggle
+<{{#if menu-toggle--IsSplitButton}}div{{else}}button{{/if}} class="pf-c-menu-toggle
   {{~#if menu-toggle--IsPrimary}}
     pf-m-primary
   {{/if}}
@@ -14,18 +14,32 @@
   {{~#if menu-toggle--IsExpanded}}
     pf-m-expanded
   {{/if}}
+  {{~#if menu-toggle--IsAction}}
+    pf-m-action
+  {{/if}}
+  {{#if menu-toggle--IsSplitButton}}
+    pf-m-split-button
+    {{~#if menu-toggle--IsDisabled}}
+      pf-m-disabled
+    {{/if}}
+  {{/if}}
   {{#if menu-toggle--modifier}} {{menu-toggle--modifier}}{{/if}}"
-  type="button"
-  {{#if menu-toggle--IsExpanded}}
-    aria-expanded="true"
-  {{else}}
-    aria-expanded="false"
-  {{/if}}
-  {{~#if menu-toggle--IsDisabled}}
-    disabled
-  {{/if}}
+  {{#unless menu-toggle--IsSplitButton}}
+    type="button"
+    {{#if menu-toggle--IsDisabled}}
+      disabled
+    {{/if}}
+    {{#if menu-toggle--IsExpanded}}
+      aria-expanded="true"
+    {{else}}
+      aria-expanded="false"
+    {{/if}}
+    {{~#if menu-toggle--IsDisabled}}
+      disabled
+    {{/if}}
+  {{/unless}}
   {{#if menu-toggle--attribute}}
     {{{menu-toggle--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</button>
+</{{#if menu-toggle--IsSplitButton}}div{{else}}button{{/if}}>

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -111,6 +111,43 @@
   --pf-c-menu-toggle--m-full-height--focus--after--BorderBottomWidth: var(--pf-global--BorderWidth--xl);
   --pf-c-menu-toggle--m-full-height--active--after--BorderBottomWidth: var(--pf-global--BorderWidth--xl);
 
+  // Split button
+  --pf-c-menu-toggle--m-split-button--BackgroundColor: var(--pf-global--BackgroundColor--100);
+
+  // Split button, child
+  --pf-c-menu-toggle--m-split-button--child--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-menu-toggle--m-split-button--child--disabled--Color: var(--pf-global--Color--dark-200);
+  --pf-c-menu-toggle--m-split-button--child--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
+
+  // Split button, action
+  --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: var(--pf-global--BorderColor--300);
+  --pf-c-menu-toggle--m-split-button--m-action--child--after--Left: 0;
+  --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomColor: var(--pf-global--BorderColor--200);
+  --pf-c-menu-toggle--m-split-button--m-action--child--hover--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-menu-toggle--m-split-button--m-action--child--hover--after--BorderBottomColor: var(--pf-global--active-color--100);
+  --pf-c-menu-toggle--m-split-button--m-action--child--focus--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-menu-toggle--m-split-button--m-action--child--focus--after--BorderBottomColor: var(--pf-global--active-color--100);
+  --pf-c-menu-toggle--m-split-button--m-action--child--active--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-menu-toggle--m-split-button--m-action--child--active--after--BorderBottomColor: var(--pf-global--active-color--100);
+  --pf-c-menu-toggle--m-split-button--m-action--child--BorderRadius: var(--pf-global--BorderRadius--sm);
+
+  // Split button action, primary
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-global--primary-color--100);
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--hover--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--focus--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--active--BackgroundColor: var(--pf-global--primary-color--200);
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BorderLeftColor: var(--pf-global--primary-color--200);
+  --pf-c-menu-toggle--m-split-button--m-action--m-primary--m-expanded--child--BackgroundColor: var(--pf-global--primary-color--200);
+
+  // Split button action, secondary
+  --pf-c-menu-toggle--m-split-button--m-action--m-secondary--child--BorderLeftColor: var(--pf-global--primary-color--100);
+
+  // Split button, controls, check
+  --pf-c-menu-toggle__button__controls--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__button__controls--MarginLeft: var(--pf-global--spacer--sm);
+
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -153,7 +190,6 @@
     --pf-c-menu-toggle--active--BackgroundColor: var(--pf-c-menu-toggle--m-primary--active--BackgroundColor);
     --pf-c-menu-toggle--m-expanded--Color: var(--pf-c-menu-toggle--m-primary--m-expanded--Color);
     --pf-c-menu-toggle--m-expanded--BackgroundColor: var(--pf-c-menu-toggle--m-primary--m-expanded--BackgroundColor);
-
 
     &,
     &::before {
@@ -246,7 +282,8 @@
     --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--m-expanded--Color);
   }
 
-  &:disabled {
+  &:disabled,
+  &.pf-m-disabled {
     --pf-c-menu-toggle--Color: var(--pf-c-menu-toggle--disabled--Color);
     --pf-c-menu-toggle--BackgroundColor: var(--pf-c-menu-toggle--disabled--BackgroundColor);
     --pf-c-menu-toggle--m-plain--Color: var(--pf-c-menu-toggle--m-plain--disabled--Color);
@@ -273,6 +310,159 @@
     --pf-c-menu-toggle--active--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-full-height--active--after--BorderBottomWidth);
 
     height: 100%;
+  }
+
+  &.pf-m-split-button {
+    --pf-c-menu-toggle__toggle-icon--MarginRight: 0;
+
+    padding: 0; // pass padding to children
+
+    > * {
+      position: relative;
+      padding: var(--pf-c-menu-toggle--PaddingTop) var(--pf-c-menu-toggle--PaddingRight) var(--pf-c-menu-toggle--PaddingBottom) var(--pf-c-menu-toggle--PaddingLeft);
+
+      &.pf-c-check {
+        --pf-c-menu-toggle--PaddingRight: 0;
+      }
+    }
+
+    > .pf-c-check {
+      --pf-c-check__input--MarginTop: 0;
+      --pf-c-check__label--Color: inherit;
+
+      align-items: center;
+      align-self: stretch;
+    }
+
+    // Split button, active
+    &.pf-m-action {
+      // stylelint-disable max-nesting-depth
+      &:where(:not(.pf-m-primary, .pf-m-secondary, .pf-m-disabled)) > * {
+        &::after {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: var(--pf-c-menu-toggle--m-split-button--m-action--child--after--Left);
+          pointer-events: none;
+          content: "";
+          border-bottom: var(--pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth) solid var(--pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomColor);
+        }
+
+        &:hover {
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-split-button--m-action--child--hover--after--BorderBottomWidth);
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomColor: var(--pf-c-menu-toggle--m-split-button--m-action--child--hover--after--BorderBottomColor);
+        }
+
+        &:focus {
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-split-button--m-action--child--focus--after--BorderBottomWidth);
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomColor: var(--pf-c-menu-toggle--m-split-button--m-action--child--focus--after--BorderBottomColor);
+        }
+
+        &:active,
+        &.pf-m-active {
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: var(--pf-c-menu-toggle--m-split-button--m-action--child--active--after--BorderBottomWidth);
+          --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomColor: var(--pf-c-menu-toggle--m-split-button--m-action--child--active--after--BorderBottomColor);
+        }
+      }
+      // stylelint-enable
+
+      // Split button, primary
+      &.pf-m-primary {
+        --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BorderLeftColor);
+        --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: 0;
+
+        // stylelint-disable max-nesting-depth, selector-max-class
+        > :where(:not(.pf-m-disabled):not([disabled])) {
+          background-color: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor);
+
+          &:hover {
+            --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--child--hover--BackgroundColor);
+          }
+
+          &:focus {
+            --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--child--focus--BackgroundColor);
+          }
+
+          &:active,
+          &.pf-m-active {
+            --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--child--active--BackgroundColor);
+          }
+        }
+
+        &.pf-m-expanded {
+          --pf-c-menu-toggle--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-primary--m-expanded--child--BackgroundColor);
+        }
+        // stylelint-enable
+      }
+
+      // Split button, secondary
+      &.pf-m-secondary {
+        --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: var(--pf-c-menu-toggle--m-split-button--m-action--m-secondary--child--BorderLeftColor);
+      }
+
+      &.pf-m-primary,
+      &.pf-m-secondary {
+        --pf-c-menu-toggle--m-split-button--m-action--child--after--BorderBottomWidth: 0;
+
+        // stylelint-disable max-nesting-depth
+        > :first-child {
+          border-top-left-radius: var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderRadius);
+          border-bottom-left-radius: var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderRadius);
+        }
+
+        > :last-child {
+          border-top-right-radius: var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderRadius);
+          border-bottom-right-radius: var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderRadius);
+        }
+
+        // enable-disable
+      }
+
+      // all subsequent buttons
+      > :not(:first-child) {
+        --pf-c-menu-toggle--m-split-button--m-action--child--after--Left: calc(var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftWidth) * -1);
+
+        border-left: var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftWidth) solid var(--pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor);
+      }
+
+      &:not(.pf-m-expanded) {
+        --pf-c-menu-toggle--after--BorderBottomColor: transparent; // leave bottom border unchanged for expanded state
+      }
+    }
+
+    // disable accent border
+    &.pf-m-disabled,
+    &[disabled] {
+      --pf-c-menu-toggle--m-split-button--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--child--disabled--BackgroundColor);
+      --pf-c-menu-toggle--m-split-button--child--Color: var(--pf-c-menu-toggle--m-split-button--child--disabled--Color);
+      --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: transparent;
+
+      &::before,
+      &::after {
+        content: none;
+      }
+    }
+
+    // disabled styles for children
+    > [disabled],
+    > .pf-m-disabled {
+      --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: transparent;
+
+      color: var(--pf-c-menu-toggle--m-split-button--child--disabled--Color);
+      background-color: var(--pf-c-menu-toggle--m-split-button--child--disabled--BackgroundColor);
+    }
+  }
+}
+
+.pf-c-menu-toggle__button {
+  color: inherit;
+  border: 0;
+
+  .pf-c-menu-toggle__controls {
+    padding-left: 0;
+    margin-right: var(--pf-c-menu-toggle__button__controls--MarginRight);
+    margin-left: var(--pf-c-menu-toggle__button__controls--MarginLeft);
   }
 }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -118,6 +118,8 @@
   --pf-c-menu-toggle--m-split-button--child--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-menu-toggle--m-split-button--child--disabled--Color: var(--pf-global--Color--dark-200);
   --pf-c-menu-toggle--m-split-button--child--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
+  --pf-c-menu-toggle--m-split-button--first-child--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle--m-split-button--last-child--PaddingLeft: 0;
 
   // Split button, action
   --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
@@ -321,14 +323,21 @@
       position: relative;
       padding: var(--pf-c-menu-toggle--PaddingTop) var(--pf-c-menu-toggle--PaddingRight) var(--pf-c-menu-toggle--PaddingBottom) var(--pf-c-menu-toggle--PaddingLeft);
 
-      &.pf-c-check {
-        --pf-c-menu-toggle--PaddingRight: 0;
+      &:first-child {
+        padding-right: var(--pf-c-menu-toggle--m-split-button--first-child--PaddingRight);
+      }
+    }
+
+    &:where(:not(.pf-m-action)) {
+      > :last-child {
+        padding-left: var(--pf-c-menu-toggle--m-split-button--last-child--PaddingLeft);
       }
     }
 
     > .pf-c-check {
+      --pf-c-menu-toggle--PaddingRight: 0;
       --pf-c-check__input--MarginTop: 0;
-      --pf-c-check__label--Color: inherit;
+      --pf-c-check__label--Color: var(--pf-c-check__label--Color, inherit);
 
       align-items: center;
       align-self: stretch;
@@ -433,7 +442,7 @@
 
     // disable accent border
     &.pf-m-disabled,
-    &[disabled] {
+    &:disabled {
       --pf-c-menu-toggle--m-split-button--child--BackgroundColor: var(--pf-c-menu-toggle--m-split-button--child--disabled--BackgroundColor);
       --pf-c-menu-toggle--m-split-button--child--Color: var(--pf-c-menu-toggle--m-split-button--child--disabled--Color);
       --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: transparent;
@@ -445,8 +454,8 @@
     }
 
     // disabled styles for children
-    > [disabled],
-    > .pf-m-disabled {
+    > .pf-m-disabled,
+    > :disabled {
       --pf-c-menu-toggle--m-split-button--m-action--child--BorderLeftColor: transparent;
 
       color: var(--pf-c-menu-toggle--m-split-button--child--disabled--Color);


### PR DESCRIPTION
closes #4612 

There are some differences between this and dropdown.
- The target are for `pf-c-menu-toggle__button` is larger than that of `pf-c-dropdown`. Ideally, it would be at least `44px` wide, but that looks a bit odd. 
- `pf-c-dropdown` doesn't support `pf-m-secondary`, `menu-toggle` does and presents an example.
- The interactions are the same