### PR TITLE
fix(tree-view): fixed non clickable areas in node

### DIFF
--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -11,9 +11,10 @@ $pf-c-tree-view--MaxNesting: 10;
   // Node
   --pf-c-tree-view__node--PaddingTop--base: var(--pf-global--spacer--sm);
   --pf-c-tree-view__node--PaddingTop: var(--pf-c-tree-view__node--PaddingTop--base);
-  --pf-c-tree-view__node--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-tree-view__node--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-tree-view__node--PaddingLeft: var(--pf-c-tree-view__node--indent--base);
+  --pf-c-tree-view__node--last-child--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-tree-view__node--Color: var(--pf-global--Color--100);
   --pf-c-tree-view__node--m-current--Color: var(--pf-global--link--Color);
   --pf-c-tree-view__node--m-current--FontWeight: var(--pf-global--FontWeight--bold);
@@ -47,8 +48,8 @@ $pf-c-tree-view--MaxNesting: 10;
   --pf-c-tree-view__node-toggle-button--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
   --pf-c-tree-view__node-toggle-button--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
 
-  // Check
-  --pf-c-tree-view__node-check--MarginRight: var(--pf-global--spacer--sm);
+  // Check label
+  --pf-c-tree-view__node-check--node-text--PaddingLeft: var(--pf-global--spacer--sm);
 
   // Badge
   --pf-c-tree-view__node-count--MarginLeft: var(--pf-global--spacer--sm);
@@ -74,7 +75,7 @@ $pf-c-tree-view--MaxNesting: 10;
   --pf-c-tree-view__node-title--FontWeight: var(--pf-global--FontWeight--bold);
 
   // Action
-  --pf-c-tree-view__action--MarginLeft: var(--pf-global--spacer--md);
+  --pf-c-tree-view__action--MarginLeft: 0; // remove in breaking change
   --pf-c-tree-view__action--focus--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-tree-view__action--Color: var(--pf-global--icon--Color--light);
   --pf-c-tree-view__action--hover--Color: var(--pf-global--icon--Color--dark);
@@ -364,6 +365,10 @@ $pf-c-tree-view--MaxNesting: 10;
     background-color: var(--pf-c-tree-view__node--focus--BackgroundColor);
   }
 
+  &:last-child {
+    --pf-c-tree-view__node--PaddingRight: var(--pf-c-tree-view__node--last-child--PaddingRight);
+  }
+
   .pf-c-tree-view__node-count {
     margin-left: var(--pf-c-tree-view__node-count--MarginLeft);
 
@@ -375,7 +380,6 @@ $pf-c-tree-view--MaxNesting: 10;
 
 .pf-c-tree-view__node-container {
   display: var(--pf-c-tree-view__node-container--Display);
-  flex-grow: 1;
 }
 
 .pf-c-tree-view__node-content {
@@ -389,8 +393,8 @@ $pf-c-tree-view--MaxNesting: 10;
   }
 }
 
-.pf-c-tree-view__node-check {
-  margin-right: var(--pf-c-tree-view__node-check--MarginRight);
+.pf-c-tree-view__node-check + .pf-c-tree-view__node-text {
+  padding-left: var(--pf-c-tree-view__node-check--node-text--PaddingLeft);
 }
 
 .pf-c-tree-view__node-toggle {

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -393,8 +393,15 @@ $pf-c-tree-view--MaxNesting: 10;
   }
 }
 
-.pf-c-tree-view__node-check + .pf-c-tree-view__node-text {
-  padding-left: var(--pf-c-tree-view__node-check--node-text--PaddingLeft);
+.pf-c-tree-view__node-check {
+  &,
+  & + .pf-c-tree-view__node-text {
+    cursor: pointer;
+  }
+
+  + .pf-c-tree-view__node-text {
+    padding-left: var(--pf-c-tree-view__node-check--node-text--PaddingLeft);
+  }
 }
 
 .pf-c-tree-view__node-toggle {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4725

---

@nicolethoen I'm wondering if this is best handled with JS and leaving the click handler on the node element - it's disabled when the node has a checkbox: https://github.com/patternfly/patternfly-react/blob/0ae1c2fe74b54b12236dcc7d64f9b3827d457d8d/packages/react-core/src/components/TreeView/TreeViewListItem.tsx#L187

I'm guessing the reason it's disabled is because a click on the check/text will bubble up to the node, triggering the node to be expanded? If so, could we use `stopPropagation` on the input and [`label.pf-c-tree-view__text`](https://github.com/patternfly/patternfly-react/blob/0ae1c2fe74b54b12236dcc7d64f9b3827d457d8d/packages/react-core/src/components/TreeView/TreeViewListItem.tsx#L187)? 

I think that's my preferred way of doing it. I can't have a button (or interactive element) wrap the checkbox + label, so to handle this with markup, I would need to add another element that comes after the check + label to make that area clickable, and I don't think we want to do that. WDYT? Also I'm tagging you since you created the issue - feel free to tag another JS dev if you'd like.

Also I fixed this - if the node has actions, the margin between the node and actions isn't clickable. This orange spot: 

<img width="1008" alt="Screen Shot 2022-03-21 at 8 04 16 PM" src="https://user-images.githubusercontent.com/35148959/159387791-ea5477e4-afef-4131-a60c-94b41cf880d8.png">

And fixed this - the orange spot between the check and text isn't clickable:

<img width="258" alt="Screen Shot 2022-03-21 at 8 17 40 PM" src="https://user-images.githubusercontent.com/35148959/159388327-044894fc-a94f-40a7-8a99-bcc05dfe3d53.png">

