### PR TITLE
feat(log-viewer): support for custom line number col size

### DIFF
--- a/src/patternfly/components/LogViewer/examples/LogViewer.md
+++ b/src/patternfly/components/LogViewer/examples/LogViewer.md
@@ -19,7 +19,15 @@ import './LogViewer.css';
 
 ### With line numbers
 ```hbs
-{{#> log-viewer log-viewer--id="log-viewer-line-number-example" log-viewer--HasLineNumbers="true" log-viewer--attribute='style="--pf-c-log-viewer__index--Width: 75px"' log-viewer--aria-label="Log viewer with line numbers"}}
+{{#> log-viewer log-viewer--id="log-viewer-line-number-example" log-viewer--HasLineNumbers="true" log-viewer--attribute='style=""' log-viewer--aria-label="Log viewer with line numbers"}}
+  {{> __log-viewer-toolbar menu--IsHidden="true"}}
+  {{> __log-viewer-main}}
+{{/log-viewer}}
+```
+
+### With line number chars specified
+```hbs
+{{#> log-viewer log-viewer--id="log-viewer-line-number-example" log-viewer--HasLineNumbers="true" log-viewer--modifier="pf-m-line-number-chars" log-viewer--attribute='style="--pf-c-log-viewer--line-number-chars: 6"' log-viewer--aria-label="Log viewer with line numbers"}}
   {{> __log-viewer-toolbar menu--IsHidden="true"}}
   {{> __log-viewer-main}}
 {{/log-viewer}}
@@ -132,7 +140,9 @@ import './LogViewer.css';
 | `.pf-m-wrap-text` | `.pf-c-log-viewer` | Modifies the log viewer text to wrap. |
 | `.pf-m-nowrap` | `.pf-c-log-viewer` | Modifies the log viewer text to not wrap. |
 | `.pf-m-line-numbers` | `.pf-c-log-viewer` | Modifies the log viewer to display line numbers. |
+| `.pf-m-line-number-chars` | `.pf-c-log-viewer` | Modifies the log viewer allow for a custom line number column size. Use with  |
 | `.pf-m-dark` | `.pf-c-log-viewer` | Modifies the log viewer content for dark theme. |
 | `.pf-m-match` | `.pf-c-log-viewer__string` | Indicates a string is a search result. |
 | `.pf-m-current` | `.pf-c-log-viewer__string` | Indicates a string is the current search result. |
+| `--pf-c-log-viewer--line-number-chars` | `.pf-c-log-viewer` | With a number passed as the value, modifies the width of the line number column to show the specified number of characters. |
 | `--pf-c-log-viewer--MaxHeight{-on-[breakpoint]}: {height}` | `.pf-c-log-viewer` |  Modifies the height value of a log viewer at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |

--- a/src/patternfly/components/LogViewer/examples/LogViewer.md
+++ b/src/patternfly/components/LogViewer/examples/LogViewer.md
@@ -140,7 +140,7 @@ import './LogViewer.css';
 | `.pf-m-wrap-text` | `.pf-c-log-viewer` | Modifies the log viewer text to wrap. |
 | `.pf-m-nowrap` | `.pf-c-log-viewer` | Modifies the log viewer text to not wrap. |
 | `.pf-m-line-numbers` | `.pf-c-log-viewer` | Modifies the log viewer to display line numbers. |
-| `.pf-m-line-number-chars` | `.pf-c-log-viewer` | Modifies the log viewer allow for a custom line number column size. Use with  |
+| `.pf-m-line-number-chars` | `.pf-c-log-viewer` | Modifies the log viewer allow for a custom line number column size. Use with `--pf-c-log-viewer--line-number-chars`. |
 | `.pf-m-dark` | `.pf-c-log-viewer` | Modifies the log viewer content for dark theme. |
 | `.pf-m-match` | `.pf-c-log-viewer__string` | Indicates a string is a search result. |
 | `.pf-m-current` | `.pf-c-log-viewer__string` | Indicates a string is the current search result. |

--- a/src/patternfly/components/LogViewer/log-viewer.scss
+++ b/src/patternfly/components/LogViewer/log-viewer.scss
@@ -25,22 +25,23 @@
   // List
   --pf-c-log-viewer__list--Height: auto;
   --pf-c-log-viewer--m-line-numbers__list--Left: var(--pf-c-log-viewer__index--Width);
+  --pf-c-log-viewer__list--FontFamily: var(--pf-global--FontFamily--monospace);
+  --pf-c-log-viewer__list--FontSize: var(--pf-global--FontSize--sm);
 
   // Index
   --pf-c-log-viewer__index--Display: none;
   --pf-c-log-viewer__index--Width: #{pf-size-prem(65px)}; // default width
   --pf-c-log-viewer__index--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-log-viewer__index--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-log-viewer__index--FontFamily: var(--pf-global--FontFamily--monospace);
-  --pf-c-log-viewer__index--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-log-viewer__index--Color: var(--pf-global--Color--200);
   --pf-c-log-viewer__index--BackgroundColor: transparent;
+  --pf-c-log-viewer--line-number-chars: 4.4; // it's close enough to the existing default
+  --pf-c-log-viewer--m-line-number-chars__index--PaddingRight: var(--pf-global--spacer--xs);
+  --pf-c-log-viewer--m-line-number-chars__index--Width: calc(1ch * var(--pf-c-log-viewer--line-number-chars) + var(--pf-c-log-viewer__index--PaddingRight) + var(--pf-c-log-viewer__index--PaddingLeft));
 
   // Text
   --pf-c-log-viewer__text--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-log-viewer__text--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-log-viewer__text--FontFamily: var(--pf-global--FontFamily--monospace);
-  --pf-c-log-viewer__text--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-log-viewer__text--Color: var(--pf-global--Color--100);
   --pf-c-log-viewer__text--WordBreak: break-all;
   --pf-c-log-viewer__text--WhiteSpace: break-spaces;
@@ -113,6 +114,11 @@
     }
   }
 
+  &.pf-m-line-number-chars {
+    --pf-c-log-viewer__index--PaddingRight: var(--pf-c-log-viewer--m-line-number-chars__index--PaddingRight);
+    --pf-c-log-viewer__index--Width: var(--pf-c-log-viewer--m-line-number-chars__index--Width);
+  }
+
   // Nested toolbar
   .pf-c-toolbar {
     --pf-c-toolbar--PaddingTop: var(--pf-c-log-viewer--c-toolbar--PaddingTop);
@@ -160,6 +166,8 @@
 .pf-c-log-viewer__list {
   position: relative;
   height: var(--pf-c-log-viewer__list--Height);
+  font-family: var(--pf-c-log-viewer__list--FontFamily);
+  font-size: var(--pf-c-log-viewer__list--FontSize);
 }
 
 .pf-c-log-viewer__list-item {
@@ -187,8 +195,8 @@
   width: var(--pf-c-log-viewer__index--Width);
   padding-right: var(--pf-c-log-viewer__index--PaddingRight);
   padding-left: var(--pf-c-log-viewer__index--PaddingLeft);
-  font-family: var(--pf-c-log-viewer__index--FontFamily);
-  font-size: var(--pf-c-log-viewer__index--FontSize);
+  font-family: var(--pf-c-log-viewer__index--FontFamily, inherit);
+  font-size: var(--pf-c-log-viewer__index--FontSize, inherit);
   color: var(--pf-c-log-viewer__index--Color);
   user-select: none;
   background-color: var(--pf-c-log-viewer__index--BackgroundColor);
@@ -199,8 +207,8 @@
   display: block;
   padding-right: var(--pf-c-log-viewer__text--PaddingRight);
   padding-left: var(--pf-c-log-viewer__text--PaddingLeft);
-  font-family: var(--pf-c-log-viewer__text--FontFamily);
-  font-size: var(--pf-c-log-viewer__text--FontSize);
+  font-family: var(--pf-c-log-viewer__text--FontFamily, inherit);
+  font-size: var(--pf-c-log-viewer__text--FontSize, inherit);
   color: var(--pf-c-log-viewer__text--Color);
   word-break: var(--pf-c-log-viewer__text--WordBreak);
   white-space: var(--pf-c-log-viewer__text--WhiteSpace);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5067

@DaoDaoNoCode I created a new class for this so we don't change or break the existing line number column width/padding or the existing vars. If you think it's fine just to update, I can remove the need for the class.

Also do you see any issue with moving the font-family/size properties from the index + text elements up to the parent list?

