### PR TITLE
chore(page/modal/wizard): made scrollable regions keyboard focusable

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -331,6 +331,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 | `aria-hidden="true"` | Parent element containing the page contents when modal is open | Hides main contents of the page from screen readers. The element with `.pf-c-modal-box` must not be a descendent of the element with `aria-hidden="true"`. For more info see [trapping focus](/accessibility/product-development-guide#trapping-focus). **Required** |
 | `form="[id of form in modal body]"` | `.pf-c-modal-box__footer .pf-c-button` | Associates a submit button in the modal footer with a form in the modal body. For use when the submit button is outside of the `<form>` that the button submits. |
+| `tabindex="0"` | `.pf-c-modal-box__body` | If a modal box body has overflow content that triggers a scrollbar, to ensure that the content is keyboard accessible, the body must include either a focusable element within the scrollable region or the body itself must be focusable by adding `tabindex="0"`. |
 
 ### Usage
 | Class | Applied | Outcome |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -218,6 +218,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | `id="[id]"` | `.pf-c-page__main` | Provides a hook for sending focus to new content. **Required** |
 | `aria-expanded="true/false"` | `.pf-c-page__header-brand-toggle > .pf-c-button` | Indicates that the expandable content is visible and the current state of the contents. **Required** |
 | `aria-controls="[id of nav]"` | `.pf-c-page__header-brand-toggle > .pf-c-button` | Identifies the element controlled by the toggle. **Required**
+| `tabindex="0"` | `.pf-c-page__main-section.pf-m-overflow-scroll` | If a page section has overflow content that triggers a scrollbar, to ensure that the content is keyboard accessible, the page section must include either a focusable element within the scrollable region or the page section itself must be focusable by adding `tabindex="0"`. |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -486,6 +486,7 @@ import './Wizard.css'
 | `aria-expanded="true"` | `.pf-c-wizard__nav-link` | Indicates that the link subnav is visible. **Required** |
 | `aria-expanded="false"` | `.pf-c-wizard__nav-link` | Indicates that the link subnav is hidden. **Required** |
 | `tabindex="-1"` | `a.pf-c-wizard__nav-link` | Removes a link from keyboard focus. **Required for disabled links with `.pf-m-disabled`** |
+| `tabindex="0"` | `.pf-c-wizard__main` | If the wizard main section has overflow content that triggers a scrollbar, to ensure that the content is keyboard accessible, the section must include either a focusable element within the scrollable region or the section itself must be focusable by adding `tabindex="0"`. |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/Wizard/wizard-main.hbs
+++ b/src/patternfly/components/Wizard/wizard-main.hbs
@@ -1,4 +1,5 @@
 <{{#if wizard-main--type}}{{wizard-main--type}}{{else}}main{{/if}} class="pf-c-wizard__main{{#if wizard-main--modifier}} {{wizard-main--modifier}}{{/if}}"
+  tabindex="0"
   {{#if wizard-main--attribute}}
     {{{wizard-main--attribute}}}
   {{/if}}>

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -53,7 +53,7 @@ section: components
             This is a modal description. The description will not scroll with the body contents.
           {{/modal-box-description}}
         {{/modal-box-header}}
-        {{#> modal-box-body}}
+        {{#> modal-box-body modal-box-body--attribute='tabindex="0"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
           <p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -65,6 +65,7 @@ wrapperTag: div
       page-template--HasFooter="true"
       page-template-gallery--IsLongGallery="true"
       page-template-gallery--modifier="pf-m-overflow-scroll"
+      page-template-gallery--attribute='tabindex="0"'
       page-template-title--modifier="pf-m-shadow-bottom"
       page-template-footer--modifier="pf-m-shadow-top"
 }}

--- a/src/patternfly/demos/Page/page-template-gallery.hbs
+++ b/src/patternfly/demos/Page/page-template-gallery.hbs
@@ -1,3 +1,3 @@
-{{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier=page-template-gallery--modifier}}
+{{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier=page-template-gallery--modifier page-main-section--attribute=page-template-gallery--attribute}}
   {{> page-template-gallery-cards}}
 {{/page-main-section}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4733
fixes https://github.com/patternfly/patternfly/issues/4734
fixes https://github.com/patternfly/patternfly/issues/4735


@nicolethoen also added this to our modal example with long content, that scrolls when the viewport is short enough.