### PR TITLE
fix(dropdown): disabled top positioning when using static variation

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -146,6 +146,18 @@
 
     transform: translateY(var(--pf-c-app-launcher--m-top__menu--TranslateY));
   }
+
+  &.pf-m-static {
+    --pf-c-app-launcher--m-top__menu--TranslateY: 0;
+
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    z-index: auto;
+    min-width: min-content;
+  }
 }
 
 .pf-c-app-launcher__menu-search {

--- a/src/patternfly/components/AppLauncher/examples/application-launcher.md
+++ b/src/patternfly/components/AppLauncher/examples/application-launcher.md
@@ -342,6 +342,7 @@ import './application-launcher.css'
 | `.pf-m-expanded` | `.pf-c-app-launcher` | Modifies for the expanded state. |
 | `.pf-m-top` | `.pf-c-app-launcher` | Modifies to display the menu above the toggle. |
 | `.pf-m-align-right` | `.pf-c-app-launcher__menu` | Modifies to display the menu aligned to the right edge of the toggle. |
+| `.pf-m-static` | `.pf-c-app-launcher__menu` | Modifies to position the menu statically to support custom positioning. |
 | `.pf-m-disabled` | `a.pf-c-app-launcher__menu-item` | Modifies to display the menu item as disabled. |
 | `.pf-m-external` | `.pf-c-app-launcher__menu-item` | Modifies to display the menu item as having an external link icon on hover/focus. |
 | `.pf-m-favorite` | `.pf-c-app-launcher__menu-wrapper` | Modifies wrapper to indicate that the item row has been favorited. |

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -56,6 +56,18 @@
 
     transform: translateY(var(--pf-c-date-picker--m-top__calendar--TranslateY));
   }
+
+  &.pf-m-static {
+    --pf-c-date-picker--m-top__calendar--TranslateY: 0;
+
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    z-index: auto;
+    min-width: min-content;
+  }
 }
 
 // stylelint-disable no-invalid-position-at-import-rule

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -92,3 +92,4 @@ import './DatePicker.css'
 | `.pf-m-top` | `.pf-c-date-picker` | Modifies to display the calendar above the date picker. |
 | `.pf-m-error` | `.pf-c-date-picker__helper-text` | Modifies the helper text for the invalid/error state. |
 | `.pf-m-align-right` | `.pf-c-date-picker__calendar` | Modifies the calendar to align the calendar to the right edge of the date picker. |
+| `.pf-m-static` | `.pf-c-date-picker__calendar` | Modifies the calendar to be statically positioned to support custom positioning. |

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -639,6 +639,9 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 
     position: static;
     top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
     z-index: auto;
     min-width: min-content;
   }

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -635,6 +635,8 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
   &.pf-m-static {
+    --pf-c-dropdown--m-top__menu--TranslateY: 0;
+
     position: static;
     top: auto;
     z-index: auto;

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -206,6 +206,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-m-top` | `.pf-c-dropdown` | Modifies to display the menu above the toggle. |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the left edge of the toggle at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the right edge of the toggle at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
+| `.pf-m-static` | `.pf-c-dropdown__menu` | Modifies a dropdown menu to be statically positioned to support custom positioning. |
 | `.pf-m-split-button` | `.pf-c-dropdown__toggle` | Modifies the dropdown toggle area to allow for interactive elements. |
 | `.pf-m-action` | `.pf-c-dropdown__toggle.pf-m-split-button` | Modifies the dropdown toggle for when an action is placed beside a toggle button in a split button dropdown. |
 | `.pf-m-text` | `.pf-c-dropdown__menu-item` | Modifies a menu item to be non-interactive text. |
@@ -219,4 +220,3 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-m-icon` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding an icon. |
 | `.pf-m-active` | `.pf-c-dropdown__toggle` | Modifies the dropdown menu toggle for the active state. |
 | `.pf-m-description` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding a description. |
-| `.pf-m-static` | `.pf-c-dropdown__menu` | Modifies a dropdown menu for popper placement support. |

--- a/src/patternfly/components/OptionsMenu/examples/options-menu.md
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu.md
@@ -200,6 +200,7 @@ import './options-menu.css'
 | `.pf-m-top` | `.pf-c-options-menu` | Modifies to display the menu above the toggle. |
 | `.pf-m-align-right` | `.pf-c-options-menu__menu` | Modifies to display the menu aligned to the right edge of the toggle |
 | `.pf-m-expanded` | `.pf-c-options-menu` |  Modifies for the expanded state. |
+| `.pf-m-static` | `.pf-c-options-menu__menu` | Modifies to position the menu statically to support custom positioning. |
 | `.pf-m-plain` | `.pf-c-options-menu__toggle` |  Modifies to display the toggle with no border. **Note:** Can be combined with `.pf-m-text` to create a normal text toggle with no border. |
 | `.pf-m-disabled` | `.pf-c-options-menu__toggle` | Modifies to display the options menu toggle as disabled. This applies to `pf-c-options-menu__toggle` and should not be used in lieu of the `disabled` attribute on `pf-c-options-menu__toggle`. When this is used, `disabled` should also be added to any form elements in `.pf-c-options-menu__toggle` |
 | `.pf-m-text` | `.pf-c-options-menu__toggle` |  For use when the `.pf-c-options-menu__toggle` is a `<div>` or some non-interactive elment, and you're using a custom `.pf-c-options-menu__toggle-button` to toggle the options menu. |

--- a/src/patternfly/components/OptionsMenu/examples/options-menu.md
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu.md
@@ -200,7 +200,7 @@ import './options-menu.css'
 | `.pf-m-top` | `.pf-c-options-menu` | Modifies to display the menu above the toggle. |
 | `.pf-m-align-right` | `.pf-c-options-menu__menu` | Modifies to display the menu aligned to the right edge of the toggle |
 | `.pf-m-expanded` | `.pf-c-options-menu` |  Modifies for the expanded state. |
-| `.pf-m-static` | `.pf-c-options-menu__menu` | Modifies to position the menu statically to support custom positioning. |
+| `.pf-m-static` | `.pf-c-options-menu__menu` | Modifies the menu to be statically positioned to support custom positioning. |
 | `.pf-m-plain` | `.pf-c-options-menu__toggle` |  Modifies to display the toggle with no border. **Note:** Can be combined with `.pf-m-text` to create a normal text toggle with no border. |
 | `.pf-m-disabled` | `.pf-c-options-menu__toggle` | Modifies to display the options menu toggle as disabled. This applies to `pf-c-options-menu__toggle` and should not be used in lieu of the `disabled` attribute on `pf-c-options-menu__toggle`. When this is used, `disabled` should also be added to any form elements in `.pf-c-options-menu__toggle` |
 | `.pf-m-text` | `.pf-c-options-menu__toggle` |  For use when the `.pf-c-options-menu__toggle` is a `<div>` or some non-interactive elment, and you're using a custom `.pf-c-options-menu__toggle-button` to toggle the options menu. |

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -248,6 +248,18 @@
 
     transform: translateY(var(--pf-c-options-menu--m-top__menu--TranslateY));
   }
+
+  &.pf-m-static {
+    --pf-c-options-menu--m-top__menu--TranslateY: 0;
+
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    z-index: auto;
+    min-width: min-content;
+  }
 }
 
 .pf-c-options-menu__menu-item {

--- a/src/patternfly/components/SearchInput/examples/SearchInput.md
+++ b/src/patternfly/components/SearchInput/examples/SearchInput.md
@@ -229,4 +229,6 @@ import './SearchInput.css'
 | `.pf-c-search-input__menu-list-item` | `<div>` | Initiates the search input dropdown menu list item. |
 | `.pf-c-search-input__menu-item` | `<div>` | Initiates the search input dropdown menu item. |
 | `.pf-c-search-input__menu-item-text` | `<span>` | Initiates the search input dropdown menu item text. |
+| `.pf-m-top` | `.pf-c-search-input__menu` | Modifies the menu to display above the toggle. |
+| `.pf-m-static` | `.pf-c-search-input__menu` | Modifies the menu to be statically positioned to support custom positioning. |
 | `.pf-m-hint` | `.pf-c-search-input__text-input` | Modifies the text input for hint text styles. |

--- a/src/patternfly/components/SearchInput/search-input.scss
+++ b/src/patternfly/components/SearchInput/search-input.scss
@@ -170,6 +170,18 @@
 
     transform: translateY(var(--pf-c-search-input--m-top__menu--TranslateY));
   }
+
+  &.pf-m-static {
+    --pf-c-search-input--m-top__menu--TranslateY: 0;
+
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    z-index: auto;
+    min-width: min-content;
+  }
 }
 
 .pf-c-search-input__menu-body {

--- a/src/patternfly/components/Select/examples/Select.md
+++ b/src/patternfly/components/Select/examples/Select.md
@@ -47,6 +47,7 @@ The single select should be used when the user is selecting an option from a lis
 | `.pf-c-select__menu-item-icon` | `<i>` |  Initiates the selected item icon. |
 | `.pf-m-top` | `.pf-c-select` |  Modifies the select menu to display above the toggle. |
 | `.pf-m-align-right` | `.pf-c-select__menu` |  Modifies the select menu to display right aligned to the toggle. |
+| `.pf-m-static` | `.pf-c-select__menu` |  Modifies the select menu to be statically positioned to support custom positioning. |
 | `.pf-m-active` | `.pf-c-select` | Forces display of the active state of the toggle. |
 
 ## States

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -486,8 +486,13 @@
   }
 
   &.pf-m-static {
+    --pf-c-select__menu--m-top--TranslateY: 0;
+
     position: static;
     top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
     z-index: auto;
     min-width: min-content;
   }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5188

@thatblindgeye this disables the dropdown's `.pf-m-top` modifier from doing anything with the dropdown menu when `.pf-m-static` is set. That was probably just an oversight when we added `.pf-m-static`. You can test it by adding the classes manually in the core workspace.