### PR TITLE
chore(flex,toolbar): use gap for space-items

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -16,6 +16,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   // Group
   --pf-c-toolbar__group--Display: flex;
+  --pf-c-toolbar__group--RowGap: 0;
+  --pf-c-toolbar__group--ColumnGap: 0;
 
   // Sticky
   --pf-c-toolbar--m-sticky--ZIndex: var(--pf-global--ZIndex--xs);
@@ -210,6 +212,8 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   align-items: center;
   margin-right: var(--pf-c-toolbar--spacer);
+  row-gap: var(--pf-c-toolbar__group--RowGap);
+  column-gap: var(--pf-c-toolbar__group--ColumnGap);
 
   // Button group
   &.pf-m-button-group {
@@ -508,11 +512,10 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
     @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-c-toolbar--spacer-map {
         .pf-m-space-items-#{$spacer}#{$breakpoint-name} {
-          > * {
-            --pf-c-toolbar--spacer: #{$spacer-value};
-          }
+          --pf-c-toolbar__group--RowGap: #{$spacer-value};
+          --pf-c-toolbar__group--ColumnGap: #{$spacer-value};
 
-          > :last-child {
+          > * {
             --pf-c-toolbar--spacer: 0;
           }
         }

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -212,8 +212,7 @@ $pf-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl"
 
   align-items: center;
   margin-right: var(--pf-c-toolbar--spacer);
-  row-gap: var(--pf-c-toolbar__group--RowGap);
-  column-gap: var(--pf-c-toolbar__group--ColumnGap);
+  gap: var(--pf-c-toolbar__group--RowGap) var(--pf-c-toolbar__group--ColumnGap);
 
   // Button group
   &.pf-m-button-group {

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -23,7 +23,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
-  gap: var(--pf-l-flex--RowGap, --pf-l-flex--ColumnGap);
+  gap: var(--pf-l-flex--RowGap) var(--pf-l-flex--ColumnGap);
 
   &:last-child {
     --pf-l-flex--spacer: 0;

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -7,6 +7,8 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   --pf-l-flex--Display: flex;
   --pf-l-flex--FlexWrap: wrap;
   --pf-l-flex--AlignItems: baseline;
+  --pf-l-flex--RowGap: 0;
+  --pf-l-flex--ColumnGap: 0;
   --pf-l-flex--m-row--AlignItems: baseline;
   --pf-l-flex--m-row-reverse--AlignItems: baseline;
   --pf-l-flex--item--Order: 0;
@@ -21,6 +23,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
+  gap: var(--pf-l-flex--RowGap, --pf-l-flex--ColumnGap);
 
   &:last-child {
     --pf-l-flex--spacer: 0;
@@ -283,11 +286,10 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
     @include pf-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
         &.pf-m-space-items-#{$spacer}#{$breakpoint-name} {
-          > * {
-            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
-          }
+          --pf-l-flex--RowGap: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+          --pf-l-flex--ColumnGap: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
 
-          > :last-child {
+          > * {
             --pf-l-flex--spacer: 0;
           }
         }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3348

This changes pf-m-space-items to use gap instead of margins. Individual spacing is still done with margins. The two are not compatible, so I'll need to update the docs as well if this is what we want to do.