### PR TITLE
fix(labels): updated label truncation

### DIFF
--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -12,36 +12,48 @@ import './Label.css'
 
 ```hbs
 {{#> label label--id="default-grey"}}
-  Grey
+  {{#> label-text}}
+    Grey
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-grey-icon"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Grey icon
+  {{#> label-text}}
+    Grey icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-grey-close" label--isRemovable="true"}}
-  Grey removable
+  {{#> label-text}}
+    Grey removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-grey-icon-close" label--isRemovable="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Grey icon removable
+  {{#> label-text}}
+    Grey icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-grey-link" label-content--IsLink="true"}}
-  Grey link
+  {{#> label-text}}
+    Grey link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-grey-link-close" label-content--IsLink="true" label--isRemovable="true"}}
-  Grey link removable
+  {{#> label-text}}
+    Grey link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-grey-icon-close-truncate" label--isRemovable="true"}}
+{{#> label label--id="default-grey-icon-close-truncate" label--isRemovable="true" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -53,36 +65,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-blue" label--modifier="pf-m-blue"}}
-  Blue
+  {{#> label-text}}
+    Blue
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-icon" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Blue icon
+  {{#> label-text}}
+    Blue icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
-  Blue removable
+  {{#> label-text}}
+    Blue removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Blue icon removable
+  {{#> label-text}}
+    Blue icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-link" label-content--IsLink="true" label--modifier="pf-m-blue"}}
-  Blue link
+  {{#> label-text}}
+    Blue link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-blue-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-blue"}}
-  Blue link removable
+  {{#> label-text}}
+    Blue link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-blue-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-blue"}}
+{{#> label label--id="default-blue-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-blue" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -94,36 +118,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-green" label--modifier="pf-m-green"}}
-  Green
+  {{#> label-text}}
+    Green
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-icon" label--modifier="pf-m-green"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Green icon
+  {{#> label-text}}
+    Green icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-close" label--isRemovable="true" label--modifier="pf-m-green"}}
-  Green removable
+  {{#> label-text}}
+    Green removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Green icon removable
+  {{#> label-text}}
+    Green icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-link" label-content--IsLink="true" label--modifier="pf-m-green"}}
-  Green link
+  {{#> label-text}}
+    Green link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-green-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-green"}}
-  Green link removable
+  {{#> label-text}}
+    Green link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-green-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-green"}}
+{{#> label label--id="default-green-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-green" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -135,36 +171,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-orange" label--modifier="pf-m-orange"}}
-  Orange
+  {{#> label-text}}
+    Orange
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-icon" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Orange icon
+  {{#> label-text}}
+    Orange icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
-  Orange removable
+  {{#> label-text}}
+    Orange removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Orange icon removable
+  {{#> label-text}}
+    Orange icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-link" label-content--IsLink="true" label--modifier="pf-m-orange"}}
-  Orange link
+  {{#> label-text}}
+    Orange link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-orange-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-orange"}}
-  Orange link removable
+  {{#> label-text}}
+    Orange link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-orange-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-orange"}}
+{{#> label label--id="default-orange-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-orange" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -176,36 +224,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-red" label--modifier="pf-m-red"}}
-  Red
+  {{#> label-text}}
+    Red
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-icon" label--modifier="pf-m-red"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Red icon
+  {{#> label-text}}
+    Red icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-close" label--isRemovable="true" label--modifier="pf-m-red"}}
-  Red removable
+  {{#> label-text}}
+    Red removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Red icon removable
+  {{#> label-text}}
+    Red icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-link" label-content--IsLink="true" label--modifier="pf-m-red"}}
-  Red link
+  {{#> label-text}}
+    Red link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-red-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-red"}}
-  Red link removable
+  {{#> label-text}}
+    Red link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-red-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-red"}}
+{{#> label label--id="default-red-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-red" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -217,36 +277,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-purple" label--modifier="pf-m-purple"}}
-  Purple
+  {{#> label-text}}
+    Purple
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-icon" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Purple icon
+  {{#> label-text}}
+    Purple icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
-  Purple removable
+  {{#> label-text}}
+    Purple removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Purple icon removable
+  {{#> label-text}}
+    Purple icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-link" label-content--IsLink="true" label--modifier="pf-m-purple"}}
-  Purple link
+  {{#> label-text}}
+    Purple link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-purple-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-purple"}}
-  Purple link removable
+  {{#> label-text}}
+    Purple link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-purple-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-purple"}}
+{{#> label label--id="default-purple-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-purple" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -258,36 +330,48 @@ import './Label.css'
 <br><br>
 
 {{#> label label--id="default-cyan" label--modifier="pf-m-cyan"}}
-  Cyan
+  {{#> label-text}}
+    Cyan
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-icon" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Cyan icon
+  {{#> label-text}}
+    Cyan icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
+  {{#> label-text}}
     Cyan removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Cyan icon removable
+  {{#> label-text}}
+    Cyan icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-link" label-content--IsLink="true" label--modifier="pf-m-cyan"}}
-  Cyan link
+  {{#> label-text}}
+    Cyan link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="default-cyan-link-close" label-content--IsLink="true" label--isRemovable="true" label--modifier="pf-m-cyan"}}
-  Cyan link removable
+  {{#> label-text}}
+    Cyan link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="default-cyan-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-cyan"}}
+{{#> label label--id="default-cyan-icon-close-truncate" label--isRemovable="true" label--modifier="pf-m-cyan" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -344,225 +428,309 @@ import './Label.css'
 
 ```hbs
 {{#> label label--id="outline-grey" label--modifier="pf-m-outline"}}
-  Grey
+  {{#> label-text}}
+    Grey
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-icon" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Grey icon
+  {{#> label-text}}
+    Grey icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
-  Grey removable
+  {{#> label-text}}
+    Grey removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-icon-close" label--isRemovable="true" label--modifier="pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Grey icon removable
+  {{#> label-text}}
+    Grey icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-link" label-content--IsLink="true" label--modifier="pf-m-outline"}}
-  Grey link
+  {{#> label-text}}
+    Grey link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-grey-link-close" label-content--IsLink="true" label--modifier="pf-m-outline" label--isRemovable="true"}}
-  Grey link removable
+  {{#> label-text}}
+    Grey link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-blue" label--modifier="pf-m-blue pf-m-outline"}}
-  Blue
+  {{#> label-text}}
+    Blue
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-icon" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Blue icon
+  {{#> label-text}}
+    Blue icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
-  Blue removable
+  {{#> label-text}}
+    Blue removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-icon-close" label--isRemovable="true" label--modifier="pf-m-blue pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Blue icon removable
+  {{#> label-text}}
+    Blue icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue"}}
-  Blue link
+  {{#> label-text}}
+    Blue link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-blue-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-blue" label--isRemovable="true"}}
-  Blue link removable
+  {{#> label-text}}
+    Blue link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-green" label--modifier="pf-m-green pf-m-outline"}}
-  Green
+  {{#> label-text}}
+    Green
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-icon" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Green icon
+  {{#> label-text}}
+    Green icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
-  Green removable
+  {{#> label-text}}
+    Green removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-icon-close" label--isRemovable="true" label--modifier="pf-m-green pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Green icon removable
+  {{#> label-text}}
+    Green icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green"}}
-  Green link
+  {{#> label-text}}
+    Green link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-green-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-green" label--isRemovable="true"}}
-  Green link removable
+  {{#> label-text}}
+    Green link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-orange" label--modifier="pf-m-orange pf-m-outline"}}
-  Orange
+  {{#> label-text}}
+    Orange
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-icon" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Orange icon
+  {{#> label-text}}
+    Orange icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
-  Orange removable
+  {{#> label-text}}
+    Orange removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-icon-close" label--isRemovable="true" label--modifier="pf-m-orange pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Orange icon removable
+  {{#> label-text}}
+    Orange icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange"}}
-  Orange link
+  {{#> label-text}}
+    Orange link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-orange-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-orange" label--isRemovable="true"}}
-  Orange link removable
+  {{#> label-text}}
+    Orange link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-red" label--modifier="pf-m-red pf-m-outline"}}
-  Red
+  {{#> label-text}}
+    Red
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-icon" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Red icon
+  {{#> label-text}}
+    Red icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
-  Red removable
+  {{#> label-text}}
+    Red removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-icon-close" label--isRemovable="true" label--modifier="pf-m-red pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Red icon removable
+  {{#> label-text}}
+    Red icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red"}}
-  Red link
+  {{#> label-text}}
+    Red link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-red-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-red" label--isRemovable="true"}}
-  Red link removable
+  {{#> label-text}}
+    Red link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-purple" label--modifier="pf-m-purple pf-m-outline"}}
-  Purple
+  {{#> label-text}}
+    Purple
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-icon" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Purple icon
+  {{#> label-text}}
+    Purple icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
-  Purple removable
+  {{#> label-text}}
+    Purple removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-icon-close" label--isRemovable="true" label--modifier="pf-m-purple pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Purple icon removable
+  {{#> label-text}}
+    Purple icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple"}}
-  Purple link
+  {{#> label-text}}
+    Purple link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-purple-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-purple" label--isRemovable="true"}}
-  Purple link removable
+  {{#> label-text}}
+    Purple link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
 
 {{#> label label--id="outline-cyan" label--modifier="pf-m-cyan pf-m-outline"}}
-  Cyan
+  {{#> label-text}}
+    Cyan
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-icon" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Cyan icon
+  {{#> label-text}}
+    Cyan icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
-  Cyan removable
+  {{#> label-text}}
+    Cyan removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-icon-close" label--isRemovable="true" label--modifier="pf-m-cyan pf-m-outline"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Cyan icon removable
+  {{#> label-text}}
+    Cyan icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-link" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan"}}
-  Cyan link
+  {{#> label-text}}
+    Cyan link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="outline-cyan-link-close" label-content--IsLink="true" label--modifier="pf-m-outline pf-m-cyan" label--isRemovable="true"}}
-  Cyan link removable
+  {{#> label-text}}
+    Cyan link removable
+  {{/label-text}}
 {{/label}}
 
 <br><br>
@@ -604,36 +772,48 @@ import './Label.css'
 
 ```hbs
 {{#> label label--id="default-compact" label--modifier="pf-m-compact"}}
-  Compact
+  {{#> label-text}}
+    Compact
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="compact-icon" label--modifier="pf-m-compact"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Compact icon
+  {{#> label-text}}
+    Compact icon
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="compact-close" label--modifier="pf-m-compact" label--isRemovable="true"}}
-  Compact removable
+  {{#> label-text}}
+    Compact removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="compact-icon-close" label--modifier="pf-m-compact" label--isRemovable="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
-  Compact icon removable
+  {{#> label-text}}
+    Compact icon removable
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="compact-link" label--modifier="pf-m-compact" label-content--IsLink="true"}}
-  Compact link
+  {{#> label-text}}
+    Compact link
+  {{/label-text}}
 {{/label}}
 
 {{#> label label--id="compact-link-close" label--modifier="pf-m-compact" label-content--IsLink="true" label--isRemovable="true"}}
-  Compact link removable
+  {{#> label-text}}
+    Compact link removable
+  {{/label-text}}
 {{/label}}
 
-{{#> label label--id="compact-icon-close-truncate" label--modifier="pf-m-compact" label--isRemovable="true"}}
+{{#> label label--id="compact-icon-close-truncate" label--modifier="pf-m-compact" label--isRemovable="true" label--IsTruncated="true"}}
   {{#> label-icon}}
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
   {{/label-icon}}
@@ -650,7 +830,9 @@ This style of label is used to indicate overflow within a label group.
 
 ```hbs
 {{#> label label--id="overflow" label--IsOverflow="true"}}
-  Overflow
+  {{#> label-text}}
+    Overflow
+  {{/label-text}}
 {{/label}}
 ```
 
@@ -712,5 +894,6 @@ This style of label is used to add new labels to a label group.
 | `.pf-m-purple` | `.pf-c-label` | Modifies the label to have purple colored styling. |
 | `.pf-m-cyan` | `.pf-c-label` | Modifies the label to have cyan colored styling. |
 | `.pf-m-gold` | `.pf-c-label` | Modifies the label to have gold colored styling. |
+| `.pf-m-auto-width` | `.pf-c-label` | Modifies label to have max-width to auto. |
 | `.pf-m-editable` | `.pf-c-label` | Modifies label for editable styles. |
 | `.pf-m-editable-active` | `.pf-c-label.pf-m-editable` | Modifies editable label for active styles. |

--- a/src/patternfly/components/Label/label-editable-content.hbs
+++ b/src/patternfly/components/Label/label-editable-content.hbs
@@ -1,8 +1,8 @@
 <{{#if label-editable-content--type}}{{label-editable-content--type}}{{else if label--IsEditableActive}}input{{else}}button{{/if}} class="pf-c-label__content{{#if label-editable-content--modifier}} {{label-editable-content--modifier}}{{/if}}"
   id="{{label--id}}-editable-content"
-  {{#if label--IsEditableActive}} 
-    type="text" 
-    value="{{~> @partial-block}}"{{else}} 
+  {{#if label--IsEditableActive}}
+    type="text"
+    value="{{~> @partial-block}}"{{else}}
     currvalue="{{~> @partial-block}}"
   {{/if}}
   {{#if label-editable-content--aria-label}}

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -1,4 +1,11 @@
-<{{# if label--type}}{{label--type}}{{else if label--IsOverflow}}button{{else if label--IsAdd}}button{{else}}span{{/if}} class="pf-c-label{{#if label--IsOverflow}} pf-m-overflow{{/if}}{{#if label--IsAdd}} pf-m-add{{/if}}{{#if label--modifier}} {{label--modifier}}{{/if}}{{#if label--IsEditable}} pf-m-editable{{/if}}{{#if label--IsEditableActive}} pf-m-editable-active{{/if}}"
+<{{# if label--type}}{{label--type}}{{else if label--IsOverflow}}button{{else if label--IsAdd}}button{{else}}span{{/if}} class="pf-c-label{{#if label--modifier}} {{label--modifier}}{{/if}}
+  {{~#if label--IsAdd}} pf-m-add{{/if}}
+  {{~#if label--IsOverflow}} pf-m-overflow{{/if}}
+  {{~#if label--IsEditable}} pf-m-editable{{/if}}
+  {{~#if label--IsEditableActive}} pf-m-editable-active{{/if}}
+  {{~#unless label--IsTruncated}}
+    pf-m-auto-width
+  {{/unless}}"
   {{#if label--IsOverflow}}type="button"{{else if label--IsAdd}}type="button"{{/if}}
   {{#if label--attribute}}
     {{{label--attribute}}}

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -180,7 +180,6 @@
   --pf-c-label--m-editable--m-editable-active__content--before--BorderColor: transparent;
 
   position: relative;
-  max-width: 100%;
   padding: var(--pf-c-label--PaddingTop) var(--pf-c-label--PaddingRight) var(--pf-c-label--PaddingBottom) var(--pf-c-label--PaddingLeft);
   font-size: var(--pf-c-label--FontSize);
   color: var(--pf-c-label--Color);
@@ -406,6 +405,8 @@
 
   // remove at breaking change
   &.pf-m-auto-width {
+    max-width: 100%;
+
     --pf-c-label__text--MaxWidth: 100%;
   }
 }

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -180,6 +180,7 @@
   --pf-c-label--m-editable--m-editable-active__content--before--BorderColor: transparent;
 
   position: relative;
+  max-width: 100%;
   padding: var(--pf-c-label--PaddingTop) var(--pf-c-label--PaddingRight) var(--pf-c-label--PaddingBottom) var(--pf-c-label--PaddingLeft);
   font-size: var(--pf-c-label--FontSize);
   color: var(--pf-c-label--Color);
@@ -401,6 +402,11 @@
     --pf-c-label__content--link--hover--before--BorderColor: var(--pf-c-label--m-overflow__content--link--hover--before--BorderColor);
     --pf-c-label__content--link--focus--before--BorderWidth: var(--pf-c-label--m-overflow__content--link--focus--before--BorderWidth);
     --pf-c-label__content--link--focus--before--BorderColor: var(--pf-c-label--m-overflow__content--link--focus--before--BorderColor);
+  }
+
+  // remove at breaking change
+  &.pf-m-auto-width {
+    --pf-c-label__text--MaxWidth: 100%;
   }
 }
 

--- a/src/patternfly/components/LabelGroup/examples/LabelGroup.md
+++ b/src/patternfly/components/LabelGroup/examples/LabelGroup.md
@@ -17,7 +17,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label 1
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -25,7 +27,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -33,7 +37,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -51,7 +57,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -59,7 +67,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -67,12 +77,16 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsOverflow="true"}}
-          3 more
+          {{#> label-text}}
+            3 more
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -90,7 +104,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -98,7 +114,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -106,7 +124,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -114,7 +134,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -122,12 +144,16 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsOverflow="true"}}
-          3 less
+          {{#> label-text}}
+            3 less
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -145,7 +171,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -153,7 +181,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -161,12 +191,16 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsAdd="true"}}
-          Add Label
+          {{#> label-text}}
+            Add Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -187,7 +221,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -195,7 +231,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -203,7 +241,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -224,7 +264,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -232,7 +274,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -240,7 +284,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -248,7 +294,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 4
+          {{#> label-text}}
+            Label 4
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -256,7 +304,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 5
+          {{#> label-text}}
+            Label 5
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -264,7 +314,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 6
+          {{#> label-text}}
+            Label 6
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -283,7 +335,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -291,7 +345,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -299,7 +355,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -317,7 +375,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -325,7 +385,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -333,12 +395,16 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsOverflow="true"}}
-          3 more
+          {{#> label-text}}
+            3 more
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -356,7 +422,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -364,7 +432,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -372,7 +442,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -380,7 +452,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -388,12 +462,16 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsOverflow="true"}}
-          3 less
+          {{#> label-text}}
+            3 less
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -414,7 +492,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -422,7 +502,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -430,7 +512,9 @@ cssPrefix: pf-c-label-group
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -449,17 +533,23 @@ cssPrefix: pf-c-label-group
     {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby="' label-group--id '-label"')}}
       {{#> label-group-list-item}}
         {{#> label}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-blue"}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green"}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -534,17 +624,23 @@ In addition to the JavaScript management of [editable labels](/components/label#
     {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green" label--id=(concat label-group--id '-editable-label-static-1') label--isRemovable="true"}}
-          Static label 1
+          {{#> label-text}}
+            Static label 1
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green" label--id=(concat label-group--id '-editable-label-static-2') label--isRemovable="true"}}
-          Static label 2
+          {{#> label-text}}
+            Static label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green" label--id=(concat label-group--id '-editable-label-static-3') label--isRemovable="true"}}
-          Static label 3
+          {{#> label-text}}
+            Static label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item label-group-list-item--modifier="pf-m-textarea"}}
@@ -562,12 +658,16 @@ In addition to the JavaScript management of [editable labels](/components/label#
     {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green" label--id=(concat label-group--id '-editable-label-static-1') label--isRemovable="true"}}
-          Static label 1
+          {{#> label-text}}
+            Static label 1
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green" label--id=(concat label-group--id '-editable-label-static-2') label--isRemovable="true"}}
-          Static label 2
+          {{#> label-text}}
+            Static label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -603,7 +703,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -611,7 +713,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -619,7 +723,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -637,7 +743,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -645,7 +753,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -653,12 +763,16 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
         {{#> label label--IsOverflow="true" label--modifier="pf-m-compact"}}
-          3 more
+          {{#> label-text}}
+            3 more
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}
@@ -676,7 +790,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label
+          {{#> label-text}}
+            Label
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -684,7 +800,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 2
+          {{#> label-text}}
+            Label 2
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
       {{#> label-group-list-item}}
@@ -692,7 +810,9 @@ In addition to the JavaScript management of [editable labels](/components/label#
           {{#> label-icon}}
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           {{/label-icon}}
-          Label 3
+          {{#> label-text}}
+            Label 3
+          {{/label-text}}
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}

--- a/src/patternfly/components/LabelGroup/label-group.scss
+++ b/src/patternfly/components/LabelGroup/label-group.scss
@@ -42,7 +42,6 @@
   --pf-c-label-group__textarea--PaddingLeft: var(--pf-global--spacer--xs);
 
   display: inline-flex;
-  max-width: 100%;
 
   &.pf-m-category {
     padding-top: var(--pf-c-label-group--m-category--PaddingTop);
@@ -125,14 +124,12 @@
 .pf-c-label-group__list {
   display: inline-flex;
   flex-wrap: wrap;
-  min-width: 0;
   margin-right: var(--pf-c-label-group__list--MarginRight);
   margin-bottom: var(--pf-c-label-group__list--MarginBottom);
 }
 
 .pf-c-label-group__list-item {
   display: inline-flex;
-  min-width: 0;
   margin-right: var(--pf-c-label-group__list-item--MarginRight);
   margin-bottom: var(--pf-c-label-group__list-item--MarginBottom);
 }

--- a/src/patternfly/components/LabelGroup/label-group.scss
+++ b/src/patternfly/components/LabelGroup/label-group.scss
@@ -42,6 +42,7 @@
   --pf-c-label-group__textarea--PaddingLeft: var(--pf-global--spacer--xs);
 
   display: inline-flex;
+  max-width: 100%;
 
   &.pf-m-category {
     padding-top: var(--pf-c-label-group--m-category--PaddingTop);
@@ -104,6 +105,16 @@
   }
 }
 
+.pf-c-label-group,
+.pf-c-label-group__main {
+  max-width: 100%; // limit max width of group and __main to their container
+}
+
+.pf-c-label-group__list,
+.pf-c-label-group__list-item {
+  min-width: 0; // fix min-width, flex bug
+}
+
 .pf-c-label-group__main {
   display: flex;
   flex: 1;
@@ -114,12 +125,14 @@
 .pf-c-label-group__list {
   display: inline-flex;
   flex-wrap: wrap;
+  min-width: 0;
   margin-right: var(--pf-c-label-group__list--MarginRight);
   margin-bottom: var(--pf-c-label-group__list--MarginBottom);
 }
 
 .pf-c-label-group__list-item {
   display: inline-flex;
+  min-width: 0;
   margin-right: var(--pf-c-label-group__list-item--MarginRight);
   margin-bottom: var(--pf-c-label-group__list-item--MarginBottom);
 }


### PR DESCRIPTION
Closes #4795 

This PR 
- adds `.pf-m-auto-width` support to `.pf-c-label`, which sets `--pf-c-label__text--MaxWidth` to 100%. We would remove this at breaking change and make this the default. 
- adds `.pf-c-label__text` to labels by default, which allows the label text to truncate by default
- sets `.pf-c-label-group` and childrens' `max-width`s to ensure they don't exceed their containers