### PR TITLE
fix(table): right align table action cells

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1010,6 +1010,10 @@
   vertical-align: middle;
 }
 
+.pf-c-table__action {
+  text-align: right;
+}
+
 // Inline edit
 .pf-c-table__inline-edit-action {
   --pf-c-table--cell--PaddingLeft: 0;


### PR DESCRIPTION
closes [#4716](https://github.com/patternfly/patternfly/issues/4716)

Preview: 
- https://patternfly-pr-4717.surge.sh/components/table#overflow-menu-usage-mobile 

To view update, remove one of the overflow menu buttons

![Screenshot 2023-02-15 at 11 28 10 AM](https://user-images.githubusercontent.com/5385435/219090344-fcc4cbcf-d7a0-46a9-8c3d-a9e9b4689c84.png)
