### PR TITLE
fix(slider): fixed excessive wrapping of labels

### DIFF
--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -165,6 +165,7 @@
 .pf-c-slider__step-label {
   position: absolute;
   top: var(--pf-c-slider__step-label--Top);
+  word-break: normal;
   transform: translateX(var(--pf-c-slider__step-label--TranslateX));
 }
 


### PR DESCRIPTION
Fixes #5053 

This fixes excessive (every character) wrapping resulting from an absolutely positioned element within another.
However, note that 
- long words without breaks won't break, and could cause horizontal overlap.
- normal word breaks could cause vertical overlap if there's something directly below
- There are ways to fix this ([more info here](https://codesandbox.io/s/slider-word-wrap-fl44nh?file=/style.css)) but require a fixed min or max width.

