### PR TITLE
fix(chip group): fixes an overflow problem

### DIFF
--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -43,6 +43,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  min-width: 0;
   padding: var(--pf-c-chip--PaddingTop) var(--pf-c-chip--PaddingRight) var(--pf-c-chip--PaddingBottom) var(--pf-c-chip--PaddingLeft);
   list-style: none;
   background-color: var(--pf-c-chip--BackgroundColor);

--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -55,6 +55,7 @@
   flex-wrap: wrap;
   align-items: center;
   min-width: 0;
+  max-width: 100%;
 }
 
 .pf-c-chip-group__list-item {

--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -41,6 +41,7 @@
   flex: 1;
   flex-wrap: wrap;
   align-items: baseline;
+  min-width: 0;
 }
 
 .pf-c-chip-group__list {
@@ -53,10 +54,12 @@
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
+  min-width: 0;
 }
 
 .pf-c-chip-group__list-item {
   display: inline-flex;
+  min-width: 0;
   margin-right: var(--pf-c-chip-group__list-item--MarginRight);
   margin-bottom: var(--pf-c-chip-group__list-item--MarginBottom);
 }


### PR DESCRIPTION
Fixes #4685 
The overlap in the select shown in the related issue is caused by the chips not ellipsing when the width of the container is too narrow to fit them. This is caused by flex objects having a default min-width of auto rather than 0.
The overflow would also happen to all chip groups besides in the typeahead select (if they were too narrow) and this fixes that as well.
To test, look at chip groups and typeahead select and manually set a max-width on the container to be very narrow.
