### PR TITLE
chore(form): improve accessible label on form elements in examples/demos

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -13,7 +13,7 @@ cssPrefix: pf-c-form
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
         Name
       {{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -40,7 +40,7 @@ cssPrefix: pf-c-form
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
         Information
       {{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for information field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Textarea example"')}}{{/form-control}}
@@ -51,7 +51,7 @@ cssPrefix: pf-c-form
       {{#> form-label}}
         Label (no top padding)
       {{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for label field" form-group-label-help--aria-describedby=(concat form--id form-group--id '-legend')}}
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
       {{#> check}}
@@ -75,7 +75,7 @@ cssPrefix: pf-c-form
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
         Name
       {{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -222,7 +222,7 @@ cssPrefix: pf-c-form
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
           Name
         {{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
         info
@@ -255,7 +255,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label1"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -264,7 +264,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label2"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -310,7 +310,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -319,7 +319,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -363,7 +363,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -372,7 +372,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -415,7 +415,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -424,7 +424,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -442,7 +442,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -451,7 +451,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -474,7 +474,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -483,7 +483,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -516,7 +516,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -525,7 +525,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -536,7 +536,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label3"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 3{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 3 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -545,7 +545,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label4"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 4{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 4 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -570,10 +570,12 @@ cssPrefix: pf-c-form
 | `id` | `.pf-c-form__group-label` | Generates an `id` for use in the `aria-labelledby` attribute in a checkbox or radio form group. |
 | `id` | `.pf-c-form__field-group-title-text` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |
 | `id` | `.pf-c-form__field-group-toggle-button > button` | Generates an `id` for use in the `aria-labelledby` attribute in an expandable field group's toggle button. |
-| `aria-labelledby="{label id}"` | `.pf-c-form__group`, `.pf-c-form__section`, `.pf-c-form__field-group` | Provides an accessible label for form groups, form sections, and form field groups. |**Required for form groups, form sections, and form field groups that contain labels.** |
+| `aria-labelledby="{label id}"` | `.pf-c-form__group`, `.pf-c-form__section`, `.pf-c-form__field-group` | Provides an accessible label for form groups, form sections, and form field groups. **Required for form groups, form sections, and form field groups that contain labels.** |
 | `aria-label` | `.pf-c-form__field-group-toggle-button > button` | Provides an accessible label for the field group toggle button. |
 | `aria-labelledby="{title id} {toggle button id}"` | `.pf-c-form__field-group-toggle-button > button` | Provides an accessible label for the field group toggle button. |
 | `aria-expanded="true/false"` | `.pf-c-form__field-group-toggle-button > button` | Indicates whether the field group body is visible or hidden. |
+| `id="{form_label_id}"` | `.pf-c-form__label` |  Generates an `id` for use in the `aria-describedby` attribute in a `.pf-c-form__group-label-help`. |
+| `aria-label="{descriptive text}" aria-describedby="{form_label_id}"` | `.pf-c-form__group-label-help` |  Provides an accessible label on a button that provides additional information for a form element. |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -196,7 +196,7 @@ cssPrefix: pf-c-form
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
-  {{#> form-group form-group--id="info"}}
+  {{#> form-group form-group--id="-info"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}
         Information
@@ -254,7 +254,7 @@ cssPrefix: pf-c-form
 {{#> form form--id="form-expandable-field-groups"}}
   {{#> form-group form-group--id="-label1"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
       {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
@@ -309,7 +309,7 @@ cssPrefix: pf-c-form
         {{#> form-field-group-body}}
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
               {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
@@ -362,7 +362,7 @@ cssPrefix: pf-c-form
       {{/reset}}
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
           {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -69,7 +69,7 @@ cssPrefix: pf-c-form
 
 ### Horizontal layout at a custom breakpoint
 ```hbs
-{{#> form form--modifier="pf-m-horizontal-on-sm" form--id="form-horizontal"}}
+{{#> form form--modifier="pf-m-horizontal-on-sm" form--id="form-horizontal-custom-breakpoint"}}
   {{#> form-group form-group--id="-name"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
@@ -254,8 +254,8 @@ cssPrefix: pf-c-form
 {{#> form form--id="form-expandable-field-groups"}}
   {{#> form-group form-group--id="-label1"}}
     {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -264,7 +264,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label2"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -309,8 +309,8 @@ cssPrefix: pf-c-form
         {{#> form-field-group-body}}
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -319,7 +319,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -362,8 +362,8 @@ cssPrefix: pf-c-form
       {{/reset}}
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}label 1{{/form-label}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -372,7 +372,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -415,7 +415,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -424,7 +424,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -442,7 +442,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -451,7 +451,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -474,7 +474,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -483,7 +483,7 @@ cssPrefix: pf-c-form
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
             {{#> form-group-label}}
               {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+              {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
               {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -516,7 +516,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -525,7 +525,7 @@ cssPrefix: pf-c-form
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for Label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+          {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -536,7 +536,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label3"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 3{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 3 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for label 3 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -545,7 +545,7 @@ cssPrefix: pf-c-form
   {{#> form-group form-group--id="-label4"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 4{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for Label 4 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for label 4 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}

--- a/src/patternfly/components/Form/form-group-label-help.hbs
+++ b/src/patternfly/components/Form/form-group-label-help.hbs
@@ -1,5 +1,6 @@
 <button class="pf-c-form__group-label-help{{#if form-group-label-help--modifier}} {{form-group-label-help--modifier}}{{/if}}"
-  aria-label="More info"
+  aria-label="{{#if form-group-label-help--aria-label}}{{form-group-label-help--aria-label}}{{else}}More information{{/if}}"
+  {{#if form-group-label-help--aria-describedby}} aria-describedby='{{form-group-label-help--aria-describedby}}'{{/if}}
   {{#if form-group-label-help--attribute}}
     {{{form-group-label-help--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Form/form-group-label-help.hbs
+++ b/src/patternfly/components/Form/form-group-label-help.hbs
@@ -1,5 +1,5 @@
 <button class="pf-c-form__group-label-help{{#if form-group-label-help--modifier}} {{form-group-label-help--modifier}}{{/if}}"
-  aria-label="{{#if form-group-label-help--aria-label}}{{form-group-label-help--aria-label}}{{else}}More information{{/if}}"
+  aria-label="{{#if form-group-label-help--aria-label}}{{form-group-label-help--aria-label}}{{else if form-group--id}}More information for {{form-group--id}}{{else}}More information{{/if}}"
   {{#if form-group-label-help--aria-describedby}} aria-describedby="{{form-group-label-help--aria-describedby}}"{{/if}}
   {{#if form-group-label-help--attribute}}
     {{{form-group-label-help--attribute}}}

--- a/src/patternfly/components/Form/form-group-label-help.hbs
+++ b/src/patternfly/components/Form/form-group-label-help.hbs
@@ -1,6 +1,6 @@
 <button class="pf-c-form__group-label-help{{#if form-group-label-help--modifier}} {{form-group-label-help--modifier}}{{/if}}"
   aria-label="{{#if form-group-label-help--aria-label}}{{form-group-label-help--aria-label}}{{else}}More information{{/if}}"
-  {{#if form-group-label-help--aria-describedby}} aria-describedby='{{form-group-label-help--aria-describedby}}'{{/if}}
+  {{#if form-group-label-help--aria-describedby}} aria-describedby="{{form-group-label-help--aria-describedby}}"{{/if}}
   {{#if form-group-label-help--attribute}}
     {{{form-group-label-help--attribute}}}
   {{/if}}>

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -27,7 +27,7 @@ section: components
   {{#> form-group form-group--id="-phone"}}
     {{#> form-group-label}}
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Phone number{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for phone number field"  form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="tel" placeholder="Example, (555) 555-5555" id="' form--id form-group--id '" name="' form--id form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
@@ -120,7 +120,7 @@ section: components
    {{#> form-group form-group--IsCheckGroup="true" form-group--id="-contact"}}
     {{#> form-group-label form-group-label--modifier="pf-m-no-padding-top"}}
       {{#> form-label }}How can we contact you?{{/form-label}}
-      {{> form-group-label-help}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for contact field" form-group-label-help--aria-describedby=(concat form--id form-group--id '-legend')}}
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
       {{#> check}}
@@ -293,7 +293,7 @@ section: components
     {{#> form-group form-group--id="-clientid"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Client ID{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for client id field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
@@ -302,7 +302,7 @@ section: components
     {{#> form-group form-group--id="-name"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Full name{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for full name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
@@ -311,7 +311,7 @@ section: components
     {{#> form-group form-group--id="-description"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Description{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for description field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
@@ -325,7 +325,7 @@ section: components
     {{#> form-group form-group--id="-rooturl"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Root URL{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for root URL field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
@@ -334,7 +334,7 @@ section: components
     {{#> form-group form-group--id="-uris"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'id="' form--id form-group--id '"') required="true"}}Valid redirect URIs{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for valid redirect URIs field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
         {{#> input-group}}
@@ -366,7 +366,7 @@ section: components
     {{#> form-group form-group--id="-home-url"}}
       {{#> form-group-label}}
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Home URL{{/form-label}}
-        {{> form-group-label-help}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for home URL field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label}}
       {{#> form-group-control}}
         {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -198,7 +198,7 @@ section: components
                 {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
                   Name
                 {{/form-label}}
-                {{> form-group-label-help}}
+                {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
               {{/form-group-label}}
               {{#> form-group-control}}
                 {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -209,7 +209,7 @@ section: components
                 {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
                   E-mail
                 {{/form-label}}
-                {{> form-group-label-help}}
+                {{> form-group-label-help form-group-label-help--aria-label="More information for email field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
               {{/form-group-label}}
               {{#> form-group-control}}
                 {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
@@ -220,7 +220,7 @@ section: components
                 {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}
                   Address
                 {{/form-label}}
-                {{> form-group-label-help}}
+                {{> form-group-label-help form-group-label-help--aria-label="More information for address field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
               {{/form-group-label}}
               {{#> form-group-control}}
                 {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}

--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -9,18 +9,18 @@ section: demos
 
 ```hbs
 {{#> form form--id="password-generator-demo--initial"}}
-  {{#> form-group}}
+  {{#> form-group form-group--id="-password"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
-            {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
-        {{> form-group-label-help}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> input-group}}
-          {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="password" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
+          {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="password" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
         {{/form-control}}
         {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
           <i class="fas fa-eye" aria-hidden="true"></i>

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -9,18 +9,18 @@ section: demos
 ### Initial state
 ```hbs
 {{#> form form--id="password-strength-demo--initial"}}
-  {{#> form-group}}
+  {{#> form-group form-group--id="-password"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
-            {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
-        {{> form-group-label-help}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> input-group}}
-          {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="" placeholder="Password"')}}
+          {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
         {{/form-control}}
         {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
           <i class="fas fa-eye-slash" aria-hidden="true"></i>
@@ -50,18 +50,18 @@ section: demos
 ### Invalid password
 ```hbs
 {{#> form  form--id="password-strength-demo--invalid"}}
-  {{#> form-group}}
+  {{#> form-group form-group--id="-password"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
-            {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
-        {{> form-group-label-help}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> input-group}}
-        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$RedHat78" placeholder="Password"')}}
+        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$RedHat78" placeholder="Password"')}}
         {{/form-control}}
         {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
           <i class="fas fa-eye-slash" aria-hidden="true"></i>
@@ -91,11 +91,11 @@ section: demos
 ### Valid, weak password
 ```hbs
 {{#> form  form--id="password-strength-demo--weak"}}
-  {{#> form-group}}
+  {{#> form-group form-group--id="-password"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
-            {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
-        {{> form-group-label-help}}
+            {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
         {{#> helper-text}}
@@ -108,7 +108,7 @@ section: demos
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> input-group}}
-        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$Can3Read" placeholder="Password"')}}
+        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can3Read" placeholder="Password"')}}
         {{/form-control}}
         {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
           <i class="fas fa-eye-slash" aria-hidden="true"></i>
@@ -138,11 +138,11 @@ section: demos
 ### Valid, strong password
 ```hbs
 {{#> form  form--id="password-strength-demo--strong"}}
-  {{#> form-group}}
+  {{#> form-group form-group--id="-password"}}
     {{#> form-group-label form-group-label-info="true"}}
       {{#> form-group-label-main}}
-        {{#> form-label form-label--attribute=(concat 'for="' form--id '-password"') required="true"}}Password{{/form-label}}
-        {{> form-group-label-help}}
+        {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
+        {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
         {{#> helper-text}}
@@ -155,7 +155,7 @@ section: demos
     {{/form-group-label}}
     {{#> form-group-control}}
       {{#> input-group}}
-        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id '-password" name="' form--id '-password" aria-label="Password input" value="Marie$Can8Read3Pass@Word" placeholder="Password"')}}
+        {{#> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can8Read3Pass@Word" placeholder="Password"')}}
         {{/form-control}}
         {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
           <i class="fas fa-eye-slash" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #4453 

This adds `aria-described` by on the form field "more info" buttons  and improves the `aria-label` text so that core matches patternfly-react.