### PR TITLE
fix(tabs): added responsive bp to vert tabs

### DIFF
--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -161,11 +161,11 @@ import './Sidebar.css'
 | `.pf-c-sidebar__panel` | `<div>` | Initiates the sidebar panel element. **Required** |
 | `.pf-c-sidebar__content` | `<div>` | Initiates the sidebar content element. **Required** |
 | `.pf-m-gutter` | `.pf-c-sidebar` | Modifies the sidebar component to add a gutter between the panel and content. |
-| `.pf-m-full-height` | `.pf-c-sidebar` | Modifies the sidebar and its children to full height of their container. |
 | `.pf-m-stack` | `.pf-c-sidebar` | Modifies the sidebar to stack the panel on top of the content. |
 | `.pf-m-split` | `.pf-c-sidebar` | Modifies the sidebar to position the panel and content side by side. |
 | `.pf-m-panel-right` | `.pf-c-sidebar` | Modifies the sidebar to place the panel to the right of the content. |
 | `.pf-m-sticky` | `.pf-c-sidebar__panel` | Modifies the panel to be sticky to the top of the layout. |
+| `.pf-m-full-height` | `.pf-c-sidebar__panel, .pf-c-sidebar__content [@md breakpoint]`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__panel`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__content` | Modifies the panel or content elment to be full height of its parent. |
 | `.pf-m-static` | `.pf-c-sidebar__panel` | Modifies the panel to be positioned statically. |
 | `.pf-m-width-{default, 25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-c-sidebar__panel` | Modifies the panel width at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). **Note:** does not apply when the panel is stacked on top of the content. |
 | `.pf-m-no-background` | `.pf-c-sidebar`, `.pf-c-sidebar__panel, .pf-c-sidebar__content` | Modifies the element to have a transparent background. |

--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -161,6 +161,7 @@ import './Sidebar.css'
 | `.pf-c-sidebar__panel` | `<div>` | Initiates the sidebar panel element. **Required** |
 | `.pf-c-sidebar__content` | `<div>` | Initiates the sidebar content element. **Required** |
 | `.pf-m-gutter` | `.pf-c-sidebar` | Modifies the sidebar component to add a gutter between the panel and content. |
+| `.pf-m-full-height` | `.pf-c-sidebar` | Modifies the sidebar and its children to full height of their container. |
 | `.pf-m-stack` | `.pf-c-sidebar` | Modifies the sidebar to stack the panel on top of the content. |
 | `.pf-m-split` | `.pf-c-sidebar` | Modifies the sidebar to position the panel and content side by side. |
 | `.pf-m-panel-right` | `.pf-c-sidebar` | Modifies the sidebar to place the panel to the right of the content. |

--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -165,7 +165,7 @@ import './Sidebar.css'
 | `.pf-m-split` | `.pf-c-sidebar` | Modifies the sidebar to position the panel and content side by side. |
 | `.pf-m-panel-right` | `.pf-c-sidebar` | Modifies the sidebar to place the panel to the right of the content. |
 | `.pf-m-sticky` | `.pf-c-sidebar__panel` | Modifies the panel to be sticky to the top of the layout. |
-| `.pf-m-full-height` | `.pf-c-sidebar__panel, .pf-c-sidebar__content [@md breakpoint]`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__panel`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__content` | Modifies the panel or content elment to be full height of its parent. |
+| `.pf-m-full-height` | `.pf-c-sidebar__panel, .pf-c-sidebar__content [@md breakpoint]`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__panel`, `.pf-c-sidebar.pf-m-split .pf-c-sidebar__content` | Modifies the panel or content element to be full height of its parent. |
 | `.pf-m-static` | `.pf-c-sidebar__panel` | Modifies the panel to be positioned statically. |
 | `.pf-m-width-{default, 25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-c-sidebar__panel` | Modifies the panel width at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). **Note:** does not apply when the panel is stacked on top of the content. |
 | `.pf-m-no-background` | `.pf-c-sidebar`, `.pf-c-sidebar__panel, .pf-c-sidebar__content` | Modifies the element to have a transparent background. |

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -61,6 +61,16 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   // Full height
   --pf-c-sidebar__main--child--m-full-height--AlignSelf: stretch;
+  --pf-c-tabs--m-vertical__list--before--BorderWidth: 0;
+
+  .pf-c-tabs {
+    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
+
+    &.pf-m-box {
+      --pf-c-tabs__link--before--BorderRightWidth: 0;
+      --pf-c-tabs--m-box__link--last-child--before--BorderRightWidth: 0;
+    }
+  }
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-sidebar__main--FlexDirection: var(--pf-c-sidebar__main--md--FlexDirection);
@@ -69,6 +79,15 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--Top: var(--pf-c-sidebar__panel--md--Top);
     --pf-c-sidebar__panel--Position: var(--pf-c-sidebar__panel--md--Position);
+
+    .pf-c-tabs {
+      --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+
+      &.pf-m-box {
+        --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+        --pf-c-tabs--m-box__link--last-child--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
+    }
   }
 
   @media (min-width: $pf-global--breakpoint--xl) {
@@ -108,6 +127,15 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: var(--pf-c-sidebar--m-stack__panel--BoxShadow);
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-stack--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-stack--m-panel-right__panel--Order);
+
+    .pf-c-tabs {
+      --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
+
+      &.pf-m-box {
+        --pf-c-tabs__link--before--BorderRightWidth: 0;
+        --pf-c-tabs--m-box__link--last-child--before--BorderRightWidth: 0;
+      }
+    }
   }
 
   &.pf-m-split {
@@ -120,16 +148,14 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: none;
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-split--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-split--m-panel-right__panel--Order);
-  }
 
-  // disable borders on default layout switch
-  &:where(:not(.pf-m-split)) .pf-c-tabs {
-    --pf-c-tabs__link--before--BorderRightColor: transparent;
-    --pf-c-tabs--m-vertical__list--before--BorderColor: transparent;
+    .pf-c-tabs {
+      --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
 
-    @media (min-width: $pf-global--breakpoint--md) {
-      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs--before--BorderColor);
-      --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
+      &.pf-m-box {
+        --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+        --pf-c-tabs--m-box__link--last-child--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
     }
   }
 

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -88,15 +88,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     }
   }
 
-  &.pf-m-full-height {
-    --pf-c-sidebar__main--AlignItems: stretch;
-
-    &,
-    .pf-c-sidebar__main {
-      height: 100%;
-    }
-  }
-
   &.pf-m-panel-right {
     --pf-c-sidebar__panel--Order: var(--pf-c-sidebar--m-panel-right__panel--Order);
 
@@ -136,6 +127,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   display: flex;
   flex-direction: var(--pf-c-sidebar__main--FlexDirection);
   align-items: var(--pf-c-sidebar__main--AlignItems);
+  height: 100%;
 }
 
 .pf-c-sidebar__panel {

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -91,8 +91,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   &.pf-m-full-height {
     --pf-c-sidebar__main--AlignItems: stretch;
 
-    height: 100%;
-
+    &,
     .pf-c-sidebar__main {
       height: 100%;
     }
@@ -157,6 +156,20 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   &.pf-m-static {
     --pf-c-sidebar__panel--Position: static;
     --pf-c-sidebar__panel--Top: auto;
+  }
+
+  > .pf-c-tabs {
+    --pf-c-tabs--m-vertical--MaxWidth: auto; // when tabs are part of the sidebar, unset max width
+
+    &.pf-m-vertical.pf-m-box {
+      --pf-c-tabs__link--before--BorderRightColor: transparent;
+      --pf-c-tabs--m-vertical__list--before--BorderColor: transparent;
+
+      @media (min-width: $pf-global--breakpoint--md) {
+        --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs--before--BorderColor);
+        --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
+      }
+    }
   }
 }
 

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -130,15 +130,31 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-split--child--Height);
   }
 
+  // disable borders on default layout switch
+  &:where(:not(.pf-m-split)) .pf-c-tabs {
+    --pf-c-tabs__link--before--BorderRightColor: transparent;
+    --pf-c-tabs--m-vertical__list--before--BorderColor: transparent;
+
+    @media (min-width: $pf-global--breakpoint--md) {
+      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs--before--BorderColor);
+      --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
+    }
+  }
+
   height: 100%;
 }
 
+// Height options apply to the default layout switch (stack to split at $md breakpoint) and the split variant default
 .pf-c-sidebar__content,
 .pf-c-sidebar__panel {
   height: var(--pf-c-sidebar--child--Height);
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);
+  }
+
+  @at-root .pf-c-sidebar.pf-m-split & {
+    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-split--child--Height);
   }
 
   &.pf-m-full-height {
@@ -175,17 +191,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   }
 
   > .pf-c-tabs {
-    --pf-c-tabs--m-vertical--MaxWidth: auto; // when tabs are part of the sidebar, unset max width
-
-    &.pf-m-vertical.pf-m-box {
-      --pf-c-tabs__link--before--BorderRightColor: transparent;
-      --pf-c-tabs--m-vertical__list--before--BorderColor: transparent;
-
-      @media (min-width: $pf-global--breakpoint--md) {
-        --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs--before--BorderColor);
-        --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
-      }
-    }
+    --pf-c-tabs--m-vertical--MaxWidth: auto; // when tabs are part of the sidebar, unset max width allowing them to fill sidebar
   }
 }
 

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -1,11 +1,8 @@
 $pf-c-sidebar--breakpoint-map--width: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
-
 .pf-c-sidebar {
   --pf-c-sidebar--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-sidebar--child--Height: auto;
-  --pf-c-sidebar--child--md--Height: auto;
 
   // Main
   --pf-c-sidebar__main--FlexDirection: column;
@@ -30,7 +27,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar--m-stack__panel--Top: 0;
   --pf-c-sidebar--m-stack__panel--BoxShadow: var(--pf-c-sidebar__panel--BoxShadow--base);
   --pf-c-sidebar--m-stack--m-panel-right__panel--Order: 0;
-  --pf-c-sidebar--m-stack--child--Height: auto;
 
   // Split
   --pf-c-sidebar--m-split__main--AlignItems: start;
@@ -38,7 +34,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar--m-split__panel--Position: static;
   --pf-c-sidebar--m-split__panel--Top: auto;
   --pf-c-sidebar--m-split--m-panel-right__panel--Order: 1;
-  --pf-c-sidebar--m-split--child--Height: auto;
 
   // Panel
   --pf-c-sidebar__panel--FlexBasis--base: auto;
@@ -65,7 +60,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar__panel--m-sticky--Position: sticky;
 
   // Full height
-  --pf-c-sidebar--child--m-full-height--Height: 100%;
+  --pf-c-sidebar__main--child--m-full-height--AlignSelf: stretch;
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-sidebar__main--FlexDirection: var(--pf-c-sidebar__main--md--FlexDirection);
@@ -74,7 +69,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--Top: var(--pf-c-sidebar__panel--md--Top);
     --pf-c-sidebar__panel--Position: var(--pf-c-sidebar__panel--md--Position);
-    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);
   }
 
   @media (min-width: $pf-global--breakpoint--xl) {
@@ -114,7 +108,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: var(--pf-c-sidebar--m-stack__panel--BoxShadow);
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-stack--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-stack--m-panel-right__panel--Order);
-    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-stack--child--Height);
   }
 
   &.pf-m-split {
@@ -127,7 +120,6 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: none;
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-split--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-split--m-panel-right__panel--Order);
-    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-split--child--Height);
   }
 
   // disable borders on default layout switch
@@ -141,25 +133,14 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     }
   }
 
-  height: 100%;
+  min-height: 100%;
 }
 
 // Height options apply to the default layout switch (stack to split at $md breakpoint) and the split variant default
 .pf-c-sidebar__content,
 .pf-c-sidebar__panel {
-  height: var(--pf-c-sidebar--child--Height);
-
-  @media (min-width: $pf-global--breakpoint--md) {
-    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);
-  }
-
-  @at-root .pf-c-sidebar.pf-m-split & {
-    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-split--child--Height);
-  }
-
   &.pf-m-full-height {
-    --pf-c-sidebar--child--md--Height: var(--pf-c-sidebar--child--m-full-height--Height); // default layout switch height update
-    --pf-c-sidebar--m-split--child--Height: var(--pf-c-sidebar--child--m-full-height--Height); // split child layout update
+    align-self: var(--pf-c-sidebar__main--child--m-full-height--AlignSelf); // split child layout update
   }
 }
 
@@ -167,7 +148,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   display: flex;
   flex-direction: var(--pf-c-sidebar__main--FlexDirection);
   align-items: var(--pf-c-sidebar__main--AlignItems);
-  height: 100%;
+  min-height: 100%;
 }
 
 .pf-c-sidebar__panel {

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -69,9 +69,9 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-sidebar__main--FlexDirection: var(--pf-c-sidebar__main--md--FlexDirection);
-    --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--BoxShadow: none;
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--md--FlexBasis);
+    --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--Top: var(--pf-c-sidebar__panel--md--Top);
     --pf-c-sidebar__panel--Position: var(--pf-c-sidebar__panel--md--Position);
     --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -88,6 +88,16 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     }
   }
 
+  &.pf-m-full-height {
+    --pf-c-sidebar__main--AlignItems: stretch;
+
+    height: 100%;
+
+    .pf-c-sidebar__main {
+      height: 100%;
+    }
+  }
+
   &.pf-m-panel-right {
     --pf-c-sidebar__panel--Order: var(--pf-c-sidebar--m-panel-right__panel--Order);
 

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -4,6 +4,8 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
 .pf-c-sidebar {
   --pf-c-sidebar--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-sidebar--child--Height: auto;
+  --pf-c-sidebar--child--md--Height: auto;
 
   // Main
   --pf-c-sidebar__main--FlexDirection: column;
@@ -28,6 +30,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar--m-stack__panel--Top: 0;
   --pf-c-sidebar--m-stack__panel--BoxShadow: var(--pf-c-sidebar__panel--BoxShadow--base);
   --pf-c-sidebar--m-stack--m-panel-right__panel--Order: 0;
+  --pf-c-sidebar--m-stack--child--Height: auto;
 
   // Split
   --pf-c-sidebar--m-split__main--AlignItems: start;
@@ -35,6 +38,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar--m-split__panel--Position: static;
   --pf-c-sidebar--m-split__panel--Top: auto;
   --pf-c-sidebar--m-split--m-panel-right__panel--Order: 1;
+  --pf-c-sidebar--m-split--child--Height: auto;
 
   // Panel
   --pf-c-sidebar__panel--FlexBasis--base: auto;
@@ -60,13 +64,17 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --pf-c-sidebar__panel--m-sticky--Top: 0;
   --pf-c-sidebar__panel--m-sticky--Position: sticky;
 
+  // Full height
+  --pf-c-sidebar--child--m-full-height--Height: 100%;
+
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-sidebar__main--FlexDirection: var(--pf-c-sidebar__main--md--FlexDirection);
+    --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--BoxShadow: none;
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--md--FlexBasis);
-    --pf-c-sidebar__main--AlignItems: var(--pf-c-sidebar__main--md--AlignItems);
     --pf-c-sidebar__panel--Top: var(--pf-c-sidebar__panel--md--Top);
     --pf-c-sidebar__panel--Position: var(--pf-c-sidebar__panel--md--Position);
+    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);
   }
 
   @media (min-width: $pf-global--breakpoint--xl) {
@@ -106,6 +114,7 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: var(--pf-c-sidebar--m-stack__panel--BoxShadow);
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-stack--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-stack--m-panel-right__panel--Order);
+    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-stack--child--Height);
   }
 
   &.pf-m-split {
@@ -118,9 +127,24 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --pf-c-sidebar__panel--BoxShadow: none;
     --pf-c-sidebar__panel--FlexBasis: var(--pf-c-sidebar__panel--m-split--FlexBasis);
     --pf-c-sidebar--m-panel-right__panel--Order: var(--pf-c-sidebar--m-split--m-panel-right__panel--Order);
+    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--m-split--child--Height);
   }
 
   height: 100%;
+}
+
+.pf-c-sidebar__content,
+.pf-c-sidebar__panel {
+  height: var(--pf-c-sidebar--child--Height);
+
+  @media (min-width: $pf-global--breakpoint--md) {
+    --pf-c-sidebar--child--Height: var(--pf-c-sidebar--child--md--Height);
+  }
+
+  &.pf-m-full-height {
+    --pf-c-sidebar--child--md--Height: var(--pf-c-sidebar--child--m-full-height--Height); // default layout switch height update
+    --pf-c-sidebar--m-split--child--Height: var(--pf-c-sidebar--child--m-full-height--Height); // split child layout update
+  }
 }
 
 .pf-c-sidebar__main {

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -57,13 +57,6 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Vertical
-```hbs
-{{#> tabs tabs--id="vertical-example" tabs--modifier="pf-m-vertical"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
-{{/tabs}}
-```
-
 ### Box
 ```hbs
 {{#> tabs tabs--id="box-example" tabs--modifier="pf-m-box"}}
@@ -75,13 +68,6 @@ import './Tabs.css'
 ```hbs
 {{#> tabs tabs--id="box-overflow-example" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
-{{/tabs}}
-```
-
-### Box vertical
-```hbs
-{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
@@ -201,6 +187,20 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
+### Vertical
+```hbs
+{{#> tabs tabs--id="vertical-example" tabs--modifier="pf-m-vertical"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+{{/tabs}}
+```
+
+### Box vertical
+```hbs
+{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+{{/tabs}}
+```
+
 ### Vertical expandable
 ```hbs
 {{#> tabs tabs--id="vertical-expandable-example" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical"}}
@@ -212,6 +212,14 @@ import './Tabs.css'
 ### Vertical expanded
 ```hbs
 {{#> tabs tabs--id="vertical-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical, box, expanded
+```hbs
+{{#> tabs tabs--id="vertical-box-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box"}}
   {{> tabs-toggle}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -194,7 +194,7 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Box vertical
+### Vertical box
 ```hbs
 {{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
@@ -217,7 +217,7 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Vertical, box, expanded
+### Vertical box expanded
 ```hbs
 {{#> tabs tabs--id="vertical-box-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box"}}
   {{> tabs-toggle}}
@@ -348,6 +348,7 @@ Whenever a list of tabs is unique on the current page, it can be used in a `<nav
 | `.pf-m-border-bottom` | `.pf-c-tabs` | Adds a bottom border to secondary tabs. |
 | `.pf-m-box` | `.pf-c-tabs` | Applies box styling to the tab component. |
 | `.pf-m-vertical` | `.pf-c-tabs` | Applies vertical styling to the tab component. |
+| `.pf-m-sticky` | `.pf-c-tabs.pf-m-vertical` | Modifies tab list to be sticky to the top of its container. |
 | `.pf-m-fill` | `.pf-c-tabs` | Modifies the tabs to fill the available space. |
 | `.pf-m-current` | `.pf-c-tabs__item` | Indicates that a tab item is currently selected. |
 | `.pf-m-action` | `.pf-c-tabs__item` | Indicates that a tab item contains actions other than the tab link. |

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -35,7 +35,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical--m-non-expandable--border--Left: 0;
 
   // Box
+  --pf-c-tabs--m-box__link--last-child--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
+  --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
 
   // Alt color scheme
   --pf-c-tabs--m-color-scheme--light-300__link--BackgroundColor: transparent;
@@ -84,6 +86,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--before--BorderBottomWidth: 0;
   --pf-c-tabs__link--before--BorderLeftWidth: 0;
   --pf-c-tabs__link--before--Left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+  --pf-c-tabs__link--disabled--before--BorderRightWidth: 0;
   --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
 
@@ -261,7 +264,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   &.pf-m-box {
     --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor);
     --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-box__link--disabled--BackgroundColor);
+    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
     --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
     --pf-c-tabs__link--after--Top: 0;
     --pf-c-tabs__link--after--Bottom: auto;
 
@@ -462,6 +467,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // Box, vertical
   &.pf-m-box.pf-m-vertical {
     --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
+    --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
+    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
 
@@ -732,6 +739,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   &.pf-m-aria-disabled {
     --pf-c-tabs__link--Color: var(--pf-c-tabs__link--disabled--Color);
     --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__link--disabled--BackgroundColor);
+    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--disabled--before--BorderRightWidth);
     --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--disabled--before--BorderBottomWidth);
     --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--disabled--before--BorderLeftWidth);
     --pf-c-tabs__link--after--BorderWidth: 0;

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -410,8 +410,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   &.pf-m-vertical.pf-m-expandable {
-    --pf-c-tabs__link--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
-    --pf-c-tabs__link--before--BorderRightColor: transparent;
+    --pf-c-tabs__link--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm)); // updated vertical expandable padding to match toggle
     --pf-c-tabs__list--before--Left: var(--pf-c-tabs--m-vertical--m-expandable--before--Left);
 
     // stylelint-disable selector-max-class

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -16,15 +16,27 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
   --pf-c-tabs--m-page-insets--xl--inset: var(--pf-global--spacer--lg); // make this the default inset at breaking change
 
+  // Expandable
+  --pf-c-tabs--m-expandable__toggle--MarginTop: var(--pf-global--spacer--sm);
+
   // Vertical
   --pf-c-tabs--m-vertical--Width: 100%;
-  --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
+  --pf-c-tabs--m-vertical--MaxWidth: auto;
   --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
   --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
   --pf-c-tabs--m-vertical__list--before--BorderTopWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderBottomWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
+  --pf-c-tabs--m-vertical__item--MarginTop: var(--pf-c-tabs--inset);
+  --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
+
+  // Vertical, expandable
+  --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-global--spacer--md);
+  --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-global--spacer--md);
+
+  // Vertical, non-expandable
+  --pf-c-tabs--m-vertical--m-non-expandable--border--Left: 0;
 
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
@@ -44,6 +56,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__item--m-action__link--PaddingRight: var(--pf-global--spacer--sm);
 
   // Tab link
+  --pf-c-tabs__link--PaddingLeft--base: var(--pf-global--spacer--md);
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);
   --pf-c-tabs__link--FontSize: var(--pf-global--FontSize--md);
   --pf-c-tabs__link--BackgroundColor: transparent;
@@ -51,7 +64,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
   --pf-c-tabs__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-global--palette--black-150);
   --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
@@ -132,9 +145,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__toggle-text--MarginLeft: 0;
   --pf-c-tabs__toggle-button__toggle-text--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-tabs__toggle-button__toggle-text--Color: var(--pf-global--Color--100);
-  --pf-c-tabs__toggle-button--MarginTop: calc(-1 * var(--pf-global--spacer--form-element));
-  --pf-c-tabs__toggle-button--MarginBottom: calc(-1 * var(--pf-global--spacer--form-element));
-  --pf-c-tabs__toggle-button--MarginLeft: calc(-1 * var(--pf-global--spacer--md));
+  --pf-c-tabs__toggle-button--MarginTop: 0; // update at breaking change
+  --pf-c-tabs__toggle-button--MarginBottom: 0; // update at breaking change
+  --pf-c-tabs__toggle-button--MarginLeft: 0; // update at breaking change
   --pf-c-tabs--m-expanded__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-tabs--m-expanded__toggle-icon--Rotate: 90deg;
 
@@ -315,156 +328,186 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   // Vertical
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    &.pf-m-vertical {
-      --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width);
-      --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset);
-      --pf-c-tabs--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
-      --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
-      --pf-c-tabs__link--before--Left: 0;
-      --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
-      --pf-c-tabs__link--after--Top: 0;
-      --pf-c-tabs__link--after--Bottom: 0;
-      --pf-c-tabs__link--after--Right: auto;
-      --pf-c-tabs__list--ScrollSnapTypeAxis: var(--pf-c-tabs--m-vertical__list--ScrollSnapTypeAxis);
+  &.pf-m-vertical,
+  &.pf-m-expandable {
+    --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width);
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset);
+    --pf-c-tabs--before--BorderBottomWidth: 0;
+    --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
+    --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
+    --pf-c-tabs__link--before--Left: 0;
+    --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0;
+    --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
+    --pf-c-tabs__link--after--Top: 0;
+    --pf-c-tabs__link--after--Bottom: 0;
+    --pf-c-tabs__link--after--Right: auto;
+    --pf-c-tabs__list--ScrollSnapTypeAxis: var(--pf-c-tabs--m-vertical__list--ScrollSnapTypeAxis);
 
-      display: inline-flex;
+    display: inline-flex;
+    flex-direction: column;
+    height: 100%; // If not a flex child, set height
+    padding: 0; // Because vertical variant has no scroll buttons, reset padding
+    overflow: visible; // remove in breaking change release
+
+    .pf-c-tabs__list {
+      position: relative;
       flex-direction: column;
-      height: 100%; // If not a flex child, set height
-      padding: 0; // Because vertical variant has no scroll buttons, reset padding
-      overflow: visible; // remove in breaking change release
+      flex-grow: 1;
+      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
 
-      .pf-c-tabs__list {
-        position: relative;
-        flex-direction: column;
-        flex-grow: 1;
-        max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
-
-        // stylelint-disable max-nesting-depth
-        &::before {
-          position: absolute;
-          right: auto;
-          border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
-          border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
-        }
-        // stylelint-enable
-      }
-
-      // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
-      .pf-c-tabs__item:first-child {
-        margin-top: var(--pf-c-tabs--inset);
-      }
-
-      .pf-c-tabs__item:last-child {
-        margin-bottom: var(--pf-c-tabs--inset);
-      }
-
-      // Set hover on left border
-      .pf-c-tabs__link {
-        --pf-c-tabs__link--after--BorderTopWidth: 0;
-        --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth);
-
-        max-width: 100%;
-        text-align: left;
-      }
-
-      .pf-c-tabs__item-text {
-        max-width: 100%;
-        overflow-wrap: break-word;
-      }
-
-      @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
-        $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
-
-        // stylelint-disable max-nesting-depth
-        @include pf-apply-breakpoint($breakpoint) {
-          &.pf-m-expandable#{$breakpoint-name} {
-            --pf-c-tabs__list--Display: none;
-            --pf-c-tabs__list--Visibility: hidden;
-            --pf-c-tabs__toggle--Display: flex;
-            --pf-c-tabs__toggle--Visibility: visible;
-          }
-
-          &.pf-m-non-expandable#{$breakpoint-name} {
-            --pf-c-tabs__list--Display: flex;
-            --pf-c-tabs__list--Visibility: visible;
-            --pf-c-tabs__toggle--Display: none;
-            --pf-c-tabs__toggle--Visibility: hidden;
-          }
-        }
-        // stylelint-enable
-      }
-
-      &.pf-m-expanded {
-        --pf-c-tabs__list--Display: flex;
-        --pf-c-tabs__list--Visibility: visible;
-        --pf-c-tabs__toggle--MarginBottom: var(--pf-c-tabs--m-expanded__toggle--MarginBottom);
-        --pf-c-tabs__toggle-icon--Color: var(--pf-c-tabs--m-expanded__toggle-icon--Color);
-        --pf-c-tabs__toggle-icon--Rotate: var(--pf-c-tabs--m-expanded__toggle-icon--Rotate);
-      }
-    }
-
-    // Box, vertical
-    &.pf-m-box.pf-m-vertical {
-      --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
-      --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
-      --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
-      --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
-      --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
-      --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
-
-      .pf-c-tabs__list::before {
-        right: 0;
-        left: auto;
-      }
-
-      // stylelint-disable selector-max-class, max-nesting-depth
-      // Remove border from last-child
-      .pf-c-tabs__item:last-child {
-        --pf-c-tabs__link--before--BorderBottomWidth: 0;
-        --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
-      }
-
-      // Add border right color and weight
-      .pf-c-tabs__item.pf-m-current {
-        --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
-        --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
-        --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
-
-        &:first-child {
-          --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
-        }
-      }
-
-      // Add border right color and weight
-      .pf-c-tabs__item:first-child.pf-m-current {
-        --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
-      }
-
-      // Offset vertical border to overlap horizontal border
-      .pf-c-tabs__link::after {
-        top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
-      }
-
-      // Undo offset to .pf-m-current adjacent item
-      .pf-c-tabs__item:first-child .pf-c-tabs__link::after,
-      .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item .pf-c-tabs__link::after {
-        top: 0;
+      // stylelint-disable max-nesting-depth
+      &::before {
+        position: absolute;
+        right: auto;
+        border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+        border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
       }
       // stylelint-enable
     }
 
-    &.pf-m-secondary {
-      --pf-c-tabs__link--FontSize: var(--pf-c-tabs--m-secondary__link--FontSize);
-      --pf-c-tabs__item-close--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-close--c-button--FontSize);
-      --pf-c-tabs__add--c-button--FontSize: var(--pf-c-tabs--m-secondary__add--c-button--FontSize);
+    // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
+    .pf-c-tabs__item:first-child {
+      margin-top: var(--pf-c-tabs--m-vertical__item--MarginTop);
     }
 
-    &.pf-m-page-insets {
-      --pf-c-tabs--inset: var(--pf-c-tabs--m-page-insets--inset);
+    .pf-c-tabs__item:last-child {
+      margin-bottom: var(--pf-c-tabs--m-vertical__item--MarginBottom);
     }
+
+    // Set hover on left border
+    .pf-c-tabs__link {
+      --pf-c-tabs__link--after--BorderTopWidth: 0;
+      --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth);
+
+      max-width: 100%;
+      text-align: left;
+    }
+
+    .pf-c-tabs__item-text {
+      max-width: 100%;
+      overflow-wrap: break-word;
+    }
+
+    &.pf-m-expanded {
+      --pf-c-tabs__list--Display: flex;
+      --pf-c-tabs__list--Visibility: visible;
+      --pf-c-tabs__toggle--MarginBottom: var(--pf-c-tabs--m-expanded__toggle--MarginBottom);
+      --pf-c-tabs__toggle-icon--Color: var(--pf-c-tabs--m-expanded__toggle-icon--Color);
+      --pf-c-tabs__toggle-icon--Rotate: var(--pf-c-tabs--m-expanded__toggle-icon--Rotate);
+    }
+  }
+
+  &.pf-m-vertical.pf-m-expandable {
+    --pf-c-tabs__link--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
+    --pf-c-tabs__link--before--BorderRightColor: transparent;
+
+    .pf-c-tabs__list::before,
+    .pf-c-tabs__link::after,
+    .pf-c-tabs__item.pf-m-action .pf-c-tabs__link::after {
+      left: var(--pf-c-tabs--m-vertical--m-expandable--border--Left);
+    }
+
+    &.pf-m-box {
+      --pf-c-tabs--m-vertical__item--MarginTop: 0;
+      --pf-c-tabs--m-vertical__item--MarginBottom: 0;
+      --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
+    }
+
+    .pf-c-tabs__toggle {
+      margin-top: var(--pf-c-tabs--m-expandable__toggle--MarginTop);
+    }
+  }
+
+  @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint) {
+      &.pf-m-expandable#{$breakpoint-name} {
+        --pf-c-tabs__list--Display: none;
+        --pf-c-tabs__list--Visibility: hidden;
+        --pf-c-tabs__toggle--Display: flex;
+        --pf-c-tabs__toggle--Visibility: visible;
+      }
+
+      &.pf-m-non-expandable#{$breakpoint-name} {
+        --pf-c-tabs__list--Display: flex;
+        --pf-c-tabs__list--Visibility: visible;
+        --pf-c-tabs__toggle--Display: none;
+        --pf-c-tabs__toggle--Visibility: hidden;
+      }
+
+      &.pf-m-vertical.pf-m-non-expandable#{$breakpoint-name} {
+        --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
+        --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-c-tabs--m-vertical--m-non-expandable--border--Left);
+        --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--border-color--base);
+        --pf-c-tabs--m-expandable__toggle--MarginTop: 0;
+
+        &.pf-m-box {
+          --pf-c-tabs--m-vertical__item--MarginTop: var(--pf-c-tabs--inset);
+          --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
+        }
+      }
+    }
+  }
+
+  // Box, vertical
+  &.pf-m-box.pf-m-vertical {
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
+    --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
+    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+    --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
+    --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
+
+    .pf-c-tabs__list::before {
+      right: 0;
+      left: auto;
+    }
+
+    // stylelint-disable selector-max-class, max-nesting-depth
+    // Remove border from last-child
+    .pf-c-tabs__item:last-child {
+      --pf-c-tabs__link--before--BorderBottomWidth: 0;
+      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+    }
+
+    // Add border right color and weight
+    .pf-c-tabs__item.pf-m-current {
+      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
+      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
+      --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+
+      &:first-child {
+        --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
+    }
+
+    // Add border right color and weight
+    .pf-c-tabs__item:first-child.pf-m-current {
+      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+    }
+
+    // Offset vertical border to overlap horizontal border
+    .pf-c-tabs__link::after {
+      top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+    }
+
+    // Undo offset to .pf-m-current adjacent item
+    .pf-c-tabs__item:first-child .pf-c-tabs__link::after,
+    .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item .pf-c-tabs__link::after {
+      top: 0;
+    }
+    // stylelint-enable
+  }
+
+  &.pf-m-secondary {
+    --pf-c-tabs__link--FontSize: var(--pf-c-tabs--m-secondary__link--FontSize);
+    --pf-c-tabs__item-close--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-close--c-button--FontSize);
+    --pf-c-tabs__add--c-button--FontSize: var(--pf-c-tabs--m-secondary__add--c-button--FontSize);
+  }
+
+  &.pf-m-page-insets {
+    --pf-c-tabs--inset: var(--pf-c-tabs--m-page-insets--inset);
   }
 
   &.pf-m-overflow {
@@ -509,7 +552,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   margin-left: var(--pf-c-tabs__toggle-text--MarginLeft);
   color: var(--pf-c-tabs__toggle-text--Color, inherit);
 }
-
 
 // Tab list
 .pf-c-tabs__list {
@@ -586,6 +628,10 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 .pf-c-tabs__list::before,
 .pf-c-tabs__add::before {
   border: 0;
+}
+
+.pf-c-tabs__list::before {
+  left: var(--pf-c-tabs--m-vertical--m-expandable--border--Left);
 }
 
 // Tab link

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -429,6 +429,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   &.pf-m-vertical::before {
+    --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
+    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+
     position: absolute;
     top: 0;
     right: 0;
@@ -479,8 +482,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // Box, vertical
   &.pf-m-box.pf-m-vertical {
     --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
-    --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
-    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -25,8 +25,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderBottomWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
-  --pf-c-tabs--m-vertical__item--MarginTop: var(--pf-c-tabs--inset);
-  --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
+  --pf-c-tabs--m-vertical__item--first-child--MarginTop: var(--pf-c-tabs--inset);
+  --pf-c-tabs--m-vertical__item--last-child--MarginBottom: var(--pf-c-tabs--inset);
 
   // Vertical, expandable
   --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-global--spacer--md);
@@ -342,30 +342,15 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     display: inline-flex;
     flex-direction: column;
+    max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
     height: 100%; // If not a flex child, set height
     padding: 0; // Because vertical variant has no scroll buttons, reset padding
     overflow: visible; // remove in breaking change release
-
-    // &.pf-m-sticky::before {
-    //   position: absolute;
-    //   top: 0;
-    //   right: 0;
-    //   bottom: 0;
-    //   left: 0;
-    //   border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
-    //   border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
-
-
-    //   .pf-c-tabs__list::before {
-    //     display: none; // update at breaking change
-    //   }
-    // }
 
     .pf-c-tabs__list {
       position: relative;
       flex-direction: column;
       flex-grow: 1;
-      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
 
       // stylelint-disable max-nesting-depth
       &::before {
@@ -379,11 +364,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
     .pf-c-tabs__item:first-child {
-      margin-top: var(--pf-c-tabs--m-vertical__item--MarginTop);
+      margin-top: var(--pf-c-tabs--m-vertical__item--first-child--MarginTop);
     }
 
     .pf-c-tabs__item:last-child {
-      margin-bottom: var(--pf-c-tabs--m-vertical__item--MarginBottom);
+      margin-bottom: var(--pf-c-tabs--m-vertical__item--last-child--MarginBottom);
     }
 
     // Set hover on left border
@@ -422,8 +407,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // stylelint-enable
 
     &.pf-m-box {
-      --pf-c-tabs--m-vertical__item--MarginTop: 0;
-      --pf-c-tabs--m-vertical__item--MarginBottom: 0;
+      --pf-c-tabs--m-vertical__item--first-child--MarginTop: 0;
+      --pf-c-tabs--m-vertical__item--last-child--MarginBottom: 0;
       --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
     }
   }
@@ -471,8 +456,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
         // stylelint-disable max-nesting-depth
         &.pf-m-box {
-          --pf-c-tabs--m-vertical__item--MarginTop: var(--pf-c-tabs--inset);
-          --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
+          --pf-c-tabs--m-vertical__item--first-child--MarginTop: var(--pf-c-tabs--inset);
+          --pf-c-tabs--m-vertical__item--last-child--MarginBottom: var(--pf-c-tabs--inset);
         }
         // stylelint-enable
       }
@@ -666,7 +651,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 .pf-c-tabs__add::before {
   border: 0;
 }
-
 
 // Tab link
 .pf-c-tabs__link {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -402,11 +402,13 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     --pf-c-tabs__link--before--BorderRightColor: transparent;
     --pf-c-tabs__list--before--Left: var(--pf-c-tabs--m-vertical--m-expandable--before--Left);
 
+    // stylelint-disable selector-max-class
     .pf-c-tabs__list::before,
     .pf-c-tabs__link::after,
     .pf-c-tabs__item.pf-m-action .pf-c-tabs__link::after {
       left: var(--pf-c-tabs--m-vertical--m-expandable--before--Left);
     }
+    // stylelint-enable
 
     &.pf-m-box {
       --pf-c-tabs--m-vertical__item--MarginTop: 0;
@@ -439,14 +441,16 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
       &.pf-m-vertical.pf-m-non-expandable#{$breakpoint-name} {
         --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
-        --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs--m-vertical--m-non-expandable--border--Left);
         --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--border-color--base);
         --pf-c-tabs--m-expandable__toggle--MarginTop: 0;
+        --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs--m-vertical--m-non-expandable--border--Left);
 
+        // stylelint-disable max-nesting-depth
         &.pf-m-box {
           --pf-c-tabs--m-vertical__item--MarginTop: var(--pf-c-tabs--inset);
           --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
         }
+        // stylelint-enable
       }
     }
   }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -346,20 +346,20 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     padding: 0; // Because vertical variant has no scroll buttons, reset padding
     overflow: visible; // remove in breaking change release
 
-    &.pf-m-sticky::before {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
-      border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
+    // &.pf-m-sticky::before {
+    //   position: absolute;
+    //   top: 0;
+    //   right: 0;
+    //   bottom: 0;
+    //   left: 0;
+    //   border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+    //   border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
 
 
-      .pf-c-tabs__list::before {
-        display: none; // update at breaking change
-      }
-    }
+    //   .pf-c-tabs__list::before {
+    //     display: none; // update at breaking change
+    //   }
+    // }
 
     .pf-c-tabs__list {
       position: relative;
@@ -425,6 +425,20 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       --pf-c-tabs--m-vertical__item--MarginTop: 0;
       --pf-c-tabs--m-vertical__item--MarginBottom: 0;
       --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
+    }
+  }
+
+  &.pf-m-vertical::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+    border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
+
+    .pf-c-tabs__list::before {
+      display: contents; // update at breaking change
     }
   }
 
@@ -533,20 +547,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     position: sticky;
     top: calc(var(--pf-c-tabs--inset) * -1);
     flex-grow: 0;
-  }
-
-  &.pf-m-vertical.pf-m-box::before {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
-    border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
-
-    .pf-c-tabs__list::before {
-      display: contents; // update at breaking change
-    }
   }
 }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -16,12 +16,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
   --pf-c-tabs--m-page-insets--xl--inset: var(--pf-global--spacer--lg); // make this the default inset at breaking change
 
-  // Expandable
-  --pf-c-tabs--m-expandable__toggle--MarginTop: var(--pf-global--spacer--sm);
-
   // Vertical
   --pf-c-tabs--m-vertical--Width: 100%;
-  --pf-c-tabs--m-vertical--MaxWidth: auto;
+  --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
   --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
   --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
   --pf-c-tabs--m-vertical__list--before--BorderTopWidth: 0;
@@ -349,6 +346,21 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     padding: 0; // Because vertical variant has no scroll buttons, reset padding
     overflow: visible; // remove in breaking change release
 
+    &.pf-m-sticky::before {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+      border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
+
+
+      .pf-c-tabs__list::before {
+        display: none; // update at breaking change
+      }
+    }
+
     .pf-c-tabs__list {
       position: relative;
       flex-direction: column;
@@ -414,10 +426,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       --pf-c-tabs--m-vertical__item--MarginTop: 0;
       --pf-c-tabs--m-vertical__item--MarginBottom: 0;
       --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
-    }
-
-    .pf-c-tabs__toggle {
-      margin-top: var(--pf-c-tabs--m-expandable__toggle--MarginTop);
     }
   }
 
@@ -521,6 +529,26 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       overflow: visible;
     }
   }
+
+  &.pf-m-sticky .pf-c-tabs__list {
+    position: sticky;
+    top: calc(var(--pf-c-tabs--inset) * -1);
+    flex-grow: 0;
+  }
+
+  &.pf-m-vertical.pf-m-box::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+    border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
+
+    .pf-c-tabs__list::before {
+      display: contents; // update at breaking change
+    }
+  }
 }
 
 // Expandable toggle
@@ -570,6 +598,10 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   scroll-snap-type: var(--pf-c-tabs__list--ScrollSnapType);
   visibility: var(--pf-c-tabs__list--Visibility);
   -webkit-overflow-scrolling: touch;
+
+  &::before {
+    left: var(--pf-c-tabs__list--before--Left);
+  }
 }
 
 // Tabs item
@@ -635,9 +667,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   border: 0;
 }
 
-.pf-c-tabs__list::before {
-  left: var(--pf-c-tabs__list--before--Left);
-}
 
 // Tab link
 .pf-c-tabs__link {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -315,152 +315,156 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   }
 
   // Vertical
-  &.pf-m-vertical {
-    --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width);
-    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset);
-    --pf-c-tabs--before--BorderBottomWidth: 0;
-    --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
-    --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
-    --pf-c-tabs__link--before--Left: 0;
-    --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0;
-    --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
-    --pf-c-tabs__link--after--Top: 0;
-    --pf-c-tabs__link--after--Bottom: 0;
-    --pf-c-tabs__link--after--Right: auto;
-    --pf-c-tabs__list--ScrollSnapTypeAxis: var(--pf-c-tabs--m-vertical__list--ScrollSnapTypeAxis);
+  @media screen and (min-width: $pf-global--breakpoint--md) {
+    &.pf-m-vertical {
+      --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width);
+      --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset);
+      --pf-c-tabs--before--BorderBottomWidth: 0;
+      --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop);
+      --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom);
+      --pf-c-tabs__link--before--Left: 0;
+      --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0;
+      --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
+      --pf-c-tabs__link--after--Top: 0;
+      --pf-c-tabs__link--after--Bottom: 0;
+      --pf-c-tabs__link--after--Right: auto;
+      --pf-c-tabs__list--ScrollSnapTypeAxis: var(--pf-c-tabs--m-vertical__list--ScrollSnapTypeAxis);
 
-    display: inline-flex;
-    flex-direction: column;
-    height: 100%; // If not a flex child, set height
-    padding: 0; // Because vertical variant has no scroll buttons, reset padding
-    overflow: visible; // remove in breaking change release
-
-    .pf-c-tabs__list {
-      position: relative;
+      display: inline-flex;
       flex-direction: column;
-      flex-grow: 1;
-      max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
+      height: 100%; // If not a flex child, set height
+      padding: 0; // Because vertical variant has no scroll buttons, reset padding
+      overflow: visible; // remove in breaking change release
 
-      &::before {
-        position: absolute;
-        right: auto;
-        border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
-        border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
-      }
-    }
+      .pf-c-tabs__list {
+        position: relative;
+        flex-direction: column;
+        flex-grow: 1;
+        max-width: var(--pf-c-tabs--m-vertical--MaxWidth);
 
-    // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
-    .pf-c-tabs__item:first-child {
-      margin-top: var(--pf-c-tabs--inset);
-    }
-
-    .pf-c-tabs__item:last-child {
-      margin-bottom: var(--pf-c-tabs--inset);
-    }
-
-    // Set hover on left border
-    .pf-c-tabs__link {
-      --pf-c-tabs__link--after--BorderTopWidth: 0;
-      --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth);
-
-      max-width: 100%;
-      text-align: left;
-    }
-
-    .pf-c-tabs__item-text {
-      max-width: 100%;
-      overflow-wrap: break-word;
-    }
-
-    @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
-      $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
-
-      @include pf-apply-breakpoint($breakpoint) {
         // stylelint-disable max-nesting-depth
-        &.pf-m-expandable#{$breakpoint-name} {
-          --pf-c-tabs__list--Display: none;
-          --pf-c-tabs__list--Visibility: hidden;
-          --pf-c-tabs__toggle--Display: flex;
-          --pf-c-tabs__toggle--Visibility: visible;
-        }
-
-        &.pf-m-non-expandable#{$breakpoint-name} {
-          --pf-c-tabs__list--Display: flex;
-          --pf-c-tabs__list--Visibility: visible;
-          --pf-c-tabs__toggle--Display: none;
-          --pf-c-tabs__toggle--Visibility: hidden;
+        &::before {
+          position: absolute;
+          right: auto;
+          border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
+          border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
         }
         // stylelint-enable
       }
-    }
 
-    &.pf-m-expanded {
-      --pf-c-tabs__list--Display: flex;
-      --pf-c-tabs__list--Visibility: visible;
-      --pf-c-tabs__toggle--MarginBottom: var(--pf-c-tabs--m-expanded__toggle--MarginBottom);
-      --pf-c-tabs__toggle-icon--Color: var(--pf-c-tabs--m-expanded__toggle-icon--Color);
-      --pf-c-tabs__toggle-icon--Rotate: var(--pf-c-tabs--m-expanded__toggle-icon--Rotate);
-    }
-  }
+      // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
+      .pf-c-tabs__item:first-child {
+        margin-top: var(--pf-c-tabs--inset);
+      }
 
-  // Box, vertical
-  &.pf-m-box.pf-m-vertical {
-    --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
-    --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
-    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
-    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
-    --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
-    --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
+      .pf-c-tabs__item:last-child {
+        margin-bottom: var(--pf-c-tabs--inset);
+      }
 
-    .pf-c-tabs__list::before {
-      right: 0;
-      left: auto;
-    }
+      // Set hover on left border
+      .pf-c-tabs__link {
+        --pf-c-tabs__link--after--BorderTopWidth: 0;
+        --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth);
 
-    // stylelint-disable selector-max-class
-    // Remove border from last-child
-    .pf-c-tabs__item:last-child {
-      --pf-c-tabs__link--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
-    }
+        max-width: 100%;
+        text-align: left;
+      }
 
-    // Add border right color and weight
-    .pf-c-tabs__item.pf-m-current {
-      --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
-      --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
-      --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+      .pf-c-tabs__item-text {
+        max-width: 100%;
+        overflow-wrap: break-word;
+      }
 
-      &:first-child {
-        --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+      @each $breakpoint, $breakpoint-value in $pf-c-tabs--breakpoint-map {
+        $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+        // stylelint-disable max-nesting-depth
+        @include pf-apply-breakpoint($breakpoint) {
+          &.pf-m-expandable#{$breakpoint-name} {
+            --pf-c-tabs__list--Display: none;
+            --pf-c-tabs__list--Visibility: hidden;
+            --pf-c-tabs__toggle--Display: flex;
+            --pf-c-tabs__toggle--Visibility: visible;
+          }
+
+          &.pf-m-non-expandable#{$breakpoint-name} {
+            --pf-c-tabs__list--Display: flex;
+            --pf-c-tabs__list--Visibility: visible;
+            --pf-c-tabs__toggle--Display: none;
+            --pf-c-tabs__toggle--Visibility: hidden;
+          }
+        }
+        // stylelint-enable
+      }
+
+      &.pf-m-expanded {
+        --pf-c-tabs__list--Display: flex;
+        --pf-c-tabs__list--Visibility: visible;
+        --pf-c-tabs__toggle--MarginBottom: var(--pf-c-tabs--m-expanded__toggle--MarginBottom);
+        --pf-c-tabs__toggle-icon--Color: var(--pf-c-tabs--m-expanded__toggle-icon--Color);
+        --pf-c-tabs__toggle-icon--Rotate: var(--pf-c-tabs--m-expanded__toggle-icon--Rotate);
       }
     }
 
-    // Add border right color and weight
-    .pf-c-tabs__item:first-child.pf-m-current {
-      --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+    // Box, vertical
+    &.pf-m-box.pf-m-vertical {
+      --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
+      --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
+      --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+      --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
+      --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
+      --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
+
+      .pf-c-tabs__list::before {
+        right: 0;
+        left: auto;
+      }
+
+      // stylelint-disable selector-max-class, max-nesting-depth
+      // Remove border from last-child
+      .pf-c-tabs__item:last-child {
+        --pf-c-tabs__link--before--BorderBottomWidth: 0;
+        --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
+
+      // Add border right color and weight
+      .pf-c-tabs__item.pf-m-current {
+        --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor);
+        --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base);
+        --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
+
+        &:first-child {
+          --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+        }
+      }
+
+      // Add border right color and weight
+      .pf-c-tabs__item:first-child.pf-m-current {
+        --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+      }
+
+      // Offset vertical border to overlap horizontal border
+      .pf-c-tabs__link::after {
+        top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+      }
+
+      // Undo offset to .pf-m-current adjacent item
+      .pf-c-tabs__item:first-child .pf-c-tabs__link::after,
+      .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item .pf-c-tabs__link::after {
+        top: 0;
+      }
+      // stylelint-enable
     }
 
-    // Offset vertical border to overlap horizontal border
-    .pf-c-tabs__link::after {
-      top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+    &.pf-m-secondary {
+      --pf-c-tabs__link--FontSize: var(--pf-c-tabs--m-secondary__link--FontSize);
+      --pf-c-tabs__item-close--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-close--c-button--FontSize);
+      --pf-c-tabs__add--c-button--FontSize: var(--pf-c-tabs--m-secondary__add--c-button--FontSize);
     }
 
-    // Undo offset to .pf-m-current adjacent item
-    .pf-c-tabs__item:first-child .pf-c-tabs__link::after,
-    .pf-c-tabs__item.pf-m-current + .pf-c-tabs__item .pf-c-tabs__link::after {
-      top: 0;
+    &.pf-m-page-insets {
+      --pf-c-tabs--inset: var(--pf-c-tabs--m-page-insets--inset);
     }
-    // stylelint-enable
-  }
-
-  &.pf-m-secondary {
-    --pf-c-tabs__link--FontSize: var(--pf-c-tabs--m-secondary__link--FontSize);
-    --pf-c-tabs__item-close--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-close--c-button--FontSize);
-    --pf-c-tabs__add--c-button--FontSize: var(--pf-c-tabs--m-secondary__add--c-button--FontSize);
-  }
-
-  &.pf-m-page-insets {
-    --pf-c-tabs--inset: var(--pf-c-tabs--m-page-insets--inset);
   }
 
   &.pf-m-overflow {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -32,8 +32,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical__item--MarginBottom: var(--pf-c-tabs--inset);
 
   // Vertical, expandable
-  --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-global--spacer--md);
-  --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-global--spacer--md);
+  --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-global--spacer--md);
 
   // Vertical, non-expandable
   --pf-c-tabs--m-vertical--m-non-expandable--border--Left: 0;
@@ -50,6 +49,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // List
   --pf-c-tabs__list--Display: flex;
   --pf-c-tabs__list--Visibility: visible;
+  --pf-c-tabs__list--before--Left: 0;
 
   // Item
   --pf-c-tabs__item--m-action--before--ZIndex: var(--pf-global--ZIndex--xs);
@@ -400,17 +400,18 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   &.pf-m-vertical.pf-m-expandable {
     --pf-c-tabs__link--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
     --pf-c-tabs__link--before--BorderRightColor: transparent;
+    --pf-c-tabs__list--before--Left: var(--pf-c-tabs--m-vertical--m-expandable--before--Left);
 
     .pf-c-tabs__list::before,
     .pf-c-tabs__link::after,
     .pf-c-tabs__item.pf-m-action .pf-c-tabs__link::after {
-      left: var(--pf-c-tabs--m-vertical--m-expandable--border--Left);
+      left: var(--pf-c-tabs--m-vertical--m-expandable--before--Left);
     }
 
     &.pf-m-box {
       --pf-c-tabs--m-vertical__item--MarginTop: 0;
       --pf-c-tabs--m-vertical__item--MarginBottom: 0;
-      --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
+      --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs__link--before--Left); // reset left border for box variant
     }
 
     .pf-c-tabs__toggle {
@@ -438,7 +439,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
       &.pf-m-vertical.pf-m-non-expandable#{$breakpoint-name} {
         --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
-        --pf-c-tabs--m-vertical--m-expandable--border--Left: var(--pf-c-tabs--m-vertical--m-non-expandable--border--Left);
+        --pf-c-tabs--m-vertical--m-expandable--before--Left: var(--pf-c-tabs--m-vertical--m-non-expandable--border--Left);
         --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__link--before--border-color--base);
         --pf-c-tabs--m-expandable__toggle--MarginTop: 0;
 
@@ -631,7 +632,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 }
 
 .pf-c-tabs__list::before {
-  left: var(--pf-c-tabs--m-vertical--m-expandable--border--Left);
+  left: var(--pf-c-tabs__list--before--Left);
 }
 
 // Tab link

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -36,7 +36,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
-  --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
 
   // Alt color scheme
   --pf-c-tabs--m-color-scheme--light-300__link--BackgroundColor: transparent;
@@ -85,7 +84,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--before--BorderBottomWidth: 0;
   --pf-c-tabs__link--before--BorderLeftWidth: 0;
   --pf-c-tabs__link--before--Left: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
-  --pf-c-tabs__link--disabled--before--BorderRightWidth: 0;
   --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
 
@@ -264,8 +262,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor);
     --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-box__link--disabled--BackgroundColor);
     --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base);
-    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
-    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
     --pf-c-tabs__link--after--Top: 0;
     --pf-c-tabs__link--after--Bottom: auto;
 
@@ -415,7 +411,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   &.pf-m-vertical::before {
     --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0;
-    --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
 
     position: absolute;
     top: 0;
@@ -467,7 +462,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   // Box, vertical
   &.pf-m-box.pf-m-vertical {
     --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset);
-    --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
     --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0;
 
@@ -480,7 +474,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // Remove border from last-child
     .pf-c-tabs__item:last-child {
       --pf-c-tabs__link--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs--m-box__link--last-child--before--BorderRightWidth);
     }
 
     // Add border right color and weight
@@ -738,7 +732,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   &.pf-m-aria-disabled {
     --pf-c-tabs__link--Color: var(--pf-c-tabs__link--disabled--Color);
     --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__link--disabled--BackgroundColor);
-    --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--disabled--before--BorderRightWidth);
     --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--disabled--before--BorderBottomWidth);
     --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--disabled--before--BorderLeftWidth);
     --pf-c-tabs__link--after--BorderWidth: 0;

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -281,6 +281,90 @@ section: components
 {{/inline}}
 ```
 
+### Vertical tabs
+
+```hbs isFullscreen
+{{> page-template page-template--id="vertical-tabs-example"}}
+
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> card card--modifier="pf-m"}}
+      {{#> sidebar sidebar--id="vertical-tabs-example"}}
+        {{#> sidebar-panel}}
+          {{#> tabs tabs--id=(concat sidebar--id "-tabs") tabs--modifier="pf-m-vertical pf-m-box"}}
+            {{#> tabs-list}}
+              {{> __tabs-item
+                __tabs-item--current="true"
+                __tabs-item--id="pod-info"
+                __tabs-item--aria-label="Pod information"
+                __tabs-item--text="Pod information"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-pod-info-panel"')}}
+              {{> __tabs-item
+                __tabs-item--id="editable-aspects"
+                __tabs-item--aria-label="editable aspects"
+                __tabs-item--text="Editable Aspects"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-editable-aspects-panel"')}}
+            {{/tabs-list}}
+          {{/tabs}}
+        {{/sidebar-panel}}
+        {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+          {{/tab-content}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}
+            <p>Editable aspects content</p>
+          {{/tab-content}}
+        {{/sidebar-content}}
+      {{/sidebar}}
+    {{/card}}
+  {{/page-main-section}}
+{{/inline}}
+```
+
+### Vertical tabs, full height
+
+```hbs isFullscreen
+{{> page-template page-template--id="vertical-tabs-example-full-height"}}
+
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> card card--modifier="pf-m-full-height"}}
+      {{#> sidebar sidebar--id="vertical-tabs-example-full-height" sidebar--modifier="pf-m-full-height"}}
+        {{#> sidebar-panel}}
+          {{#> tabs tabs--id=(concat sidebar--id "-tabs") tabs--modifier="pf-m-vertical pf-m-box"}}
+            {{#> tabs-list}}
+              {{> __tabs-item
+                __tabs-item--current="true"
+                __tabs-item--id="pod-info"
+                __tabs-item--aria-label="Pod information"
+                __tabs-item--text="Pod information"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-pod-info-panel"')}}
+              {{> __tabs-item
+                __tabs-item--id="editable-aspects"
+                __tabs-item--aria-label="editable aspects"
+                __tabs-item--text="Editable Aspects"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-editable-aspects-panel"')}}
+            {{/tabs-list}}
+          {{/tabs}}
+        {{/sidebar-panel}}
+        {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+          {{/tab-content}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}
+            <p>Editable aspects content</p>
+          {{/tab-content}}
+        {{/sidebar-content}}
+      {{/sidebar}}
+    {{/card}}
+  {{/page-main-section}}
+{{/inline}}
+```
+
 ### Nested tabs
 ```hbs isFullscreen
 {{> page-template page-template--id="nested-tabs-example"}}

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -293,7 +293,7 @@ section: components
     {{#> card}}
       {{#> sidebar sidebar--id="vertical-tabs-example"}}
         {{#> sidebar-panel}}
-          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expanded"}}
             {{> tabs-toggle}}
             {{#> tabs-list}}
               {{> __tabs-item
@@ -336,7 +336,7 @@ section: components
     {{#> card}}
       {{#> sidebar sidebar--id="vertical-tabs-example"}}
         {{#> sidebar-panel}}
-          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expanded"}}
             {{> tabs-toggle}}
             {{#> tabs-list}}
               {{> __tabs-item
@@ -377,9 +377,9 @@ section: components
   {{> page-template-title}}
   {{#> page-main-section}}
     {{#> card card--modifier="pf-m-full-height"}}
-      {{#> sidebar sidebar--id="vertical-tabs-example-full-height" sidebar--modifier="pf-m-full-height"}}
-        {{#> sidebar-panel}}
-          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+      {{#> sidebar sidebar--id="vertical-tabs-example-full-height"}}
+        {{#> sidebar-panel sidebar-panel--modifier="pf-m-full-height"}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expanded pf-m-sticky"}}
             {{> tabs-toggle}}
             {{#> tabs-list}}
               {{> __tabs-item
@@ -398,6 +398,26 @@ section: components
         {{/sidebar-panel}}
         {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
           {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
+            <p>Pod information content</p>
             <p>Pod information content</p>
           {{/tab-content}}
           {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -290,10 +290,54 @@ section: components
   {{> page-template-breadcrumb}}
   {{> page-template-title}}
   {{#> page-main-section}}
-    {{#> card card--modifier="pf-m"}}
+    {{#> card}}
       {{#> sidebar sidebar--id="vertical-tabs-example"}}
         {{#> sidebar-panel}}
-          {{#> tabs tabs--id=(concat sidebar--id "-tabs") tabs--modifier="pf-m-vertical pf-m-box"}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+            {{> tabs-toggle}}
+            {{#> tabs-list}}
+              {{> __tabs-item
+                __tabs-item--current="true"
+                __tabs-item--id="pod-info"
+                __tabs-item--aria-label="Pod information"
+                __tabs-item--text="Pod information"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-pod-info-panel"')}}
+              {{> __tabs-item
+                __tabs-item--id="editable-aspects"
+                __tabs-item--aria-label="editable aspects"
+                __tabs-item--text="Editable Aspects"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-editable-aspects-panel"')}}
+            {{/tabs-list}}
+          {{/tabs}}
+        {{/sidebar-panel}}
+        {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+          {{/tab-content}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}
+            <p>Editable aspects content</p>
+          {{/tab-content}}
+        {{/sidebar-content}}
+      {{/sidebar}}
+    {{/card}}
+  {{/page-main-section}}
+{{/inline}}
+```
+
+### Vertical, box tabs
+
+```hbs isFullscreen
+{{> page-template page-template--id="vertical-box-tabs-example"}}
+
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> card}}
+      {{#> sidebar sidebar--id="vertical-tabs-example"}}
+        {{#> sidebar-panel}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+            {{> tabs-toggle}}
             {{#> tabs-list}}
               {{> __tabs-item
                 __tabs-item--current="true"
@@ -335,7 +379,8 @@ section: components
     {{#> card card--modifier="pf-m-full-height"}}
       {{#> sidebar sidebar--id="vertical-tabs-example-full-height" sidebar--modifier="pf-m-full-height"}}
         {{#> sidebar-panel}}
-          {{#> tabs tabs--id=(concat sidebar--id "-tabs") tabs--modifier="pf-m-vertical pf-m-box"}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-expandable pf-m-non-expandable-on-md pf-m-expanded"}}
+            {{> tabs-toggle}}
             {{#> tabs-list}}
               {{> __tabs-item
                 __tabs-item--current="true"


### PR DESCRIPTION
Closes #3915 

This PR
- Adds demos for vertical tabs in sidebar component
- Adds demos for vertical, full height tabs in sidebar component
- Adds `.pf-m-full-height` to the sidebar component
- Wraps `.pf-c-tabs.pf-m-vertical` and variants in a `md` media query

Design files:
- https://marvelapp.com/prototype/dj6cag1/screen/87992106
- https://marvelapp.com/prototype/5fba0cj/screen/73740954

Previews:
- https://patternfly-pr-4850.surge.sh/components/tabs/html-demos/vertical-tabs/
- https://patternfly-pr-4850.surge.sh/components/tabs/html-demos/vertical-box-tabs
- https://patternfly-pr-4850.surge.sh/components/tabs/html-demos/vertical-tabs-full-height/
