### PR TITLE
fix(SearchInput/TextInputGroup): remove browser clear icons

### DIFF
--- a/src/patternfly/components/SearchInput/search-input.scss
+++ b/src/patternfly/components/SearchInput/search-input.scss
@@ -122,6 +122,13 @@
   padding: var(--pf-c-search-input__text-input--PaddingTop) var(--pf-c-search-input__text-input--PaddingRight) var(--pf-c-search-input__text-input--PaddingBottom) var(--pf-c-search-input__text-input--PaddingLeft);
   border: 0;
 
+  &[type="search"]::-webkit-search-decoration,
+  &[type="search"]::-webkit-search-cancel-button,
+  &[type="search"]::-webkit-search-results-button,
+  &[type="search"]::-webkit-search-results-decoration {
+    display: none;
+  }
+
   &,
   &.pf-m-hint {
     grid-area: text-input;

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -157,6 +157,13 @@
   padding: var(--pf-c-text-input-group__text-input--PaddingTop) var(--pf-c-text-input-group__text-input--PaddingRight) var(--pf-c-text-input-group__text-input--PaddingBottom) var(--pf-c-text-input-group__text-input--PaddingLeft);
   border: 0;
 
+  &[type="search"]::-webkit-search-decoration,
+  &[type="search"]::-webkit-search-cancel-button,
+  &[type="search"]::-webkit-search-results-button,
+  &[type="search"]::-webkit-search-results-decoration {
+    display: none;
+  }
+
   &,
   &.pf-m-hint {
     grid-area: text-input;


### PR DESCRIPTION
closes #5210

I added the rules to both files because Core uses `pf-c-search-input` classes for the Search Input, but React uses Text Input Group under the hood (not sure if there's an issue open about making this more consistent, I didn't come across one). 

This [How to Remove “X” icon from search input field or input type search](https://medium.com/@rion.mrk/how-to-remove-x-icon-from-search-input-field-or-input-type-search-db3c808405fb) article is what I came across.

To test (use Chromium or Safari):

1. Go to [search input preview build](https://patternfly-pr-5211.surge.sh/components/search-input)
2. Update the first example so the `input` has `type="search"`
3. Enter text in the input and notice how an icon does not get rendered by the browser
4. Do steps 2-3 on the [HTML search input](https://www.patternfly.org/v4/components/search-input/html) on the live site, and notice how an icon does get rendered