### PR TITLE
chore(avatar): use correct avatar image, simplify hbs

### DIFF
--- a/src/patternfly/components/Avatar/avatar.hbs
+++ b/src/patternfly/components/Avatar/avatar.hbs
@@ -1,4 +1,12 @@
-<img class="pf-c-avatar{{#if avatar--modifier}} {{avatar--modifier}}{{/if}}"
+<img class="pf-c-avatar
+  {{~#if avatar--IsLight}} pf-m-light
+  {{~else if avatar--IsDark}} pf-m-dark{{/if}}
+  {{~#if avatar--modifier}} {{avatar--modifier}}{{/if}}"
+  alt="{{#if avatar--AltText}}{{avatar--AltText}}{{else}}Avatar image{{/if}}"
+  src="
+    {{~#if avatar--Src}}{{avatar--Src}}
+    {{~else if avatar--IsDark}}/assets/images/img_avatar-dark.svg
+    {{~else}}/assets/images/img_avatar-light.svg{{/if}}"
   {{#if avatar--attribute}}
     {{{avatar--attribute}}}
   {{/if}}> 

--- a/src/patternfly/components/Avatar/avatar.hbs
+++ b/src/patternfly/components/Avatar/avatar.hbs
@@ -10,3 +10,4 @@
   {{#if avatar--attribute}}
     {{{avatar--attribute}}}
   {{/if}}> 
+  

--- a/src/patternfly/components/Avatar/examples/Avatar.md
+++ b/src/patternfly/components/Avatar/examples/Avatar.md
@@ -9,37 +9,37 @@ import './Avatar.css'
 ## Examples
 ### Basic
 ```hbs
-{{> avatar avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image"'}}
+{{> avatar}}
 ```
 
 ### Bordered - light
 ```hbs
-{{> avatar avatar--modifier="pf-m-light" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image light"'}}
+{{> avatar avatar--IsLight="true" avatar--AltText="Avatar image light"}}
 ```
 
 ### Bordered - dark
 ```hbs
-{{> avatar avatar--modifier="pf-m-dark" avatar--attribute='src="/assets/images/img_avatar-dark.svg" alt="Avatar image dark"'}}
+{{> avatar avatar--IsDark="true" avatar--AltText="Avatar image dark"}}
 ```
 
 ### Small
 ```hbs
-{{> avatar avatar--modifier="pf-m-sm" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image small"'}}
+{{> avatar avatar--modifier="pf-m-sm" avatar--AltText="Avatar image small"}}
 ```
 
 ### Medium
 ```hbs
-{{> avatar avatar--modifier="pf-m-md" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image medium"'}}
+{{> avatar avatar--modifier="pf-m-md" avatar--AltText="Avatar image medium"}}
 ```
 
 ### Large
 ```hbs
-{{> avatar avatar--modifier="pf-m-lg" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image large"'}}
+{{> avatar avatar--modifier="pf-m-lg" avatar--AltText="Avatar image large"}}
 ```
 
 ### Extra large
 ```hbs
-{{> avatar avatar--modifier="pf-m-xl" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image extra large"'}}
+{{> avatar avatar--modifier="pf-m-xl" avatar--AltText="Avatar image extra large"}}
 ```
 
 ## Documentation
@@ -49,7 +49,7 @@ The avatar component provides a default SVG icon. If an image is used it should 
 ### Accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `alt` | `.pf-c-avatar` | The alt attribute specifies an alternate text for an image, if the image cannot be displayed. **Required** |
+| `alt` | `.pf-c-avatar` | The alt attribute describes the appearance and function of the avatar image. **Required** |
 
 ### Usage
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -31,7 +31,7 @@
   {{else if dropdown--template--MenuToggleImageText}}
     {{#> dropdown-toggle}}
       {{#> dropdown-toggle-image}}
-        {{> avatar avatar--attribute='src="/assets/images/img_avatar.svg" alt="Avatar image"'}}
+        {{> avatar}}
       {{/dropdown-toggle-image}}
       {{#> dropdown-toggle-text}}
         Ned Username

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -490,7 +490,7 @@ import './MenuToggle.css'
 ```hbs
 {{#> menu-toggle}}
   {{#> menu-toggle-icon}}
-    {{> avatar avatar--modifier="pf-m-light" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image light"'}}
+    {{> avatar}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
     Ned Username
@@ -504,7 +504,7 @@ import './MenuToggle.css'
 
 {{#> menu-toggle menu-toggle--IsExpanded="true"}}
   {{#> menu-toggle-icon}}
-    {{> avatar avatar--modifier="pf-m-light" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image light"'}}
+    {{> avatar}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
     Ned Username
@@ -518,7 +518,7 @@ import './MenuToggle.css'
 
 {{#> menu-toggle menu-toggle--IsDisabled="true"}}
   {{#> menu-toggle-icon}}
-    {{> avatar avatar--modifier="pf-m-light" avatar--attribute='src="/assets/images/img_avatar-light.svg" alt="Avatar image light"'}}
+    {{> avatar}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
     Ned Username

--- a/src/patternfly/demos/Masthead/masthead-template-content-icon-group.hbs
+++ b/src/patternfly/demos/Masthead/masthead-template-content-icon-group.hbs
@@ -51,7 +51,7 @@
   {{#> dropdown dropdown--modifier="pf-m-full-height" dropdown--id=(concat masthead--id "-profile") dropdown--attribute='style="--pf-c-dropdown--MaxWidth: 20ch;"' dropdown--IsExpanded=masthead-template-content-icon-group--profile-dropdown--IsExpanded}}
     {{#> dropdown-toggle}}
       {{#> dropdown-toggle-image}}
-        {{> avatar avatar--attribute='src="/assets/images/img_avatar.svg" alt="Avatar image"'}}
+        {{> avatar}}
       {{/dropdown-toggle-image}}
       {{#> dropdown-toggle-text}}
         Ned Username

--- a/src/patternfly/demos/Page/page-template-header-tools-elements.hbs
+++ b/src/patternfly/demos/Page/page-template-header-tools-elements.hbs
@@ -21,5 +21,5 @@
       {{> dropdown dropdown--id=(concat page--id '-dropdown-kebab-2') dropdown-toggle--modifier="pf-m-plain" dropdown-toggle--text="John Smith"}}
     {{/page-header-tools-item}}
   {{/page-header-tools-group}}
-  {{#> avatar avatar--attribute='src="/assets/images/img_avatar.svg" alt="Avatar image"'}}{{/avatar}}
+  {{> avatar}}
 {{/page-header-tools}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5023

* Updates the `alt` description in the docs - https://patternfly-pr-5026.surge.sh/components/avatar#accessibility
* Dropdown toggle avatar - https://patternfly-pr-5026.surge.sh/components/dropdown#dropdown-with-image-and-text
* Menu toggle avatar - https://patternfly-pr-5026.surge.sh/components/menu-toggle#with-avatar-and-text
* Masthead menu toggle avatar in full page demo template - https://patternfly-pr-5026.surge.sh/components/page/html-demos/basic/

Also updates the avatar handlebars template logic to simplify things a bit and use the right image by default, so checking the avatar component page would be good - https://patternfly-pr-5026.surge.sh/components/avatar