### PR TITLE
feat(page): adds full-height modifier

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -224,7 +224,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-page` | `<div>` |   Declares the page component. |
-| `.pf-m-full-height` | `.pf-c-page` |   Sets the page to be full height. Eliminates the need to ensure that all tags above the `.pf-c-page` have height of 100% set. |
+| `.pf-m-full-height` | `.pf-c-page` |   Sets the page to be full height. Eliminates the need to ensure that all ancestors of `.pf-c-page` have height of 100% set. |
 | `.pf-c-page__header` | `<header>` |   Declares the page header. |
 | `.pf-c-page__header-brand` | `<div>` |   Creates a header container to nest the brand component. |
 | `.pf-c-page__header-brand-toggle` | `<div>` |   Creates a container to nest the sidebar toggle. |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -224,6 +224,7 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-page` | `<div>` |   Declares the page component. |
+| `.pf-m-full-height` | `.pf-c-page` |   Sets the page to be full height. Eliminates the need to ensure that all tags above the `.pf-c-page` have height of 100% set. |
 | `.pf-c-page__header` | `<header>` |   Declares the page header. |
 | `.pf-c-page__header-brand` | `<div>` |   Creates a header container to nest the brand component. |
 | `.pf-c-page__header-brand-toggle` | `<div>` |   Creates a container to nest the sidebar toggle. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -207,6 +207,12 @@ $pf-c-page--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
       "header header"
       "nav main";
   }
+
+  // full height
+  &.pf-m-full-height {
+    height: 100vh;
+    height: 100dvh;
+  }
 }
 
 // Header

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -13,7 +13,7 @@ wrapperTag: div
 
 ### Full height page
 Using the `.pf-m-full-height` modifier class on the page component eliminates the need to ensure that the `<html>` and `<body>` tags, and any other ancestors of `.pf-c-page`, have height set to 100%.
-```hbs isFullscreen
+```hbs isFullscreen isBeta
 {{> page-template page-template--id="page-demo-full-height" page-template--modifier="pf-m-full-height"}}
 ```
 

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -12,7 +12,7 @@ wrapperTag: div
 ```
 
 ### Full height page
-Using the `pf-m-full-height` modifier on the page component eliminates the need to ensure that the `<html>` and `<body>` tags, and any other tags above `.pf-c-page`, have height set to 100%.
+Using the `.pf-m-full-height` modifier class on the page component eliminates the need to ensure that the `<html>` and `<body>` tags, and any other ancestors of `.pf-c-page`, have height set to 100%.
 ```hbs isFullscreen
 {{> page-template page-template--id="page-demo-full-height" page-template--modifier="pf-m-full-height"}}
 ```
@@ -116,4 +116,4 @@ Using the `pf-m-full-height` modifier on the page component eliminates the need 
 ```
 
 ## Documentation
-To make the page component take up the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component.
+To make the page component take up the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component. Alternatively, use the `.pf-m-full-height` modifier class on the page component.

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -11,6 +11,12 @@ wrapperTag: div
 {{> page-template page-template--id="page-demo-basic"}}
 ```
 
+### Full height page
+Using the `pf-m-full-height` modifier on the page component eliminates the need to ensure that the `<html>` and `<body>` tags, and any other tags above `.pf-c-page`, have height set to 100%.
+```hbs isFullscreen
+{{> page-template page-template--id="page-demo-full-height" page-template--modifier="pf-m-full-height"}}
+```
+
 ### Sticky horizontal subnav
 ```hbs isFullscreen
 {{> page-template

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -116,4 +116,4 @@ Using the `.pf-m-full-height` modifier class on the page component eliminates th
 ```
 
 ## Documentation
-To make the page component take up the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component. Alternatively, use the `.pf-m-full-height` modifier class on the page component.
+To make the page component fill the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component. Alternatively, use the `.pf-m-full-height` modifier class on the page component.


### PR DESCRIPTION
This adds a modifier to the page component that sets the height using viewport units to eliminate the need to ensure that all elements above the page are set to 100% height.

Fixes #4822 