### PR TITLE
feat(menu-toggle): updated typeahead variant layout/spacing

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -204,33 +204,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-expanded-example" menu-toggle--IsExpanded="true" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -238,33 +238,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -273,33 +273,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-disabled-example"  menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -307,33 +307,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-disabled-example"  menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -343,11 +343,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -356,11 +356,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -369,11 +369,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -383,11 +383,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -396,11 +396,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -409,11 +409,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -423,11 +423,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -436,11 +436,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -449,11 +449,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-controls}}
-    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-button}}
-  {{/menu-toggle-controls}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 
@@ -555,11 +555,13 @@ import './MenuToggle.css'
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Clear input"'}}
         <i class="fas fa-times fa-fw" aria-hidden="true"></i>
       {{/button}}
-      {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-        {{> menu-toggle-toggle-icon}}
-      {{/menu-toggle-button}}
     {{/text-input-group-utilities}}
   {{/text-input-group}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -344,7 +344,7 @@ import './MenuToggle.css'
     Action
   {{/menu-toggle-button}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-     {{#> menu-toggle-controls}}
+    {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
     {{/menu-toggle-controls}}
   {{/menu-toggle-button}}

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -204,33 +204,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-expanded-example" menu-toggle--IsExpanded="true" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -238,33 +238,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -273,33 +273,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-disabled-example"  menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -307,33 +307,33 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-disabled-example"  menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--text="10 selected" check--IsDisabled="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -343,11 +343,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -356,11 +356,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -369,11 +369,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -383,11 +383,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -396,11 +396,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -409,11 +409,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -423,11 +423,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -436,11 +436,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 
 &nbsp;
@@ -449,11 +449,11 @@ import './MenuToggle.css'
   {{#> menu-toggle-button}}
     Action
   {{/menu-toggle-button}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
+  {{#> menu-toggle-controls}}
+    {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
       {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
+    {{/menu-toggle-button}}
+  {{/menu-toggle-controls}}
 {{/menu-toggle}}
 ```
 
@@ -555,13 +555,11 @@ import './MenuToggle.css'
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Clear input"'}}
         <i class="fas fa-times fa-fw" aria-hidden="true"></i>
       {{/button}}
+      {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+        {{> menu-toggle-toggle-icon}}
+      {{/menu-toggle-button}}
     {{/text-input-group-utilities}}
   {{/text-input-group}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
-    {{#> menu-toggle-controls}}
-      {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
 {{/menu-toggle}}
 ```
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -151,10 +151,8 @@
   --pf-c-menu-toggle__button__controls--MarginLeft: var(--pf-global--spacer--sm);
 
   // Typeahead
-  --pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginTop: calc(var(--pf-c-menu-toggle--PaddingTop) * -1);
-  --pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginRight: calc(var(--pf-c-menu-toggle--PaddingRight) * -1);
-  --pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginBottom: calc(var(--pf-c-menu-toggle--PaddingBottom) * -1);
-  --pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginLeft: calc(var(--pf-c-menu-toggle--PaddingLeft) * -1);
+  --pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu-toggle--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight: var(--pf-global--spacer--sm);
 
   position: relative;
@@ -324,17 +322,24 @@
   }
 
   &.pf-m-typeahead {
+    padding: 0;
+
+    .pf-c-menu-toggle__button {
+      height: 100%;
+      padding-right: var(--pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingLeft);
+      padding-left: var(--pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingRight);
+      margin-left: 0;
+    }
+
     .pf-c-text-input-group {
       --pf-c-text-input-group__utilities--c-button--PaddingRight: var(--pf-c-menu-toggle--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight);
+      --pf-c-text-input-group__utilities--MarginRight: 0;
 
       flex: 1;
-      margin: var(--pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginTop) var(--pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginRight) var(--pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginBottom) var(--pf-c-menu-toggle--m-typeahead--c-text-input-group--MarginLeft);
     }
   }
 
   &.pf-m-split-button {
-    --pf-c-menu-toggle__toggle-icon--MarginRight: 0;
-
     padding: 0; // pass padding to children
 
     > * {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -322,6 +322,9 @@
   }
 
   &.pf-m-typeahead {
+    --pf-c-menu-toggle__controls--PaddingLeft: 0;
+
+    align-items: stretch;
     padding: 0;
 
     .pf-c-menu-toggle__button {
@@ -499,12 +502,6 @@
 .pf-c-menu-toggle__button {
   color: inherit;
   border: 0;
-
-  .pf-c-menu-toggle__controls {
-    padding-left: 0;
-    margin-right: var(--pf-c-menu-toggle__button__controls--MarginRight);
-    margin-left: var(--pf-c-menu-toggle__button__controls--MarginLeft);
-  }
 }
 
 .pf-c-menu-toggle__icon {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -339,9 +339,6 @@
   }
 
   &.pf-m-split-button {
-    --pf-c-menu-toggle__controls--MarginRight: var(--pf-c-menu-toggle__button__controls--MarginRight);
-    --pf-c-menu-toggle__controls--MarginLeft: var(--pf-c-menu-toggle__button__controls--MarginLeft);
-
     padding: 0; // pass padding to children
 
     > * {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -92,6 +92,7 @@
   --pf-c-menu-toggle__count--MarginLeft: var(--pf-global--spacer--sm);
 
   // Controls
+  --pf-c-menu-toggle__controls--PaddingRight: 0;
   --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-global--spacer--md);
 
   // Toggle icon
@@ -147,12 +148,12 @@
   --pf-c-menu-toggle--m-split-button--m-action--m-secondary--child--BorderLeftColor: var(--pf-global--primary-color--100);
 
   // Split button, controls, check
-  --pf-c-menu-toggle__button__controls--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-menu-toggle__button__controls--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__button__controls--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__button__controls--PaddingRight: var(--pf-global--spacer--sm);
 
   // Typeahead
-  --pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-menu-toggle--m-typeahead__controls--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-menu-toggle--m-typeahead__controls--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-menu-toggle--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight: var(--pf-global--spacer--sm);
 
   position: relative;
@@ -322,17 +323,11 @@
   }
 
   &.pf-m-typeahead {
-    --pf-c-menu-toggle__controls--PaddingLeft: 0;
+    --pf-c-menu-toggle__controls--PaddingRight: var(--pf-c-menu-toggle--m-typeahead__controls--PaddingRight);
+    --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-c-menu-toggle--m-typeahead__controls--PaddingLeft);
 
     align-items: stretch;
     padding: 0;
-
-    .pf-c-menu-toggle__button {
-      height: 100%;
-      padding-right: var(--pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingLeft);
-      padding-left: var(--pf-c-menu-toggle--m-typeahead--c-menu-toggle__button--PaddingRight);
-      margin-left: 0;
-    }
 
     .pf-c-text-input-group {
       --pf-c-text-input-group__utilities--c-button--PaddingRight: var(--pf-c-menu-toggle--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight);
@@ -343,6 +338,9 @@
   }
 
   &.pf-m-split-button {
+    --pf-c-menu-toggle__controls--PaddingRight: var(--pf-c-menu-toggle__button__controls--PaddingRight);
+    --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-c-menu-toggle__button__controls--PaddingLeft);
+
     padding: 0; // pass padding to children
 
     > * {
@@ -525,6 +523,7 @@
 }
 
 .pf-c-menu-toggle__controls {
+  padding-right: var(--pf-c-menu-toggle__controls--PaddingRight);
   padding-left: var(--pf-c-menu-toggle__controls--PaddingLeft);
   margin-left: auto;
 }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -91,7 +91,7 @@
   // Count
   --pf-c-menu-toggle__count--MarginLeft: var(--pf-global--spacer--sm);
 
-  // Controls
+  // Controls -- update element/vars to "control" in breaking change
   --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-menu-toggle__controls--MarginLeft: auto;
   --pf-c-menu-toggle__controls--MarginRight: 0;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -92,8 +92,9 @@
   --pf-c-menu-toggle__count--MarginLeft: var(--pf-global--spacer--sm);
 
   // Controls
-  --pf-c-menu-toggle__controls--PaddingRight: 0;
   --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-menu-toggle__controls--MarginLeft: auto;
+  --pf-c-menu-toggle__controls--MarginRight: 0;
 
   // Toggle icon
   --pf-c-menu-toggle__toggle-icon--MarginRight: var(--pf-global--spacer--sm);
@@ -148,12 +149,12 @@
   --pf-c-menu-toggle--m-split-button--m-action--m-secondary--child--BorderLeftColor: var(--pf-global--primary-color--100);
 
   // Split button, controls, check
-  --pf-c-menu-toggle__button__controls--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-menu-toggle__button__controls--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__button__controls--MarginRight: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle__button__controls--MarginLeft: var(--pf-global--spacer--sm);
 
   // Typeahead
-  --pf-c-menu-toggle--m-typeahead__controls--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-menu-toggle--m-typeahead__controls--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-menu-toggle--m-typeahead__controls--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-menu-toggle--m-typeahead__controls--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-menu-toggle--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight: var(--pf-global--spacer--sm);
 
   position: relative;
@@ -323,8 +324,8 @@
   }
 
   &.pf-m-typeahead {
-    --pf-c-menu-toggle__controls--PaddingRight: var(--pf-c-menu-toggle--m-typeahead__controls--PaddingRight);
-    --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-c-menu-toggle--m-typeahead__controls--PaddingLeft);
+    --pf-c-menu-toggle__button__controls--MarginRight: var(--pf-c-menu-toggle--m-typeahead__controls--MarginRight);
+    --pf-c-menu-toggle__button__controls--MarginLeft: var(--pf-c-menu-toggle--m-typeahead__controls--MarginLeft);
 
     align-items: stretch;
     padding: 0;
@@ -338,8 +339,8 @@
   }
 
   &.pf-m-split-button {
-    --pf-c-menu-toggle__controls--PaddingRight: var(--pf-c-menu-toggle__button__controls--PaddingRight);
-    --pf-c-menu-toggle__controls--PaddingLeft: var(--pf-c-menu-toggle__button__controls--PaddingLeft);
+    --pf-c-menu-toggle__controls--MarginRight: var(--pf-c-menu-toggle__button__controls--MarginRight);
+    --pf-c-menu-toggle__controls--MarginLeft: var(--pf-c-menu-toggle__button__controls--MarginLeft);
 
     padding: 0; // pass padding to children
 
@@ -498,6 +499,10 @@
 }
 
 .pf-c-menu-toggle__button {
+  --pf-c-menu-toggle__controls--PaddingLeft: 0;
+  --pf-c-menu-toggle__controls--MarginRight: var(--pf-c-menu-toggle__button__controls--MarginRight);
+  --pf-c-menu-toggle__controls--MarginLeft: var(--pf-c-menu-toggle__button__controls--MarginLeft);
+
   color: inherit;
   border: 0;
 }
@@ -523,9 +528,9 @@
 }
 
 .pf-c-menu-toggle__controls {
-  padding-right: var(--pf-c-menu-toggle__controls--PaddingRight);
   padding-left: var(--pf-c-menu-toggle__controls--PaddingLeft);
-  margin-left: auto;
+  margin-right: var(--pf-c-menu-toggle__controls--MarginRight);
+  margin-left: var(--pf-c-menu-toggle__controls--MarginLeft);
 }
 
 .pf-c-menu-toggle__toggle-icon {


### PR DESCRIPTION
Follow-up to #4673, where the hierarchy of elements has been changed in split button and typeahead variants to be `controls -> button -> icon` versus what was previously `button -> controls -> icon`. Padding and margins were adjusted accordingly.

Associated issue: #4666

React issue that needs typeahead toggle: https://github.com/patternfly/patternfly-react/issues/6888