### PR TITLE
fix(LabelGroup): updated tab order to match visual order

### DIFF
--- a/src/patternfly/components/LabelGroup/examples/LabelGroup.md
+++ b/src/patternfly/components/LabelGroup/examples/LabelGroup.md
@@ -438,13 +438,50 @@ cssPrefix: pf-c-label-group
 {{/label-group}}
 ```
 
-### Vertical category removable
+### Vertical category removable, updated markup
 ```hbs
 
+{{#> label-group label-group--id="label-group-vertical-category-removable-2" label-group--modifier="pf-m-vertical pf-m-category"}}
+  {{#> label-group-main}}
+    {{#> label-group-header}}
+      {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label"  tabindex="0"')}}
+        Group label with really long text
+      {{/label-group-label}}
+      {{> label-group-close}}
+    {{/label-group-header}}
+    {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby="' label-group--id '-label"')}}
+      {{#> label-group-list-item}}
+        {{#> label}}
+          Label
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--modifier="pf-m-blue"}}
+          Label 2
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--modifier="pf-m-green"}}
+          Label 3
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOverflow="true"}}
+          3 more
+        {{/label}}
+      {{/label-group-list-item}}
+    {{/label-group-list}}
+  {{/label-group-main}}
+{{/label-group}}
+```
+
+### Vertical category removable
+
+```hbs
 {{#> label-group label-group--id="label-group-vertical-category-removable" label-group--modifier="pf-m-vertical pf-m-category"}}
   {{#> label-group-main}}
-    {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label"')}}
-      Group label
+    {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label" tabindex="0"')}}
+      Group label with really long text
     {{/label-group-label}}
     {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby="' label-group--id '-label"')}}
       {{#> label-group-list-item}}
@@ -460,6 +497,11 @@ cssPrefix: pf-c-label-group
       {{#> label-group-list-item}}
         {{#> label label--modifier="pf-m-green"}}
           Label 3
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOverflow="true"}}
+          3 more
         {{/label}}
       {{/label-group-list-item}}
     {{/label-group-list}}

--- a/src/patternfly/components/LabelGroup/label-group-header.hbs
+++ b/src/patternfly/components/LabelGroup/label-group-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-label-group__header{{#if label-group-header--modifier}} {{label-group-header--modifier}}{{/if}}"
+  {{#if label-group-header--attribute}}
+    {{{label-group-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/LabelGroup/label-group.scss
+++ b/src/patternfly/components/LabelGroup/label-group.scss
@@ -141,6 +141,10 @@
   margin-left: var(--pf-c-label-group__close--MarginLeft);
 }
 
+.pf-c-label-group__header {
+  display: flex;
+}
+
 .pf-c-label-group__textarea {
   min-width: var(--pf-c-label-group__textarea--MinWidth);
   padding: var(--pf-c-label-group__textarea--PaddingTop) var(--pf-c-label-group__textarea--PaddingRight) var(--pf-c-label-group__textarea--PaddingBottom) var(--pf-c-label-group__textarea--PaddingLeft);


### PR DESCRIPTION
WIP for #5122 

Had a conversation with @mcoker regarding this and #5157. The tldr is that this can be a bit of a gray area, where both the visual order and the logical/expected order both make sense.

The following link should link to the "Vertical category removable, updated markup" example which shows a potential fix for the linked issue. The example immediately below it, "Vertical category removable", is the behavior seen in our React repo.
[Label group](https://patternfly-pr-5172.surge.sh/components/label-group#vertical-category-removable-updated-markup)

For label group with truncated label + overflow button + close button, the visual order seems to be more left to right, top to bottom, e.g. the label should receive focus, then the close button (visually to the right of the label), then the overflow. However:

- If you view it more as a column then top to bottom, left to right also makes sense. E.g., the label receives focus, then the overflow (within the same "column" as the label, then over to the next "column" the close button receives focus.
- The horizontal label group tab order currently is setup in a way that tab order + visual order just happen to match, but updating the tab order for the vertical label group could be confusing since you'd be going from label > overflow > close button, to label > close button > overflow

[Placing the interactive elements in an order that follows sequences and relationships within the content](https://www.w3.org/WAI/WCAG21/Techniques/general/G59) may be relevant.

@jessiehuff @nicolethoen your input would be appreciated