### PR TITLE
fix(text-input-group): fix chip/filter wrapping

### DIFF
--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -50,7 +50,7 @@ import './TextInputGroup.css'
 
 ### Filters
 ```hbs
-{{#> text-input-group text-input-group--id="filters"}}
+{{#> text-input-group text-input-group--id="text-input-group-filters"}}
   {{#> text-input-group-main}}
     {{> text-input-group--chip-group}}
     {{#> text-input-group-text}}
@@ -67,7 +67,7 @@ import './TextInputGroup.css'
 
 ### Filters expanded
 ```hbs
-{{#> text-input-group text-input-group--id="filters-expanded" text-input-group--chip-group--IsLong="true"}}
+{{#> text-input-group text-input-group--id="text-input-group-filters-expanded" text-input-group--chip-group--IsLong="true"}}
   {{#> text-input-group-main}}
     {{> text-input-group--chip-group}}
     {{#> text-input-group-text}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -50,7 +50,7 @@ import './TextInputGroup.css'
 
 ### Filters
 ```hbs
-{{#> text-input-group text-input-group--id="text-input-group-filters"}}
+{{#> text-input-group text-input-group--id="filters"}}
   {{#> text-input-group-main}}
     {{> text-input-group--chip-group}}
     {{#> text-input-group-text}}
@@ -67,7 +67,7 @@ import './TextInputGroup.css'
 
 ### Filters expanded
 ```hbs
-{{#> text-input-group text-input-group--id="text-input-group-filters-expanded" text-input-group--chip-group--IsLong="true"}}
+{{#> text-input-group text-input-group--id="filters-expanded" text-input-group--chip-group--IsLong="true"}}
   {{#> text-input-group-main}}
     {{> text-input-group--chip-group}}
     {{#> text-input-group-text}}

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -20,9 +20,9 @@
   --pf-c-text-input-group__main--ColumnGap: var(--pf-global--spacer--sm);
 
   // Chip group
-  --pf-c-text-input-group__c-chip-group__main--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-text-input-group__c-chip-group__main--PaddingRight: var(--pf-global--spacer--xs);
-  --pf-c-text-input-group__c-chip-group__main--PaddingBottom: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group--c-chip-group__main--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group--c-chip-group__main--PaddingRight: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group--c-chip-group__main--PaddingBottom: var(--pf-global--spacer--xs);
 
   // Text input
   --pf-c-text-input-group__text-input--PaddingTop: var(--pf-global--spacer--form-element);
@@ -98,9 +98,9 @@
   }
 
   .pf-c-chip-group__main {
-    padding-top: var(--pf-c-text-input-group__c-chip-group__main--PaddingTop);
-    padding-right: var(--pf-c-text-input-group__c-chip-group__main--PaddingRight);
-    padding-bottom: var(--pf-c-text-input-group__c-chip-group__main--PaddingBottom);
+    padding-top: var(--pf-c-text-input-group--c-chip-group__main--PaddingTop);
+    padding-right: var(--pf-c-text-input-group--c-chip-group__main--PaddingRight);
+    padding-bottom: var(--pf-c-text-input-group--c-chip-group__main--PaddingBottom);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -167,7 +167,6 @@
   position: relative;
   width: 100%;
   min-width: var(--pf-c-text-input-group__text-input--MinWidth);
-  height: fit-content;
   padding: var(--pf-c-text-input-group__text-input--PaddingTop) var(--pf-c-text-input-group__text-input--PaddingRight) var(--pf-c-text-input-group__text-input--PaddingBottom) var(--pf-c-text-input-group__text-input--PaddingLeft);
   border: 0;
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -16,11 +16,13 @@
   // Main
   --pf-c-text-input-group__main--first-child--not--text-input--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-text-input-group__main--m-icon__text-input--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-text-input-group__main--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__main--ColumnGap: var(--pf-global--spacer--sm);
 
   // Chip group
-  --pf-c-text-input-group__chip-group__main--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-text-input-group__chip-group__main--PaddingRight: var(--pf-global--spacer--xs);
-  --pf-c-text-input-group__chip-group__main--PaddingBottom: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__c-chip-group__main--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__c-chip-group__main--PaddingRight: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__c-chip-group__main--PaddingBottom: var(--pf-global--spacer--xs);
 
   // Text input
   --pf-c-text-input-group__text-input--PaddingTop: var(--pf-global--spacer--form-element);
@@ -84,7 +86,7 @@
   display: flex;
   flex: 1;
   flex-wrap: wrap;
-  gap: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
+  gap: var(--pf-c-text-input-group__main--RowGap) var(--pf-c-text-input-group__main--ColumnGap);
   min-width: 0;
 
   &.pf-m-icon {
@@ -96,9 +98,9 @@
   }
 
   .pf-c-chip-group__main {
-    padding-top: var(--pf-c-text-input-group__chip-group__main--PaddingTop);
-    padding-right: var(--pf-c-text-input-group__chip-group__main--PaddingRight);
-    padding-bottom: var(--pf-c-text-input-group__chip-group__main--PaddingBottom);
+    padding-top: var(--pf-c-text-input-group__c-chip-group__main--PaddingTop);
+    padding-right: var(--pf-c-text-input-group__c-chip-group__main--PaddingRight);
+    padding-bottom: var(--pf-c-text-input-group__c-chip-group__main--PaddingBottom);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -121,7 +121,6 @@
   grid-template-columns: 1fr;
   grid-template-areas: "text-input";
   flex: 1;
-  align-items: center;
 
   &::before,
   &::after {

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -120,6 +120,7 @@
   grid-template-columns: 1fr;
   grid-template-areas: "text-input";
   flex: 1;
+  align-items: center;
 
   &::before,
   &::after {
@@ -165,6 +166,7 @@
   position: relative;
   width: 100%;
   min-width: var(--pf-c-text-input-group__text-input--MinWidth);
+  height: fit-content;
   padding: var(--pf-c-text-input-group__text-input--PaddingTop) var(--pf-c-text-input-group__text-input--PaddingRight) var(--pf-c-text-input-group__text-input--PaddingBottom) var(--pf-c-text-input-group__text-input--PaddingLeft);
   border: 0;
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -104,10 +104,7 @@
   }
 
   .pf-c-chip-group li,
-  .pf-c-chip-group__list li {
-    min-width: fit-content;
-  }
-
+  .pf-c-chip-group__list li,
   .pf-c-chip.pf-m-overflow {
     min-width: fit-content;
   }

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -103,9 +103,13 @@
     }
   }
 
-  .pf-c-chip-group,
-  .pf-c-chip-group__list {
-    flex-wrap: nowrap;
+  .pf-c-chip-group li,
+  .pf-c-chip-group__list li {
+    min-width: fit-content;
+  }
+
+  .pf-c-chip.pf-m-overflow {
+    min-width: fit-content;
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -83,6 +83,7 @@
 .pf-c-text-input-group__main {
   display: flex;
   flex: 1;
+  flex-wrap: wrap;
   gap: var(--pf-global--spacer--sm);
   min-width: 0;
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -84,7 +84,7 @@
   display: flex;
   flex: 1;
   flex-wrap: wrap;
-  gap: var(--pf-global--spacer--sm);
+  gap: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
   min-width: 0;
 
   &.pf-m-icon {
@@ -93,20 +93,6 @@
 
   > :first-child:not(.pf-c-text-input-group__text) {
     margin-left: var(--pf-c-text-input-group__main--first-child--not--text-input--MarginLeft);
-  }
-
-  // Scroll chip group horizontally if there is overflow
-  .pf-c-chip-group {
-    overflow: auto;
-
-    // Hide scrollbar for IE, Edge and Firefox
-    -ms-overflow-style: none;  // IE and Edge
-    scrollbar-width: none;  // Firefox
-
-    // Hide scrollbar for Chrome, Safari and Opera
-    &::-webkit-scrollbar {
-      display: none;
-    }
   }
 
   .pf-c-chip-group__main {

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -17,6 +17,11 @@
   --pf-c-text-input-group__main--first-child--not--text-input--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-text-input-group__main--m-icon__text-input--PaddingLeft: var(--pf-global--spacer--xl);
 
+  // Chip group
+  --pf-c-text-input-group__chip-group__main--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__chip-group__main--PaddingRight: var(--pf-global--spacer--xs);
+  --pf-c-text-input-group__chip-group__main--PaddingBottom: var(--pf-global--spacer--xs);
+
   // Text input
   --pf-c-text-input-group__text-input--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-text-input-group__text-input--PaddingRight: var(--pf-global--spacer--sm);
@@ -103,10 +108,10 @@
     }
   }
 
-  .pf-c-chip-group li,
-  .pf-c-chip-group__list li,
-  .pf-c-chip.pf-m-overflow {
-    min-width: fit-content;
+  .pf-c-chip-group__main {
+    padding-top: var(--pf-c-text-input-group__chip-group__main--PaddingTop);
+    padding-right: var(--pf-c-text-input-group__chip-group__main--PaddingRight);
+    padding-bottom: var(--pf-c-text-input-group__chip-group__main--PaddingBottom);
   }
 }
 


### PR DESCRIPTION
This removes the rule preventing the chip group from wrapping within a text input group, and changes the min-width from 0 to fit-content so that the chips don't get too small to read. This isn't foolproof at extremely small widths but mostly alleviates the problem.
Also fixed a duplicate id in the example causing an axe error.

Fixes #4885 