### PR TITLE
POC: Per component dark theme

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ const sassFiles = [
   './src/patternfly/base/patternfly*.scss',
   './src/patternfly/{components,layouts,patterns,utilities}/**/*.scss',
   '!./src/patternfly/**/_all.scss',
+  './src/patternfly/themes/dark/base.scss',
   // No need to compile component theme sass files to empty css files
   '!./src/patternfly/components/**/themes/**/*.scss'
 ];

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,3 +1,6 @@
+@import "../../themes/dark/imports";
+@import "./themes/dark/button";
+
 .pf-c-button {
   // Component
   --pf-c-button--PaddingTop: var(--pf-global--spacer--form-element);
@@ -625,4 +628,8 @@
   .pf-c-button {
     --pf-c-button--FontWeight: var(--pf-global--FontWeight--semi-bold);
   }
+}
+
+:where(#{$pf-theme-dark-class}) {
+  @include button;
 }

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -1,3 +1,6 @@
+@import "../../themes/dark/imports";
+@import "./themes/dark/chip";
+
 .pf-c-chip {
   --pf-c-chip--PaddingTop: var(--pf-global--spacer--xs);
   --pf-c-chip--PaddingRight: var(--pf-global--spacer--sm);
@@ -110,4 +113,8 @@
 .pf-c-chip__icon + .pf-c-chip__text,
 .pf-c-chip__text + .pf-c-chip__icon {
   margin-left: var(--pf-c-chip__icon--MarginLeft);
+}
+
+:where(#{$pf-theme-dark-class}) {
+  @include chip;
 }

--- a/src/patternfly/themes/dark/base.scss
+++ b/src/patternfly/themes/dark/base.scss
@@ -1,0 +1,8 @@
+@import "imports";
+
+:where(#{$pf-theme-dark-class}) {
+  // global overrides
+  @include placeholders; // fixes pf-t-dark in dark theme
+  @include globals($pf-theme-dark-class); // global CSS
+  @include _variables($pf-theme-dark-class); // dark css vars
+}

--- a/src/patternfly/themes/dark/imports.scss
+++ b/src/patternfly/themes/dark/imports.scss
@@ -1,0 +1,11 @@
+// global imports
+@import "globals"; // dark global css
+@import "../../sass-utilities/functions"; // functions
+@import "../../sass-utilities/colors"; // base colors
+@import "colors"; // dark colors
+@import "../../sass-utilities/scss-variables"; // base scss vars
+@import "scss-variables"; // dark scss vars
+@import "mixins"; // dark mixins
+@import "placeholders"; // dark placeholders
+@import "variables"; // dark global css vars
+$pf-theme-dark-class: ".pf-theme-dark" !default;


### PR DESCRIPTION
Then in a react application, would just have to import
```
import "@patternfly/patternfly/themes/dark/base.css";
```

and attach `.pf-theme-dark` class to the `<html />`

