### PR TITLE
fix(global): added custom property to override root font-size

### DIFF
--- a/src/patternfly/base/_base.scss
+++ b/src/patternfly/base/_base.scss
@@ -1,11 +1,13 @@
 // stylelint-disable no-invalid-position-at-import-rule
 
+// remove in breaking change
 @if $pf-global--load-pf-3 {
   @import url("https://fonts.googleapis.com/css?family=Open+Sans");
   @import url("https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.37.10/css/patternfly.min.css");
   @import url("https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.37.10/css/patternfly-additions.min.css");
 }
 
+// remove pf3 shield styles in breaking change
 @import "shield-inheritable";
 @import "shield-noninheritable";
 

--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -1,4 +1,5 @@
 // Set common reset styles for patternfly components
+// remove in breaking change. this should come from globals, and can be opted out
 [class*="pf-c-"] {
   &,
   &::before,
@@ -9,13 +10,14 @@
   }
 }
 
+// remove in breaking change
 @if $pf-global--unset-root-font-size {
   // Since PF3 sets root font size to 10px, we need to unset it.
   // This doesn't affect PF3.
   // https://github.com/twbs/bootstrap/blob/v3.4.0/less/scaffolding.less#L23
   // stylelint-disable
   html {
-    font-size: unset !important; // the important is needed because we don't know if pf3 will be loaded after pfnext
+    font-size: var(--pf-global--root--FontSize, unset) !important; // the important is needed because we don't know if pf3 will be loaded after pfnext
   }
   // stylelint-enable
 }

--- a/src/patternfly/base/_fonts.scss
+++ b/src/patternfly/base/_fonts.scss
@@ -153,7 +153,7 @@
   font-display: fallback;
 }
 
-
+// remove in breaking change
 @if $pf-global--enable-font-overpass-cdn {
   // stylelint-disable no-invalid-position-at-import-rule
   @import url("https://fonts.googleapis.com/css?family=Overpass|Overpass+Mono");


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5028

This PR allows you to set a custom `font-size` with this rule that was added to PF4 to override PF3's `font-size` on `html`

https://github.com/patternfly/patternfly/blob/9ab78a81b9d6d63cd7795fa82b1ff673abba5332/src/patternfly/base/_common.scss#L12-L21

An issue with updating this rule is that it's so fundamental, if we introduce a change that inadvertently causes an issue with the way someone is using PF now, it would likely impact the entire site/app.

The solution in this PR is probably the simplest approach, though it does require a value passed for the `font-size`, which may be a limitation since you can't allow `html` to `inherit` its `font-size` from some other dynamic/unknown style. To override the `font-size` with this PR, you would just declare the custom property like so:

```
:root {
  --pf-global--root--FontSize: [custom value];
}
```

Would this work @Marc19 and @warmbowski? I like this because it doesn't add any bloat, and is overridable like any of our other global vars. 

## Other options

1. Update the current selector that unsets the `font-size` currently to:

    ```
    html:where(:not(.pf-no-root-font-size)) {
      font-size: var(--pf-global--root--FontSize, unset) !important;
    }
    ```
    * This would allow an opt-out at the class level to disable the declaration entirely and inherit from some other system without having to explicitly set the `font-size`. This seems like the best of both worlds - you can opt out of the declaration entirely with a class on the `html` element, and override the size with a custom value if preferred.
      * My only hesitation with this is that `:where()` was introduced relatively recently (though it's within our officially supported browsers) and may break some users, which we always try to avoid if we can unless we're fixing a critical bug and there is no other workaround. We could write a fallback with `@supports not selector(:where(...)) {}` with the original rule, but `@supports selector` support is similar to `:where()`, with safari at least.
1. Add another compiled stylesheet that omits the rule by setting `$pf-global--unset-root-font-size: false;`, similar to [patternfly-base-no-reset.scss](https://github.com/patternfly/patternfly/blob/main/src/patternfly/patternfly-base-no-reset.scss). This would also be fine, but I'd like to avoid adding another compiled stylesheet if possible since it has the potential to get a little complicated to combine different features in these custom compiled variations.

cc @srambach @mattnolting 