### PR TITLE
fix(dropdown): added menu position combinator

### DIFF
--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -299,8 +299,9 @@
   background-clip: padding-box;
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
 
-  &:only-child {
-    position: initial;
+  &:only-child,
+  &.pf-m-static {
+    position: static;
   }
 }
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -302,6 +302,9 @@
   &:only-child,
   &.pf-m-static {
     position: static;
+    top: auto;
+    z-index: auto;
+    min-width: auto;
   }
 }
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -304,7 +304,7 @@
     position: static;
     top: auto;
     z-index: auto;
-    min-width: auto;
+    min-width: min-content;
   }
 }
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -291,6 +291,7 @@
 .pf-c-context-selector__menu {
   @include pf-t-light;
 
+  position: absolute;
   top: var(--pf-c-context-selector__menu--Top);
   z-index: var(--pf-c-context-selector__menu--ZIndex);
   min-width: 100%;
@@ -298,8 +299,8 @@
   background-clip: padding-box;
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
 
-  .pf-c-context-selector__toggle + & {
-    position: absolute;
+  &:only-child {
+    position: initial;
   }
 }
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -299,7 +299,6 @@
   background-clip: padding-box;
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
 
-  &:only-child,
   &.pf-m-static {
     position: static;
     top: auto;

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -65,7 +65,6 @@
   --pf-c-context-selector__menu-list--PaddingTop: var(--pf-c-context-selector__menu--PaddingTop); // reference spacer directly at breaking change
   --pf-c-context-selector__menu-list--PaddingBottom: var(--pf-global--spacer--sm);
 
-
   // Menu item
   --pf-c-context-selector__menu-list-item--Color: var(--pf-global--Color--dark-100);
   --pf-c-context-selector__menu-list-item--PaddingTop: var(--pf-global--spacer--sm);
@@ -292,13 +291,16 @@
 .pf-c-context-selector__menu {
   @include pf-t-light;
 
-  position: absolute;
   top: var(--pf-c-context-selector__menu--Top);
   z-index: var(--pf-c-context-selector__menu--ZIndex);
   min-width: 100%;
   background-color: var(--pf-c-context-selector__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--pf-c-context-selector__menu--BoxShadow);
+
+  .pf-c-context-selector__toggle + & {
+    position: absolute;
+  }
 }
 
 .pf-c-context-selector__menu-search {

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -118,7 +118,6 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--Top: calc(100% + var(--pf-global--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--sm);
-  --pf-c-dropdown__menu--MinWidth: min-content;
   --pf-c-dropdown--m-top__menu--Top: 0;
   --pf-c-dropdown--m-top__menu--TranslateY: calc(-100% - var(--pf-global--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
@@ -624,17 +623,18 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 }
 
 .pf-c-dropdown__menu {
+  position: absolute;
   top: var(--pf-c-dropdown__menu--Top);
   z-index: var(--pf-c-dropdown__menu--ZIndex);
-  min-width: var(--pf-c-dropdown__menu--MinWidth);
   padding-top: var(--pf-c-dropdown__menu--PaddingTop);
   padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
   background: var(--pf-c-dropdown__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
-  &:only-child {
-    position: initial;
+  &:only-child,
+  &.pf-m-static {
+    position: static;
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -635,6 +635,9 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   &:only-child,
   &.pf-m-static {
     position: static;
+    top: auto;
+    z-index: auto;
+    min-width: auto;
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -632,7 +632,6 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   background-clip: padding-box;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
-  &:only-child,
   &.pf-m-static {
     position: static;
     top: auto;

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -118,6 +118,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--Top: calc(100% + var(--pf-global--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--sm);
+  --pf-c-dropdown__menu--MinWidth: min-content;
   --pf-c-dropdown--m-top__menu--Top: 0;
   --pf-c-dropdown--m-top__menu--TranslateY: calc(-100% - var(--pf-global--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
@@ -625,15 +626,15 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 .pf-c-dropdown__menu {
   top: var(--pf-c-dropdown__menu--Top);
   z-index: var(--pf-c-dropdown__menu--ZIndex);
-  min-width: min-content;
+  min-width: var(--pf-c-dropdown__menu--MinWidth);
   padding-top: var(--pf-c-dropdown__menu--PaddingTop);
   padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
   background: var(--pf-c-dropdown__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
-  .pf-c-dropdown__toggle + & {
-    position: absolute;
+  &:only-child {
+    position: initial;
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -637,7 +637,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
     position: static;
     top: auto;
     z-index: auto;
-    min-width: auto;
+    min-width: min-content;
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -623,14 +623,18 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 }
 
 .pf-c-dropdown__menu {
-  position: absolute;
   top: var(--pf-c-dropdown__menu--Top);
   z-index: var(--pf-c-dropdown__menu--ZIndex);
+  min-width: min-content;
   padding-top: var(--pf-c-dropdown__menu--PaddingTop);
   padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
   background: var(--pf-c-dropdown__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
+
+  .pf-c-dropdown__toggle + & {
+    position: absolute;
+  }
 }
 
 .pf-c-dropdown .pf-c-menu,

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -219,3 +219,4 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-m-icon` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding an icon. |
 | `.pf-m-active` | `.pf-c-dropdown__toggle` | Modifies the dropdown menu toggle for the active state. |
 | `.pf-m-description` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding a description. |
+| `.pf-m-static` | `.pf-c-dropdown__menu` | Modifies a dropdown menu for popper placement support. |

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -465,7 +465,6 @@
 }
 
 .pf-c-select__menu {
-  position: absolute;
   top: var(--pf-c-select__menu--Top);
   z-index: var(--pf-c-select__menu--ZIndex);
   width: var(--pf-c-select__menu--Width);
@@ -483,6 +482,10 @@
   .pf-c-select.pf-m-top & {
     top: 0;
     transform: translateY(var(--pf-c-select__menu--m-top--TranslateY));
+  }
+
+  .pf-c-select__toggle + & {
+    position: absolute;
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -484,8 +484,8 @@
     transform: translateY(var(--pf-c-select__menu--m-top--TranslateY));
   }
 
-  .pf-c-select__toggle + & {
-    position: absolute;
+  &:only-child {
+    position: initial;
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -490,7 +490,7 @@
     position: static;
     top: auto;
     z-index: auto;
-    min-width: auto;
+    min-width: min-content;
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -488,6 +488,9 @@
   &:only-child,
   &.pf-m-static {
     position: static;
+    top: auto;
+    z-index: auto;
+    min-width: auto;
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -465,6 +465,7 @@
 }
 
 .pf-c-select__menu {
+  position: absolute;
   top: var(--pf-c-select__menu--Top);
   z-index: var(--pf-c-select__menu--ZIndex);
   width: var(--pf-c-select__menu--Width);
@@ -484,8 +485,9 @@
     transform: translateY(var(--pf-c-select__menu--m-top--TranslateY));
   }
 
-  &:only-child {
-    position: initial;
+  &:only-child,
+  &.pf-m-static {
+    position: static;
   }
 }
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -485,7 +485,6 @@
     transform: translateY(var(--pf-c-select__menu--m-top--TranslateY));
   }
 
-  &:only-child,
   &.pf-m-static {
     position: static;
     top: auto;


### PR DESCRIPTION
closes #4861 

Possible approach. When popper is used, a duplicate component is added to the DOM. By using an adjacent sibling combinator, we can target non-popper menus. 

