### PR TITLE
fix(drawer): removed min-height

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -345,7 +345,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 // Modified content children
 .pf-c-drawer__body {
-  min-height: 0;
   padding: var(--pf-c-drawer--child--PaddingTop) var(--pf-c-drawer--child--PaddingRight) var(--pf-c-drawer--child--PaddingBottom) var(--pf-c-drawer--child--PaddingLeft);
 
   // No padding


### PR DESCRIPTION
Fixes #4797 

As far as I can tell, this update not only fixed the `__body` padding issue, but also fixes an overlay issue caused by `min-height`. 

**Before** 

<img width="954" alt="Screen Shot 2022-05-10 at 7 48 45 PM" src="https://user-images.githubusercontent.com/5385435/167742828-e190e248-3693-49e2-a2d0-7d111db5bbf7.png">

**After**

<img width="969" alt="Screen Shot 2022-05-10 at 7 49 20 PM" src="https://user-images.githubusercontent.com/5385435/167742842-8be5f747-e9e7-4a65-bb2c-4469a24bed21.png">
