### PR TITLE
fix(form-control): fixed placeholder variation menu item color

### DIFF
--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -44,7 +44,7 @@ import './FormControl.css'
   <option value="Other">Other</option>
 {{/form-control}}
 <br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-standard" name="select-standard" aria-label="Standard select example"'}}
+{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-placeholder-enabled" name="select-placeholder-enabled" aria-label="Placeholder enabled select example"'}}
   <option value="" selected>Please choose</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -35,6 +35,16 @@ import './FormControl.css'
 ### Select
 ```hbs
 {{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-standard" name="select-standard" aria-label="Standard select example"'}}
+  <option value="" selected disabled>Please choose</option>
+  <option value="Mr">Mr</option>
+  <option value="Miss">Miss</option>
+  <option value="Mrs">Mrs</option>
+  <option value="Ms">Ms</option>
+  <option value="Dr">Dr</option>
+  <option value="Other">Other</option>
+{{/form-control}}
+<br><br>
+{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-standard" name="select-standard" aria-label="Standard select example"'}}
   <option value="" selected>Please choose</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -407,6 +407,16 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
 
     &.pf-m-placeholder {
       color: var(--pf-c-form-control--placeholder--Color);
+
+      * {
+        color: var(--pf-global--Color--100);
+
+        // stylelint-disable max-nesting-depth
+        &:disabled {
+          color: revert;
+        }
+        // stylelint-enable
+      }
     }
   }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -62,6 +62,7 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
 
   // input placeholder style
   --pf-c-form-control--placeholder--Color: var(--pf-global--Color--dark-200);
+  --pf-c-form-control--placeholder--child--Color: var(--pf-global--Color--100);
 
   // input disabled style
   --pf-c-form-control--disabled--Color: var(--pf-global--disabled-color--100);
@@ -409,7 +410,7 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
       color: var(--pf-c-form-control--placeholder--Color);
 
       * {
-        color: var(--pf-global--Color--100);
+        color: var(--pf-c-form-control--placeholder--child--Color);
 
         // stylelint-disable max-nesting-depth
         &:disabled {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4772

When a form select has the placeholder modifier to turn the selected item text grey in a collapsed select menu, in chrome on linux (and FF on mac, probably other places, too), the placeholder color is applying to the items in the expanded menu, too, and they should not.

These screenshots are from FF on https://www.patternfly.org/v4/components/form-select

#### Non-placeholder - the non-disabled items are black text
<img width="610" alt="Screen Shot 2022-04-06 at 3 22 40 PM" src="https://user-images.githubusercontent.com/35148959/162064565-849d30aa-e879-4df0-8234-68690ac9d75b.png">

#### Placeholder - all of the items are set to the placeholder color
<img width="476" alt="Screen Shot 2022-04-06 at 3 22 19 PM" src="https://user-images.githubusercontent.com/35148959/162064570-48f177ed-b398-4153-a01c-944ab6379dd3.png">

