### PR TITLE
chore(build): updated to documentation-framework@1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@patternfly/patternfly-a11y": "4.3.1",
     "@patternfly/react-charts": "6.84.8",
     "@patternfly/react-code-editor": "4.72.8",
+    "@patternfly/react-core": "4.234.1",
     "@patternfly/react-table": "4.100.8",
     "@starptech/prettyhtml": "^0.10.0",
     "babel-eslint": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@commitlint/config-conventional": "^13.1.0",
     "@fortawesome/fontawesome": "^1.1.8",
     "@octokit/rest": "^16.40.1",
+    "@patternfly/documentation-framework": "1.2.5",
     "@patternfly/patternfly-a11y": "4.3.1",
     "@patternfly/react-charts": "6.84.8",
     "@patternfly/react-code-editor": "4.72.8",
@@ -79,7 +80,6 @@
     "stylelint-scss": "^4.0.0",
     "stylelint-value-no-unknown-custom-properties": "^3.0.0",
     "surge": "^0.21.3",
-    "@patternfly/documentation-framework": "1.1.34",
     "unified": "^9.2.0",
     "webpack": "^4.43.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,10 @@
     acorn-static-class-features "^1.0.0"
     astring "^1.7.5"
 
-"@patternfly/documentation-framework@1.1.34":
-  version "1.1.34"
-  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-1.1.34.tgz#8ae1f45dbdfd0215118dbe47f656f30656bf4935"
-  integrity sha512-p7VOxzn0ENmYHXlffdEEq7aWBqvbN8n0yvhwYH2cwiDgl90kdvkE+JoTsCP+4PFKk7quPtB/cb/iDIBfQvGGQg==
+"@patternfly/documentation-framework@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-1.2.5.tgz#c327bb182ff81be0abb5f84221e460db808a06fc"
+  integrity sha512-Zy+V2qwZaE37arQoHBzA88GkQUoq5kNYf+kbs6pgqHaFdiAaczsRRyKhq55sqcKjR85l57VV3QIRw7FYYBafow==
   dependencies:
     "@babel/core" "7.18.2"
     "@babel/plugin-proposal-class-properties" "7.17.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,6 +1452,19 @@
     react-dropzone "9.0.0"
     tslib "^2.0.0"
 
+"@patternfly/react-core@4.234.1":
+  version "4.234.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.234.1.tgz#4a2bfb7feb1622cda2c54015b1a76f85a661f413"
+  integrity sha512-i5iKvT0Vx9Zftg4imF07UzNaJJcruH2TStnI6/OVPXm8JNoaG990B8nUmQDOzXblTTy2rb9EZM1D4v9d7eRM9g==
+  dependencies:
+    "@patternfly/react-icons" "^4.85.1"
+    "@patternfly/react-styles" "^4.84.1"
+    "@patternfly/react-tokens" "^4.86.1"
+    focus-trap "6.9.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
 "@patternfly/react-core@^4.231.8":
   version "4.231.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz#2f9de38ecdd2fc53c63aff55433984fcf93a5fe6"
@@ -1470,10 +1483,20 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.82.8.tgz#59ab1a139d3fc586fd384a58816e4608a060ee32"
   integrity sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==
 
+"@patternfly/react-icons@^4.85.1":
+  version "4.85.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.85.1.tgz#7004ce03413c4cc26114559d60f0732e29e221ad"
+  integrity sha512-ixBTqSosbliqWh6PT+MeGkkkvEbsLu2rhzkSJ+ZuhQjup/GIxEfXO5qQVWNoCWOfMFXBjUqdI20TrTYdoyflSg==
+
 "@patternfly/react-styles@^4.81.8":
   version "4.81.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.81.8.tgz#8d2f103e03a7edd997218600a54bd2cd452d3348"
   integrity sha512-Q5FiureSSCMIuz+KLMcEm1317TzbXcwmg2q5iNDRKyf/K+5CT6tJp0Wbtk3FlfRvzli4u/7YfXipahia5TL+tA==
+
+"@patternfly/react-styles@^4.84.1":
+  version "4.84.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.84.1.tgz#358ba4a2e01b6b9411f8678baa6f42c70fb83a5c"
+  integrity sha512-gcaOyPm47IDe2/FL9aFc3rsb42Xa3yUZDsiBpmI+HxK0fiWWkBj4lk+AgBZaVWP7TXcn8Gjp+JmrZyoKWewxaw==
 
 "@patternfly/react-table@4.100.8":
   version "4.100.8"
@@ -1491,6 +1514,11 @@
   version "4.83.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.83.8.tgz#3055ea6f4c195d59840d1ce0ceaa59da76104f9a"
   integrity sha512-Z/MHXNY8PQOuBFGUar2yzPVbz3BNJuhB+Dnk5RJcc/iIn3S+VlSru7g6v5jqoV/+a5wLqZtLGEBp8uhCZ7Xkig==
+
+"@patternfly/react-tokens@^4.86.1":
+  version "4.86.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.86.1.tgz#a36395a3f64ee6b53804f63303d5ff0a7a2a8a4a"
+  integrity sha512-KYYkjFuEFJqr8XVEsXFzFzMQ7T5O/l7begCZF605PjRXp0b48QwTq/IFykYJh2aY5QwvNXnHaD3vtUzq3K7EVg==
 
 "@reach/router@1.3.4":
   version "1.3.4"


### PR DESCRIPTION
I noticed the docs build was failing in https://github.com/patternfly/patternfly/pull/5037:

> './node_modules/@patternfly/documentation-framework/components/example/example.js\n'
> "Module not found: Error: Can't resolve '@patternfly/react-core/next' in '/home/runner/work/patternfly/patternfly/node_modules/@patternfly/documentation-framework/components/example'\n"

So I added `@patternfly/react-core` as a dependency, too, since it wasn't before, and all looks good.

Is that the right fix for this?