### PR TITLE
fix(DataList): selectable item states

### DIFF
--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -27,8 +27,6 @@
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
   --pf-c-data-list__item--BorderBottomColor: var(--pf-global--BorderColor--300);
   --pf-c-data-list__item--BorderBottomWidth: #{pf-size-prem(8px)};
-  --pf-c-data-list__item--m-selectable--hover--item--BorderTopColor: var(--pf-c-data-list__item--BorderBottomColor);
-  --pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth: var(--pf-c-data-list__item--BorderBottomWidth);
   --pf-c-data-list__item--sm--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-data-list__item--sm--BorderBottomColor: var(--pf-global--BorderColor--100);
 
@@ -238,13 +236,21 @@
 
   &::before {
     position: absolute;
-    top: var(--pf-c-data-list__item--before--Top);
+    top: 0;
     bottom: 0;
     left: 0;
     width: var(--pf-c-data-list__item--before--Width);
     content: "";
     background-color: var(--pf-c-data-list__item--before--BackgroundColor);
     transition: var(--pf-c-data-list__item--before--Transition);
+  }
+
+  &:first-of-type::before {
+    top: var(--pf-c-data-list__item--before--Top);
+  }
+
+  &:last-of-type::before {
+    bottom: var(--pf-c-data-list__item--before--Top);
   }
 
   &.pf-m-selectable {
@@ -256,28 +262,12 @@
 
       position: relative;
       z-index: var(--pf-c-data-list__item--m-selected--ZIndex);
-
-      &:hover,
-      &:focus {
-        margin-bottom: var(--pf-c-data-list__item--BorderBottomWidth);
-        border-bottom-width: 0;
-      }
     }
 
     &:hover,
     &:focus {
       position: relative;
       z-index: var(--pf-c-data-list__item--m-selectable--hover--ZIndex);
-
-      &:not(.pf-m-selected):not(:last-child) {
-        --pf-c-data-list__item--BorderBottomWidth: 0;
-
-        // stylelint-disable
-        + .pf-c-data-list__item {
-          border-top: var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth) solid var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopColor);
-        }
-        // stylelint-enable
-      }
     }
 
     &:hover {

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -257,7 +257,8 @@
       position: relative;
       z-index: var(--pf-c-data-list__item--m-selected--ZIndex);
 
-      &:hover {
+      &:hover,
+      &:focus {
         margin-bottom: var(--pf-c-data-list__item--BorderBottomWidth);
         border-bottom-width: 0;
       }

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -251,6 +251,18 @@
     cursor: pointer;
     outline-offset: var(--pf-c-data-list__item--m-selectable--OutlineOffset);
 
+    &.pf-m-selected {
+      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
+
+      position: relative;
+      z-index: var(--pf-c-data-list__item--m-selected--ZIndex);
+
+      &:hover {
+        margin-bottom: var(--pf-c-data-list__item--BorderBottomWidth);
+        border-bottom-width: 0;
+      }
+    }
+
     &:hover,
     &:focus {
       position: relative;
@@ -278,14 +290,6 @@
     &:active {
       box-shadow: var(--pf-c-data-list__item--m-selectable--active--BoxShadow);
     }
-  }
-
-  &.pf-m-selected {
-    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
-
-    position: relative;
-    z-index: var(--pf-c-data-list__item--m-selected--ZIndex);
-    box-shadow: var(--pf-c-data-list__item--m-selected--BoxShadow);
   }
 
   &.pf-m-ghost-row {

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -800,8 +800,8 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ### Selectable expandable rows
 ```hbs
-{{#> data-list data-list--id="data-list-selectable-expandable-rows" data-list-item--IsSelectable="true" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--id="item-1" data-list-item--expanded="true"}}
+{{#> data-list data-list--id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
+  {{#> data-list-item data-list-item--id="item-1" data-list-item--expanded="true" data-list-item--IsSelectable="true" data-list-item--IsSelected="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle1 ' data-list--id '-item1" id="' data-list--id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content1"')}}{{/data-list-toggle}}
@@ -837,7 +837,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-3" data-list-item--expanded="true"}}
+  {{#> data-list-item data-list-item--id="item-3" data-list-item--expanded="true" data-list-item--IsSelectable="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle3 ' data-list--id '-item3" id="' data-list--id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content3"')}}{{/data-list-toggle}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -760,7 +760,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content (selected)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}


### PR DESCRIPTION
# content

###### `DataList` component

- fix selected items' undesired dividing border on hover
- remove selected items' box shadow, to avoid showing in between items
- place the `&.pf-m-selected` selector as a child of `&.pf-m-selectable` (may break usage, not API)

###### `DataList` example / _**Selectable rows**_

- update item text to reflect the selected state

###### `DataList` example / _**Selectable expandable rows**_

- remove redundant item prop from the list element (`isSelectable`)
- add `isSelected` where needed to reflect the example's intention. this fixes _expanded & selected_ items' color
- add `isSelectable` where missing (that is - anywhere `isSelected` already exists), to enable items' intended selected state


# screenshots

**note:** interaction states are demonstrated on the first list item.

### [data-list / selectable rows][1]

| state | before | after |
| --- | --- | --- |
| - | <img width="1087" alt="selectable-rows-before" src="https://user-images.githubusercontent.com/1401288/166828929-c29d258d-99a6-4b17-b57f-949bbf5bec8a.png"> | <img width="1084" alt="selectable-rows-after" src="https://user-images.githubusercontent.com/1401288/166828917-4e2b7e26-5831-48b7-ba8b-9c10ef1fa025.png"> |
| hover | <img width="1084" alt="selectable-rows-item-hover-before" src="https://user-images.githubusercontent.com/1401288/166828992-a3b6f92f-a205-4fea-8587-d474f8d9d5c3.png"> | <img width="1084" alt="selectable-rows-item-hover-after" src="https://user-images.githubusercontent.com/1401288/166828973-844e6d21-8763-4d2e-ba19-c9281fb69f43.png"> |
| active | <img width="1084" alt="selectable-rows-item-active-before" src="https://user-images.githubusercontent.com/1401288/166828957-5b4027c2-d4ec-47f3-9562-275c6a22792f.png"> | <img width="1084" alt="selectable-rows-item-active-after" src="https://user-images.githubusercontent.com/1401288/166828943-1344f5b7-08d9-4d83-8a15-b5dd9c14853b.png"> |


### [data-list / selectable rows][1] (stacked layout)

| state | before | after |
| --- | --- | --- |
| - | <img width="447" alt="selectable-rows-stacked-before" src="https://user-images.githubusercontent.com/1401288/166829006-29e5807a-68a8-4b7f-aaa1-5e9a1c077f74.png"> | <img width="448" alt="selectable-rows-stacked-after" src="https://user-images.githubusercontent.com/1401288/166829004-0c1b39fe-b5b1-4aa2-80b2-3a913b84c687.png"> |
| hover | <img width="448" alt="selectable-rows-stacked-item-hover-before" src="https://user-images.githubusercontent.com/1401288/166829016-f107159c-9532-47ce-92c3-8ebd8c51444e.png"> | <img width="448" alt="selectable-rows-stacked-item-hover-after" src="https://user-images.githubusercontent.com/1401288/166829013-b2c7955b-b68b-4b63-88c2-8ae6b298b0b4.png"> |
| active | <img width="447" alt="selectable-rows-stacked-item-active-before" src="https://user-images.githubusercontent.com/1401288/166829011-2608b962-b88a-47a2-9e1f-3065746d1d08.png"> | <img width="448" alt="selectable-rows-stacked-item-active-after" src="https://user-images.githubusercontent.com/1401288/166829009-f6fbfe6f-6814-4b5b-ad25-1e535de4c57f.png"> |


### [data-list / selectable expandable rows][2]

| before | after |
| --- | --- |
| <img width="1084" alt="selectable-expandable-rows-before" src="https://user-images.githubusercontent.com/1401288/166828903-53bf6eb5-6027-4ad7-81bf-8f362ccf3ac2.png"> | <img width="1084" alt="selectable-expandable-rows-after" src="https://user-images.githubusercontent.com/1401288/166828881-b4294cd7-b9e4-4c4e-a295-9bb70b250b71.png"> |


# ticketing

fixes #3847





[1]: https://www.patternfly.org/v4/components/data-list/html/#selectable-rows
[2]: https://www.patternfly.org/v4/components/data-list/html/#selectable-expandable-rows