### PR TITLE
feat(Backdrop): adjusted color of spinner component

### DIFF
--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -10,6 +10,10 @@
   width: 100%;
   height: 100%;
   background-color: var(--pf-c-backdrop--BackgroundColor);
+
+  .pf-c-spinner {
+    --pf-c-spinner--Color: var(--pf-global--primary-color--light-100);
+  }
 }
 
 .pf-c-backdrop__open {

--- a/src/patternfly/components/Backdrop/examples/Backdrop.md
+++ b/src/patternfly/components/Backdrop/examples/Backdrop.md
@@ -6,8 +6,19 @@ cssPrefix: pf-c-backdrop
 
 ## Examples
 ### Basic
+
 ```hbs isFullscreen
 {{#> backdrop}}
+{{/backdrop}}
+```
+
+### With spinner
+
+```hbs isFullscreen
+{{#> backdrop}}
+  {{#> bullseye}}
+    {{#> spinner spinner--IsSvg="true"}}Loading...{{/spinner}}
+  {{/bullseye}}
 {{/backdrop}}
 ```
 


### PR DESCRIPTION
Closes #5174 

Included a full screen example to show the update + to match React, but can delete it if it's not necessary. The spinner does slightly change color when toggling the dark theme on and off as well.