### PR TITLE
fix(menu): removed footer bottom border when scrollable

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -182,8 +182,6 @@
   --pf-c-menu__footer--BoxShadow: none;
   --pf-c-menu__footer--after--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-menu__footer--after--BorderTopColor: var(--pf-global--BorderColor--100);
-  --pf-c-menu__footer--after--BorderBottomWidth: 0;
-  --pf-c-menu__footer--after--BorderBottomColor: var(--pf-global--BorderColor--100);
   --pf-c-menu--m-scrollable__footer--BoxShadow: var(--pf-global--BoxShadow--sm-top);
   --pf-c-menu--m-scrollable__footer--after--BorderTopWidth: 0;
   --pf-c-menu--m-scrollable__footer--after--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
@@ -334,7 +332,6 @@
     --pf-c-menu__content--MaxHeight: var(--pf-c-menu--m-scrollable__content--MaxHeight);
     --pf-c-menu__footer--BoxShadow: var(--pf-c-menu--m-scrollable__footer--BoxShadow);
     --pf-c-menu__footer--after--BorderTopWidth: var(--pf-c-menu--m-scrollable__footer--after--BorderTopWidth);
-    --pf-c-menu__footer--after--BorderBottomWidth: var(--pf-c-menu--m-scrollable__footer--after--BorderBottomWidth);
 
     .pf-c-menu__content {
       overflow-y: auto;
@@ -738,7 +735,6 @@
     pointer-events: none;
     content: "";
     border-top: var(--pf-c-menu__footer--after--BorderTopWidth) solid var(--pf-c-menu__footer--after--BorderTopColor);
-    border-bottom: var(--pf-c-menu__footer--after--BorderBottomWidth) solid var(--pf-c-menu__footer--after--BorderBottomColor);
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5006

Putting this up for review. We added that bottom border when we created the plain variation of the menu in this PR - https://github.com/patternfly/patternfly/pull/4392. The problem is that the bottom border seems unnecessary in both the default component (when the menu has a box shadow) and the plain variation (box shadow is removed), and creates a double border if you put the menu in something with a border, like a flat card - https://codesandbox.io/s/agitated-sanderson-xjy56g?file=/index.html