### PR TITLE
fix(Menu): prevented hidden drilldown items from being focusable

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -317,10 +317,15 @@
   // stylelint-disable selector-max-class
   &.pf-m-drilled-in > .pf-c-menu__content > .pf-c-menu__list {
     overflow: visible;
+    visibility: hidden;
 
     > .pf-c-divider,
     > .pf-c-menu__list-item:not(.pf-m-current-path) {
       display: none; // hide all siblings of current path to maintain proper menu height
+    }
+
+    > .pf-c-menu__list-item.pf-m-current-path {
+      visibility: hidden;
     }
   }
   // stylelint-enable


### PR DESCRIPTION
Closes #5241

cc @kmcfaul

I had tracked down what selectors would need to be set to `visibility: hidden` without causing anything else to become visually hidden/cause other bugs. Both Jessie and Nicole were able to confirm that this works with their VoiceOver; I was running into a bug where when drilling out of a menu, the visual VO focus indicator was on the correct menu item, but it would jump to the TS code toggle when trying to navigate to the next item. JAWS and NVDA did not have this issue, though.

@mcoker, in trying to look at other drilldown implementations, I came across [Foundations drilldown menu](https://get.foundation/sites/docs/drilldown-menu.html). The markup looks pretty similar to what we have, though one difference I wanted to mention was their use of an `is-active` class when a menu item that contains a menu is drilled into. Wondering if something like that might help reduce some of the specificity we're using for some of the drilldown CSS.