### PR TITLE
feat(button): adds a count to the link button

### DIFF
--- a/src/patternfly/components/Button/button-count.hbs
+++ b/src/patternfly/components/Button/button-count.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-button__count{{#if button-count--modifier}} {{button-count--modifier}}{{/if}}"
+  {{#if button-count--attribute}}
+    {{{button-count--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -282,7 +282,7 @@
       --pf-c-button--m-primary--BackgroundColor: var(--pf-c-button--m-primary--active--BackgroundColor);
     }
 
-    &:not(:disabled):not(.pf-m-disabled) .pf-c-badge.pf-m-unread {
+    .pf-c-badge.pf-m-unread {
       border: var(--pf-c-button--m-primary__c-badge--BorderWidth) solid var(--pf-c-button--m-primary__c-badge--BorderColor);
     }
   }
@@ -576,9 +576,10 @@
     color: var(--pf-c-button--disabled--Color);
     background-color: var(--pf-c-button--disabled--BackgroundColor);
 
-    & .pf-c-badge {
+    .pf-c-badge {
       --pf-c-badge--m-unread--Color: var(--pf-c-button--disabled__c-badge--Color);
       --pf-c-badge--m-unread--BackgroundColor: var(--pf-c-button--disabled__c-badge--BackgroundColor);
+      --pf-c-button--m-primary__c-badge--BorderWidth: 0;
     }
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -192,6 +192,13 @@
   --pf-c-button--m-in-progress--m-plain__progress--Left: 50%;
   --pf-c-button--m-in-progress--m-plain__progress--TranslateX: -50%;
 
+  // Count
+  --pf-c-button__count--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-button--disabled__c-badge--Color: var(--pf-global--Color--dark-100);
+  --pf-c-button--disabled__c-badge--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-button--m-primary__c-badge--BorderColor: var(--pf-global--BorderColor--300);
+  --pf-c-button--m-primary__c-badge--BorderWidth: var(--pf-global--BorderWidth--sm); // used only for primary, unread, not disabled
+
   position: relative;
   display: inline-block;
   padding: var(--pf-c-button--PaddingTop) var(--pf-c-button--PaddingRight) var(--pf-c-button--PaddingBottom) var(--pf-c-button--PaddingLeft);
@@ -273,6 +280,10 @@
     &.pf-m-active {
       --pf-c-button--m-primary--Color: var(--pf-c-button--m-primary--active--Color);
       --pf-c-button--m-primary--BackgroundColor: var(--pf-c-button--m-primary--active--BackgroundColor);
+    }
+
+    &:not(:disabled):not(.pf-m-disabled) .pf-c-badge.pf-m-unread {
+      border: var(--pf-c-button--m-primary__c-badge--BorderWidth) solid var(--pf-c-button--m-primary__c-badge--BorderColor);
     }
   }
 
@@ -564,6 +575,11 @@
 
     color: var(--pf-c-button--disabled--Color);
     background-color: var(--pf-c-button--disabled--BackgroundColor);
+
+    & .pf-c-badge {
+      --pf-c-badge--m-unread--Color: var(--pf-c-button--disabled__c-badge--Color);
+      --pf-c-badge--m-unread--BackgroundColor: var(--pf-c-button--disabled__c-badge--BackgroundColor);
+    }
   }
 
   &.pf-m-aria-disabled {
@@ -618,6 +634,12 @@
   .pf-c-spinner {
     --pf-c-spinner--Color: currentcolor;
   }
+}
+
+.pf-c-button__count {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--pf-c-button__count--MarginLeft);
 }
 
 // RedHat Font overrides

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -386,7 +386,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
 | `.pf-c-button__icon` | `<span>` | Initiates a button icon. |
 | `.pf-c-button__progress` | `<span>` | Initiates a button progress container. |
-| `.pf-c-button__count` | `<span>` | Initiates a button count container. |
+| `.pf-c-button__count` | `<span>` | Initiates a button count container. **Note:** Count should only be used on link buttons.|
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -352,12 +352,19 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 {{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
   View issues
   {{#> button-count}}
+    {{#> badge badge--modifier="pf-m-unread"}}
+      7
+    {{/badge}}
+  {{/button-count}}
+{{/button}}
+{{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
+  View issues
+  {{#> button-count}}
     {{#> badge badge--modifier="pf-m-read"}}
       7
     {{/badge}}
   {{/button-count}}
 {{/button}}
-
 ```
 
 ## Documentation

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -347,6 +347,19 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 {{/button}}
 ```
 
+### Link button with a count
+```hbs
+{{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
+  View issues
+  {{#> button-count}}
+    {{#> badge badge--modifier="pf-m-read"}}
+      7
+    {{/badge}}
+  {{/button-count}}
+{{/button}}
+
+```
+
 ## Documentation
 ### Overview
 Always add a modifier class to add color to the button.
@@ -373,6 +386,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
 | `.pf-c-button__icon` | `<span>` | Initiates a button icon. |
 | `.pf-c-button__progress` | `<span>` | Initiates a button progress container. |
+| `.pf-c-button__count` | `<span>` | Initiates a button count container. |
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -348,7 +348,7 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 ```
 
 ### Link button with a count
-```hbs
+```hbs isBeta
 {{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
   View issues
   {{#> button-count}}

--- a/src/patternfly/components/Button/themes/dark/button.scss
+++ b/src/patternfly/components/Button/themes/dark/button.scss
@@ -33,6 +33,7 @@
     --pf-c-button--m-control--focus--after--BorderBottomColor: var(--pf-global--primary-color--100);
     --pf-c-button--m-control--m-expanded--after--BorderBottomColor: var(--pf-global--primary-color--100);
     --pf-c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
+    --pf-c-button--m-primary__c-badge--BorderColor: var(--pf-global--Color--100);
 
     &.pf-m-control:disabled {
       &::after {


### PR DESCRIPTION
This adds a count as an optional component of the button. Design feels this should only be used with the link button (and so only that variant is shown as an example), but for completeness we've made sure the other variants display adequately. 
Direct link: https://patternfly-pr-5029.surge.sh/components/button#link-button-with-a-count
The other variants are shown here:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/19825616/183995101-ace1a248-d3c9-4930-b547-c54267dcbc8d.png">

Other decisions per @mmenestr and @mceledonia:
- The badge color does not change on hover
- Disabling the button causes the badge (even if blue/unread) to display as read/gray.

Fixes #5012 

