### PR TITLE
[blocked] Enable dark theme switch

### DIFF
--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -3,6 +3,7 @@ module.exports = {
   hasGdprBanner: false,
   hasFooter: false,
   hasVersionSwitcher: false,
+  hasDarkThemeSwitcher: true,
   sideNavItems: [
     { section: 'developer-resources' },
     { section: 'components' },


### PR DESCRIPTION
Enables the switch for the dark theme from patternfly-org. Depends on https://github.com/patternfly/patternfly-org/pull/3014 being merged.
Fixes #4936 