### PR TITLE
feat(tabs): added help popover, refactored tab action

### DIFF
--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -17,6 +17,12 @@
   {{#if button--IsInlineLinkSpan}}
     role="button"
   {{/if}}
+  {{#if button--aria-label}}
+    aria-label="{{button--aria-label}}"
+  {{/if}}
+  {{#if button--IsDisabled}}
+    disabled
+  {{/if}}
   {{#if button--attribute}}
     {{{button--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Tabs/__tabs-all.hbs
+++ b/src/patternfly/components/Tabs/__tabs-all.hbs
@@ -1,0 +1,36 @@
+  {{#> tabs tabs--id=(concat __tabs-all--id "-default-example") tabs--modifier="pf-m-scrollable"}}
+    {{> __tabs-list}}
+  {{/tabs}}
+
+  <br><br>
+
+  {{#> tabs tabs--id=(concat __tabs-all--id "-box-example") tabs--modifier="pf-m-box pf-m-scrollable"}}
+    {{> __tabs-list}}
+  {{/tabs}}
+
+  <br><br>
+
+  {{#> tabs tabs--id=(concat __tabs-all--id "-box-light-300-example") tabs--modifier="pf-m-box pf-m-color-scheme--light-300 pf-m-scrollable"}}
+    {{> __tabs-list}}
+  {{/tabs}}
+
+  <br><br>
+
+  {{#> tabs tabs--id=(concat __tabs-all--id "-icons-text-example") tabs--modifier="pf-m-scrollable"}}
+    {{> __tabs-list __tabs-list--HasIcons="true"}}
+  {{/tabs}}
+
+  <br><br>
+
+  {{#> tabs tabs--id=(concat __tabs-all--id "-filled-example") tabs--modifier="pf-m-fill" __tabs-list--IsScrollable=reset}}
+    {{> __tabs-list __tabs-list--IsShort="true"}}
+  {{/tabs}}
+
+  <br><br>
+
+  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-primary-example") tabs--modifier="pf-m-scrollable"}}
+    {{> __tabs-list}}
+  {{/tabs}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-secondary-example") tabs--modifier="pf-m-scrollable" tabs--IsSecondary="true"}}
+    {{> __tabs-list}}
+  {{/tabs}}

--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -10,6 +10,7 @@ __tabs-list--IsOverflowSelected: bool
 __tabs-list--IsShort: bool
 __tabs-list--IsLong: bool
 __tabs-item--NoText: bool
+__tabs-list--HasHelp: bool
 __tabs-list--HasClose: bool
 __tabs-list--IsCloseDisabled: bool
 ------------------------------------
@@ -25,7 +26,7 @@ __tabs-list--IsCloseDisabled: bool
   {{/if}}
 {{/unless}}
 
-{{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose}}
+{{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
   {{> __tabs-item
     __tabs-item--id="users"
     __tabs-item--icon-name="fas fa-users"
@@ -62,14 +63,35 @@ __tabs-list--IsCloseDisabled: bool
         __tabs-item--text="ARIA disabled"
         tabs-link--IsAriaDisabled="true"
         }}
+        {{#if __tabs-list--IsHelpDisabled}}
+          {{> __tabs-item
+            __tabs-item--id="help-disabled"
+            __tabs-item--icon-name="download"
+            __tabs-item--aria-label="Help disabled"
+            __tabs-item--text="Help disabled"
+            tabs-link--IsDisabled="true"
+            tabs-item-action--IsHelpDisabled="true"
+            }}
+        {{/if}}
         {{#if __tabs-list--IsCloseDisabled}}
           {{> __tabs-item
             __tabs-item--id="close-disabled"
-            __tabs-item--icon-name="laptop"
+            __tabs-item--icon-name="code"
             __tabs-item--aria-label="Close disabled"
             __tabs-item--text="Close disabled"
             tabs-link--IsDisabled="true"
-            tabs-item-close-button--attribute="disabled"
+            tabs-item-action--IsCloseDisabled="true"
+            }}
+        {{/if}}
+        {{#if __tabs-list--IsHelpCloseDisabled}}
+          {{> __tabs-item
+            __tabs-item--id="help-close-disabled"
+            __tabs-item--icon-name="folder"
+            __tabs-item--aria-label="Help and disabled"
+            __tabs-item--text="Help and close disabled"
+            tabs-link--IsDisabled="true"
+            tabs-item-action--IsHelpDisabled="true"
+            tabs-item-action--IsCloseDisabled="true"
             }}
         {{/if}}
     {{else}}

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -6,311 +6,331 @@ cssPrefix: pf-c-tabs
 
 import './Tabs.css'
 
-## Examples
+# Examples
 
-### Default
+## Default
+
+### Default tabs example
 ```hbs
-{{#> tabs tabs--id="default-example"}}
+{{#> tabs tabs--id="default-tabs"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Usage
-
+### Default tabs usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-disabled` | `a.pf-c-tabs__link` | Modifies a tabs link for disabled styles. |
 | `.pf-m-aria-disabled` | `.pf-c-tabs__link` | Modifies a tabs link for disabled styles, but is still hoverable/focusable. |
 
-### Default overflow beginning of list
+## Overflow
+
+### Overflow beginning of list example
 ```hbs
-{{#> tabs tabs--id="default-overflow-beginning-of-list-example" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--id="overflow-beginning-of-list" tabs--modifier="pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
 {{/tabs}}
 ```
 
-### Usage
-
+### Overflow beginning of list usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-scrollable` | `.pf-c-tabs` | Enables the directional scroll buttons. |
 | `.pf-c-tabs__scroll-button` | `<button>` | Initiates a tabs component scroll button. |
 
-### Horizontal overflow
+### Horizontal overflow example
 ```hbs isBeta
-{{#> tabs tabs--id="horizontal-overflow-example" __tabs-list--IsOverflow="true"}}
+{{#> tabs tabs--id="horizontal-overflow" __tabs-list--IsOverflow="true"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
-### Horizontal overflow expanded
+### Horizontal overflow expanded example
 ```hbs isBeta
-{{#> tabs tabs--id="horizontal-overflow-expanded-example" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowExpanded="true"}}
+{{#> tabs tabs--id="horizontal-overflow-expanded" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowExpanded="true"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
-### Horizontal overflow selected
+### Horizontal overflow selected example
 ```hbs isBeta
-{{#> tabs tabs--id="horizontal-overflow-selected-example" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowSelected="true"}}
+{{#> tabs tabs--id="horizontal-overflow-selected" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowSelected="true"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
-### Vertical
+## Vertical
+
+### Vertical tabs example
 ```hbs
-{{#> tabs tabs--id="vertical-example" tabs--modifier="pf-m-vertical"}}
+{{#> tabs tabs--id="vertical-tabs" tabs--modifier="pf-m-vertical"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Box
+### Vertical expandable example
 ```hbs
-{{#> tabs tabs--id="box-example" tabs--modifier="pf-m-box"}}
+{{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expanded example
+```hbs
+{{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable responsive example
+```hbs
+{{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable example (legacy)
+```hbs
+{{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expanded example (legacy)
+```hbs
+{{#> tabs tabs--id="vertical-expanded-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable responsive example (legacy)
+```hbs
+{{#> tabs tabs--id="vertical-expandable-responsive-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+## Box
+
+### Box tabs example
+```hbs
+{{#> tabs tabs--id="box-tabs" tabs--modifier="pf-m-box"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Box overflow
+### Box overflow example
 ```hbs
-{{#> tabs tabs--id="box-overflow-example" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
+{{#> tabs tabs--id="box-overflow" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
 {{/tabs}}
 ```
 
-### Box vertical
+### Box vertical example
 ```hbs
-{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
+{{#> tabs tabs--id="box-vertical" tabs--modifier="pf-m-box pf-m-vertical"}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Box tabs color scheme light 300
+### Box tabs color scheme light 300 example
 ```hbs
-{{#> tabs tabs--modifier="pf-m-box pf-m-color-scheme--light-300" tabs--id="box-tabs-alt-color-scheme"}}
+{{#> tabs tabs--modifier="pf-m-box pf-m-color-scheme--light-300" tabs--id="box-tabs-color-scheme-light-300"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 <div className="tabs-example-block tabs-example-block--m-color-scheme--light-300"></div>
 ```
 
-### Inset
+## Tab insets
+
+### Default tab insets example
 ```hbs
-{{#> tabs tabs--id="inset-example" tabs--modifier="pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
+{{#> tabs tabs--id="default-tab-insets" tabs--modifier="pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
   {{> __tabs-list}}
 {{/tabs}}
 ```
 
-### Inset box
+### Box tab insets example
 ```hbs
-{{#> tabs tabs--id="inset-box-example" tabs--modifier="pf-m-box pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
+{{#> tabs tabs--id="box-tab-insets" tabs--modifier="pf-m-box pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
   {{> __tabs-list}}
 {{/tabs}}
 ```
 
-### Page insets
+### Page insets example
 ```hbs
-{{#> tabs tabs--id="page-insets-example" tabs--modifier="pf-m-page-insets"}}
+{{#> tabs tabs--id="page-insets" tabs--modifier="pf-m-page-insets"}}
   {{> __tabs-list}}
 {{/tabs}}
 ```
 
-### Usage
-
+### Insets usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-inset-{none, sm, md, lg, xl, 2xl, 3xl}{-on-[sm, md, lg, xl, 2xl]}` | `.pf-c-tabs` | Modifies the tabs component padding/inset to visually match padding of other adjacent components. |
 | `.pf-m-page-insets` | `.pf-c-tabs` | Modifies the tabs component padding/inset to visually match padding of page elements. |
 
-### Icons and text
+## Icons
+
+### Icons and text example
 ```hbs
-{{#> tabs tabs--id="icons-example"}}
+{{#> tabs tabs--id="icons-and-text"}}
   {{> __tabs-list __tabs-list--HasIcons="true"}}
 {{/tabs}}
 ```
 
-### Tabs with sub tabs
+## Sub tabs
+
+### Tabs with sub tabs example
 ```hbs
-{{#> tabs tabs--id="default-parent-example" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--id="tabs-with-sub-tabs" tabs--modifier="pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--id="default-child-example" tabs--IsSecondary="true" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--id="tabs-with-sub-tabs-secondary" tabs--IsSecondary="true" tabs--modifier="pf-m-scrollable"}}
   {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
-### Box tabs with sub tabs
+### Box tabs with sub tabs example
 ```hbs
-{{#> tabs tabs--id="box-parent-example" tabs--modifier="pf-m-box pf-m-scrollable"}}
+{{#> tabs tabs--id="box-tabs-with-sub-tabs" tabs--modifier="pf-m-box pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--id="box-child-example" tabs--IsSecondary="true" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--id="box-tabs-with-sub-tabs-secondary" tabs--IsSecondary="true" tabs--modifier="pf-m-scrollable"}}
   {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
-### Filled
+## Filled
+
+### Filled tabs example
 ```hbs
-{{#> tabs tabs--id="filled-example" tabs--modifier="pf-m-fill"}}
+{{#> tabs tabs--id="filled-tabs" tabs--modifier="pf-m-fill"}}
   {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
-### Filled with icons
+### Filled with icons example
 ```hbs
-{{#> tabs tabs--id="filled-with-icons-example" tabs--modifier="pf-m-fill"}}
+{{#> tabs tabs--id="filled-with-icons" tabs--modifier="pf-m-fill"}}
   {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
-### Filled box
+### Filled box example
 ```hbs
-{{#> tabs tabs--id="filled-box-example" tabs--modifier="pf-m-fill pf-m-box"}}
+{{#> tabs tabs--id="filled-box" tabs--modifier="pf-m-fill pf-m-box"}}
   {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
-### Filled box with icons
+### Filled box with icons example
 ```hbs
-{{#> tabs tabs--id="filled-box-with-icons-example" tabs--modifier="pf-m-fill pf-m-box"}}
+{{#> tabs tabs--id="filled-box-with-icons" tabs--modifier="pf-m-fill pf-m-box"}}
   {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
-## Usage
+### Filled usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-fill`  | `.pf-c-tabs` | Modifies the tabs to fill the available space. **Required** |
 
-### Using the nav element
+## Tabs as navigation
+
+### Using the nav element example
 ```hbs
-{{#> tabs tabs--id="default-scroll-nav-example" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Tabs nav"' tabs-link--isLink="true"}}
+{{#> tabs tabs--id="using-the-nav-element" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Tabs nav"' tabs-link--isLink="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Sub nav using the nav element
+### Sub tabs using the nav element example
 ```hbs
-{{#> tabs tabs--id="primary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true"}}
   {{> __tabs-list}}
 {{/tabs}}
 
-{{#> tabs tabs--id="secondary-nav-example" tabs--type="nav" tabs--attribute='aria-label="Tabs secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-secondary"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element-secondary" tabs--type="nav" tabs--attribute='aria-label="Tabs secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-secondary"}}
   {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
-### Vertical expandable
-```hbs
-{{#> tabs tabs--id="vertical-expandable-example" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
+## Tab item actions
+
+### Help button example
+```hbs isBeta
+{{> __tabs-all
+      __tabs-all--id="help-button"
+      __tabs-list--IsDisabled="true"
+      __tabs-list--IsAction="true"
+      __tabs-list--IsScrollable="true"
+      __tabs-list--DisabledFirstScrollButton="true"
+      __tabs-list--HasHelp="true" __tabs-list--IsHelpDisabled="true"}}
 ```
 
-### Vertical expanded
-```hbs
-{{#> tabs tabs--id="vertical-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
+### Close button example
+```hbs isBeta
+{{> __tabs-all
+      __tabs-all--id="close-button"
+      __tabs-list--IsDisabled="true"
+      __tabs-list--IsAction="true"
+      __tabs-list--HasClose="true"
+      __tabs-list--IsCloseDisabled="true"
+      __tabs-list--IsScrollable="true"
+      __tabs-list--DisabledFirstScrollButton="true"}}
 ```
 
-### Vertical expandable (responsive)
-```hbs
-{{#> tabs tabs--id="vertical-expandable-responsive-example" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
+### Help and close button example
+```hbs isBeta
+{{> __tabs-all
+      __tabs-all--id="help-close-button"
+      __tabs-list--IsDisabled="true"
+      __tabs-list--IsAction="true"
+      __tabs-list--IsScrollable="true"
+      __tabs-list--DisabledFirstScrollButton="true"
+      __tabs-list--HasHelp="true"
+      __tabs-list--HasClose="true"
+      __tabs-list--IsHelpDisabled="true"
+      __tabs-list--IsCloseDisabled="true"
+      __tabs-list--IsHelpCloseDisabled="true"}}
 ```
 
-### Vertical expandable (legacy)
+## Add tab button
+
+### Add tab button example
 ```hbs
-{{#> tabs tabs--id="vertical-expandable-legacy-example" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expanded (legacy)
-```hbs
-{{#> tabs tabs--id="vertical-expanded-legacy-example" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expandable (responsive, legacy)
-```hbs
-{{#> tabs tabs--id="vertical-expandable-responsive-legacy-example" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Close button
-```hbs
-{{#> tabs tabs--id="close-default-example" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="close-box-example" tabs--modifier="pf-m-box pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="close-box-light-300-example" tabs--modifier="pf-m-box pf-m-color-scheme--light-300 pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="close-icons-text-example" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="close-filled-example" tabs--modifier="pf-m-fill pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="close-secondary-primary-example" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-{{#> tabs tabs--id="close-secondary-secondary-example" tabs--modifier="pf-m-scrollable" tabs--IsSecondary="true"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsCloseDisabled="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true"}}
-{{/tabs}}
-```
-
-### Add tab button
-```hbs
-{{#> tabs tabs--id="add-default-example" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--id="default-tabs-add-tab-button" tabs--modifier="pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
-{{#> tabs tabs--id="add-secondary-example" tabs--modifier="pf-m-scrollable" tabs--IsSecondary="true"}}
+{{#> tabs tabs--id="default-tabs-add-tab-button-secondary" tabs--modifier="pf-m-scrollable" tabs--IsSecondary="true"}}
   {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 
 <br><br>
 
-{{#> tabs tabs--id="add-box-example" tabs--modifier="pf-m-box pf-m-scrollable"}}
+{{#> tabs tabs--id="box-tabs-add-tab-button" tabs--modifier="pf-m-box pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 
 <br><br>
 
-{{#> tabs tabs--id="add-box-light-300-example" tabs--modifier="pf-m-box pf-m-color-scheme--light-300 pf-m-scrollable"}}
+{{#> tabs tabs--id="box-tabs-add-tab-button-color-scheme-light-300 " tabs--modifier="pf-m-box pf-m-color-scheme--light-300 pf-m-scrollable"}}
   {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 ```
 
+## Documentation
+
+### Overview
 The tabs component should only be used to change content views within a page. The similar-looking but semantically different [horizontal nav component](/components/navigation/#horizontal) is available for general navigation use cases.
 
 Tabs should be used with the [tab content component](/components/tab-content).
@@ -318,7 +338,6 @@ Tabs should be used with the [tab content component](/components/tab-content).
 Whenever a list of tabs is unique on the current page, it can be used in a `<nav>` element. Cases where the same set of tabs are duplicated in multiple regions on a page (e.g. cards on a dashboard) are less likely to benefit from using the `<nav>` element.
 
 ### Usage
-
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-tabs` | `<nav>`, `<div>` | Initiates the tabs component. **Required** |

--- a/src/patternfly/components/Tabs/tabs-item-action-icon.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-action-icon.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-tabs__item-action-icon{{#if tabs-item-action-icon--modifier}} {{tabs-item-action-icon--modifier}}{{/if}}"
+  {{#if tabs-item-action-icon--attribute}}
+    {{{tabs-item-action-icon--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Tabs/tabs-item-action.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-action.hbs
@@ -1,0 +1,27 @@
+<span class="pf-c-tabs__item-action
+  {{#if tabs-item-action--IsHelp}} pf-m-help{{/if}}
+  {{#if tabs-item-action--modifier}} {{tabs-item-action--modifier}}{{/if}}"
+  {{#if tabs-item-action--attribute}}
+    {{{tabs-item-action--attribute}}}
+  {{/if}}>
+  {{#if tabs-item-action--IsHelp}}
+    {{#> tabs-item-action-button tabs-item-action-button--aria-label=(concat "More info for " __tabs-item--text " label") tabs-item-action-button--IsDisabled=tabs-item-action--IsHelpDisabled}}
+      <i class="pf-icon pf-icon-help" aria-hidden="true"></i>
+    {{/tabs-item-action-button}}
+  {{/if}}
+  {{#if tabs-item-action--IsClose}}
+    {{#> tabs-item-action-button tabs-item-action-button--aria-label=(concat "Close " __tabs-item--text) tabs-item-action-button--IsDisabled=tabs-item-action--IsCloseDisabled}}
+      <i class="fas fa-times" aria-hidden="true"></i>
+    {{/tabs-item-action-button}}
+  {{/if}}
+</span>
+
+{{#*inline "tabs-item-action-button"}}
+  {{#> button button--modifier="pf-m-plain"
+    button--aria-label=tabs-item-action-button--aria-label
+    button--IsDisabled=tabs-item-action-button--IsDisabled}}
+    {{#> tabs-item-action-icon}}
+      {{> @partial-block}}
+    {{/tabs-item-action-icon}}
+  {{/button}}
+{{/inline}}

--- a/src/patternfly/components/Tabs/tabs-item-close-icon.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-close-icon.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-tabs__item-close-icon{{#if tabs-item-close-icon--modifier}} {{tabs-item-close-icon--modifier}}{{/if}}"
-  {{#if tabs-item-close-icon--attribute}}
-    {{{tabs-item-close-icon--attribute}}}
-  {{/if}}>
-    <i class="fas fa-times" aria-hidden="true"></i>
-</span>

--- a/src/patternfly/components/Tabs/tabs-item-close.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-close.hbs
@@ -1,8 +1,0 @@
-<span class="pf-c-tabs__item-close{{#if tabs-item-close--modifier}} {{tabs-item-close--modifier}}{{/if}}"
-  {{#if tabs-item-close--attribute}}
-    {{{tabs-item-close--attribute}}}
-  {{/if}}>
-  {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-label="Close tab" ' tabs-item-close-button--attribute)}}
-    {{> tabs-item-close-icon}}
-  {{/button}}
-</span>

--- a/src/patternfly/components/Tabs/tabs-item.hbs
+++ b/src/patternfly/components/Tabs/tabs-item.hbs
@@ -15,7 +15,10 @@
     {{{tabs-item--attribute}}}
   {{/if}}>
   {{> @partial-block}}
+  {{#if tabs-item--HasHelp}}
+    {{> tabs-item-action tabs-item-action--IsHelp="true"}}
+  {{/if}}
   {{#if tabs-item--HasClose}}
-    {{> tabs-item-close}}
+    {{> tabs-item-action tabs-item-action--IsClose="true"}}
   {{/if}}
 </li>

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -41,7 +41,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Item
   --pf-c-tabs__item--m-action--before--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-tabs__item--m-action__link--PaddingRight: var(--pf-global--spacer--sm);
 
   // Tab link
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);
@@ -60,8 +59,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical__link--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-tabs--m-box__link--BackgroundColor: var(--pf-global--BackgroundColor--200);
   --pf-c-tabs--m-box__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
-  --pf-c-tabs--m-box__item-close--c-button--disabled--BackgroundColor: var(--pf-global--palette--black-400);
+  --pf-c-tabs--m-box__item-action--c-button--disabled--BackgroundColor: var(--pf-global--palette--black-400);
   --pf-c-tabs--m-secondary__link--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-tabs__item--m-action__link--PaddingRight: var(--pf-global--spacer--xs);
 
   // Link before
   --pf-c-tabs__link--before--border-color--base: var(--pf-global--BorderColor--100);
@@ -138,14 +138,19 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-expanded__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-tabs--m-expanded__toggle-icon--Rotate: 90deg;
 
-  // Close button
-  --pf-c-tabs__item-close--c-button--FontSize: var(--pf-global--FontSize--xs);
-  --pf-c-tabs--m-secondary__item-close--c-button--FontSize: var(--pf-global--icon--FontSize--sm);
-  --pf-c-tabs__item-close--c-button--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-tabs__item-close--c-button--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-tabs__item-close--c-button--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-tabs__item-close--c-button--OutlineOffset: #{pf-size-prem(-3px)};
-  --pf-c-tabs__item-close-icon--MarginTop: #{pf-size-prem(2px)};
+  // Item action
+  --pf-c-tabs__item-action--c-button--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-tabs--m-secondary__item-action--c-button--FontSize: var(--pf-global--icon--FontSize--sm);
+  --pf-c-tabs__item-action--c-button--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tabs__item-action--c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tabs__item-action--c-button--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-tabs__item-action--c-button--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-tabs__item-action--last-child--c-button--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-tabs__item-action--c-button--OutlineOffset: #{pf-size-prem(-3px)};
+  --pf-c-tabs__item-action-icon--MarginTop: #{pf-size-prem(2px)};
+
+  // Item help
+  --pf-c-tabs__item-action--m-help--c-button--PaddingLeft: var(--pf-global--spacer--xs);
 
   // Add button
   --pf-c-tabs__add--before--BorderColor: var(--pf-c-tabs__link--before--border-color--base);
@@ -309,8 +314,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__link--disabled--BackgroundColor);
     }
 
-    .pf-c-tabs__item-close .pf-c-button {
-      --pf-c-button--m-plain--disabled--Color: var(--pf-c-tabs--m-box__item-close--c-button--disabled--BackgroundColor);
+    .pf-c-tabs__item-action .pf-c-button {
+      --pf-c-button--m-plain--disabled--Color: var(--pf-c-tabs--m-box__item-action--c-button--disabled--BackgroundColor);
     }
   }
 
@@ -455,7 +460,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   &.pf-m-secondary {
     --pf-c-tabs__link--FontSize: var(--pf-c-tabs--m-secondary__link--FontSize);
-    --pf-c-tabs__item-close--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-close--c-button--FontSize);
+    --pf-c-tabs__item-action--c-button--FontSize: var(--pf-c-tabs--m-secondary__item-action--c-button--FontSize);
     --pf-c-tabs__add--c-button--FontSize: var(--pf-c-tabs--m-secondary__add--c-button--FontSize);
   }
 
@@ -704,22 +709,31 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   transform: rotate(var(--pf-c-tabs__link-toggle-icon--Rotate));
 }
 
-.pf-c-tabs__item-close {
+.pf-c-tabs__item-action {
   display: flex;
 
   .pf-c-button {
-    --pf-c-button--FontSize: var(--pf-c-tabs__item-close--c-button--FontSize);
-    --pf-c-button--PaddingTop: var(--pf-c-tabs__item-close--c-button--PaddingTop);
-    --pf-c-button--PaddingBottom: var(--pf-c-tabs__item-close--c-button--PaddingBottom);
-    --pf-c-button--PaddingLeft: var(--pf-c-tabs__item-close--c-button--PaddingLeft);
+    --pf-c-button--FontSize: var(--pf-c-tabs__item-action--c-button--FontSize);
+    --pf-c-button--PaddingTop: var(--pf-c-tabs__item-action--c-button--PaddingTop);
+    --pf-c-button--PaddingRight: var(--pf-c-tabs__item-action--c-button--PaddingRight);
+    --pf-c-button--PaddingBottom: var(--pf-c-tabs__item-action--c-button--PaddingBottom);
+    --pf-c-button--PaddingLeft: var(--pf-c-tabs__item-action--c-button--PaddingLeft);
 
-    outline-offset: var(--pf-c-tabs__item-close--c-button--OutlineOffset);
+    outline-offset: var(--pf-c-tabs__item-action--c-button--OutlineOffset);
+  }
+
+  &.pf-m-help {
+    --pf-c-tabs__item-action--c-button--PaddingLeft: var(--pf-c-tabs__item-action--m-help--c-button--PaddingLeft);
+  }
+
+  &:last-child {
+    --pf-c-tabs__item-action--c-button--PaddingRight: var(--pf-c-tabs__item-action--last-child--c-button--PaddingRight);
   }
 }
 
-.pf-c-tabs__item-close-icon {
+.pf-c-tabs__item-action-icon {
   display: inline-block;
-  margin-top: var(--pf-c-tabs__item-close-icon--MarginTop);
+  margin-top: var(--pf-c-tabs__item-action-icon--MarginTop);
 }
 
 // Scroll buttons


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5139

Convenience link - https://patternfly-pr-5213.surge.sh/components/tabs#tab-item-actions

* refactors the close and help buttons to be generic tab actions - so we can add more things like this, or open it up to users to add their own actions. Renames the close class and vars, but this is beta in both core and react so should be OK. I can rework that if needed and build help as its own class w/ vars.
* Decreases the spacing a bit after the tab text if it has an action. This lets me easier adjust the spacing between the help button and tab text to be less than the close button and help text. I can rework this if needed.
  * before
    ![www patternfly org_v4_](https://user-images.githubusercontent.com/35148959/199636181-6cac4839-2079-4f39-a805-31876cfd4e2a.png)
  * after
    ![localhost_8001_components_tabs](https://user-images.githubusercontent.com/35148959/199636172-6a85497d-9393-4bd1-ab9e-6cf63d5abc46.png)
* updates the examples page a bit to add titles for the sections and groups a bunch of common handlebars partial attrs to be defined on a single block level instead of per hbs partial call

Here are some outlines that show the actual spacing per clickable thing in the tab

* Help
  ![localhost_8001_components_tabs (1)](https://user-images.githubusercontent.com/35148959/199636884-b457e839-1037-48e2-92f9-ded48ad6560d.png)

* Close
  ![localhost_8001_components_tabs (2)](https://user-images.githubusercontent.com/35148959/199636891-35f512cf-1a76-480c-abaa-ca20327473a9.png)

* Help and close
  ![localhost_8001_components_tabs (3)](https://user-images.githubusercontent.com/35148959/199636896-98d0889a-d3e7-4370-bcef-bc3957973338.png)
