### PR TITLE
Remove phantom scrollbar in drilldown menu

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -196,6 +196,8 @@
   box-shadow: var(--pf-c-menu--BoxShadow);
 
   .pf-c-menu__content {
+    overflow: visible hidden;
+
     & & {
       overflow: visible;
     }
@@ -264,7 +266,6 @@
       left: 100%;
       width: 100%;
       transition: var(--pf-c-menu--m-drilldown--c-menu--Transition);
-      transition: 2s;
 
       // stylelint-disable selector-max-class
       &.pf-m-drilled-in {


### PR DESCRIPTION
Fixes #4748 

I think this fixes it without breaking the scrollable menu but it is difficult to test within core. Here's a codepen with the fix, and the animation speed has been slowed so that you can see it. You can also remove a comment in index.tsx to test with the menu scrollable. https://codesandbox.io/s/drilldown-menu-phantom-scrollbar-fix-s674xf?file=/styles.css

This PR also removes an extra transition duration that was probably left in accidentally during development.