### PR TITLE
fix(global): updated code and pre elements to use PF mono font stack

### DIFF
--- a/src/patternfly/base/_globals.scss
+++ b/src/patternfly/base/_globals.scss
@@ -87,6 +87,11 @@
     text-align: left;
   }
 
+  code,
+  pre {
+    font-family: var(--pf-global--FontFamily--monospace);
+  }
+
   // Patternfly base styles
 
   *,


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4763

#### Browser default mono font (old default)
<img width="1339" alt="Screen Shot 2022-04-08 at 6 16 26 PM" src="https://user-images.githubusercontent.com/35148959/162545529-ba46c302-e325-4e02-8242-d0157168d632.png">

#### Liberation mono (new default)
<img width="1339" alt="Screen Shot 2022-04-08 at 6 16 31 PM" src="https://user-images.githubusercontent.com/35148959/162545528-e3dfe596-2f99-4c7c-98b1-0f455b422d6f.png">

#### Red hat mono (new default if opted into redhat mono font via [`.pf-m-redhatmono-font`](https://www.patternfly.org/v4/developer-resources/red-hat-font#available-opt-ins)
<img width="1339" alt="Screen Shot 2022-04-08 at 6 16 41 PM" src="https://user-images.githubusercontent.com/35148959/162545525-7014bc3a-d249-4bc8-b8c7-e1ae8f73fc55.png">

