### PR TITLE
fix(chip-group): fixed premature wrapping

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -26,6 +26,8 @@
   --pf-c-chip-group__list-item--MarginRight: var(--pf-global--spacer--xs);
   --pf-c-chip-group__list-item--MarginBottom: var(--pf-global--spacer--xs);
 
+  max-width: 100%;
+
   &.pf-m-category {
     padding-top: var(--pf-c-chip-group--m-category--PaddingTop);
     padding-right: var(--pf-c-chip-group--m-category--PaddingRight);
@@ -55,7 +57,6 @@
   flex-wrap: wrap;
   align-items: center;
   min-width: 0;
-  max-width: 100%;
 }
 
 .pf-c-chip-group__list-item {


### PR DESCRIPTION
closes #4874 

Looks like the `max-width` on `.pf-c-chip-group__list` is the issue. 

**Before:** 

![Screen Shot 2022-05-26 at 3 16 03 PM](https://user-images.githubusercontent.com/5385435/170560933-7b53426b-fb53-4945-9315-f6bf5f3e9394.png)

**After:**

![Screen Shot 2022-05-26 at 3 17 04 PM](https://user-images.githubusercontent.com/5385435/170561052-410e11ae-13df-478d-b76f-5d916c048a15.png)

**Very narrow:** The list still remains confined by the wrapper without the need for `max-width`. 

![Screen Shot 2022-05-26 at 3 17 15 PM](https://user-images.githubusercontent.com/5385435/170561066-d52dbcd7-b105-478e-9567-d466acf02a65.png)

