### PR TITLE
fix(page): fixed sticky-on section padding

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -548,9 +548,16 @@ $pf-c-page--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   padding-left: var(--pf-c-page__main-nav--PaddingLeft);
   background-color: var(--pf-c-page__main-nav--BackgroundColor);
 
-  &.pf-m-sticky-top,
-  .pf-c-page__main-group.pf-m-sticky-top &:last-child {
-    padding-bottom: var(--pf-c-page__main-nav--m-sticky-top--PaddingBottom);
+  // Responsive height modifiers for sticky top/bottom
+  @each $breakpoint, $breakpoint-value in $pf-c-page--height-breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}-height, "");
+
+    @include pf-apply-height-breakpoint($breakpoint) {
+      &.pf-m-sticky-top#{$breakpoint-name},
+      .pf-c-page__main-group.pf-m-sticky-top#{$breakpoint-name} &:last-child {
+        padding-bottom: var(--pf-c-page__main-nav--m-sticky-top--PaddingBottom);
+      }
+    }
   }
 }
 
@@ -580,9 +587,16 @@ $pf-c-page--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
     --pf-c-page__main-section--PaddingTop: var(--pf-c-page__main-breadcrumb--main-section--PaddingTop);
   }
 
-  &.pf-m-sticky-top,
-  .pf-c-page__main-group.pf-m-sticky-top &:last-child {
-    --pf-c-page__main-breadcrumb--PaddingBottom: var(--pf-c-page__main-breadcrumb--m-sticky-top--PaddingBottom);
+  // Responsive height modifiers for sticky top/bottom
+  @each $breakpoint, $breakpoint-value in $pf-c-page--height-breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}-height, "");
+
+    @include pf-apply-height-breakpoint($breakpoint) {
+      &.pf-m-sticky-top#{$breakpoint-name},
+      .pf-c-page__main-group.pf-m-sticky-top#{$breakpoint-name} &:last-child {
+        --pf-c-page__main-breadcrumb--PaddingBottom: var(--pf-c-page__main-breadcrumb--m-sticky-top--PaddingBottom);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5009

@mmenestr @mcarrano 

This happens when the section switches between sticky and not. It happened before (a sticky section had more padding than it would if it was not sticky), but it wasn't as visible since the sticky modifier was either on or off - it didn't change dynamically as the viewport height changed.

![Jul-29-2022 11-50-58](https://user-images.githubusercontent.com/35148959/181807773-977f9b62-3809-4e5c-a06c-2d6b192245e6.gif)
![Jul-29-2022 11-52-01](https://user-images.githubusercontent.com/35148959/181807779-66d34df8-227f-45dc-bb49-48a393f1d252.gif)

I wanted to check to see if you think this is an issue. If so, I think we could solve it a couple of ways...

1) Change the padding on the breadcrumb and nav sections so that there is top/bottom padding all of the time (regardless of whether it's sticky or not) that looks appropriate both when the section is sticky and not. That's likely a breaking change as who knows how that might interfere with ways users are using these sections - for example, if they have dividers between sections currently, changing the section padding could move the divider in a way that it doesn't look right.

2) Add this padding to any section that is set to be sticky at some breakpoint, regardless of whether it's actually sticky or not. ie, a breadcrumb section that's sticky on the medium height breakpoint would always have that extra padding, including below the medium breakpoint when it isn't sticky.

**edit:** I'll add that I think #1 would probably be a better long term solution. We're going to run into the same issue using the resize observer where it dynamically applies the sticky class via JS depending on the viewport size. If we go with #2 above, we'll need a unique way to allow the resize observer to attach a class to the section that it's observing that updates the section padding independently from the class that makes the section sticky.