### PR TITLE
fix(tree-view): made selectable node text a button to fix keyboard a11y

### DIFF
--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -902,7 +902,7 @@ beta: true
 | `.pf-c-tree-view__node-toggle` | `<span>`, `<button>` | Initiates a tree view toggle. |
 | `.pf-c-tree-view__node-toggle-icon` | `<span>` | Initiates a tree view toggle icon. |
 | `.pf-c-tree-view__node-title` | `<span>` | Initiates a tree view node title. |
-| `.pf-c-tree-view__node-text` | `<span>` | Initiates tree view text. |
+| `.pf-c-tree-view__node-text` | `<span>`, `<button>` | Initiates tree view text. **Note:** Use a `<button>` when the node is expandable and selectable. |
 | `.pf-c-tree-view__node-icon` | `<span>` | Initiates a tree view icon. |
 | `.pf-c-tree-view__node-check` | `<span>` | Initiates a tree view check. |
 | `.pf-c-tree-view__action` | `<div>` | Initiates a tree view action wrapper. |

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -1,7 +1,7 @@
 {{#if tree-view-node--HasCheckbox}}
   {{> __tree-view-node tree-view-node--type="label" tree-view-node--IsSelectable=tree-view-list-item--IsExpandable}}
 {{else if tree-view-node--IsSelectable}}
-  {{> __tree-view-node tree-view-node--type="div"}}
+  {{> __tree-view-node tree-view-node--type="div" tree-view-node-text--type="button"}}
 {{else}}
   {{> __tree-view-node}}
 {{/if}}

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -453,6 +453,8 @@ $pf-c-tree-view--MaxNesting: 10;
     cursor: pointer;
   }
 
+  font-weight: inherit;
+  color: inherit;
   text-align: left;
   border: 0;
 }

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -452,6 +452,9 @@ $pf-c-tree-view--MaxNesting: 10;
   @at-root label#{&} {
     cursor: pointer;
   }
+
+  text-align: left;
+  border: 0;
 }
 
 .pf-c-tree-view__node-title {


### PR DESCRIPTION
Makes the text element a `<button>` when a node is selectable and expandable.

convenience link - https://patternfly-pr-5107.surge.sh/components/tree-view#with-selectable-expandable-nodes

---

fixes https://github.com/patternfly/patternfly/issues/5106