### PR TITLE
chore(form): add complex form demo

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -249,117 +249,26 @@ cssPrefix: pf-c-form
   {{/form-group}}
 {{/form}}
 ```
-### Field groups
+### Field group (non-expandable)
 ```hbs
-{{#> form form--id="form-expandable-field-groups"}}
-  {{#> form-group form-group--id="-label1"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id="-label2"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-field-group form-field-group--id=(concat form--id '-field-group1') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
+{{#> form form--id="form-field-group"}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-field-group')}}
     {{#> form-field-group-header}}
       {{#> form-field-group-header-main}}
         {{#> form-field-group-title}}
-          {{#> form-field-group-title-text}}Field group 1{{/form-field-group-title-text}}
+          {{#> form-field-group-title-text}}Field group Title{{/form-field-group-title-text}}
         {{/form-field-group-title}}
         {{#> form-field-group-header-description}}
-          Field group 1 description text.
+          Field group description text
         {{/form-field-group-header-description}}
       {{/form-field-group-header-main}}
       {{#> form-field-group-header-actions}}
-        {{#> button button--modifier="pf-m-link"}}
-          Delete all
-        {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}
-          Add parameter
+          Action
         {{/button}}
       {{/form-field-group-header-actions}}
     {{/form-field-group-header}}
     {{#> form-field-group-body}}
-      {{#> form-field-group form-field-group--id=(concat form--id '-field-group2') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
-        {{#> form-field-group-header}}
-          {{#> form-field-group-header-main}}
-            {{#> form-field-group-title}}
-              {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Nested field group 1{{/form-field-group-title-text}}
-            {{/form-field-group-title}}
-            {{#> form-field-group-header-description}}
-              Nested field group 1 description text.
-            {{/form-field-group-header-description}}
-          {{/form-field-group-header-main}}
-          {{#> form-field-group-header-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
-              <i class="fas fa-trash"></i>
-            {{/button}}
-          {{/form-field-group-header-actions}}
-        {{/form-field-group-header}}
-        {{#> form-field-group-body}}
-          {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
-            {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-            {{/form-group-label}}
-            {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-            {{/form-group-control}}
-          {{/form-group}}
-          {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
-            {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-            {{/form-group-label}}
-            {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-            {{/form-group-control}}
-          {{/form-group}}
-        {{/form-field-group-body}}
-      {{/form-field-group}}
-      {{#> reset form-field-group--IsExpanded=reset}}
-        {{#> form-field-group form-field-group--id=(concat form--id '-field-group3') form-field-group--IsExpandable="true"}}
-          {{#> form-field-group-header}}
-            {{#> form-field-group-header-main}}
-              {{#> form-field-group-title}}
-                {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Nested field group 2{{/form-field-group-title-text}}
-              {{/form-field-group-title}}
-            {{/form-field-group-header-main}}
-            {{#> form-field-group-header-actions}}
-              {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
-                <i class="fas fa-trash"></i>
-              {{/button}}
-            {{/form-field-group-header-actions}}
-          {{/form-field-group-header}}
-        {{/form-field-group}}
-        {{#> form-field-group form-field-group--id=(concat form--id '-field-group4') form-field-group--IsExpandable="true"}}
-          {{#> form-field-group-header}}
-            {{#> form-field-group-header-main}}
-              {{#> form-field-group-title}}
-                {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Nested field group 3{{/form-field-group-title-text}}
-              {{/form-field-group-title}}
-              {{#> form-field-group-header-description}}
-                Nested field group 3 description text.
-              {{/form-field-group-header-description}}
-            {{/form-field-group-header-main}}
-            {{#> form-field-group-header-actions}}
-              {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
-                <i class="fas fa-trash"></i>
-              {{/button}}
-            {{/form-field-group-header-actions}}
-          {{/form-field-group-header}}
-        {{/form-field-group}}
-      {{/reset}}
       {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
         {{#> form-group-label}}
           {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
@@ -380,34 +289,38 @@ cssPrefix: pf-c-form
       {{/form-group}}
     {{/form-field-group-body}}
   {{/form-field-group}}
-  {{#> form-field-group form-field-group--id=(concat form--id '-field-group5') form-field-group--IsExpandable="true"}}
+{{/form}}
+```
+
+### Expandable and nested field groups
+```hbs
+{{#> form form--id="form-expandable-field-groups"}}
+
+  {{#> form-field-group form-field-group--id=(concat form--id '-field-group-1') form-field-group--IsExpandable="true"}}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Field group 1{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+        {{#> form-field-group-header-description}}
+          Field group 1 description text
+        {{/form-field-group-header-description}}
+      {{/form-field-group-header-main}}
+      {{#> form-field-group-header-actions}}
+        {{#> button button--modifier="pf-m-secondary"}}
+          Action
+        {{/button}}
+      {{/form-field-group-header-actions}}
+    {{/form-field-group-header}}
+  {{/form-field-group}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-field-group-2') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
     {{#> form-field-group-header}}
       {{#> form-field-group-header-main}}
         {{#> form-field-group-title}}
           {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Field group 2{{/form-field-group-title-text}}
         {{/form-field-group-title}}
         {{#> form-field-group-header-description}}
-          Field group 1 description text.
-        {{/form-field-group-header-description}}
-      {{/form-field-group-header-main}}
-      {{#> form-field-group-header-actions}}
-        {{#> button button--modifier="pf-m-link"}}
-          Delete all
-        {{/button}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Add parameter
-        {{/button}}
-      {{/form-field-group-header-actions}}
-    {{/form-field-group-header}}
-  {{/form-field-group}}
-  {{#> form-field-group form-field-group--id=(concat form--id '-field-group6') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
-    {{#> form-field-group-header}}
-      {{#> form-field-group-header-main}}
-        {{#> form-field-group-title}}
-          {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Field group 3{{/form-field-group-title-text}}
-        {{/form-field-group-title}}
-        {{#> form-field-group-header-description}}
-          Field group 1 description text.
+          Field group 2 description text
         {{/form-field-group-header-description}}
       {{/form-field-group-header-main}}
     {{/form-field-group-header}}
@@ -430,44 +343,12 @@ cssPrefix: pf-c-form
           {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
         {{/form-group-control}}
       {{/form-group}}
-      {{#> form-field-group form-field-group--id=(concat form--id '-field-group7') form-field-group--IsExpandable=reset}}
+      {{#> form-field-group form-field-group--id=(concat form--id '-field-group-3') form-field-group--IsExpandable=reset}}
         {{#> form-field-group-header}}
           {{#> form-field-group-header-main}}
             {{#> form-field-group-title}}
-              {{#> form-field-group-title-text}}Nested field group 1 (non-expandable){{/form-field-group-title-text}}
+              {{#> form-field-group-title-text}}Nested field group 3{{/form-field-group-title-text}}
             {{/form-field-group-title}}
-          {{/form-field-group-header-main}}
-        {{/form-field-group-header}}
-        {{#> form-field-group-body}}
-          {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
-            {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-            {{/form-group-label}}
-            {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-            {{/form-group-control}}
-          {{/form-group}}
-          {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
-            {{#> form-group-label}}
-              {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-              {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-            {{/form-group-label}}
-            {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-            {{/form-group-control}}
-          {{/form-group}}
-        {{/form-field-group-body}}
-      {{/form-field-group}}
-      {{#> form-field-group form-field-group--id=(concat form--id '-field-group8') form-field-group--IsExpandable=reset}}
-        {{#> form-field-group-header}}
-          {{#> form-field-group-header-main}}
-            {{#> form-field-group-title}}
-              {{#> form-field-group-title-text}}Nested field group 2 (non-expandable){{/form-field-group-title-text}}
-            {{/form-field-group-title}}
-            {{#> form-field-group-header-description}}
-              Field group 1 description text.
-            {{/form-field-group-header-description}}
           {{/form-field-group-header-main}}
         {{/form-field-group-header}}
         {{#> form-field-group-body}}
@@ -493,64 +374,7 @@ cssPrefix: pf-c-form
       {{/form-field-group}}
     {{/form-field-group-body}}
   {{/form-field-group}}
-  {{#> form-field-group form-field-group--id=(concat form--id '-field-group9')}}
-    {{#> form-field-group-header}}
-      {{#> form-field-group-header-main}}
-        {{#> form-field-group-title}}
-          {{#> form-field-group-title-text}}Field group 4 (non-expandable){{/form-field-group-title-text}}
-        {{/form-field-group-title}}
-        {{#> form-field-group-header-description}}
-          Field group 1 description text.
-        {{/form-field-group-header-description}}
-      {{/form-field-group-header-main}}
-      {{#> form-field-group-header-actions}}
-        {{#> button button--modifier="pf-m-link"}}
-          Delete all
-        {{/button}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Add parameter
-        {{/button}}
-      {{/form-field-group-header-actions}}
-    {{/form-field-group-header}}
-    {{#> form-field-group-body}}
-      {{#> form-group form-group--id=(concat form-field-group--id "-label1")}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 1{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-        {{/form-group-control}}
-      {{/form-group}}
-      {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
-        {{#> form-group-label}}
-          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 2{{/form-label}}
-          {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-        {{/form-group-label}}
-        {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-        {{/form-group-control}}
-      {{/form-group}}
-    {{/form-field-group-body}}
-  {{/form-field-group}}
-  {{#> form-group form-group--id="-label3"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 3{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for label 3 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id="-label4"}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Label 4{{/form-label}}
-      {{> form-group-label-help form-group-label-help--aria-label="More information for label 4 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
-    {{/form-group-control}}
-  {{/form-group}}
+
 {{/form}}
 ```
 

--- a/src/patternfly/components/LabelGroup/label-group.scss
+++ b/src/patternfly/components/LabelGroup/label-group.scss
@@ -42,6 +42,7 @@
   --pf-c-label-group__textarea--PaddingLeft: var(--pf-global--spacer--xs);
 
   display: inline-flex;
+  align-items: center;
 
   &.pf-m-category {
     padding-top: var(--pf-c-label-group--m-category--PaddingTop);

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -375,3 +375,385 @@ section: components
   {{/form-section}}
 {{/form}}
 ```
+
+### Complex form
+```hbs
+{{#> form form--id="form-demo-sections-complex-form"}}
+  {{!-- Name field --}}
+  {{#> form-group form-group--id=(concat form--id "-name")}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Name{{/form-label}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+    {{/form-group-control}}
+  {{/form-group}}
+
+  {{!-- Label input --}}
+  {{#> form-group form-group--id=(concat form--id "-labels")}}
+    {{#> form-group-label}}
+      {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"')}}Labels{{/form-label}}
+      {{> form-group-label-help form-group-label-help--aria-label="More information for labels field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
+    {{/form-group-label}}
+    {{#> form-group-control}}
+        {{#> text-input-group text-input-group--attribute=(concat 'id="' form--id form-group--id '"')}}
+          {{#> text-input-group-main}}
+          {{#> label-group}}
+            {{#> label-group-main}}
+              {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
+                {{#> label-group-list-item}}
+                  {{#> label  label--isRemovable="true" label--id=(concat label-group--id '-label-1')}}
+                    {{#> label-icon}}
+                      <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                    {{/label-icon}}
+                    prometheus=k8s
+                  {{/label}}
+                {{/label-group-list-item}}
+                {{#> label-group-list-item}}
+                  {{#> label label--modifier="pf-m-blue" label--isRemovable="true" label--id=(concat label-group--id '-label-2')}}
+                    {{#> label-icon}}
+                      <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                    {{/label-icon}}
+                    new
+                  {{/label}}
+                {{/label-group-list-item}}
+                {{#> label-group-list-item}}
+                  {{#> label label--IsAdd="true"}}
+                    Add Label
+                  {{/label}}
+                {{/label-group-list-item}}
+              {{/label-group-list}}
+            {{/label-group-main}}
+          {{/label-group}}
+              {{#> text-input-group-text}}
+      {{> text-input-group-text-input}}
+    {{/text-input-group-text}}
+            {{/text-input-group-main}}
+        {{/text-input-group}} 
+    {{/form-group-control}}
+  {{/form-group}}
+
+  {{!-- Alerting field group --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-alerting') form-field-group--IsExpandable="true" }}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text}}Alerting{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+        {{#> form-field-group-header-description}}
+          Define details regarding alerting.
+        {{/form-field-group-header-description}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+  {{/form-field-group}}
+
+  {{!-- Query field group --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-query') form-field-group--IsExpandable="true" }}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text}}Query{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+        {{#> form-field-group-header-description}}
+          The query specification defines the query command line flags when starting.
+        {{/form-field-group-header-description}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+  {{/form-field-group}}
+  
+  {{!-- Affinity field group --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-affinity') form-field-group--IsExpandable="true" }}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text}}Affinity{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+        {{#> form-field-group-header-description}}
+          If specified, the pod's scheduling constraints.
+        {{/form-field-group-header-description}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+    {{#> form-field-group-body}}
+
+      {{!-- nested Node Affinity field group --}}
+      {{#> form-field-group form-field-group--id=(concat form--id '-node-affinity') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
+        {{#> form-field-group-header}}
+          {{#> form-field-group-header-main}}
+            {{#> form-field-group-title}}
+              {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Node affinity{{/form-field-group-title-text}}
+            {{/form-field-group-title}}
+            {{#> form-field-group-header-description}}
+              Describes node affinity scheduling rules for the pod.
+            {{/form-field-group-header-description}}
+          {{/form-field-group-header-main}}
+        {{/form-field-group-header}}
+        {{#> form-field-group-body}}
+
+          {{!-- additional level nested field group --}}
+          {{#> form-field-group form-field-group--id=(concat form--id '-node-affinity-required') form-field-group--IsExpandable="true" form-field-group--IsExpanded=reset}}
+            {{#> form-field-group-header}}
+              {{#> form-field-group-header-main}}
+                {{#> form-field-group-title}}
+                  {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Required during scheduling, ignored during execution{{/form-field-group-title-text}}
+                {{/form-field-group-title}}
+                {{#> form-field-group-header-description}}
+                  The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements.
+                {{/form-field-group-header-description}}
+              {{/form-field-group-header-main}}
+            {{/form-field-group-header}}
+          {{/form-field-group}}
+
+          {{!-- second additional level nested field group --}}
+          {{#> form-field-group form-field-group--id=(concat form--id '-node-affinity-required-2') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
+            {{#> form-field-group-header}}
+              {{#> form-field-group-header-main}}
+                {{#> form-field-group-title}}
+                  {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Required during scheduling, ignored during execution{{/form-field-group-title-text}}
+                {{/form-field-group-title}}
+                {{#> form-field-group-header-description}}
+                  The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements.
+                {{/form-field-group-header-description}}
+              {{/form-field-group-header-main}}
+            {{/form-field-group-header}}
+            {{#> form-field-group-body}}
+
+              {{!-- node selector terms (repeating field) --}}
+              {{#> form-section form-section--id=(concat form--id '-node-selector-terms')}}
+
+                {{!-- node selector terms multiple inputs --}}
+                {{#> form-group form-group--id="-node-selector-terms"}}
+                  {{#> form-group-label}}
+                    {{#> form-label form-label--attribute=(concat 'id="' form--id form-group--id '-title"') required="true"}}Node selector terms{{/form-label}}
+                  {{/form-group-label}}
+                  {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
+                    {{#> input-group}}
+                      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '-input-1" name="' form--id form-group--id '-input-1" aria-labelledby="' form--id form-group--id ' ' form--id form-group--id '-title"')}}{{/form-control}}
+                      {{!-- {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}} --}}
+                      {{!-- Required. A list of node selector terms. The terms are ORed. --}}
+                      {{!-- {{/form-helper-text}} --}}
+                      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+                        <i class="fas fa-minus-circle" aria-hidden="true"></i>
+                      {{/button}}
+
+                    {{/input-group}}
+                    {{#> button button--modifier="pf-m-link pf-m-inline"}}
+                      {{#> button-icon button-icon--modifier="pf-m-start"}}
+                        <i class="fas fa-plus-circle" aria-hidden="true"></i>
+                      {{/button-icon}}
+                      Add valid redirect URI
+                    {{/button}}
+                  {{/form-group-control}}
+                {{/form-group}}
+
+              {{/form-section}}
+
+            {{/form-field-group-body}}
+          {{/form-field-group}}
+
+        {{/form-field-group-body}}
+      {{/form-field-group}}{{!-- nested Node Affinity field group --}}
+
+      {{!-- nested Node Pod field group --}}
+      {{#> form-field-group form-field-group--id=(concat form--id '-pod-affinity') form-field-group--IsExpandable="true"}}
+        {{#> form-field-group-header}}
+          {{#> form-field-group-header-main}}
+            {{#> form-field-group-title}}
+              {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Pod affinity{{/form-field-group-title-text}}
+            {{/form-field-group-title}}
+            {{#> form-field-group-header-description}}
+              Describes pod affinity scheduling rules (e.g. co-locate the pod in the same node, zone, etc. as some other pods).
+            {{/form-field-group-header-description}}
+          {{/form-field-group-header-main}}
+        {{/form-field-group-header}}
+      {{/form-field-group}}{{!-- nested Pod Affinity field group --}}
+
+
+    {{/form-field-group-body}}
+  {{/form-field-group}}{{!-- Affinity field group --}}
+  
+  {{!-- Routing field group --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-routing') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Routing{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+    {{#> form-field-group-body}}
+      {{!-- create route checkbox --}}
+      {{#> form-group form-group--IsCheckGroup="true" form-group--id=(concat form-field-group--id "-create-route")}}
+        {{#> form-group-control}}
+          {{#> check}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '-create-route" name="' form--id form-group--id '-create-route"')}}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '-create-route"')}}Create a route to the application{{/check-label}}
+          {{/check}}
+          {{#> form-helper-text form-helper-text--type="div" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-legend" aria-live="polite"')}}
+            {{#> helper-text}}
+              {{#> helper-text-item}}
+                {{#> helper-text-item-text}}Exposes your appplication at a public URL.{{/helper-text-item-text}}
+              {{/helper-text-item}}
+            {{/helper-text}}
+          {{/form-helper-text}}
+        {{/form-group-control}}
+      {{/form-group}}
+      {{!-- hostname input --}}
+      {{#> form-group form-group--id=(concat form-field-group--id "-hostname")}}
+        {{#> form-group-label}}
+          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') }}Hostname{{/form-label}}
+        {{/form-group-label}}
+        {{#> form-group-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" ')}}{{/form-control}}
+          {{#> form-helper-text form-helper-text--type="div" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
+            {{#> helper-text}}
+              {{#> helper-text-item}}
+                {{#> helper-text-item-text}}Public hostname for the route. If not specified, a hostname is generated.{{/helper-text-item-text}}
+              {{/helper-text-item}}
+            {{/helper-text}}
+          {{/form-helper-text}}
+        {{/form-group-control}}
+      {{/form-group}}
+      {{!-- path input with placeholder --}}
+      {{#> form-group form-group--id=(concat form-field-group--id "-path")}}
+        {{#> form-group-label}}
+          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') }}Path{{/form-label}}
+        {{/form-group-label}}
+        {{#> form-group-control}}
+          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" placeholder="/" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+          {{#> form-helper-text form-helper-text--type="div" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
+            {{#> helper-text}}
+              {{#> helper-text-item}}
+                {{#> helper-text-item-text}}Path that the router watches to route traffic to the service.{{/helper-text-item-text}}
+              {{/helper-text-item}}
+            {{/helper-text}}
+          {{/form-helper-text}}
+        {{/form-group-control}}
+      {{/form-group}}
+      {{!-- security checkbox --}}
+      {{#> form-group form-group--IsCheckGroup="true" form-group--id=(concat form-field-group--id "-security")}}
+        {{#> form-group-label}}
+          {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') }}Security{{/form-label}}
+        {{/form-group-label}}
+        {{#> form-group-control}}
+          {{#> check}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' form--id form-group--id '-check-1" name="' form--id form-group--id '-check-1"')}}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' form--id form-group--id '-check-1"')}}Secure Route{{/check-label}}
+          {{/check}}
+          {{#> form-helper-text form-helper-text--type="div" form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}}
+            {{#> helper-text}}
+              {{#> helper-text-item}}
+                {{#> helper-text-item-text}}Routes can be secured using several TLS termination types for serving certificates.{{/helper-text-item-text}}
+              {{/helper-text-item}}
+            {{/helper-text}}
+          {{/form-helper-text}}
+        {{/form-group-control}}
+      {{/form-group}}
+    {{/form-field-group-body}}
+  {{/form-field-group}}
+
+  {{!-- Health checks field group --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-health-checks') form-field-group--IsExpandable="true" form-field-group--IsExpanded="true"}}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text form-field-group-title-text--attribute=(concat 'id="' form-field-group--id '-title"')}}Health checks{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+    {{#> form-field-group-body}}
+      {{!-- Readiness non-expandable field group --}}
+      {{#> form-field-group form-field-group--id=(concat form--id '-readiness') form-field-group--IsExpandable=reset}}
+        {{#> form-field-group-header}}
+          {{#> form-field-group-header-main}}
+            {{#> form-field-group-title}}
+              {{#> form-field-group-title-text}}Readiness probe{{/form-field-group-title-text}}
+            {{/form-field-group-title}}
+            {{#> form-field-group-header-description}}
+              A readiness probe checks if the container is ready to handle requests. A failed readiness probe means that a container should not receive any traffic from a proxy, even if it's running.
+            {{/form-field-group-header-description}}
+          {{/form-field-group-header-main}}
+        {{/form-field-group-header}}
+        {{#> form-field-group-body}}
+          {{#> form-group form-group--id=(concat form-field-group--id "-add-readiness")}}
+
+            {{#> form-group-control}}
+                    {{#> button button--modifier="pf-m-link pf-m-inline"}}
+                      {{#> button-icon button-icon--modifier="pf-m-start"}}
+                        <i class="fas fa-plus-circle" aria-hidden="true"></i>
+                      {{/button-icon}}
+                      Add liveness probe
+                    {{/button}}
+            {{/form-group-control}}
+          {{/form-group}}
+
+        {{/form-field-group-body}}
+      {{/form-field-group}}
+      {{!-- Startup probe non-expandable field group --}}
+      {{#> form-field-group form-field-group--id=(concat form--id '-startup') form-field-group--IsExpandable=reset}}
+        {{#> form-field-group-header}}
+          {{#> form-field-group-header-main}}
+            {{#> form-field-group-title}}
+              {{#> form-field-group-title-text}}Liveness probe{{/form-field-group-title-text}}
+            {{/form-field-group-title}}
+            {{#> form-field-group-header-description}}
+              A startup probe checks if the application within the container is started.
+            {{/form-field-group-header-description}}
+          {{/form-field-group-header-main}}
+        {{/form-field-group-header}}
+        {{#> form-field-group-body}}
+          {{#> form-group form-group--id=(concat form-field-group--id "-add-startup")}}
+
+            {{#> form-group-control}}
+                    {{#> button button--modifier="pf-m-link pf-m-inline"}}
+                      {{#> button-icon button-icon--modifier="pf-m-start"}}
+                        <i class="fas fa-plus-circle" aria-hidden="true"></i>
+                      {{/button-icon}}
+                      Add startup probe
+                    {{/button}}
+            {{/form-group-control}}
+          {{/form-group}}
+
+        {{/form-field-group-body}}
+      {{/form-field-group}}
+    {{/form-field-group-body}}
+  {{/form-field-group}}
+
+  {{!-- Build configuration --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-build-configuration') form-field-group--IsExpandable="true"}}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text}}Build configuration{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+      {{/form-field-group-header-main}}
+      {{#> form-field-group-header-actions}}
+        {{#> button button--modifier="pf-m-secondary"}}
+          Import
+        {{/button}}
+      {{/form-field-group-header-actions}}
+    {{/form-field-group-header}}
+  {{/form-field-group}}
+
+  {{!-- Deployment --}}
+  {{#> form-field-group form-field-group--id=(concat form--id '-deployment') form-field-group--IsExpandable="true"}}
+    {{#> form-field-group-header}}
+      {{#> form-field-group-header-main}}
+        {{#> form-field-group-title}}
+          {{#> form-field-group-title-text}}Deployment{{/form-field-group-title-text}}
+        {{/form-field-group-title}}
+      {{/form-field-group-header-main}}
+    {{/form-field-group-header}}
+  {{/form-field-group}}
+
+  {{!-- Form action buttons --}}
+  {{#> form-actions}}
+    {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+      Save
+    {{/button}}
+    {{#> button button--modifier="pf-m-secondary" button--IsReset="true"}}
+      Cancel
+    {{/button}}
+  {{/form-actions}}
+{{/form}}
+```


### PR DESCRIPTION
Simplifies the existing [nested field group example](https://patternfly-pr-4865.surge.sh/components/form#expandable-and-nested-field-groups) to scope it to just nested field groups, and moves and expands the existing demo to the [HTML demos](https://patternfly-pr-4865.surge.sh/components/form/html-demos#complex-form).

Fixes #4148 