### PR TITLE
fix(popover): aligned edge of close button icon with content

### DIFF
--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -47,7 +47,7 @@
   // Close
   --pf-c-popover--c-button--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-popover--c-button--Top: calc(var(--pf-c-popover__content--PaddingTop) - var(--pf-global--spacer--form-element)); // align top of button with top of text
-  --pf-c-popover--c-button--Right: var(--pf-global--spacer--md);
+  --pf-c-popover--c-button--Right: calc(var(--pf-c-popover__content--PaddingRight) - var(--pf-global--spacer--md)); // align right of content
   --pf-c-popover--c-button--sibling--PaddingRight: var(--pf-global--spacer--2xl);
 
   // Header


### PR DESCRIPTION
Fixes #4781 

applied following:
`--pf-c-popover--c-button--Right: calc(var(--pf-c-popover__content--PaddingRight) - var(--pf-global--spacer--md));`

Initially tried using
`var(--pf-c-button--PaddingRIght) but did not work, in its place I used var(--pf-global--spacer--md)`

![image](https://user-images.githubusercontent.com/96086344/180322465-f67fc5fb-74e6-404e-9668-f226ae343597.png)
