### PR TITLE
fix(masthead): keep default/dynamic viewport based inset when using resize observer

### DIFF
--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -156,13 +156,9 @@ $pf-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     @media screen and (min-width: $pf-global--breakpoint--md) {
       @include pf-c-masthead--m-display-inline;
     }
-
-    @media screen and (min-width: $pf-global--breakpoint--xl) {
-      --pf-c-masthead--inset: var(--pf-c-masthead--xl--inset);
-    }
   }
 
-  .pf-c-page:where(.pf-m-breakpoint-xl) & {
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-masthead--inset: var(--pf-c-masthead--xl--inset);
   }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4916