### PR TITLE
fix(toolbar): added center and baseline alignments

### DIFF
--- a/scripts/gulp/html.js
+++ b/scripts/gulp/html.js
@@ -37,6 +37,16 @@ hbsInstance.registerHelper('ifEquals', (arg1, arg2, options) => {
 //   something else
 // {{/ifEquals}}
 
+hbsInstance.registerHelper('ternary', (testValue, trueValue, fallback) => {
+  return testValue ? trueValue : fallback;
+});
+
+// Using ternary
+// if custom value for select--width: {{#> select select--width='160px'}}Filter by name{{/select}}
+// else custom value for select--width: {{#> select)}}Filter by name{{/select}}
+// {{#> select select--id=(concat toolbar--id '-select-name') select--width=(ternary toolbar-items-search-filter--width toolbar-items-search-filter--width '175px') select-toggle--icon="fas fa-filter"}}
+// {{> toolbar-item-search-filter toolbar-items-search-filter--width="300px"}}
+
 function compileHBS0(srcFiles) {
   return srcFiles.pipe(
     through2.obj((chunk, _, cb2) => {

--- a/src/patternfly/components/Select/select.hbs
+++ b/src/patternfly/components/Select/select.hbs
@@ -4,6 +4,9 @@
   {{~#if select--IsWarning}} pf-m-warning{{/if}}
   {{~#if select--IsInvalid}} pf-m-invalid{{/if}}
   {{~#if select--modifier}} {{select--modifier}}{{/if}}"
+  {{#if select--width}}
+    style="width: {{select--width}}"
+  {{/if}}
   {{#if select--attribute}}
     {{{select--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -665,9 +665,7 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align right, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-items-center` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
-| `.pf-m-align-items-baseline` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
 | `.pf-m-align-self-center` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to center. |
-| `.pf-m-align-self-baseline` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to baseline. |
 | `.pf-m-label` | `.pf-c-toolbar__item` | Modifies toolbar item to label. |
 | `.pf-m-chip-container` | `.pf-c-toolbar__content`, `.pf-c-toolbar__group` | Modifies the toolbar element for applied filters layout. |
 | `.pf-m-overflow-container` | `.pf-c-toolbar__item`, `.pf-c-toolbar__group` | Modifies the toolbar element to hide overflow and respond to available space. Used for horizontal navigation. |

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -665,7 +665,9 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align right, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-items-center` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
+| `.pf-m-align-items-baseline` | `.pf-c-toolbar__group` | Modifies toolbar group to vertically align children to baseline. |
 | `.pf-m-align-self-center` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to center. |
+| `.pf-m-align-self-baseline` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to baseline. |
 | `.pf-m-label` | `.pf-c-toolbar__item` | Modifies toolbar item to label. |
 | `.pf-m-chip-container` | `.pf-c-toolbar__content`, `.pf-c-toolbar__group` | Modifies the toolbar element for applied filters layout. |
 | `.pf-m-overflow-container` | `.pf-c-toolbar__item`, `.pf-c-toolbar__group` | Modifies the toolbar element to hide overflow and respond to available space. Used for horizontal navigation. |

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -34,6 +34,10 @@ Toolbar relies on groups (`.pf-c-toolbar__group`) and items (`.pf-c-toolbar__ite
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to be shown, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align right, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
+| `.pf-m-align-items-center` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
+| `.pf-m-align-items-baseline` | `.pf-c-toolbar__group` | Modifies toolbar group to vertically align children to baseline. |
+| `.pf-m-align-self-center` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to center. |
+| `.pf-m-align-self-baseline` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to baseline. |
 
 ### Special notes
 

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -665,6 +665,7 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align right, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-items-center` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
+| `.pf-m-align-items-baseline` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
 | `.pf-m-align-self-center` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to center. |
 | `.pf-m-align-self-baseline` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to baseline. |
 | `.pf-m-label` | `.pf-c-toolbar__item` | Modifies toolbar item to label. |

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -664,6 +664,9 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-toolbar__content`, `.pf-c-toolbar__content-section`, `.pf-c-toolbar__item`, `.pf-c-toolbar__group` | Modifies toolbar element to be shown, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align right, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-c-toolbar > *` | Modifies toolbar element to align left, at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
+| `.pf-m-align-items-center` | `.pf-c-toolbar__content-section`, `.pf-c-toolbar__group` | Modifies toolbar element to vertically align children to center. |
+| `.pf-m-align-self-center` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to center. |
+| `.pf-m-align-self-baseline` | `.pf-c-toolbar__group`, `.pf-c-toolbar__item` | Modifies toolbar element to vertically align self to baseline. |
 | `.pf-m-label` | `.pf-c-toolbar__item` | Modifies toolbar item to label. |
 | `.pf-m-chip-container` | `.pf-c-toolbar__content`, `.pf-c-toolbar__group` | Modifies the toolbar element for applied filters layout. |
 | `.pf-m-overflow-container` | `.pf-c-toolbar__item`, `.pf-c-toolbar__group` | Modifies the toolbar element to hide overflow and respond to available space. Used for horizontal navigation. |

--- a/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
@@ -8,9 +8,9 @@
       {{/if}}
     {{/select}}
     {{#if toolbar-items-search-filter--text}}
-      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder=(concat "Filter by " toolbar-items-search-filter--text)}}
+      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder=(concat "Filter by " toolbar-items-search-filter--text) text-input-group--attribute='style="width: auto"'}}
     {{else}}
-      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Filter by name"}}
+      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Filter by name" text-input-group--attribute='style="width: auto"'}}
     {{/if}}
   {{/input-group}}
 {{/toolbar-item}}

--- a/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-item-search-filter.hbs
@@ -1,8 +1,16 @@
 {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-search-filter ' toolbar-item-search-filter--modifier)}}
   {{#> input-group input-group--attribute=(concat 'aria-label="search filter" role="group"')}}
-    {{#> select select--attribute='style="width: 175px"' select--id=(concat toolbar--id '-select-name') select-toggle--icon="fas fa-filter"}}
-      Name
+    {{#> select select--id=(concat toolbar--id '-select-name') select--width=(ternary toolbar-items-search-filter--width toolbar-items-search-filter--width '175px') select-toggle--icon="fas fa-filter"}}
+      {{#if toolbar-items-search-filter--text}}
+        {{{toolbar-items-search-filter--text}}}
+      {{else}}
+        Name
+      {{/if}}
     {{/select}}
-    {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Filter by name"}}
+    {{#if toolbar-items-search-filter--text}}
+      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder=(concat "Filter by " toolbar-items-search-filter--text)}}
+    {{else}}
+      {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Filter by name"}}
+    {{/if}}
   {{/input-group}}
 {{/toolbar-item}}

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -10,7 +10,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--md);
 
-
   // Item
   --pf-c-toolbar__item--Display: block;
   --pf-c-toolbar__item--MinWidth--base: auto;
@@ -592,3 +591,4 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 .pf-c-toolbar__content-section > :last-child {
   --pf-c-toolbar--spacer: 0;
 }
+

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -1,7 +1,7 @@
 // Don't remove this magic comment. See gulpfile.js.
 // @import "../../sass-utilities/all";
 $pf-c-toolbar--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
-$pf-c-toolbar--spacer-map: build-spacer-map();
+$pf-c-toolbar--spacer-map: build-spacer-map("none", "sm", "md", "lg");
 $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-toolbar {
@@ -217,19 +217,19 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   margin-right: var(--pf-c-toolbar--spacer);
 
   &.pf-m-align-items-center {
-    --pf-c-toolbar__group--AlignItems: center;
+    align-items: center;
   }
 
   &.pf-m-align-items-baseline {
-    --pf-c-toolbar__group--AlignItems: baseline;
+    align-items: baseline;
   }
 
   &.pf-m-align-self-center {
-    --pf-c-toolbar__group--AlignSelf: center;
+    align-self: center;
   }
 
   &.pf-m-align-self-baseline {
-    --pf-c-toolbar__group--AlignSelf: baseline;
+    align-self: baseline;
   }
 
   // Button group
@@ -297,11 +297,11 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   margin-right: var(--pf-c-toolbar--spacer);
 
   &.pf-m-align-self-center {
-    --pf-c-toolbar__item--AlignSelf: center;
+    align-self: center;
   }
 
   &.pf-m-align-self-baseline {
-    --pf-c-toolbar__item--AlignSelf: baseline;
+    align-self: baseline;
   }
 
   // Overflow menu
@@ -388,7 +388,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   width: 100%;
 
   &.pf-m-align-items-center {
-    --pf-c-toolbar__content-section--AlignItems: center;
+    align-items: center;
   }
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   // Item
   --pf-c-toolbar__item--Display: block;
   --pf-c-toolbar__item--MinWidth--base: auto;
-  --pf-c-toolbar__item--AlignSelf: baseline;
+  --pf-c-toolbar__item--AlignSelf: auto;
 
   // Group
   --pf-c-toolbar__group--Display: flex;
@@ -220,16 +220,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
     --pf-c-toolbar__group--AlignItems: center;
   }
 
-  &.pf-m-align-items-baseline {
-    --pf-c-toolbar__group--AlignItems: baseline;
-  }
-
   &.pf-m-align-self-center {
     --pf-c-toolbar__group--AlignSelf: center;
-  }
-
-  &.pf-m-align-self-baseline {
-    --pf-c-toolbar__group--AlignSelf: baseline;
   }
 
   // Button group
@@ -298,10 +290,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   &.pf-m-align-self-center {
     --pf-c-toolbar__item--AlignSelf: center;
-  }
-
-  &.pf-m-align-self-baseline {
-    --pf-c-toolbar__item--AlignSelf: baseline;
   }
 
   // Overflow menu
@@ -389,10 +377,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   &.pf-m-align-items-center {
     --pf-c-toolbar__content-section--AlignItems: center;
-  }
-
-  &.pf-m-align-items-baseline {
-    --pf-c-toolbar__content-section--AlignItems: baseline;
   }
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -9,13 +9,18 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--RowGap: var(--pf-global--spacer--lg);
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-toolbar--AlignItems--base: baseline;
+  --pf-c-toolbar--AlignSelf--base: auto;
 
   // Item
   --pf-c-toolbar__item--Display: block;
   --pf-c-toolbar__item--MinWidth--base: auto;
+  --pf-c-toolbar__item--AlignSelf: var(--pf-c-toolbar--AlignSelf--base);
 
   // Group
   --pf-c-toolbar__group--Display: flex;
+  --pf-c-toolbar__group--AlignItems: var(--pf-c-toolbar--AlignItems--base);
+  --pf-c-toolbar__group--AlignSelf: var(--pf-c-toolbar--AlignSelf--base);
 
   // Sticky
   --pf-c-toolbar--m-sticky--ZIndex: var(--pf-global--ZIndex--xs);
@@ -28,6 +33,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   // Content section
   --pf-c-toolbar__content-section--Display: flex;
+  --pf-c-toolbar__content-section--AlignItems: var(--pf-c-toolbar--AlignItems--base);
 
   // Insets
   --pf-c-toolbar--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
@@ -208,8 +214,16 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   @include pf-hidden-visible(var(--pf-c-toolbar__group--Display));
 
-  align-items: center;
+  align-items: var(--pf-c-toolbar__group--AlignSelf);
   margin-right: var(--pf-c-toolbar--spacer);
+
+  &.pf-m-align-self-center {
+    --pf-c-toolbar__group--AlignSelf: center;
+  }
+
+  &.pf-m-align-self-baseline {
+    --pf-c-toolbar__group--AlignSelf: baseline;
+  }
 
   // Button group
   &.pf-m-button-group {
@@ -270,9 +284,18 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @include pf-build-css-variable-stack("--pf-c-toolbar__item--MinWidth--base", "--pf-c-toolbar__item--MinWidth", $pf-c-toolbar--breakpoint-map);
   @include pf-hidden-visible(var(--pf-c-toolbar__item--Display));
 
+  align-self: var(--pf-c-toolbar__item--AlignSelf);
   width: var(--pf-c-toolbar__item--Width--base);
   min-width: var(--pf-c-toolbar__item--MinWidth--base);
   margin-right: var(--pf-c-toolbar--spacer);
+
+  &.pf-m-align-self-center {
+    --pf-c-toolbar__item--AlignSelf: center;
+  }
+
+  &.pf-m-align-self-baseline {
+    --pf-c-toolbar__item--AlignSelf: baseline;
+  }
 
   // Overflow menu
   &.pf-m-overflow-menu {
@@ -329,7 +352,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   }
 }
 
-
 .pf-c-toolbar__expand-all-icon {
   display: inline-block;
   transition: var(--pf-c-toolbar__expand-all-icon--Transition);
@@ -339,7 +361,6 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 .pf-c-toolbar__content,
 .pf-c-toolbar__content-section {
   flex-wrap: wrap;
-  align-items: center;
 }
 
 // Content
@@ -347,6 +368,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @include pf-hidden-visible(var(--pf-c-toolbar__content--Display));
 
   position: relative;
+  align-items: center;
   padding-right: var(--pf-c-toolbar__content--PaddingRight);
   padding-left: var(--pf-c-toolbar__content--PaddingLeft);
 }
@@ -355,7 +377,12 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 .pf-c-toolbar__content-section {
   @include pf-hidden-visible(var(--pf-c-toolbar__content-section--Display));
 
+  align-items: var(--pf-c-toolbar__content-section--AlignItems);
   width: 100%;
+
+  &.pf-m-align-items-center {
+    --pf-c-toolbar__content-section--AlignItems: center;
+  }
 }
 
 // Expandable content

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -10,6 +10,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--md);
 
+
   // Item
   --pf-c-toolbar__item--Display: block;
   --pf-c-toolbar__item--MinWidth--base: auto;

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -9,18 +9,16 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   --pf-c-toolbar--RowGap: var(--pf-global--spacer--lg);
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-toolbar--AlignItems--base: baseline;
-  --pf-c-toolbar--AlignSelf--base: auto;
 
   // Item
   --pf-c-toolbar__item--Display: block;
   --pf-c-toolbar__item--MinWidth--base: auto;
-  --pf-c-toolbar__item--AlignSelf: var(--pf-c-toolbar--AlignSelf--base);
+  --pf-c-toolbar__item--AlignSelf: baseline;
 
   // Group
   --pf-c-toolbar__group--Display: flex;
-  --pf-c-toolbar__group--AlignItems: var(--pf-c-toolbar--AlignItems--base);
-  --pf-c-toolbar__group--AlignSelf: var(--pf-c-toolbar--AlignSelf--base);
+  --pf-c-toolbar__group--AlignItems: baseline;
+  --pf-c-toolbar__group--AlignSelf: auto;
 
   // Sticky
   --pf-c-toolbar--m-sticky--ZIndex: var(--pf-global--ZIndex--xs);
@@ -33,7 +31,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   // Content section
   --pf-c-toolbar__content-section--Display: flex;
-  --pf-c-toolbar__content-section--AlignItems: var(--pf-c-toolbar--AlignItems--base);
+  --pf-c-toolbar__content-section--AlignItems: baseline;
 
   // Insets
   --pf-c-toolbar--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
@@ -214,7 +212,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   @include pf-hidden-visible(var(--pf-c-toolbar__group--Display));
 
-  align-items: var(--pf-c-toolbar__group--AlignSelf);
+  align-items: var(--pf-c-toolbar__group--AlignItems);
   margin-right: var(--pf-c-toolbar--spacer);
 
   &.pf-m-align-self-center {

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -213,7 +213,16 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
   @include pf-hidden-visible(var(--pf-c-toolbar__group--Display));
 
   align-items: var(--pf-c-toolbar__group--AlignItems);
+  align-self: var(--pf-c-toolbar__group--AlignSelf);
   margin-right: var(--pf-c-toolbar--spacer);
+
+  &.pf-m-align-items-center {
+    --pf-c-toolbar__group--AlignItems: center;
+  }
+
+  &.pf-m-align-items-baseline {
+    --pf-c-toolbar__group--AlignItems: baseline;
+  }
 
   &.pf-m-align-self-center {
     --pf-c-toolbar__group--AlignSelf: center;
@@ -380,6 +389,10 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   &.pf-m-align-items-center {
     --pf-c-toolbar__content-section--AlignItems: center;
+  }
+
+  &.pf-m-align-items-baseline {
+    --pf-c-toolbar__content-section--AlignItems: baseline;
   }
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -1,7 +1,7 @@
 // Don't remove this magic comment. See gulpfile.js.
 // @import "../../sass-utilities/all";
 $pf-c-toolbar--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
-$pf-c-toolbar--spacer-map: build-spacer-map("none", "sm", "md", "lg");
+$pf-c-toolbar--spacer-map: build-spacer-map();
 $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
 .pf-c-toolbar {
@@ -220,8 +220,16 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
     --pf-c-toolbar__group--AlignItems: center;
   }
 
+  &.pf-m-align-items-baseline {
+    --pf-c-toolbar__group--AlignItems: baseline;
+  }
+
   &.pf-m-align-self-center {
     --pf-c-toolbar__group--AlignSelf: center;
+  }
+
+  &.pf-m-align-self-baseline {
+    --pf-c-toolbar__group--AlignSelf: baseline;
   }
 
   // Button group
@@ -290,6 +298,10 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   &.pf-m-align-self-center {
     --pf-c-toolbar__item--AlignSelf: center;
+  }
+
+  &.pf-m-align-self-baseline {
+    --pf-c-toolbar__item--AlignSelf: baseline;
   }
 
   // Overflow menu

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -591,4 +591,3 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 .pf-c-toolbar__content-section > :last-child {
   --pf-c-toolbar--spacer: 0;
 }
-

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -7,7 +7,7 @@ import './Toolbar.css'
 
 ## Demos
 
-### Toolbar attribute value search filter desktop
+### Toolbar attribute value search filter on desktop
 ```hbs
 {{#> toolbar toolbar--id="toolbar-attribute-value-search-filter-desktop-example"}}
   {{#> toolbar-content}}
@@ -31,7 +31,7 @@ import './Toolbar.css'
 {{/toolbar}}
 ```
 
-### Toolbar with validation desktop
+### Toolbar with validation on desktop
 ```hbs isFullscreen
 {{> page-template page-template--id="toolbar-pagination-management-example"}}
 
@@ -42,7 +42,7 @@ import './Toolbar.css'
     {{#> toolbar toolbar--id="toolbar-with-validation-example"}}
       {{#> toolbar-content}}
         {{#> toolbar-content-section}}
-          {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show"}}
+          {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show-on-2xl"}}
             {{> toolbar-toggle toolbar-toggle--IsExpanded="false"}}
             {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
               {{#> toolbar-item}}
@@ -70,10 +70,10 @@ import './Toolbar.css'
                 {{/input-group}}
               {{/toolbar-item}}
             {{/toolbar-group}}
-            {{> toolbar-item-search-filter toolbar-items-search-filter--text="Description" toolbar-items-search-filter--width="300px"}}
+            {{> toolbar-item-search-filter toolbar-items-search-filter--text="Description" toolbar-items-search-filter--width="160px"}}
           {{/toolbar-group}}
           {{#> button button--modifier="pf-m-primary"}}
-            Download history
+            Download
           {{/button}}
         {{/toolbar-content-section}}
         {{> toolbar-expandable-content}}
@@ -111,7 +111,7 @@ import './Toolbar.css'
 {{/toolbar}}
 ```
 
-### Toolbar attribute value single select filter desktop
+### Toolbar attribute value single select filter on desktop
 ```hbs
 {{#> toolbar toolbar--id="toolbar-attribute-value-single-select-filter-desktop-example"}}
   {{#> toolbar-content}}
@@ -182,7 +182,7 @@ import './Toolbar.css'
 {{/toolbar}}
 ```
 
-### Toolbar attribute value checkbox select filter desktop
+### Toolbar attribute value checkbox select filter on desktop
 ```hbs
 {{#> toolbar toolbar--id="toolbar-attribute-value-checkbox-select-filter-desktop-example"}}
   {{#> toolbar-content}}

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -31,6 +31,61 @@ import './Toolbar.css'
 {{/toolbar}}
 ```
 
+### Toolbar with validation desktop
+```hbs isFullscreen
+{{> page-template page-template--id="toolbar-pagination-management-example"}}
+
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> toolbar toolbar--id="toolbar-with-validation-example"}}
+      {{#> toolbar-content}}
+        {{#> toolbar-content-section}}
+          {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show"}}
+            {{> toolbar-toggle toolbar-toggle--IsExpanded="false"}}
+            {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+              {{#> toolbar-item}}
+                {{#> input-group input-group--attribute=(concat 'aria-label="search filter" role="group"')}}
+                  {{#> select select--id=(concat toolbar--id '-select-month') select--width='160px' select-toggle--icon="fas fa-filter"}}
+                    Last month
+                  {{/select}}
+                  {{#> date-picker date-picker--id=(concat toolbar--id "-helper-text") date-picker-helper-text--text="MM/DD/YYYY"}}
+                    {{#> input-group}}
+                      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+                      {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+                        <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+                      {{/button}}
+                    {{/input-group}}
+                  {{/date-picker}}
+                  {{#> date-picker date-picker--id=(concat toolbar--id "-invalid") date-picker-helper-text--text="Max: 08/10/2022" date-picker-helper-text--IsError="true"}}
+                    {{#> input-group}}
+                      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+                      {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
+                        <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+                      {{/button}}
+                    {{/input-group}}
+                    {{> date-picker-helper-text date-picker-helper-text--text="MM/DD/YYYY" date-picker-helper-text--IsError=false}}
+                  {{/date-picker}}
+                {{/input-group}}
+              {{/toolbar-item}}
+            {{/toolbar-group}}
+            {{> toolbar-item-search-filter toolbar-items-search-filter--text="Description" toolbar-items-search-filter--width="300px"}}
+          {{/toolbar-group}}
+          {{#> button button--modifier="pf-m-primary"}}
+            Download history
+          {{/button}}
+        {{/toolbar-content-section}}
+        {{> toolbar-expandable-content}}
+      {{/toolbar-content}}
+    {{/toolbar}}
+    <div>
+      {{> table-simple-table page--id=(concat toolbar--id '-table')}}
+    </div>
+  {{/page-main-section}}
+{{/inline}}
+```
+
 ### Toolbar attribute value search filter on mobile
 ```hbs
 {{#> toolbar toolbar--id="toolbar-attribute-value-search-filter-mobile-example"}}


### PR DESCRIPTION
closes #5030 

This PR adds:
- `.pf-m-align-items-center` to `.pf-c-toolbar__content-section` and `.pf-c-toolbar__group`
- `.pf-m-align-self-center` to `.pf-c-toolbar__group` and `.pf-c-toolbar__item`
- `.pf-m-align-self-baseline` to `.pf-c-toolbar__group` and `.pf-c-toolbar__item` 