### PR TITLE
fix(tabs): added vertical responsive support

### DIFF
--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -121,6 +121,10 @@ $pf-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   }
 
   height: 100%;
+
+  .pf-c-tabs {
+    --pf-c-tabs--m-vertical--MaxWidth: auto;
+  }
 }
 
 .pf-c-sidebar__main {

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -78,7 +78,54 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Box
+### Vertical box tabs example
+```hbs
+{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable example
+```hbs
+{{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expanded example
+```hbs
+{{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical box expanded example
+```hbs
+{{#> tabs tabs--id="vertical-box-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable responsive example
+```hbs
+{{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expandable example (legacy)
+```hbs
+{{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical expanded example (legacy)
 ```hbs
 {{#> tabs tabs--id="box-example" tabs--modifier="pf-m-box"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -78,62 +78,7 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
-### Vertical box tabs example
-```hbs
-{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
-{{/tabs}}
-```
-
-### Vertical expandable example
-```hbs
-{{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expanded example
-```hbs
-{{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical box expanded example
-```hbs
-{{#> tabs tabs--id="vertical-box-expanded-example" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expandable responsive example
-```hbs
-{{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical box expandable responsive example
-```hbs
-{{#> tabs tabs--id="vertical-box-expandable-responsive" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expandable example (legacy)
-```hbs
-{{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical"}}
-  {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
-{{/tabs}}
-```
-
-### Vertical expanded example (legacy)
+### Box
 ```hbs
 {{#> tabs tabs--id="box-example" tabs--modifier="pf-m-box"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
@@ -306,6 +251,14 @@ import './Tabs.css'
 ### Vertical expandable (responsive, legacy)
 ```hbs
 {{#> tabs tabs--id="vertical-expandable-responsive-legacy-example" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
+### Vertical box expandable responsive example
+```hbs
+{{#> tabs tabs--id="vertical-box-expandable-responsive" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
   {{> tabs-toggle}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -117,6 +117,14 @@ import './Tabs.css'
 {{/tabs}}
 ```
 
+### Vertical box expandable responsive example
+```hbs
+{{#> tabs tabs--id="vertical-box-expandable-responsive" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+  {{> tabs-toggle}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+{{/tabs}}
+```
+
 ### Vertical expandable example (legacy)
 ```hbs
 {{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--modifier="pf-m-vertical"}}
@@ -136,13 +144,6 @@ import './Tabs.css'
 ```hbs
 {{#> tabs tabs--id="box-overflow-example" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
-{{/tabs}}
-```
-
-### Box vertical
-```hbs
-{{#> tabs tabs--id="box-vertical-example" tabs--modifier="pf-m-box pf-m-vertical"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -10,21 +10,28 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--before--BorderRightWidth: 0;
   --pf-c-tabs--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base);
   --pf-c-tabs--before--BorderLeftWidth: 0;
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg);
 
   // Page insets
   --pf-c-tabs--m-page-insets--inset: var(--pf-global--spacer--md); // make this the default inset at breaking change
   --pf-c-tabs--m-page-insets--xl--inset: var(--pf-global--spacer--lg); // make this the default inset at breaking change
 
   // Vertical
+  --pf-c-tabs--m-vertical--inset--base: var(--pf-global--spacer--lg);
+  --pf-c-tabs--m-vertical--inset: var(--pf-c-tabs--m-vertical--inset--base);
   --pf-c-tabs--m-vertical--Width: 100%;
   --pf-c-tabs--m-vertical--MaxWidth: #{pf-size-prem(250px)};
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
   --pf-c-tabs--m-vertical__list--before--BorderColor: var(--pf-c-tabs--before--BorderColor);
   --pf-c-tabs--m-vertical__list--before--BorderTopWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderBottomWidth: 0;
   --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base);
+
+  // Vertical box
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
+
+  // Vertical box
+  --pf-c-tabs--m-vertical--m-box__list--after--Left: 0;
+  --pf-c-tabs--m-vertical--m-box__link--PaddingLeft: 0;
 
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
@@ -44,6 +51,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__item--m-action__link--PaddingRight: var(--pf-global--spacer--sm);
 
   // Tab link
+  --pf-c-tabs__link--PaddingLeft--base: var(--pf-global--spacer--md);
   --pf-c-tabs__link--Color: var(--pf-global--Color--200);
   --pf-c-tabs__link--FontSize: var(--pf-global--FontSize--md);
   --pf-c-tabs__link--BackgroundColor: transparent;
@@ -51,7 +59,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__link--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-tabs__link--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-tabs__link--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-tabs__link--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
   --pf-c-tabs__link--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-global--palette--black-150);
   --pf-c-tabs__item--m-current__link--Color: var(--pf-global--Color--100);
@@ -62,6 +70,22 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-box__link--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
   --pf-c-tabs--m-box__item-close--c-button--disabled--BackgroundColor: var(--pf-global--palette--black-400);
   --pf-c-tabs--m-secondary__link--FontSize: var(--pf-global--FontSize--sm);
+
+  // Vertical, expandable
+  --pf-c-tabs--m-vertical--m-expandable__link--before--Left: calc(var(--pf-global--spacer--md) + var(--pf-global--spacer--xs));
+  --pf-c-tabs--m-vertical--m-expandable__list--before--Left: calc(var(--pf-global--spacer--md) + var(--pf-global--spacer--xs));
+  --pf-c-tabs--m-vertical--m-expandable--inset: var(--pf-global--spacer--md);
+  --pf-c-tabs--m-vertical--m-non-expandable--inset: var(--pf-c-tabs--m-vertical--inset--base);
+
+  // Vertical, expandable
+  --pf-c-tabs--m-vertical--m-expanded__list--before--Left: 0;
+  --pf-c-tabs--m-vertical--m-expandable__link--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
+  --pf-c-tabs--m-vertical--m-non-expandable__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
+  --pf-c-tabs--m-vertical--m-non-expandable--m-box__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
+
+  // Expandable box
+  --pf-c-tabs--m-vertical--m-expandable--m-box--inset: 0;
+  --pf-c-tabs--m-vertical--m-non-expandable--m-box--inset: var(--pf-global--spacer--xl);
 
   // Link before
   --pf-c-tabs__link--before--border-color--base: var(--pf-global--BorderColor--100);
@@ -125,16 +149,16 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs__toggle--Display: flex;
   --pf-c-tabs__toggle--Visibility: hidden;
   --pf-c-tabs__toggle--MarginBottom: 0;
-  --pf-c-tabs--m-expanded__toggle--MarginBottom: var(--pf-global--spacer--md);
+  --pf-c-tabs--m-expanded__toggle--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-tabs__toggle-icon--Color: currentcolor;
   --pf-c-tabs__toggle-icon--Transition: var(--pf-global--Transition);
   --pf-c-tabs__toggle-icon--Rotate: 0;
   --pf-c-tabs__toggle-text--MarginLeft: 0;
   --pf-c-tabs__toggle-button__toggle-text--MarginLeft: var(--pf-global--spacer--md);
   --pf-c-tabs__toggle-button__toggle-text--Color: var(--pf-global--Color--100);
-  --pf-c-tabs__toggle-button--MarginTop: calc(-1 * var(--pf-global--spacer--form-element));
-  --pf-c-tabs__toggle-button--MarginBottom: calc(-1 * var(--pf-global--spacer--form-element));
-  --pf-c-tabs__toggle-button--MarginLeft: calc(-1 * var(--pf-global--spacer--md));
+  --pf-c-tabs__toggle-button--MarginTop: 0; // update at breaking change
+  --pf-c-tabs__toggle-button--MarginBottom: 0; // update at breaking change
+  --pf-c-tabs__toggle-button--MarginLeft: 0; // update at breaking change
   --pf-c-tabs--m-expanded__toggle-icon--Color: var(--pf-global--Color--100);
   --pf-c-tabs--m-expanded__toggle-icon--Rotate: 90deg;
 
@@ -338,6 +362,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       &::before {
         position: absolute;
         right: auto;
+        left: var(--pf-c-tabs--m-vertical__list--before--Left);
         border: solid var(--pf-c-tabs--m-vertical__list--before--BorderColor);
         border-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth) var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth) var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth) var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth);
       }
@@ -345,11 +370,11 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
     // Because vertical variant has no scroll buttons, move inset to first/last __item to prevent default scrolling behavior
     .pf-c-tabs__item:first-child {
-      margin-top: var(--pf-c-tabs--inset);
+      margin-top: var(--pf-c-tabs--m-vertical--inset);
     }
 
     .pf-c-tabs__item:last-child {
-      margin-bottom: var(--pf-c-tabs--inset);
+      margin-bottom: var(--pf-c-tabs--m-vertical--inset);
     }
 
     // Set hover on left border
@@ -376,6 +401,21 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
           --pf-c-tabs__list--Visibility: hidden;
           --pf-c-tabs__toggle--Display: flex;
           --pf-c-tabs__toggle--Visibility: visible;
+
+          // Link
+          --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs--m-vertical--m-expandable__link--PaddingLeft);
+
+          // Move link and list borders
+          --pf-c-tabs__link--before--Left: var(--pf-c-tabs--m-vertical--m-expandable__link--before--Left);
+          --pf-c-tabs--m-vertical__list--before--Left: var(--pf-c-tabs--m-vertical--m-expandable__list--before--Left);
+
+          // Vertical inset updates
+          --pf-c-tabs--m-vertical--inset: var(--pf-c-tabs--m-vertical--m-expandable--inset);
+          --pf-c-tabs--m-vertical--m-box--inset: var(--pf-c-tabs--m-vertical--m-expandable--m-box--inset);
+
+          &.pf-m-box {
+            --pf-c-tabs__link--before--BorderRightWidth: 0;
+          }
         }
 
         &.pf-m-non-expandable#{$breakpoint-name} {
@@ -383,6 +423,21 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
           --pf-c-tabs__list--Visibility: visible;
           --pf-c-tabs__toggle--Display: none;
           --pf-c-tabs__toggle--Visibility: hidden;
+
+          // Link
+          --pf-c-tabs__link--PaddingLeft: var(--pf-c-tabs--m-vertical--m-non-expandable__link--PaddingLeft);
+
+          // Move link and list borders
+          --pf-c-tabs__link--before--Left: 0;
+          --pf-c-tabs--m-vertical__list--before--Left: 0;
+
+          // Vertical inset updates
+          --pf-c-tabs--m-vertical--inset: var(--pf-c-tabs--m-vertical--m-non-expandable--inset);
+          --pf-c-tabs--m-vertical--m-box--inset: var(--pf-c-tabs--m-vertical--m-non-expandable--m-box--inset);
+
+          &.pf-m-box {
+            --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+          }
         }
         // stylelint-enable
       }
@@ -411,11 +466,17 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
       left: auto;
     }
 
+    .pf-c-tabs__item:first-child {
+      margin-top: var(--pf-c-tabs--m-vertical--m-box--inset);
+    }
+
     // stylelint-disable selector-max-class
     // Remove border from last-child
     .pf-c-tabs__item:last-child {
       --pf-c-tabs__link--before--BorderBottomWidth: 0;
       --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+
+      margin-bottom: var(--pf-c-tabs--m-vertical--m-box--inset);
     }
 
     // Add border right color and weight
@@ -437,6 +498,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // Offset vertical border to overlap horizontal border
     .pf-c-tabs__link::after {
       top: calc(var(--pf-c-tabs__link--before--border-width--base) * -1);
+      left: var(--pf-c-tabs--m-vertical--m-box__list--after--Left);
     }
 
     // Undo offset to .pf-m-current adjacent item
@@ -499,7 +561,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   margin-left: var(--pf-c-tabs__toggle-text--MarginLeft);
   color: var(--pf-c-tabs__toggle-text--Color, inherit);
 }
-
 
 // Tab list
 .pf-c-tabs__list {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -31,7 +31,6 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
   // Vertical box
   --pf-c-tabs--m-vertical--m-box__list--after--Left: 0;
-  --pf-c-tabs--m-vertical--m-box__link--PaddingLeft: 0;
 
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -30,7 +30,9 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
   --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl);
 
   // Vertical box
+  --pf-c-tabs--m-vertical--m-box__link--PaddingLeft: var(--pf-c-tabs__link--PaddingLeft--base);
   --pf-c-tabs--m-vertical--m-box__list--after--Left: 0;
+  --pf-c-tabs--m-vertical--m-box__item--last-child__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
 
   // Box
   --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--pf-c-tabs__link--before--border-width--base);
@@ -284,6 +286,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // Remove border from last-child
     .pf-c-tabs__item:last-child {
       --pf-c-tabs__link--before--BorderRightWidth: 0;
+      --pf-c-tabs__link--before--BorderBottomWidth: 0;
     }
 
     .pf-c-tabs__item.pf-m-current {
@@ -413,6 +416,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
           --pf-c-tabs--m-vertical--m-box--inset: var(--pf-c-tabs--m-vertical--m-expandable--m-box--inset);
 
           &.pf-m-box {
+            --pf-c-tabs--m-vertical__list--before--BorderRightWidth: 0;
+            --pf-c-tabs--m-vertical--m-box__item--last-child__link--before--BorderRightWidth: 0;
             --pf-c-tabs__link--before--BorderRightWidth: 0;
           }
         }
@@ -435,6 +440,8 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
           --pf-c-tabs--m-vertical--m-box--inset: var(--pf-c-tabs--m-vertical--m-non-expandable--m-box--inset);
 
           &.pf-m-box {
+            --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+            --pf-c-tabs--m-vertical--m-box__item--last-child__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
             --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
           }
         }
@@ -472,8 +479,7 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // stylelint-disable selector-max-class
     // Remove border from last-child
     .pf-c-tabs__item:last-child {
-      --pf-c-tabs__link--before--BorderBottomWidth: 0;
-      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base);
+      --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs--m-vertical--m-box__item--last-child__link--before--BorderRightWidth);
 
       margin-bottom: var(--pf-c-tabs--m-vertical--m-box--inset);
     }
@@ -492,6 +498,10 @@ $pf-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
     // Add border right color and weight
     .pf-c-tabs__item:first-child.pf-m-current {
       --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base);
+    }
+
+    .pf-c-tabs__link {
+      padding-left: var(--pf-c-tabs--m-vertical--m-box__link--PaddingLeft);
     }
 
     // Offset vertical border to overlap horizontal border

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -281,6 +281,90 @@ section: components
 {{/inline}}
 ```
 
+### Vertical tabs
+
+```hbs isFullscreen
+{{> page-template page-template--id="vertical-tabs-example"}}
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> card}}
+      {{#> sidebar sidebar--id="vertical-tabs-example"}}
+        {{#> sidebar-panel}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-non-expandable-on-md pf-m-expanded"}}
+            {{> tabs-toggle}}
+            {{#> tabs-list}}
+              {{> __tabs-item
+                __tabs-item--current="true"
+                __tabs-item--id="pod-info"
+                __tabs-item--aria-label="Pod information"
+                __tabs-item--text="Pod information"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-pod-info-panel"')}}
+              {{> __tabs-item
+                __tabs-item--id="editable-aspects"
+                __tabs-item--aria-label="editable aspects"
+                __tabs-item--text="Editable Aspects"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-editable-aspects-panel"')}}
+            {{/tabs-list}}
+          {{/tabs}}
+        {{/sidebar-panel}}
+        {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+          {{/tab-content}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}
+            <p>Editable aspects content</p>
+          {{/tab-content}}
+        {{/sidebar-content}}
+      {{/sidebar}}
+    {{/card}}
+  {{/page-main-section}}
+{{/inline}}
+```
+
+### Vertical, box tabs
+
+```hbs isFullscreen
+{{> page-template page-template--id="vertical-box-tabs-example"}}
+{{#* inline "page-template-main-content"}}
+  {{> page-template-breadcrumb}}
+  {{> page-template-title}}
+  {{#> page-main-section}}
+    {{#> card}}
+      {{#> sidebar sidebar--id="vertical-tabs-example"}}
+        {{#> sidebar-panel}}
+          {{#> tabs tabs--id=(concat sidebar--id '-tabs') tabs--IsExpandable="true" tabs--modifier="pf-m-vertical pf-m-box pf-m-non-expandable-on-md pf-m-expanded"}}
+            {{> tabs-toggle}}
+            {{#> tabs-list}}
+              {{> __tabs-item
+                __tabs-item--current="true"
+                __tabs-item--id="pod-info"
+                __tabs-item--aria-label="Pod information"
+                __tabs-item--text="Pod information"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-pod-info-panel"')}}
+              {{> __tabs-item
+                __tabs-item--id="editable-aspects"
+                __tabs-item--aria-label="editable aspects"
+                __tabs-item--text="Editable Aspects"
+                __tabs-link--attribute=(concat 'aria-controls="' tabs--id '-editable-aspects-panel"')}}
+            {{/tabs-list}}
+          {{/tabs}}
+        {{/sidebar-panel}}
+        {{#> sidebar-content tab-content--id=(concat sidebar--id "-tabs")}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--IsActive="true" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-pod-info-link" id="' tab-content--id '-pod-info-panel"')}}
+            <p>Pod information content</p>
+          {{/tab-content}}
+          {{#> tab-content tab-content-body--modifier="pf-m-padding" tab-content--attribute=(concat 'aria-labelledby="' tab-content--id '-editable-aspects-link" id="' tab-content--id '-editable-aspects-panel"')}}
+            <p>Editable aspects content</p>
+          {{/tab-content}}
+        {{/sidebar-content}}
+      {{/sidebar}}
+    {{/card}}
+  {{/page-main-section}}
+{{/inline}}
+```
+
 ### Nested tabs
 ```hbs isFullscreen
 {{> page-template page-template--id="nested-tabs-example"}}


### PR DESCRIPTION
Closes #3915 

Closing [4850](https://github.com/patternfly/patternfly/pull/4850) in favor of this PR.

This PR limits the scope to a small `.pf-c-sidebar` update and styling updates to vertical/vertical box tabs only. We'll need to create followup issues for `.pf-c-sidebar` borders and conditional formatting. 

This PR is consistent with https://marvelapp.com/prototype/5fba0cj/screen/73740954. 
- Updates styling of expandable tabs button
- Updates button padding for vertical, expandable `<li>`s
- Removes borders for expandable, vertical, box tabs
- Adds demos for vertical tabs in sidebar component

Design files:
- https://marvelapp.com/prototype/dj6cag1/screen/87992106
- https://marvelapp.com/prototype/5fba0cj/screen/73740954

Previews:
- https://patternfly-pr-5224.surge.sh/components/tabs#vertical-box-tabs-example
- https://patternfly-pr-5224.surge.sh/components/tabs/html-demos#vertical-tabs
- https://patternfly-pr-5224.surge.sh/components/tabs/html-demos#vertical-box-tabs