### PR TITLE
feat(Timestamp): create component

### DIFF
--- a/src/patternfly/components/Timestamp/examples/Timestamp.md
+++ b/src/patternfly/components/Timestamp/examples/Timestamp.md
@@ -1,5 +1,5 @@
 ---
-id: 'Timestamp'
+id: Timestamp
 beta: true
 section: components
 cssPrefix: pf-c-timestamp
@@ -7,25 +7,57 @@ cssPrefix: pf-c-timestamp
 
 ## Examples
 
-### Long format
-```hbs
-{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
-  Thursday, 14 July 2022, 1:00 PM EST
-{{/timestamp}}
-```
+### Basic
 
-### Short format
 ```hbs
-{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
-  14 July 2022, 1:00 PM EST
+{{#> timestamp}}
+  {{#> timestamp-text timestamp-text--attribute='datetime="2019-01-21T21:38"'}}
+    Thursday, 21 January 2019, 9:38 PM EST
+  {{/timestamp-text}}
 {{/timestamp}}
-```
 
-### Tiny format
-```hbs
-{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
-  14 Jul 2022, 1:00 PM EST
+<br/>
+<br/>
+
+{{#> timestamp}}
+  {{#> timestamp-text timestamp-text--attribute='datetime="2019-01-21T21:38"'}}
+    21 January 2019, 9:38 PM EST
+  {{/timestamp-text}}
+{{/timestamp}}
+
+<br/>
+<br/>
+
+{{#> timestamp}}
+  {{#> timestamp-text timestamp-text--attribute='datetime="2019-01-21T21:38"'}}
+    21 Jan. 2019, 9:38 PM EST
+  {{/timestamp-text}}
+{{/timestamp}}
+
+<br/>
+<br/>
+
+{{#> timestamp}}
+  {{#> timestamp-text timestamp-text--attribute='datetime="2022-07-15T10:00"'}}
+    1 hour ago 
+  {{/timestamp-text}}
+{{/timestamp}}
+
+<br/>
+<br/>
+
+{{#> timestamp}}
+  {{#> timestamp-text timestamp-text--attribute='datetime="2022-07-21"'}}
+    Tomorrow
+  {{/timestamp-text}}
 {{/timestamp}}
 ```
 
 ## Documentation
+
+### Usage
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-timestamp` | `<span>` | Creates a timestamp. **Required** |
+| `.pf-c-timestamp__text` | `<span>` | Create the visual text of the timestamp. **Required** |

--- a/src/patternfly/components/Timestamp/examples/Timestamp.md
+++ b/src/patternfly/components/Timestamp/examples/Timestamp.md
@@ -60,4 +60,4 @@ cssPrefix: pf-c-timestamp
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-timestamp` | `<span>` | Creates a timestamp. **Required** |
-| `.pf-c-timestamp__text` | `<span>` | Create the visual text of the timestamp. **Required** |
+| `.pf-c-timestamp__text` | `<time>` | Creates the visual text of the timestamp. **Required** |

--- a/src/patternfly/components/Timestamp/examples/Timestamp.md
+++ b/src/patternfly/components/Timestamp/examples/Timestamp.md
@@ -61,3 +61,4 @@ cssPrefix: pf-c-timestamp
 | -- | -- | -- |
 | `.pf-c-timestamp` | `<span>` | Creates a timestamp. **Required** |
 | `.pf-c-timestamp__text` | `<time>` | Creates the visual text of the timestamp. **Required** |
+| `.pf-m-help-text`| `.pf-c-timestamp` | Modifies styling for a timestamp that has help text. |

--- a/src/patternfly/components/Timestamp/examples/Timestamp.md
+++ b/src/patternfly/components/Timestamp/examples/Timestamp.md
@@ -1,0 +1,31 @@
+---
+id: 'Timestamp'
+beta: true
+section: components
+cssPrefix: pf-c-timestamp
+---
+
+## Examples
+
+### Long format
+```hbs
+{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
+  Thursday, 14 July 2022, 1:00 PM EST
+{{/timestamp}}
+```
+
+### Short format
+```hbs
+{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
+  14 July 2022, 1:00 PM EST
+{{/timestamp}}
+```
+
+### Tiny format
+```hbs
+{{#> timestamp timestamp--attribute='datetime="2022-07-14T13:00"'}}
+  14 Jul 2022, 1:00 PM EST
+{{/timestamp}}
+```
+
+## Documentation

--- a/src/patternfly/components/Timestamp/timestamp-text.hbs
+++ b/src/patternfly/components/Timestamp/timestamp-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-timestamp__text{{#if timestamp-text--modifier}} {{timestamp-text--modifier}}{{/if}}"
+  {{#if timestamp-text--attribute}}
+    {{{timestamp-text--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</span>

--- a/src/patternfly/components/Timestamp/timestamp-text.hbs
+++ b/src/patternfly/components/Timestamp/timestamp-text.hbs
@@ -1,6 +1,6 @@
-<span class="pf-c-timestamp__text{{#if timestamp-text--modifier}} {{timestamp-text--modifier}}{{/if}}"
+<time class="pf-c-timestamp__text{{#if timestamp-text--modifier}} {{timestamp-text--modifier}}{{/if}}"
   {{#if timestamp-text--attribute}}
     {{{timestamp-text--attribute}}}
   {{/if}}>
   {{>@partial-block}}
-</span>
+</time>

--- a/src/patternfly/components/Timestamp/timestamp.hbs
+++ b/src/patternfly/components/Timestamp/timestamp.hbs
@@ -1,0 +1,7 @@
+<time class="pf-c-timestamp{{#if timestamp--modifier}} {{timestamp--modifier}}{{/if}}"
+  tabindex="0"
+  {{#if timestamp--attribute}}
+    {{{timestamp--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</time>

--- a/src/patternfly/components/Timestamp/timestamp.hbs
+++ b/src/patternfly/components/Timestamp/timestamp.hbs
@@ -1,7 +1,6 @@
-<time class="pf-c-timestamp{{#if timestamp--modifier}} {{timestamp--modifier}}{{/if}}"
-  tabindex="0"
+<span class="pf-c-timestamp{{#if timestamp--modifier}} {{timestamp--modifier}}{{/if}}"
   {{#if timestamp--attribute}}
     {{{timestamp--attribute}}}
   {{/if}}>
   {{>@partial-block}}
-</time>
+</span>

--- a/src/patternfly/components/Timestamp/timestamp.hbs
+++ b/src/patternfly/components/Timestamp/timestamp.hbs
@@ -1,4 +1,4 @@
-<span class="pf-c-timestamp{{#if timestamp--modifier}} {{timestamp--modifier}}{{/if}}"
+<span class="pf-c-timestamp{{#if timestamp--IsHelp}} pf-m-help-text{{/if}}{{#if timestamp--modifier}} {{timestamp--modifier}}{{/if}}"
   {{#if timestamp--attribute}}
     {{{timestamp--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -1,24 +1,43 @@
 .pf-c-timestamp {
-  --pf-c-timestamp--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-timestamp--Color: var(--pf-global--Color--200);
-  --pf-c-timestamp--TextAlign: center;
-  --pf-c-timestamp--Cursor: pointer;
-  --pf-c-timestamp--TextDecorationLine: underline;
-  --pf-c-timestamp--TextDecorationStyle: dashed;
-  --pf-c-timestamp--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
-  --pf-c-timestamp--TextUnderlineOffset: #{pf-size-prem(4px)};
-  --pf-c-timestamp--TextDecorationColor: var(--pf-global--BorderColor--200);
+  // Timestamp text
+  --pf-c-timestamp__text--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-timestamp__text--Color: var(--pf-global--Color--200);
 
-  display: inline-block;
-  cursor: var(--pf-c-timestamp--Cursor);
+  // Help text variables for the timestamp text
+  --pf-c-timestamp__text--m-help-text--TextDecorationLine: underline;
+  --pf-c-timestamp__text--m-help-text--TextDecorationStyle: dashed;
+  --pf-c-timestamp__text--m-help-text--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
+  --pf-c-timestamp__text--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-global--BorderColor--200);
+  --pf-c-timestamp__text--m-help-text--hover--Color: var(--pf-global--Color--100);
+  --pf-c-timestamp__text--m-help-text--focus--Color: var(--pf-global--Color--100);
+  --pf-c-timestamp__text--m-help-text--hover--TextDecorationColor: var(--pf-global--Color--100);
+  --pf-c-timestamp__text--m-help-text--focus--TextDecorationColor: var(--pf-global--Color--100);
 
   .pf-c-timestamp__text {
-    font-size: var(--pf-c-timestamp--FontSize);
-    color: var(--pf-c-timestamp--Color);
-    text-decoration-line: var(--pf-c-timestamp--TextDecorationLine);
-    text-decoration-style: var(--pf-c-timestamp--TextDecorationStyle);
-    text-decoration-thickness: var(--pf-c-timestamp--TextDecorationThickness);
-    text-underline-offset: var(--pf-c-timestamp--TextUnderlineOffset);
-    text-decoration-color: var(--pf-c-timestamp--TextDecorationColor);
+    font-size: var(--pf-c-timestamp__text--FontSize);
+    color: var(--pf-c-timestamp__text--Color);
+  }
+
+  &.pf-m-help-text {
+    cursor: pointer;
+
+    .pf-c-timestamp__text {
+      text-decoration-line: var(--pf-c-timestamp__text--m-help-text--TextDecorationLine);
+      text-decoration-style: var(--pf-c-timestamp__text--m-help-text--TextDecorationStyle);
+      text-decoration-thickness: var(--pf-c-timestamp__text--m-help-text--TextDecorationThickness);
+      text-underline-offset: var(--pf-c-timestamp__text--m-help-text--TextUnderlineOffset);
+      text-decoration-color: var(--pf-c-timestamp__text--m-help-text--TextDecorationColor);
+    }
+
+    &:hover {
+      --pf-c-timestamp__text--Color: var(--pf-c-timestamp__text--m-help-text--hover--Color);
+      --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-c-timestamp__text--m-help-text--hover--TextDecorationColor);
+    }
+
+    &:focus {
+      --pf-c-timestamp__text--Color: var(--pf-c-timestamp__text--m-help-text--focus--Color);
+      --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-c-timestamp__text--m-help-text--focus--TextDecorationColor);
+    }
   }
 }

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -10,13 +10,15 @@
   --pf-c-timestamp--TextDecorationColor: var(--pf-global--BorderColor--200);
 
   display: inline-block;
-  font-size: var(--pf-c-timestamp--FontSize);
-  color: var(--pf-c-timestamp--Color);
-  text-align: var(--pf-c-timestamp--TextAlign);
   cursor: var(--pf-c-timestamp--Cursor);
-  text-decoration-line: var(--pf-c-timestamp--TextDecorationLine);
-  text-decoration-style: var(--pf-c-timestamp--TextDecorationStyle);
-  text-decoration-thickness: var(--pf-c-timestamp--TextDecorationThickness);
-  text-underline-offset: var(--pf-c-timestamp--TextUnderlineOffset);
-  text-decoration-color: var(--pf-c-timestamp--TextDecorationColor);
+
+  .pf-c-timestamp__text {
+    font-size: var(--pf-c-timestamp--FontSize);
+    color: var(--pf-c-timestamp--Color);
+    text-decoration-line: var(--pf-c-timestamp--TextDecorationLine);
+    text-decoration-style: var(--pf-c-timestamp--TextDecorationStyle);
+    text-decoration-thickness: var(--pf-c-timestamp--TextDecorationThickness);
+    text-underline-offset: var(--pf-c-timestamp--TextUnderlineOffset);
+    text-decoration-color: var(--pf-c-timestamp--TextDecorationColor);
+  }
 }

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -1,0 +1,22 @@
+.pf-c-timestamp {
+  --pf-c-timestamp--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-timestamp--Color: var(--pf-global--Color--200);
+  --pf-c-timestamp--TextAlign: center;
+  --pf-c-timestamp--Cursor: pointer;
+  --pf-c-timestamp--TextDecorationLine: underline;
+  --pf-c-timestamp--TextDecorationStyle: dashed;
+  --pf-c-timestamp--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
+  --pf-c-timestamp--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --pf-c-timestamp--TextDecorationColor: var(--pf-global--BorderColor--200);
+
+  display: inline-block;
+  font-size: var(--pf-c-timestamp--FontSize);
+  color: var(--pf-c-timestamp--Color);
+  text-align: var(--pf-c-timestamp--TextAlign);
+  cursor: var(--pf-c-timestamp--Cursor);
+  text-decoration-line: var(--pf-c-timestamp--TextDecorationLine);
+  text-decoration-style: var(--pf-c-timestamp--TextDecorationStyle);
+  text-decoration-thickness: var(--pf-c-timestamp--TextDecorationThickness);
+  text-underline-offset: var(--pf-c-timestamp--TextUnderlineOffset);
+  text-decoration-color: var(--pf-c-timestamp--TextDecorationColor);
+}

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -3,16 +3,16 @@
   --pf-c-timestamp__text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-timestamp__text--Color: var(--pf-global--Color--200);
 
-  // Help text variables for the timestamp text
-  --pf-c-timestamp__text--m-help-text--TextDecorationLine: underline;
-  --pf-c-timestamp__text--m-help-text--TextDecorationStyle: dashed;
-  --pf-c-timestamp__text--m-help-text--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
-  --pf-c-timestamp__text--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
-  --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-global--BorderColor--200);
-  --pf-c-timestamp__text--m-help-text--hover--Color: var(--pf-global--Color--100);
-  --pf-c-timestamp__text--m-help-text--focus--Color: var(--pf-global--Color--100);
-  --pf-c-timestamp__text--m-help-text--hover--TextDecorationColor: var(--pf-global--Color--100);
-  --pf-c-timestamp__text--m-help-text--focus--TextDecorationColor: var(--pf-global--Color--100);
+  // Help text variables for the timestamp
+  --pf-c-timestamp--m-help-text--TextDecorationLine: underline;
+  --pf-c-timestamp--m-help-text--TextDecorationStyle: dashed;
+  --pf-c-timestamp--m-help-text--TextDecorationThickness: var(--pf-global--BorderWidth--sm);
+  --pf-c-timestamp--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --pf-c-timestamp--m-help-text--TextDecorationColor: var(--pf-global--BorderColor--200);
+  --pf-c-timestamp--m-help-text--hover--Color: var(--pf-global--Color--100);
+  --pf-c-timestamp--m-help-text--focus--Color: var(--pf-global--Color--100);
+  --pf-c-timestamp--m-help-text--hover--TextDecorationColor: var(--pf-global--Color--100);
+  --pf-c-timestamp--m-help-text--focus--TextDecorationColor: var(--pf-global--Color--100);
 
   .pf-c-timestamp__text {
     font-size: var(--pf-c-timestamp__text--FontSize);
@@ -23,21 +23,21 @@
     cursor: pointer;
 
     .pf-c-timestamp__text {
-      text-decoration-line: var(--pf-c-timestamp__text--m-help-text--TextDecorationLine);
-      text-decoration-style: var(--pf-c-timestamp__text--m-help-text--TextDecorationStyle);
-      text-decoration-thickness: var(--pf-c-timestamp__text--m-help-text--TextDecorationThickness);
-      text-underline-offset: var(--pf-c-timestamp__text--m-help-text--TextUnderlineOffset);
-      text-decoration-color: var(--pf-c-timestamp__text--m-help-text--TextDecorationColor);
+      text-decoration-line: var(--pf-c-timestamp--m-help-text--TextDecorationLine);
+      text-decoration-style: var(--pf-c-timestamp--m-help-text--TextDecorationStyle);
+      text-decoration-thickness: var(--pf-c-timestamp--m-help-text--TextDecorationThickness);
+      text-underline-offset: var(--pf-c-timestamp--m-help-text--TextUnderlineOffset);
+      text-decoration-color: var(--pf-c-timestamp--m-help-text--TextDecorationColor);
     }
 
     &:hover {
-      --pf-c-timestamp__text--Color: var(--pf-c-timestamp__text--m-help-text--hover--Color);
-      --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-c-timestamp__text--m-help-text--hover--TextDecorationColor);
+      --pf-c-timestamp__text--Color: var(--pf-c-timestamp--m-help-text--hover--Color);
+      --pf-c-timestamp--m-help-text--TextDecorationColor: var(--pf-c-timestamp--m-help-text--hover--TextDecorationColor);
     }
 
     &:focus {
-      --pf-c-timestamp__text--Color: var(--pf-c-timestamp__text--m-help-text--focus--Color);
-      --pf-c-timestamp__text--m-help-text--TextDecorationColor: var(--pf-c-timestamp__text--m-help-text--focus--TextDecorationColor);
+      --pf-c-timestamp__text--Color: var(--pf-c-timestamp--m-help-text--focus--Color);
+      --pf-c-timestamp--m-help-text--TextDecorationColor: var(--pf-c-timestamp--m-help-text--focus--TextDecorationColor);
     }
   }
 }

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -1,7 +1,6 @@
 .pf-c-timestamp {
-  // Timestamp text
-  --pf-c-timestamp__text--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-timestamp__text--Color: var(--pf-global--Color--200);
+  --pf-c-timestamp--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-timestamp--Color: var(--pf-global--Color--200);
 
   // Help text variables for the timestamp
   --pf-c-timestamp--m-help-text--TextDecorationLine: underline;
@@ -14,29 +13,24 @@
   --pf-c-timestamp--m-help-text--hover--TextDecorationColor: var(--pf-global--Color--100);
   --pf-c-timestamp--m-help-text--focus--TextDecorationColor: var(--pf-global--Color--100);
 
-  .pf-c-timestamp__text {
-    font-size: var(--pf-c-timestamp__text--FontSize);
-    color: var(--pf-c-timestamp__text--Color);
-  }
+  font-size: var(--pf-c-timestamp--FontSize);
+  color: var(--pf-c-timestamp--Color);
 
   &.pf-m-help-text {
     cursor: pointer;
-
-    .pf-c-timestamp__text {
-      text-decoration-line: var(--pf-c-timestamp--m-help-text--TextDecorationLine);
-      text-decoration-style: var(--pf-c-timestamp--m-help-text--TextDecorationStyle);
-      text-decoration-thickness: var(--pf-c-timestamp--m-help-text--TextDecorationThickness);
-      text-underline-offset: var(--pf-c-timestamp--m-help-text--TextUnderlineOffset);
-      text-decoration-color: var(--pf-c-timestamp--m-help-text--TextDecorationColor);
-    }
+    text-decoration-line: var(--pf-c-timestamp--m-help-text--TextDecorationLine);
+    text-decoration-style: var(--pf-c-timestamp--m-help-text--TextDecorationStyle);
+    text-decoration-thickness: var(--pf-c-timestamp--m-help-text--TextDecorationThickness);
+    text-underline-offset: var(--pf-c-timestamp--m-help-text--TextUnderlineOffset);
+    text-decoration-color: var(--pf-c-timestamp--m-help-text--TextDecorationColor);
 
     &:hover {
-      --pf-c-timestamp__text--Color: var(--pf-c-timestamp--m-help-text--hover--Color);
+      --pf-c-timestamp--Color: var(--pf-c-timestamp--m-help-text--hover--Color);
       --pf-c-timestamp--m-help-text--TextDecorationColor: var(--pf-c-timestamp--m-help-text--hover--TextDecorationColor);
     }
 
     &:focus {
-      --pf-c-timestamp__text--Color: var(--pf-c-timestamp--m-help-text--focus--Color);
+      --pf-c-timestamp--Color: var(--pf-c-timestamp--m-help-text--focus--Color);
       --pf-c-timestamp--m-help-text--TextDecorationColor: var(--pf-c-timestamp--m-help-text--focus--TextDecorationColor);
     }
   }

--- a/src/patternfly/components/_all.scss
+++ b/src/patternfly/components/_all.scss
@@ -81,6 +81,7 @@
 @import "./Tabs/tabs";
 @import "./TextInputGroup/text-input-group";
 @import "./Tile/tile";
+@import "./Timestamp/timestamp";
 @import "./Title/title";
 @import "./ToggleGroup/toggle-group";
 @import "./Tooltip/tooltip";


### PR DESCRIPTION
Closes #4801 

[Timestamp preview build](https://patternfly-pr-4996.surge.sh/components/timestamp)

Some notes/items to get feedback on:

- I noticed I still need to remove the CSS variable for textalign; depending on whether there are suggested changes I can lump that in with making those updates
- Originally I had used the `<time>` element for the timestamp text, but per MDN's [time element documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time), if the `datetime` attribute is not provided then the <time> element cannot have any child elements (and must be one of the valid date/time formats on the page). Based on the design docs it seems like the timestamp usage might not really require the time element, but it might be worth looking into offering as an opt-in down the line to take advantage of (per MDN, for "better search engine results or custom features such as reminders").
- Currently the timestamp has the pointer cursor on hover, but GitHub for example doesn't change the cursor when hovering over their timestamps. I figured a pointer might better convey that something will occur on hover (a tooltip/popover appearing), but would appreciate feedback on what others think.
- Because the timestamp would have a tooltip/popover to display the UTC (or some other custom, alternative datetime value), would it make sense to have this component behave more similarly to the [description list with term help text example](https://www.patternfly.org/v4/components/description-list#term-help-text) by making the timestamp a button? Tooltip content doesn't always get announced by assistive technologies on static elements, and per the current [tooltip ally doc](https://github.com/patternfly/patternfly-org/blob/main/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md) it's not recommended to place tooltips on static elements, but this may be something to decide on/update down the line.