### PR TITLE
fix(card): fix dark theme card, light bg contrast

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -386,3 +386,10 @@
     font-weight: var(--pf-global--FontWeight--normal);
   }
 }
+
+// stylelint-disable no-invalid-position-at-import-rule
+@import "themes/dark/card";
+
+@include pf-theme-dark {
+  @include pf-theme-dark-card;
+}

--- a/src/patternfly/components/Card/themes/dark/card.scss
+++ b/src/patternfly/components/Card/themes/dark/card.scss
@@ -1,0 +1,13 @@
+@import "../../../../sass-utilities/themes/dark/all";
+
+@mixin pf-theme-dark-card() {
+  .pf-c-card {
+    --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
+
+    // Hoverable/selectable raised
+    --pf-c-card--m-hoverable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--focus--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--active--BoxShadow: var(--pf-global--BoxShadow--lg);
+  }
+}


### PR DESCRIPTION
Override the card box shadow in dark theme to provide enough contrast when the card is on the "light" background.

Fixes #4889 