### PR TITLE
Card: forces the background color on dark theme, dark section

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -386,3 +386,10 @@
     font-weight: var(--pf-global--FontWeight--normal);
   }
 }
+
+// stylelint-disable no-invalid-position-at-import-rule
+@import "themes/dark/card";
+
+@include pf-theme-dark {
+  @include pf-theme-dark-card;
+}

--- a/src/patternfly/components/Card/themes/dark/card.scss
+++ b/src/patternfly/components/Card/themes/dark/card.scss
@@ -1,7 +1,8 @@
 @import "../../../../sass-utilities/themes/dark/all";
 
 @mixin pf-theme-dark-card() {
-  .pf-c-card {
+  .pf-c-card,
+  .pf-c-card.pf-m-non-selectable-raised {
     --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
 
     // Hoverable/selectable raised
@@ -9,5 +10,9 @@
     --pf-c-card--m-selectable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
     --pf-c-card--m-selectable-raised--focus--BoxShadow: var(--pf-global--BoxShadow--lg);
     --pf-c-card--m-selectable-raised--active--BoxShadow: var(--pf-global--BoxShadow--lg);
+  }
+
+  .pf-c-page__main-section[class*="pf-m-dark-"] .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
   }
 }

--- a/src/patternfly/components/Card/themes/dark/card.scss
+++ b/src/patternfly/components/Card/themes/dark/card.scss
@@ -1,0 +1,13 @@
+@import "../../../../sass-utilities/themes/dark/all";
+
+@mixin pf-theme-dark-card() {
+  .pf-c-card {
+    --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
+
+    // Hoverable/selectable raised
+    --pf-c-card--m-hoverable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--focus--BoxShadow: var(--pf-global--BoxShadow--lg);
+    --pf-c-card--m-selectable-raised--active--BoxShadow: var(--pf-global--BoxShadow--lg);
+  }
+}


### PR DESCRIPTION
Previous PR #4889 changed the box shadow of dark theme cards, but card color was still modified slightly when on a dark section. This forces the same color for the card background when in dark theme, regardless of the section background.