### PR TITLE
feat(dropdown): adds loading state for split button checkbox

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown-toggle-check.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-toggle-check.hbs
@@ -1,10 +1,12 @@
-<label class="pf-c-dropdown__toggle-check{{#if dropdown-toggle-check--modifier}} {{dropdown-toggle-check--modifier}}{{/if}}"
+<label class="pf-c-dropdown__toggle-check
+  {{~#if dropdown-toggle-check--IsInProgress}} pf-m-in-progress{{/if}}
+  {{~#if dropdown-toggle-check--modifier}} {{dropdown-toggle-check--modifier}}{{/if}}"
   for="{{dropdown--id}}-toggle-check"
   {{#if dropdown-toggle-check--attribute}}
     {{{dropdown-toggle-check--attribute}}}
   {{/if}}>
   <input type="checkbox" id="{{dropdown--id}}-toggle-check"
-    {{#if dropdown-toggle--IsDisabled}}
+    {{#if (concat dropdown-toggle--IsDisabled dropdown-toggle-check--IsInProgress)}}
       disabled
     {{/if}}
     {{#if dropdown-toggle-check--aria-label}}
@@ -18,6 +20,9 @@
     {{#if dropdown-toggle--split-button--text}}
       aria-labelledby="{{dropdown--id}}-toggle-check {{dropdown--id}}-toggle-check-text"
     {{/if}}>
+  {{#if dropdown-toggle-check--IsProgress}}
+    {{> dropdown-toggle-progress}}
+  {{/if}}
   {{#if dropdown-toggle--split-button--text}}
     {{#> dropdown-toggle-text dropdown-toggle-text--attribute=(concat 'aria-hidden="true" id="' dropdown--id '-toggle-check-text"')}}
       {{{dropdown-toggle--split-button--text}}}

--- a/src/patternfly/components/Dropdown/dropdown-toggle-progress.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-toggle-progress.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-dropdown__toggle-progress{{#if dropdown-toggle-progress--modifier}} {{dropdown-toggle-progress--modifier}}{{/if}}"
+  {{#if dropdown-toggle-progress--attribute}}
+    {{{dropdown-toggle-progress--attribute}}}
+  {{/if}}>
+  {{> spinner spinner--IsSvg="true"}}
+</span>

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -62,6 +62,10 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
   // toggle button
   --pf-c-dropdown__toggle-button--Color: var(--pf-global--Color--100);
 
+  // toggle progress
+  --pf-c-dropdown__toggle-progress--Visibility: hidden;
+  --pf-c-dropdown__toggle-progress--c-spinner--diameter: .8em; // one off sizing to roughly match the checkbox size
+
   // split buttons
   --pf-c-dropdown__toggle--m-split-button--child--PaddingTop: var(--pf-global--spacer--form-element);
   --pf-c-dropdown__toggle--m-split-button--child--PaddingRight: var(--pf-global--spacer--xs);
@@ -341,9 +345,15 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
       align-items: center;
       cursor: pointer;
 
+      &.pf-m-in-progress {
+        --pf-c-dropdown__toggle--m-split-button__toggle-check__input--Visibility: hidden;
+        --pf-c-dropdown__toggle-progress--Visibility: visible;
+      }
+
       > input,
       .pf-c-check {
         cursor: pointer;
+        visibility: var(--pf-c-dropdown__toggle--m-split-button__toggle-check__input--Visibility, unset);
         transform: translateY(var(--pf-c-dropdown__toggle--m-split-button__toggle-check__input--TranslateY));
       }
     }
@@ -621,6 +631,16 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 
   &:last-child {
     --pf-c-dropdown__toggle-image--MarginRight: 0;
+  }
+}
+
+// Loading spinner
+.pf-c-dropdown__toggle-progress {
+  position: absolute;
+  visibility: var(--pf-c-dropdown__toggle-progress--Visibility);
+
+  .pf-c-spinner {
+    --pf-c-spinner--diameter: var(--pf-c-dropdown__toggle-progress--c-spinner--diameter);
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -64,7 +64,7 @@ $pf-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "
 
   // toggle progress
   --pf-c-dropdown__toggle-progress--Visibility: hidden;
-  --pf-c-dropdown__toggle-progress--c-spinner--diameter: .8em; // one off sizing to roughly match the checkbox size
+  --pf-c-dropdown__toggle-progress--c-spinner--diameter: var(--pf-global--FontSize--sm); // should match the checkbox input size
 
   // split buttons
   --pf-c-dropdown__toggle--m-split-button--child--PaddingTop: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -86,6 +86,15 @@ import './Dropdown.css'
 {{> dropdown dropdown--id="dropdown-split-button-text" dropdown--template--SplitButton="true" dropdown-toggle-check--CheckboxIsChecked="true" dropdown-menu--IsBulkSelect="true" dropdown-toggle--split-button--text="10 selected"}}
 ```
 
+### Split button (progress checkbox)
+```hbs isBeta
+{{> dropdown dropdown--id="dropdown-split-button-progress" dropdown--template--SplitButton="true"dropdown-toggle--HasCheckBox="true" dropdown-toggle-check--IsProgress="true"}}
+{{> dropdown dropdown--id="dropdown-split-button-in-progress" dropdown--template--SplitButton="true"dropdown-toggle--HasCheckBox="true" dropdown-toggle-check--IsProgress="true" dropdown-toggle-check--IsInProgress="true"}}
+{{> dropdown dropdown--id="dropdown-split-button-progress-text" dropdown--template--SplitButton="true" dropdown-toggle-check--CheckboxIsChecked="true" dropdown-menu--IsBulkSelect="true" dropdown-toggle--split-button--text="10 selected" dropdown-toggle-check--IsProgress="true"}}
+{{> dropdown dropdown--id="dropdown-split-button-in-progress-text" dropdown--template--SplitButton="true" dropdown-toggle-check--CheckboxIsChecked="true" dropdown-menu--IsBulkSelect="true" dropdown-toggle--split-button--text="10 selected" dropdown-toggle-check--IsProgress="true" dropdown-toggle-check--IsInProgress="true"}}
+
+```
+
 ### Split button (action)
 ```hbs
 {{> dropdown dropdown--template--SplitButton="true" dropdown--id="dropdown-split-button-action" dropdown--IsActionButton="true" dropdown-toggle--HasActionButton="true"}}
@@ -193,6 +202,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__toggle-text` | `<span>` | Defines the dropdown toggle text. **Required when text is present, adds truncation**. |
 | `.pf-c-dropdown__toggle-check` | `<label>` | Defines a checkbox in the toggle area of a split button dropdown. |
 | `.pf-c-dropdown__toggle-button` | `<button>` | Defines the toggle button for a split button dropdown. |
+| `.pf-c-dropdown__toggle-progress` | `<span>` | Defines the progress element to indicate a dropdown action is in progress. |
 | `.pf-c-dropdown__menu` | `<ul>`, `<div>` | Defines the parent wrapper of the menu items. |
 | `.pf-c-dropdown__menu-item` | `<a>` | Defines a menu item that navigates to another page. |
 | `.pf-c-dropdown__menu-item-icon` | `<span>` | Defines the wrapper for the menu item icon. |
@@ -220,3 +230,4 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-m-icon` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding an icon. |
 | `.pf-m-active` | `.pf-c-dropdown__toggle` | Modifies the dropdown menu toggle for the active state. |
 | `.pf-m-description` | `.pf-c-dropdown__menu-item` | Modifies an item to support adding a description. |
+| `.pf-m-in-progress` | `.pf-c-dropdown__toggle-check` | Modifies a toggle check element to indicate the check action is in progress. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/4926

disables the checkbox while in progress to keep the check/label from accepting events while the spinner is shown.