### PR TITLE
fix(utilities): adjust utility colors in dark theme

### DIFF
--- a/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
+++ b/src/patternfly/utilities/BackgroundColor/BackgroundColor.scss
@@ -54,5 +54,11 @@ $pf-u-background-color-options: (
 
 @include pf-utility-builder($pf-u-background-color-options, $pf-global--breakpoint-list);
 
+@import "themes/dark/BackgroundColor";
+
+@include pf-theme-dark {
+  @include pf-theme-dark-background-color;
+}
+
 // stylelint-enable
 

--- a/src/patternfly/utilities/BackgroundColor/themes/dark/BackgroundColor.scss
+++ b/src/patternfly/utilities/BackgroundColor/themes/dark/BackgroundColor.scss
@@ -3,7 +3,6 @@
 @mixin pf-theme-dark-background-color() {
   // Background color options to be redefined in theme
   $pf-u-background-color-options: (
-
     // Note that the status backgrounds are not intended to be used in dark theme; instead, a border or other indication would be used.
     background-color-default: (
       background-color var(--pf-global--BackgroundColor--100)

--- a/src/patternfly/utilities/BackgroundColor/themes/dark/BackgroundColor.scss
+++ b/src/patternfly/utilities/BackgroundColor/themes/dark/BackgroundColor.scss
@@ -1,0 +1,26 @@
+@import "../../../../sass-utilities/themes/dark/all";
+
+@mixin pf-theme-dark-background-color() {
+  // Background color options to be redefined in theme
+  $pf-u-background-color-options: (
+
+    // Note that the status backgrounds are not intended to be used in dark theme; instead, a border or other indication would be used.
+    background-color-default: (
+      background-color var(--pf-global--BackgroundColor--100)
+    ),
+    background-color-success: (
+      background-color var(--pf-global--BackgroundColor--100)
+    ),
+    background-color-info: (
+      background-color var(--pf-global--BackgroundColor--100)
+    ),
+    background-color-warning: (
+      background-color var(--pf-global--BackgroundColor--100)
+    ),
+    background-color-danger: (
+      background-color var(--pf-global--BackgroundColor--100)
+    )
+  );
+
+  @include pf-utility-builder($pf-u-background-color-options, $pf-global--breakpoint-list);
+}

--- a/src/patternfly/utilities/Text/text.scss
+++ b/src/patternfly/utilities/Text/text.scss
@@ -194,4 +194,10 @@ $pf-u-font-alignment-options: (
   white-space: nowrap !important;
 }
 
+@import "themes/dark/text";
+
+@include pf-theme-dark {
+  @include pf-theme-dark-text;
+}
+
 // stylelint-enable

--- a/src/patternfly/utilities/Text/themes/dark/text.scss
+++ b/src/patternfly/utilities/Text/themes/dark/text.scss
@@ -1,0 +1,36 @@
+@import "../../../../sass-utilities/themes/dark/all";
+
+@mixin pf-theme-dark-text() {
+  // Font color options to be redefined in theme
+  $pf-u-font-color-options: (
+    color-300: (
+      color var(--pf-global--Color--100)
+    ),
+    color-light-100: (
+      color var(--pf-global--Color-100)
+    ),
+    color-light-200: (
+      color var(--pf-global--Color-200)
+    ),
+    link-color-visited: (
+      color var(--pf-global--palette--purple-200)
+    ),
+    default-color-300: (
+      color var(--pf-global--default-color--100)
+    ),
+    success-color-200: (
+      color var(--pf-global--success-color--100)
+    ),
+    info-color-200: (
+      color var(--pf-global--info-color--100)
+    ),
+    danger-color-300: (
+      color var(--pf-global--danger-color--100)
+    ),
+    icon-color-dark: (
+      color var(--pf-global--icon--Color--dark)
+    )
+  );
+
+  @include pf-utility-builder($pf-u-font-color-options, $pf-global--breakpoint-list);
+}


### PR DESCRIPTION
Adds dark theme overrides for text color and background color utility classes.
Fixes #4929 