### PR TITLE
chore(a11y docs): removed a11y section from example pages

### DIFF
--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -303,14 +303,6 @@ In these examples `.pf-c-accordion` uses `<div>`, `.pf-c-accordion__toggle` uses
 Another variation is using the definition list:
 In these examples `.pf-c-accordion` uses `<dl>`, `.pf-c-accordion__toggle` uses `<dt><button>`, and `.pf-c-accordion__expanded-content` uses `<dd>`.
 
-### Accessibility
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `aria-expanded="false"` | `.pf-c-accordion__toggle` | Indicates that the expanded content element is hidden. **Required**|
-| `aria-expanded="true"` | `.pf-c-accordion__toggle` | Indicates that the expanded content element is visible. **Required**|
-| `hidden` | `.pf-c-accordion__expanded-content` | Indicates that the expanded content element is hidden. Use with `aria-expanded="false"` **Required** |
-| `aria-hidden="true"` | `.pf-c-accordion__toggle-icon` | Hides the icon from assistive technologies.**Required** |
-
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -407,23 +407,6 @@ cssPrefix: pf-c-alert
 ### Overview
 Add a modifier class to the default alert to change the color: `.pf-m-success`, `.pf-m-danger`, `.pf-m-warning`, or `.pf-m-info`.
 
-### Accessibility
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `aria-label="Default alert"` | `.pf-c-alert` |  Indicates the default alert. |
-| `aria-label="Success alert"` | `.pf-c-alert` |  Indicates the success alert. |
-| `aria-label="Danger alert"` | `.pf-c-alert` |  Indicates the danger alert. |
-| `aria-label="Warning alert"` | `.pf-c-alert` |  Indicates the warning alert. |
-| `aria-label="Information alert"` | `.pf-c-alert` |  Indicates the information alert. |
-| `aria-label="Close success alert: Success alert title"` | `.pf-c-button.pf-m-plain` | Indicates the close button. Please provide descriptive text to ensure assistive technologies clearly state which alert is being closed.|
-| `aria-hidden="true"` | `.pf-c-alert__icon <i>` |  Hides icon for assistive technologies. **Required** |
-| `aria-expanded="true"` | `.pf-c-alert__toggle` |  Indicates that the expandable alert description is visible. **Required for expandable alerts** |
-| `aria-expanded="false"` | `.pf-c-alert__toggle` |  Indicates that the expandable alert description is hidden. **Required for expandable alerts** |
-
-| Class | Applied to | Outcome |
-| -- | -- | -- |
-| `.pf-screen-reader` | `.pf-c-alert__title <span>` | Content that is visually hidden but accessible to assistive technologies. This should state the type of alert. **Required** |
-
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -507,11 +507,6 @@ import './Card.css'
 ### Overview
 A card is a generic rectangular container that can be used to build other components. Use a default card for regular page content and the compact variation for dashboard or small cards.
 
-### Accessibility
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `tabindex="0"` | `.pf-c-card.pf-m-selectable` | Inserts the selectable card into the tab order of the page so that it is focusable. **Required** |
-
 ### Usage
 | Class | Applied | Outcome |
 | ---- | ---- | ---- |

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -15,13 +15,6 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Accessibility
-
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `disabled` | `button.pf-c-tabs__link` | Indicates that a tabs link is disabled. **Required when disabled** |
-| `aria-disabled="true"` | `a.pf-c-tabs__link.pf-m-disabled`, `.pf-c-tabs__link.pf-m-aria-disabled` | Indicates to assistive technology that a tabs link is disabled. **Required when disabled** |
-
 ### Usage
 
 | Class | Applied to | Outcome |
@@ -35,13 +28,6 @@ import './Tabs.css'
   {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
 {{/tabs}}
 ```
-
-### Accessibility
-
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `disabled` | `.pf-c-tabs__scroll-button` | Indicates that a scroll button is disabled, when at the first or last item of a list. **Required when disabled** |
-| `aria-hidden="true"` | `.pf-c-tabs__scroll-button` | Hides the icon from assistive technologies.**Required when not scrollable** |
 
 ### Usage
 
@@ -330,17 +316,6 @@ The tabs component should only be used to change content views within a page. Th
 Tabs should be used with the [tab content component](/components/tab-content).
 
 Whenever a list of tabs is unique on the current page, it can be used in a `<nav>` element. Cases where the same set of tabs are duplicated in multiple regions on a page (e.g. cards on a dashboard) are less likely to benefit from using the `<nav>` element.
-
-### Accessibility
-
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `aria-label="Descriptive text"` | `nav.pf-c-tabs`, `nav.pf-c-tabs.pf-m-secondary` | Gives the `<nav>` an accessible label. **Required when `.pf-c-tabs` is used with `<nav>`**
-| `aria-label="Descriptive text"` | `.pf-c-inline-edit__toggle > button` | Provides an accessible description for toggle button. **Required**
-| `disabled` | `button.pf-c-tabs__link` | Indicates that a tabs link is disabled. **Required when disabled** |
-| `aria-disabled="true"` | `a.pf-c-tabs__link.pf-m-disabled`, `.pf-c-tabs__link.pf-m-aria-disabled` | Indicates to assistive technology that a tabs link is disabled. **Required when disabled** |
-| `disabled` | `.pf-c-tabs__scroll-button` | Indicates that a scroll button is disable, typically when at the first or last item of a list or scroll buttons are hidden. **Required** |
-| `aria-expanded="true"` | `.pf-c-tabs__item` | Indicates that the overflow menu tab is expanded. **Required when expanded** |
 
 ### Usage
 

--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -84,12 +84,6 @@ cssPrefix: pf-c-tooltip
 ### Overview
 A tooltip is used to provide contextual information for another component on hover.  The tooltip itself is made up of two elements: arrow and content. One of the directional modifiers (`.pf-m-left`, `.pf-m-top`, etc.) is required on the tooltip component.
 
-### Accessibility
-| Attribute | Applied to | Outcome |
-| -- | -- | -- |
-| `role="tooltip"` | `.pf-c-tooltip` | Adds a tooltip role to the tooltip component. **Required**|
-| `aria-describedby="[id of .pf-c-tooltip__content]"` or `aria-labelledby="[id of .pf-c-tooltip__content]"` |	`[element that triggers the tooltip]` | Makes the contents of the tooltip accessible to assistive technologies by associating the tooltip text with the element that triggers the tooltip. Use `aria-labelledby` if the tooltip provides a label for the element. Use `aria-describedby` if the element already has an accessible label that is different from the tooltip text. **Required**|
-
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |


### PR DESCRIPTION
Closes #5133 