### PR TITLE
fix(description-list): fix text wrap

### DIFF
--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -144,6 +144,8 @@ $pf-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md",
 }
 
 .pf-c-description-list__text {
+  min-width: 0; // this allows overflow-wrap to work
+
   &.pf-m-help-text {
     text-decoration: underline;
     cursor: pointer;


### PR DESCRIPTION
Fixes #4768 

Fixes text overflowing in data list text (when there are no spaces in the text).
