### PR TITLE
fix(card): force dk theme dk section card bg color

### DIFF
--- a/src/patternfly/components/Card/themes/dark/card.scss
+++ b/src/patternfly/components/Card/themes/dark/card.scss
@@ -1,7 +1,8 @@
 @import "../../../../sass-utilities/themes/dark/all";
 
 @mixin pf-theme-dark-card() {
-  .pf-c-card {
+  .pf-c-card,
+  .pf-c-card.pf-m-non-selectable-raised {
     --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
 
     // Hoverable/selectable raised
@@ -9,5 +10,9 @@
     --pf-c-card--m-selectable-raised--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
     --pf-c-card--m-selectable-raised--focus--BoxShadow: var(--pf-global--BoxShadow--lg);
     --pf-c-card--m-selectable-raised--active--BoxShadow: var(--pf-global--BoxShadow--lg);
+  }
+
+  .pf-c-page__main-section[class*="pf-m-dark-"] .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
   }
 }

--- a/src/patternfly/components/Card/themes/dark/card.scss
+++ b/src/patternfly/components/Card/themes/dark/card.scss
@@ -11,8 +11,4 @@
     --pf-c-card--m-selectable-raised--focus--BoxShadow: var(--pf-global--BoxShadow--lg);
     --pf-c-card--m-selectable-raised--active--BoxShadow: var(--pf-global--BoxShadow--lg);
   }
-
-  .pf-c-page__main-section[class*="pf-m-dark-"] .pf-c-card {
-    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  }
 }

--- a/src/patternfly/sass-utilities/themes/dark/placeholders.scss
+++ b/src/patternfly/sass-utilities/themes/dark/placeholders.scss
@@ -8,6 +8,10 @@
   --pf-global--link--Color--hover: #{$pf-global--link--Color--hover};
   --pf-global--BackgroundColor--100: #{$pf-global--BackgroundColor--100};
 
+  .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  }
+
   .pf-c-button {
     // primary button
     --pf-c-button--m-primary--Color: var(--pf-global--Color--light-100);


### PR DESCRIPTION
Previous PR #4889 changed the box shadow of cards on dark background. However, design would like all cards on a dark section to have the same background. 

@mceledonia In some cases, the pf-m-non-selectable-raised card is a different color. Is this the desired result? They are a different color in the normal (light) theme.