### PR TITLE
fix(formcontrol): fixed form control select dark theme icon

### DIFF
--- a/src/patternfly/components/FormControl/themes/dark/form-control.scss
+++ b/src/patternfly/components/FormControl/themes/dark/form-control.scss
@@ -2,7 +2,7 @@
 
 @mixin pf-theme-dark-form-control() {
   .pf-c-form-control {
-    --pf-c-form-control__select--BackgroundUrl: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%235ba352' d='M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z'/%3E%3C/svg%3E");
+    --pf-c-form-control__select--BackgroundUrl: #{pf-bg-svg($pf-c-form-control__select--Coordinates, $pf-c-form-control__select--ViewBox, $pf-global--Color--100)};
     --pf-c-form-control--BorderTopColor: transparent;
     --pf-c-form-control--BorderRightColor: transparent;
     --pf-c-form-control--BorderBottomColor: var(--pf-global--BorderColor--400);


### PR DESCRIPTION
Closes #5215 

Previously we were hard coding the incorrect icon in for `--pf-c-form-control__select--BackgroundUrl` in dark theme, but the icon does not change - only the color needs to change.  This PR uses the same `pf-bg-svg` SASS function in dark theme but passes in the third argument (`$svg-color`) to override the color.

Note: The color looks correct now, but I'm unclear of if there's a better variable to use (or new one to create) for this usage.