### PR TITLE
fix(Menu): fix scrollbar on flyout variant

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -241,8 +241,7 @@
 
     > .pf-c-menu__content {
       flex-grow: 1;
-      overflow: visible hidden;
-      overflow-x: hidden;
+      overflow: hidden;
       transition: var(--pf-c-menu--m-drilldown__content--Transition);
     }
 

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -196,8 +196,6 @@
   box-shadow: var(--pf-c-menu--BoxShadow);
 
   .pf-c-menu__content {
-    overflow: visible hidden;
-
     & & {
       overflow: visible;
     }
@@ -243,6 +241,7 @@
 
     > .pf-c-menu__content {
       flex-grow: 1;
+      overflow: visible hidden;
       overflow-x: hidden;
       transition: var(--pf-c-menu--m-drilldown__content--Transition);
     }


### PR DESCRIPTION
Closes #4871 

It looks like PR #4807 fix for the drilldown variant affected the flyout variant. I moved the fix introduced in that PR so that it only applies to the `pf-m-drilldown` class. Using the Codepen linked in this previous PR, I tweaked it a little to show how this fix *should* work (as I also don't believe I can test this solely in Core).

[Drilldown/flyout overflow fix codepen](https://codesandbox.io/s/drilldown-flyout-overflow-fix-s6k07v?file=/styles.css:50-127)

One point I could use clarification on is whether we would still need `overflow-x: hidden;` on line 245. If not, then I could instead replace that with `overflow: hidden` for the same result of this proposed solution it looks like.