### PR TITLE
feat(tree-view): add selectable/expandable, improve click areas

### DIFF
--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -189,64 +189,64 @@ beta: true
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application launcher" tree-view-node-text--type="label" tree-view-node--id="1"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application launcher" tree-view-node--id="1"}}
       {{/tree-view-content}}
       {{#> tree-view-list newcontext}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Application 1" tree-view-node-text--type="label" tree-view-node--id="2"}}
+            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Application 1" tree-view-node--id="2"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="3"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Settings" tree-view-node--id="3"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="4"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node--id="4"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="5"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node--id="5"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application 2" tree-view-node-text--type="label" tree-view-node--id="6"}}
+            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application 2" tree-view-node--id="6"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="7"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node--id="7"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="8"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node--id="8"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
-            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-node--text="Current" tree-view-node-text--type="label"}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-node--text="Current"}}
               {{#> tree-view-content}}
                 {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--id="9"}}
               {{/tree-view-content}}
               {{#> tree-view-list newcontext}}
                 {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--HasCheckboxSelected="true" tree-view-node--text="Loader app 1" tree-view-node-text--type="label" tree-view-node--id="10"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--HasCheckboxSelected="true" tree-view-node--text="Loader app 1" tree-view-node--id="10"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader app 2" tree-view-node-text--type="label" tree-view-node--id="11"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader app 2" tree-view-node--id="11"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Loader app 3" tree-view-node-text--type="label" tree-view-node--id="12"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Loader app 3" tree-view-node--id="12"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
               {{/tree-view-list}}
@@ -257,17 +257,17 @@ beta: true
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Cost management" tree-view-node-text--type="label" tree-view-node--id="13"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Cost management" tree-view-node--id="13"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Sources" tree-view-node-text--type="label" tree-view-node--id="14"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Sources" tree-view-node--id="14"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="This is a really really really long folder name that overflows from the width of the container." tree-view-node-text--type="label" tree-view-node--id="15"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="This is a really really really long folder name that overflows from the width of the container." tree-view-node--id="15"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
   {{/tree-view-list}}

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -895,12 +895,11 @@ beta: true
 | `.pf-c-tree-view__list` | `<ul>` | Initiates a tree view list. **Required** |
 | `.pf-c-tree-view__list-item` | `<li>` | Initiates a tree view list item. **Required** |
 | `.pf-c-tree-view__content` | `<div>` | Initiates a tree view node. **Required** |
-| `.pf-c-tree-view__node` | `<button>`, `<a>` | Initiates a tree view node. **Required** |
+| `.pf-c-tree-view__node` | `<button>`, `<label>` | Initiates a tree view node. **Required** |
 | `.pf-c-tree-view__node-container` | `<span>` | Initiates a tree view node container. **Required for compact variant** |
 | `.pf-c-tree-view__node-content` | `<span>` | Initiates a tree view node content container used to stack elements. |
 | `.pf-c-tree-view__node-count` | `<span>` | Initiates a tree view node count. |
-| `.pf-c-tree-view__node-toggle` | `<div>` | Initiates a tree view toggle. |
-| `.pf-c-tree-view__node-toggle-button` | `<button>` | Initiates a tree view toggle button. |
+| `.pf-c-tree-view__node-toggle` | `<span>`, `<button>` | Initiates a tree view toggle. |
 | `.pf-c-tree-view__node-toggle-icon` | `<span>` | Initiates a tree view toggle icon. |
 | `.pf-c-tree-view__node-title` | `<span>` | Initiates a tree view node title. |
 | `.pf-c-tree-view__node-text` | `<span>` | Initiates tree view text. |

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -911,4 +911,5 @@ beta: true
 | `.pf-m-compact` | `.pf-c-tree-view` | Modifies the tree view to the compact presentation. |
 | `.pf-m-no-background` | `.pf-c-tree-view.pf-m-compact` | Modifies the tree view compact variant node containers to have a transparent background. |
 | `.pf-m-current` | `.pf-c-tree-view__node` | Modifies the tree view node to be current. |
+| `.pf-m-selectable` | `.pf-c-tree-view__node` | For use on nodes that are expandable and selectable, when the default click action on the node selects it instead of expanding it. |
 | `.pf-m-truncate` | `.pf-c-tree-view`, `.pf-c-tree-view__node-title`, `.pf-c-tree-view__node-text` | Modifies the tree view title or text to truncate. |

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -99,7 +99,6 @@ beta: true
 ```
 
 ### With search
-
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-search}}
@@ -185,70 +184,69 @@ beta: true
 ```
 
 ### With checkboxes
-
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Application launcher" tree-view-node-text--type="label" tree-view-node--id="1"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application launcher" tree-view-node-text--type="label" tree-view-node--id="1"}}
       {{/tree-view-content}}
       {{#> tree-view-list newcontext}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Application 1" tree-view-node-text--type="label" tree-view-node--id="2"}}
+            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Application 1" tree-view-node-text--type="label" tree-view-node--id="2"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="3"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="3"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="4"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="4"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="5"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader" tree-view-node-text--type="label" tree-view-node--id="5"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Application 2" tree-view-node-text--type="label" tree-view-node--id="6"}}
+            {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Application 2" tree-view-node-text--type="label" tree-view-node--id="6"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="7"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="7"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="8"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Settings" tree-view-node-text--type="label" tree-view-node--id="8"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-node--text="Current" tree-view-node-text--type="label"}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--id="9"}}
+                {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--id="9"}}
               {{/tree-view-content}}
               {{#> tree-view-list newcontext}}
                 {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--HasCheckboxSelected="true" tree-view-node--text="Loader app 1" tree-view-node-text--type="label" tree-view-node--id="10"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--HasCheckboxSelected="true" tree-view-node--text="Loader app 1" tree-view-node-text--type="label" tree-view-node--id="10"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader app 2" tree-view-node-text--type="label" tree-view-node--id="11"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="Loader app 2" tree-view-node-text--type="label" tree-view-node--id="11"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Loader app 3" tree-view-node-text--type="label" tree-view-node--id="12"}}
+                    {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Loader app 3" tree-view-node-text--type="label" tree-view-node--id="12"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
               {{/tree-view-list}}
@@ -259,17 +257,17 @@ beta: true
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Cost management" tree-view-node-text--type="label" tree-view-node--id="13"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Cost management" tree-view-node-text--type="label" tree-view-node--id="13"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node--text="Sources" tree-view-node-text--type="label" tree-view-node--id="14"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node--text="Sources" tree-view-node-text--type="label" tree-view-node--id="14"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
     {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
       {{#> tree-view-content}}
-        {{> tree-view-node tree-view-node--type--IsDiv="true" tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="This is a really really really long folder name that overflows from the width of the container." tree-view-node-text--type="label" tree-view-node--id="15"}}
+        {{> tree-view-node tree-view-node--HasCheckbox="true" tree-view-node-check--IsChecked="true" tree-view-node--text="This is a really really really long folder name that overflows from the width of the container." tree-view-node-text--type="label" tree-view-node--id="15"}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
   {{/tree-view-list}}
@@ -277,7 +275,6 @@ beta: true
 ```
 
 ### With icons
-
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
@@ -359,7 +356,6 @@ beta: true
 ```
 
 ### With badges
-
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
@@ -495,7 +491,6 @@ beta: true
 ```
 
 ### With action item
-
 ```hbs
 {{#> tree-view}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
@@ -685,6 +680,97 @@ beta: true
 {{/tree-view}}
 ```
 
+### With selectable, expandable nodes
+```hbs
+{{#> tree-view}}
+  {{#> tree-view-list tree-view-list--IsRoot="true"}}
+    {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true" tree-view-list-item--IsExpanded="true"}}
+      {{#> tree-view-content}}
+        {{> tree-view-node tree-view-node--text="Application launcher"}}
+      {{/tree-view-content}}
+      {{#> tree-view-list newcontext}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true" tree-view-list-item--IsExpanded="true"}}
+          {{#> tree-view-content}}
+            {{> tree-view-node tree-view-node--text="Application 1"}}
+          {{/tree-view-content}}
+          {{#> tree-view-list newcontext}}
+            {{#> tree-view-list-item}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Settings"}}
+              {{/tree-view-content}}
+            {{/tree-view-list-item}}
+            {{#> tree-view-list-item}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Current"}}
+              {{/tree-view-content}}
+            {{/tree-view-list-item}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Loader"}}
+              {{/tree-view-content}}
+            {{/tree-view-list-item}}
+          {{/tree-view-list}}
+        {{/tree-view-list-item}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true" tree-view-list-item--IsExpanded="true"}}
+          {{#> tree-view-content}}
+            {{> tree-view-node tree-view-node--text="Application 2"}}
+          {{/tree-view-content}}
+          {{#> tree-view-list newcontext}}
+            {{#> tree-view-list-item}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Settings"}}
+              {{/tree-view-content}}
+            {{/tree-view-list-item}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Settings"}}
+              {{/tree-view-content}}
+            {{/tree-view-list-item}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true" tree-view-list-item--IsExpanded="true"}}
+              {{#> tree-view-content}}
+                {{> tree-view-node tree-view-node--text="Loader"}}
+              {{/tree-view-content}}
+              {{#> tree-view-list newcontext}}
+                {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+                  {{#> tree-view-content}}
+                    {{> tree-view-node tree-view-node--text="Loader app 1" tree-view-node--modifier="pf-m-current"}}
+                  {{/tree-view-content}}
+                {{/tree-view-list-item}}
+                {{#> tree-view-list-item}}
+                  {{#> tree-view-content}}
+                    {{> tree-view-node tree-view-node--text="Loader app 2"}}
+                  {{/tree-view-content}}
+                {{/tree-view-list-item}}
+                {{#> tree-view-list-item}}
+                  {{#> tree-view-content}}
+                    {{> tree-view-node tree-view-node--text="Loader app 3"}}
+                  {{/tree-view-content}}
+                {{/tree-view-list-item}}
+              {{/tree-view-list}}
+            {{/tree-view-list-item}}
+          {{/tree-view-list}}
+        {{/tree-view-list-item}}
+      {{/tree-view-list}}
+    {{/tree-view-list-item}}
+    {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+      {{#> tree-view-content}}
+        {{> tree-view-node tree-view-node--text="Cost management"}}
+      {{/tree-view-content}}
+    {{/tree-view-list-item}}
+    {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+      {{#> tree-view-content}}
+        {{> tree-view-node tree-view-node--text="Sources"}}
+      {{/tree-view-content}}
+    {{/tree-view-list-item}}
+    {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-node--IsSelectable="true"}}
+      {{#> tree-view-content}}
+        {{> tree-view-node tree-view-node--text="This is a really really really long folder name that overflows from the width of the container."}}
+      {{/tree-view-content}}
+    {{/tree-view-list-item}}
+  {{/tree-view-list}}
+{{/tree-view}}
+```
+
 ### Guides
 ```hbs
 {{#> tree-view tree-view--modifier="pf-m-guides"}}
@@ -787,8 +873,6 @@ beta: true
 ```
 
 ## Documentation
-
-### Overview
 
 ### Accessibility
 

--- a/src/patternfly/components/TreeView/templates/tree-view--base.hbs
+++ b/src/patternfly/components/TreeView/templates/tree-view--base.hbs
@@ -1,4 +1,4 @@
-{{#> tree-view tree-view--modifier=tree-view--base--modifier tree-view-node-text--type="div" tree-view--IsCompact="true"}}
+{{#> tree-view tree-view--modifier=tree-view--base--modifier tree-view--IsCompact="true"}}
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
     {{#> tree-view-list-item}}
       {{#> tree-view-content}}

--- a/src/patternfly/components/TreeView/templates/tree-view--base.hbs
+++ b/src/patternfly/components/TreeView/templates/tree-view--base.hbs
@@ -2,7 +2,7 @@
   {{#> tree-view-list tree-view-list--IsRoot="true"}}
     {{#> tree-view-list-item}}
       {{#> tree-view-content}}
-        {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+        {{#> tree-view-node}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
               apiVersion
@@ -16,7 +16,7 @@
     {{/tree-view-list-item}}
     {{#> tree-view-list-item}}
       {{#> tree-view-content}}
-        {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+        {{#> tree-view-node}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
               kind
@@ -30,7 +30,7 @@
     {{/tree-view-list-item}}
     {{#> tree-view-list-item}}
       {{#> tree-view-content}}
-        {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+        {{#> tree-view-node}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
               metadata
@@ -58,7 +58,7 @@
       {{#> tree-view-list newcontext}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   minReadySeconds
@@ -72,7 +72,7 @@
         {{/tree-view-list-item}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   paused
@@ -86,7 +86,7 @@
         {{/tree-view-list-item}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   progressDeadlineSeconds
@@ -100,7 +100,7 @@
         {{/tree-view-list-item}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   replicas
@@ -114,7 +114,7 @@
         {{/tree-view-list-item}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   revisionHistoryLimit
@@ -156,7 +156,7 @@
               {{#> tree-view-list newcontext}}
                 {{#> tree-view-list-item}}
                   {{#> tree-view-content}}
-                    {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+                    {{#> tree-view-node}}
                       {{#> tree-view-node-content}}
                         {{#> tree-view-node-title}}
                           matchLabels
@@ -172,7 +172,7 @@
             {{/tree-view-list-item}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+                {{#> tree-view-node}}
                   {{#> tree-view-node-content}}
                     {{#> tree-view-node-title}}
                       matchLabels
@@ -188,7 +188,7 @@
         {{/tree-view-list-item}}
         {{#> tree-view-list-item}}
           {{#> tree-view-content}}
-            {{#> tree-view-node tree-view-node--type--IsDiv="true"}}
+            {{#> tree-view-node}}
               {{#> tree-view-node-content}}
                 {{#> tree-view-node-title}}
                   matchLabels

--- a/src/patternfly/components/TreeView/tree-view-node-container.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-container.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-tree-view__node-container{{#if tree-view-node-container--modifier}} {{tree-view-node-container--modifier}}{{/if}}"
+<span class="pf-c-tree-view__node-container{{#if tree-view-node-container--modifier}} {{tree-view-node-container--modifier}}{{/if}}"
   {{#if tree-view-node-container--attribute}}
     {{{tree-view-node-container--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</span>

--- a/src/patternfly/components/TreeView/tree-view-node-content.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-content.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-tree-view__node-content{{#if tree-view-node-content--modifier}} {{tree-view-node-content--modifier}}{{/if}}"
+<span class="pf-c-tree-view__node-content{{#if tree-view-node-content--modifier}} {{tree-view-node-content--modifier}}{{/if}}"
   {{#if tree-view-node-content--attribute}}
     {{{tree-view-node-content--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</span>

--- a/src/patternfly/components/TreeView/tree-view-node-text.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-text.hbs
@@ -1,4 +1,7 @@
 <{{#if tree-view-node-text--type}}{{tree-view-node-text--type}}{{else}}span{{/if}} class="pf-c-tree-view__node-text{{#if tree-view-node-text--modifier}} {{tree-view-node-text--modifier}}{{/if}}"
+  {{#if tree-view-node--HasCheckbox}}
+    id="label-{{{tree-view-node--id}}}"
+  {{/if}}
   {{#if tree-view-node-text--attribute}}
     {{{tree-view-node-text--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/TreeView/tree-view-node-text.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-text.hbs
@@ -1,7 +1,4 @@
 <{{#if tree-view-node-text--type}}{{tree-view-node-text--type}}{{else}}span{{/if}} class="pf-c-tree-view__node-text{{#if tree-view-node-text--modifier}} {{tree-view-node-text--modifier}}{{/if}}"
-  {{#if tree-view-node--HasCheckbox}}
-    id="label-{{{tree-view-node--id}}}"
-  {{/if}}
   {{#if tree-view-node-text--attribute}}
     {{{tree-view-node-text--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/TreeView/tree-view-node-text.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-text.hbs
@@ -1,7 +1,4 @@
 <{{#if tree-view-node-text--type}}{{tree-view-node-text--type}}{{else}}span{{/if}} class="pf-c-tree-view__node-text{{#if tree-view-node-text--modifier}} {{tree-view-node-text--modifier}}{{/if}}"
-  {{#if tree-view-node--HasCheckbox}}
-    for="check-{{{tree-view-node--id}}}"
-  {{/if}}
   {{#if tree-view-node-text--attribute}}
     {{{tree-view-node-text--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
@@ -1,14 +1,24 @@
-<{{#if tree-view-node--HasCheckbox}}button{{else}}div{{/if}} class="pf-c-tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
-  {{#if tree-view-node--HasCheckbox}}
-    aria-label="Toggle"
-    {{#if tree-view-list-item--IsExpanded}}
-      aria-expanded="true"
-    {{else}}
-      aria-expanded="false"
+{{#if tree-view-node--HasCheckbox}}
+  {{> __tree-view-node-toggle tree-view-node-toggle--IsToggle="true"}}
+{{else if tree-view-node--IsSelectable}}
+  {{> __tree-view-node-toggle tree-view-node-toggle--IsToggle="true"}}
+{{else}}
+  {{> __tree-view-node-toggle}}
+{{/if}}
+
+{{#* inline "__tree-view-node-toggle"}}
+  <{{#if tree-view-node-toggle--IsToggle}}button{{else}}div{{/if}} class="pf-c-tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
+    {{#if tree-view-node-toggle--IsToggle}}
+      aria-label="Toggle"
+      {{#if tree-view-list-item--IsExpanded}}
+        aria-expanded="true"
+      {{else}}
+        aria-expanded="false"
+      {{/if}}
     {{/if}}
-  {{/if}}
-  {{#if tree-view-node-toggle--attribute}}
-    {{{tree-view-node-toggle--attribute}}}
-  {{/if}}>
-  {{> tree-view-node-toggle-icon}}
-</{{#if tree-view-node--HasCheckbox}}button{{else}}div{{/if}}>
+    {{#if tree-view-node-toggle--attribute}}
+      {{{tree-view-node-toggle--attribute}}}
+    {{/if}}>
+    {{> tree-view-node-toggle-icon}}
+  </{{#if tree-view-node-toggle--IsToggle}}button{{else}}div{{/if}}>
+{{/inline}}

--- a/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
@@ -1,7 +1,5 @@
 {{#if tree-view-node--HasCheckbox}}
-  {{> __tree-view-node-toggle tree-view-node-toggle--IsToggle="true"}}
-{{else if tree-view-node--IsSelectable}}
-  {{> __tree-view-node-toggle tree-view-node-toggle--IsToggle="true"}}
+  {{> __tree-view-node-toggle tree-view-node-toggle--IsToggle="true" }}
 {{else}}
   {{> __tree-view-node-toggle}}
 {{/if}}
@@ -9,12 +7,9 @@
 {{#* inline "__tree-view-node-toggle"}}
   <{{#if tree-view-node-toggle--IsToggle}}button{{else}}div{{/if}} class="pf-c-tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
     {{#if tree-view-node-toggle--IsToggle}}
+      id="toggle-{{tree-view-node--id}}"
       aria-label="Toggle"
-      {{#if tree-view-list-item--IsExpanded}}
-        aria-expanded="true"
-      {{else}}
-        aria-expanded="false"
-      {{/if}}
+      aria-labelledby="toggle-{{tree-view-node--id}} label-{{tree-view-node--id}}"
     {{/if}}
     {{#if tree-view-node-toggle--attribute}}
       {{{tree-view-node-toggle--attribute}}}

--- a/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
@@ -5,7 +5,7 @@
 {{/if}}
 
 {{#* inline "__tree-view-node-toggle"}}
-  <{{#if tree-view-node-toggle--IsToggle}}button{{else}}div{{/if}} class="pf-c-tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
+  <{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}} class="pf-c-tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
     {{#if tree-view-node-toggle--IsToggle}}
       id="toggle-{{tree-view-node--id}}"
       aria-label="Toggle"
@@ -15,5 +15,5 @@
       {{{tree-view-node-toggle--attribute}}}
     {{/if}}>
     {{> tree-view-node-toggle-icon}}
-  </{{#if tree-view-node-toggle--IsToggle}}button{{else}}div{{/if}}>
+  </{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}}>
 {{/inline}}

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -1,7 +1,5 @@
 {{#if tree-view-node--HasCheckbox}}
   {{> __tree-view-node tree-view-node--type="label"}}
-{{else if tree-view-node--IsSelectable}}
-  {{> __tree-view-node tree-view-node--type="div"}}
 {{else}}
   {{> __tree-view-node}}
 {{/if}}
@@ -13,6 +11,7 @@
     {{/if}}
     {{#if tree-view-node--HasCheckbox}}
       for="check-{{{tree-view-node--id}}}"
+      id="label-{{{tree-view-node--id}}}"
     {{/if}}
     {{#if tree-view-node--attribute}}
       {{{tree-view-node--attribute}}}

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -1,27 +1,37 @@
-<{{# if tree-view-node--type--IsDiv}}div{{else}}button{{/if}} class="pf-c-tree-view__node{{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
-  {{#if tree-view-node--type--IsDiv}}
-    tabindex="0"
-  {{/if}}
-  {{#if tree-view-node--attribute}}
-    {{{tree-view-node--attribute}}}
-  {{/if}}>
-  {{#> tree-view-node-container}}
-    {{#if tree-view-list-item--IsExpandable}}
-      {{> tree-view-node-toggle}}
+{{#if tree-view-node--HasCheckbox}}
+  {{> __tree-view-node tree-view-node--IsDiv="true"}}
+{{else if tree-view-node--IsSelectable}}
+  {{> __tree-view-node tree-view-node--IsDiv="true"}}
+{{else}}
+  {{> __tree-view-node}}
+{{/if}}
+
+{{#* inline "__tree-view-node"}}
+  <{{# if tree-view-node--IsDiv}}div{{else}}button{{/if}} class="pf-c-tree-view__node{{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
+    {{#if tree-view-node--IsDiv}}
+      tabindex="0"
     {{/if}}
-    {{#if tree-view-node--HasFolderIcon}}
-      {{> tree-view-node-icon tree-view-node-icon--IsFolder="true"}}
-    {{/if}}
-    {{#if tree-view-node--HasCheckbox}}
-      {{> tree-view-node-check}}
-    {{/if}}
-    {{#if tree-view-node--text}}
-      {{#> tree-view-node-text}}
-        {{{tree-view-node--text}}}
-      {{/tree-view-node-text}}
-    {{/if}}
-    {{#if @partial-block}}
-      {{> @partial-block}}
-    {{/if}}
-  {{/tree-view-node-container}}
-</{{# if tree-view-node--type--IsDiv}}div{{else}}button{{/if}}>
+    {{#if tree-view-node--attribute}}
+      {{{tree-view-node--attribute}}}
+    {{/if}}>
+    {{#> tree-view-node-container}}
+      {{#if tree-view-list-item--IsExpandable}}
+        {{> tree-view-node-toggle}}
+      {{/if}}
+      {{#if tree-view-node--HasFolderIcon}}
+        {{> tree-view-node-icon tree-view-node-icon--IsFolder="true"}}
+      {{/if}}
+      {{#if tree-view-node--HasCheckbox}}
+        {{> tree-view-node-check}}
+      {{/if}}
+      {{#if tree-view-node--text}}
+        {{#> tree-view-node-text}}
+          {{{tree-view-node--text}}}
+        {{/tree-view-node-text}}
+      {{/if}}
+      {{#if @partial-block}}
+        {{> @partial-block}}
+      {{/if}}
+    {{/tree-view-node-container}}
+  </{{# if tree-view-node--IsDiv}}div{{else}}button{{/if}}>
+{{/inline}}

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -1,11 +1,13 @@
 {{#if tree-view-node--HasCheckbox}}
-  {{> __tree-view-node tree-view-node--type="label"}}
+  {{> __tree-view-node tree-view-node--type="label" tree-view-node--IsSelectable="true"}}
 {{else}}
   {{> __tree-view-node}}
 {{/if}}
 
 {{#* inline "__tree-view-node"}}
-  <{{# if tree-view-node--type}}{{tree-view-node--type}}{{else}}button{{/if}} class="pf-c-tree-view__node{{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
+  <{{# if tree-view-node--type}}{{tree-view-node--type}}{{else}}button{{/if}} class="pf-c-tree-view__node
+    {{~#if tree-view-node--IsSelectable}} pf-m-selectable
+    {{~else if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
     {{#if tree-view-node--type}}
       tabindex="0"
     {{/if}}

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -1,15 +1,18 @@
 {{#if tree-view-node--HasCheckbox}}
-  {{> __tree-view-node tree-view-node--IsDiv="true"}}
+  {{> __tree-view-node tree-view-node--type="label"}}
 {{else if tree-view-node--IsSelectable}}
-  {{> __tree-view-node tree-view-node--IsDiv="true"}}
+  {{> __tree-view-node tree-view-node--type="div"}}
 {{else}}
   {{> __tree-view-node}}
 {{/if}}
 
 {{#* inline "__tree-view-node"}}
-  <{{# if tree-view-node--IsDiv}}div{{else}}button{{/if}} class="pf-c-tree-view__node{{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
-    {{#if tree-view-node--IsDiv}}
+  <{{# if tree-view-node--type}}{{tree-view-node--type}}{{else}}button{{/if}} class="pf-c-tree-view__node{{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
+    {{#if tree-view-node--type}}
       tabindex="0"
+    {{/if}}
+    {{#if tree-view-node--HasCheckbox}}
+      for="check-{{{tree-view-node--id}}}"
     {{/if}}
     {{#if tree-view-node--attribute}}
       {{{tree-view-node--attribute}}}
@@ -33,5 +36,5 @@
         {{> @partial-block}}
       {{/if}}
     {{/tree-view-node-container}}
-  </{{# if tree-view-node--IsDiv}}div{{else}}button{{/if}}>
+  </{{# if tree-view-node--type}}{{tree-view-node--type}}{{else}}button{{/if}}>
 {{/inline}}

--- a/src/patternfly/components/TreeView/tree-view-text.hbs
+++ b/src/patternfly/components/TreeView/tree-view-text.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-tree-view__text{{#if tree-view-text--modifier}} {{tree-view-text--modifier}}{{/if}}"
-  {{#if tree-view-text--attribute}}
-    {{{tree-view-text--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -36,14 +36,15 @@ $pf-c-tree-view--MaxNesting: 10;
 
   // Toggle
   --pf-c-tree-view__node-toggle--Position: absolute;
+  --pf-c-tree-view__node-toggle--Color--base: var(--pf-global--Color--200);
+  --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--Color--base);
+  --pf-c-tree-view__node-toggle--hover--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node-toggle--focus--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node-toggle--active--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__list-item--m-expanded__node-toggle--Color: var(--pf-global--Color--100);
 
   // Toggle icon
   --pf-c-tree-view__node-toggle-icon--MinWidth: var(--pf-global--FontSize--md);
-  --pf-c-tree-view__node-toggle-icon--Color: var(--pf-global--Color--200);
-  --pf-c-tree-view__node-toggle--hover__icon--Color: var(--pf-global--Color--100);
-  --pf-c-tree-view__node-toggle--focus__icon--Color: var(--pf-global--Color--100);
-  --pf-c-tree-view__node-toggle--active__icon--Color: var(--pf-global--Color--100);
-  --pf-c-tree-view__node-toggle--expanded__icon--Color: var(--pf-global--Color--100);
   --pf-c-tree-view__node-toggle-icon--Transition: transform var(--pf-global--TransitionDuration) var(--pf-global--TimingFunction);
   --pf-c-tree-view__node-toggle-button--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-tree-view__node-toggle-button--PaddingRight: var(--pf-global--spacer--md);
@@ -328,34 +329,20 @@ $pf-c-tree-view--MaxNesting: 10;
 .pf-c-tree-view__node-toggle-icon {
   display: inline-block;
   min-width: var(--pf-c-tree-view__node-toggle-icon--MinWidth);
-  color: var(--pf-c-tree-view__node-toggle-icon--Color);
   text-align: center;
   transition: var(--pf-c-tree-view__node-toggle-icon--Transition);
   transform: rotate(var(--pf-c-tree-view__node-toggle-icon--Rotate));
-
-  @at-root button.pf-c-tree-view__node,
-  button.pf-c-tree-view__node-toggle {
-    &:hover {
-      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--hover__icon--Color);
-    }
-
-    &:focus {
-      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--focus__icon--Color);
-    }
-
-    &:active {
-      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--focus__icon--Color);
-    }
-  }
 }
 
 // stylelint-disable
 .pf-c-tree-view__list-item {
   .pf-c-tree-view__list-item {
-    --pf-c-tree-view__node-toggle-icon--Rotate: var(--pf-c-tree-view__node-toggle-icon--base--Rotate); // reset nested icons
+    --pf-c-tree-view__node-toggle-icon--Rotate: var(--pf-c-tree-view__node-toggle-icon--base--Rotate); // reset nested toggle icon rotate
+    --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--Color--base); // reset nested toggle color
   }
 
   &.pf-m-expanded {
+    --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__list-item--m-expanded__node-toggle--Color);
     --pf-c-tree-view__node-toggle-icon--Rotate: var(--pf-c-tree-view__list-item--m-expanded__node-toggle-icon--Rotate);
   }
 }
@@ -394,6 +381,25 @@ $pf-c-tree-view--MaxNesting: 10;
       --pf-c-badge--m-read--BackgroundColor: var(--pf-c-tree-view__node-count--c-badge--m-read--BackgroundColor);
     }
   }
+
+  &.pf-m-selectable .pf-c-tree-view__node-toggle {
+    --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--Color--base); // resets hover/focus/active color when node triggers hover/focus/active color change
+  }
+
+  &,
+  .pf-c-tree-view__node-toggle {
+    &:hover {
+      --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--hover__icon--Color);
+    }
+
+    &:focus {
+      --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--focus__icon--Color);
+    }
+
+    &:active {
+      --pf-c-tree-view__node-toggle--Color: var(--pf-c-tree-view__node-toggle--active__icon--Color);
+    }
+  }
 }
 
 .pf-c-tree-view__node-container {
@@ -426,6 +432,7 @@ $pf-c-tree-view--MaxNesting: 10;
   padding: var(--pf-c-tree-view__node-toggle-button--PaddingTop) var(--pf-c-tree-view__node-toggle-button--PaddingRight) var(--pf-c-tree-view__node-toggle-button--PaddingBottom) var(--pf-c-tree-view__node-toggle-button--PaddingLeft);
   margin-top: var(--pf-c-tree-view__node-toggle-button--MarginTop);
   margin-bottom: var(--pf-c-tree-view__node-toggle-button--MarginBottom);
+  color: var(--pf-c-tree-view__node-toggle--Color);
   border: 0;
   transform: translateX(var(--pf-c-tree-view__list-item__list-item__node-toggle--TranslateX));
 }

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -44,7 +44,7 @@ $pf-c-tree-view--MaxNesting: 10;
   --pf-c-tree-view__node-toggle--focus__icon--Color: var(--pf-global--Color--100);
   --pf-c-tree-view__node-toggle--active__icon--Color: var(--pf-global--Color--100);
   --pf-c-tree-view__node-toggle--expanded__icon--Color: var(--pf-global--Color--100);
-  --pf-c-tree-view__node-toggle-icon--Transition: var(--pf-global--Transition);
+  --pf-c-tree-view__node-toggle-icon--Transition: transform var(--pf-global--TransitionDuration) var(--pf-global--TimingFunction);
   --pf-c-tree-view__node-toggle-button--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-tree-view__node-toggle-button--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tree-view__node-toggle-button--PaddingBottom: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -39,6 +39,11 @@ $pf-c-tree-view--MaxNesting: 10;
 
   // Toggle icon
   --pf-c-tree-view__node-toggle-icon--MinWidth: var(--pf-global--FontSize--md);
+  --pf-c-tree-view__node-toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-tree-view__node-toggle--hover__icon--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node-toggle--focus__icon--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node-toggle--active__icon--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node-toggle--expanded__icon--Color: var(--pf-global--Color--100);
   --pf-c-tree-view__node-toggle-icon--Transition: var(--pf-global--Transition);
   --pf-c-tree-view__node-toggle-button--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-tree-view__node-toggle-button--PaddingRight: var(--pf-global--spacer--md);
@@ -323,9 +328,25 @@ $pf-c-tree-view--MaxNesting: 10;
 .pf-c-tree-view__node-toggle-icon {
   display: inline-block;
   min-width: var(--pf-c-tree-view__node-toggle-icon--MinWidth);
+  color: var(--pf-c-tree-view__node-toggle-icon--Color);
   text-align: center;
   transition: var(--pf-c-tree-view__node-toggle-icon--Transition);
   transform: rotate(var(--pf-c-tree-view__node-toggle-icon--Rotate));
+
+  @at-root button.pf-c-tree-view__node,
+  button.pf-c-tree-view__node-toggle {
+    &:hover {
+      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--hover__icon--Color);
+    }
+
+    &:focus {
+      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--focus__icon--Color);
+    }
+
+    &:active {
+      --pf-c-tree-view__node-toggle-icon--Color: var(--pf-c-tree-view__node-toggle--focus__icon--Color);
+    }
+  }
 }
 
 // stylelint-disable
@@ -421,6 +442,12 @@ $pf-c-tree-view--MaxNesting: 10;
     --pf-c-tree-view__node-content--Overflow: hidden;
 
     @include pf-text-overflow;
+  }
+}
+
+.pf-c-tree-view__node-text {
+  @at-root label#{&} {
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4724
fixes https://github.com/patternfly/patternfly/issues/4725

Makes the node a `div` when the node is selectable (including nodes with checkboxes), and makes the toggle a `button`. This will require a react update to only allow a selectable node to expand when clicking on the node-toggle, otherwise clicking on the node will select it.

This also changes the icon color on hover/focus/active when clicking will expand the node
* hover/focus/active anywhere on a non-selectable node
* hover/focus/active on the toggle on a selectable node

In the original issue, we said that clicking anywhere to the left of a selectable/expandable toggle would also toggle the row, but decided against that since it isn't necessarily intuitive, and it would also mean that if you focused on a nested toggle, it would draw a focus outline around all of the area to the left of the toggle, which doesn't seem ideal or a pattern we have anywhere else as far as I'm aware. @mcarrano @mmenestr let me know if you want to change that. Right now the icon changes color when you're hovered/focused on the part of the node that will expand it.