### PR TITLE
fix(select): allow chip group to grow

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -55,7 +55,6 @@
   flex-wrap: wrap;
   align-items: center;
   min-width: 0;
-  max-width: 100%;
 }
 
 .pf-c-chip-group__list-item {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -421,6 +421,7 @@
 
   // a chip group needs a bottom margin to make some space between the chip group and typeahead input box if it wraps
   .pf-c-chip-group {
+    flex-grow: 1;
     margin-top: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginTop);
     margin-bottom: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginBottom);
   }

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -421,7 +421,6 @@
 
   // a chip group needs a bottom margin to make some space between the chip group and typeahead input box if it wraps
   .pf-c-chip-group {
-    flex-grow: 1;
     margin-top: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginTop);
     margin-bottom: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginBottom);
   }


### PR DESCRIPTION
By adding `flex-grow:1` to a chip group in the select typeahead toggle, the chip group can grow so that it doesn't wrap as soon. However, there is a trade off because that does mean that the text input will be pushed further over now that the chip group container can grow. This is mainly noticeable on very wide screens, but in general the select should be within a form or something else that limits the select to a reasonable width, so this seems acceptable.
@tlabaj @mnolting @edewit @mcarrano @mmenestr 

Fixes #4883 