### PR TITLE
feat(card): improve card header

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -106,7 +106,6 @@
   // Toggle right
   --pf-c-card__header--m-toggle-right--toggle--MarginRight: calc(var(--pf-global--spacer--form-element) * -1);
   --pf-c-card__header--m-toggle-right--toggle--MarginLeft: var(--pf-global--spacer--xs);
-  --pf-c-card__header--m-toggle-right--actions--MarginRight: 0;
 
   // Card input
   --pf-c-card__input--focus--BorderWidth: var(--pf-global--BorderWidth--md);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -329,7 +329,7 @@
   align-self: flex-start;
   order: 1;
   padding-left: var(--pf-c-card__actions--PaddingLeft);
-  margin: var(--pf-c-card__actions--MarginTop) auto var(--pf-c-card__actions--MarginBottom) auto;
+  margin: var(--pf-c-card__actions--MarginTop) 0 var(--pf-c-card__actions--MarginBottom) auto;
 
   > * + * {
     margin-left: var(--pf-c-card__actions--child--MarginLeft);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -14,6 +14,9 @@
   --pf-c-card__footer--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-card__actions--child--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-card__actions--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
+  --pf-c-card__actions--MarginRight: var(--pf-global--spacer--xs);
+  --pf-c-card__actions--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
 
   // Expandable
   --pf-c-card__header-toggle--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
@@ -296,17 +299,17 @@
     --pf-c-card__header-toggle--MarginLeft: var(--pf-c-card__header--m-toggle-right--toggle--MarginLeft);
 
     .pf-c-card__actions {
-      --pf-c-card__header-toggle--MarginRight: var(--pf-c-card__header--m-toggle-right--actions--MarginRight);
+      --pf-c-card__actions--MarginRight: var(--pf-c-card__header--m-toggle-right--actions--MarginRight);
     }
 
     .pf-c-card__header-toggle {
       order: 2;
     }
-
-    .pf-c-card__title {
-      flex: 1;
-    }
   }
+}
+
+.pf-c-card__header-main {
+  flex: 1;
 }
 
 .pf-c-card__header-toggle {
@@ -331,7 +334,7 @@
   align-self: flex-start;
   order: 1;
   padding-left: var(--pf-c-card__actions--PaddingLeft);
-  margin: var(--pf-c-card__header-toggle--MarginTop) var(--pf-c-card__header-toggle--MarginRight) var(--pf-c-card__header-toggle--MarginBottom) auto;
+  margin: var(--pf-c-card__actions--MarginTop) var(--pf-c-card__actions--MarginRight) var(--pf-c-card__actions--MarginBottom) auto;
 
   > * + * {
     margin-left: var(--pf-c-card__actions--child--MarginLeft);
@@ -344,8 +347,8 @@
   }
 
   &.pf-m-no-offset {
-    --pf-c-card__header-toggle--MarginTop: 0;
-    --pf-c-card__header-toggle--MarginBottom: 0;
+    --pf-c-card__actions--MarginTop: 0;
+    --pf-c-card__actions--MarginBottom: 0;
   }
 }
 

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -15,7 +15,6 @@
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-card__actions--child--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-card__actions--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
-  --pf-c-card__actions--MarginRight: var(--pf-global--spacer--xs);
   --pf-c-card__actions--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
 
   // Expandable
@@ -298,10 +297,6 @@
     --pf-c-card__header-toggle--MarginRight: var(--pf-c-card__header--m-toggle-right--toggle--MarginRight);
     --pf-c-card__header-toggle--MarginLeft: var(--pf-c-card__header--m-toggle-right--toggle--MarginLeft);
 
-    .pf-c-card__actions {
-      --pf-c-card__actions--MarginRight: var(--pf-c-card__header--m-toggle-right--actions--MarginRight);
-    }
-
     .pf-c-card__header-toggle {
       order: 2;
     }
@@ -334,7 +329,7 @@
   align-self: flex-start;
   order: 1;
   padding-left: var(--pf-c-card__actions--PaddingLeft);
-  margin: var(--pf-c-card__actions--MarginTop) var(--pf-c-card__actions--MarginRight) var(--pf-c-card__actions--MarginBottom) auto;
+  margin: var(--pf-c-card__actions--MarginTop) auto var(--pf-c-card__actions--MarginBottom) auto;
 
   > * + * {
     margin-left: var(--pf-c-card__actions--child--MarginLeft);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -13,7 +13,7 @@
   --pf-c-card__body--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__footer--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-card__actions--child--MarginLeft: var(--pf-global--spacer--sm);
+  --pf-c-card__actions--Gap: var(--pf-global--spacer--sm);
   --pf-c-card__actions--MarginTop: calc(var(--pf-global--spacer--form-element) * -1);
   --pf-c-card__actions--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
 
@@ -329,10 +329,7 @@
   order: 1;
   padding-left: var(--pf-c-card__actions--PaddingLeft);
   margin: var(--pf-c-card__actions--MarginTop) 0 var(--pf-c-card__actions--MarginBottom) auto;
-
-  > * + * {
-    margin-left: var(--pf-c-card__actions--child--MarginLeft);
-  }
+  gap: var(--pf-c-card__actions--Gap);
 
   + .pf-c-card__title,
   + .pf-c-card__body,

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -54,9 +54,11 @@ import './Card.css'
       {{> card--dropdown}}
       {{> card--check}}
     {{/card-actions}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-check-label"')}}
-      This is a really really really really really really really really really really long title
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-check-label"')}}
+        This is a really really really really really really really really really really long title
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     Body
@@ -89,7 +91,9 @@ import './Card.css'
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> button button--modifier="pf-m-primary"}}Action{{/button}}
     {{/card-actions}}
-    {{#> title title--modifier="pf-m-2xl" title--attribute=(concat 'id="' card--id '-check-label"')}}This is a card title{{/title}}
+    {{#> card-header-main}}
+      {{#> title title--modifier="pf-m-2xl" title--attribute=(concat 'id="' card--id '-check-label"')}}This is a card title{{/title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     Body
@@ -400,9 +404,11 @@ import './Card.css'
       {{> card--dropdown}}
       {{> card--check}}
     {{/card-actions}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      Title
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Title
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
 {{/card}}
 ```
@@ -412,7 +418,9 @@ import './Card.css'
 {{#> card card--id="card-expandable-image-example"}}
   {{#> card-header}}
     {{> card-header-toggle}}
-    <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo" width="27px">
+    {{#> card-header-main}}
+      <img src="/assets/images/pf-logo-small.svg" alt="PatternFly logo" width="27px">
+    {{/card-header-main}}
     {{#> card-actions}}
       {{> card--dropdown}}
       {{> card--check}}
@@ -430,9 +438,11 @@ import './Card.css'
       {{> card--dropdown}}
       {{> card--check}}
     {{/card-actions}}
+    {{#> card-header-main}}
     {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
       Title
     {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-expandable-content}}
     {{#> card-body}}
@@ -453,9 +463,11 @@ import './Card.css'
       {{> card--dropdown}}
       {{> card--check}}
     {{/card-actions}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      Title
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Title
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     Body
@@ -474,9 +486,11 @@ import './Card.css'
       {{> card--dropdown}}
       {{> card--check}}
     {{/card-actions}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      Title
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Title
+      {{/card-title}}
+    {{/card-header-main}}
     {{> card-header-toggle}}
   {{/card-header}}
 {{/card}}
@@ -518,7 +532,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__header-toggle` | `<div>` | Creates the expandable card toggle. |
 | `.pf-c-card__header-toggle-icon` | `<span>` | Creates the expandable card toggle icon. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card header. |
-| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card header when using an image, logo, or text. |
+| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card header when using an image, logo, or text. **Required if `.pf-c-card__header` has content outside a card header toggle or card header actions** |
 | `.pf-c-card__expandable-content` | `<div>` | Creates the expandable card's expandable content. |
 | `.pf-c-card__sr-input` | `<input>` | Creates an input which, when focused, makes a following `.pf-c-card` appear focused. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -439,9 +439,9 @@ import './Card.css'
       {{> card--check}}
     {{/card-actions}}
     {{#> card-header-main}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      Title
-    {{/card-title}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Title
+      {{/card-title}}
     {{/card-header-main}}
   {{/card-header}}
   {{#> card-expandable-content}}
@@ -532,7 +532,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__header-toggle` | `<div>` | Creates the expandable card toggle. |
 | `.pf-c-card__header-toggle-icon` | `<span>` | Creates the expandable card toggle icon. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card header. |
-| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card header when using an image, logo, or text. **Required if `.pf-c-card__header` has content outside a card header toggle or card header actions** |
+| `.pf-c-card__header-main` | `<div>` | Creates a wrapper element to be used in the card header when using an image, logo, or text. **Required if `.pf-c-card__header` has content outside of a card header toggle or card header actions** |
 | `.pf-c-card__expandable-content` | `<div>` | Creates the expandable card's expandable content. |
 | `.pf-c-card__sr-input` | `<input>` | Creates an input which, when focused, makes a following `.pf-c-card` appear focused. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -16,7 +16,7 @@ import './Card.css'
       {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab-right-aligned") dropdown-toggle--IsPlain="true"}}
     {{/card-actions}}
     {{#> card-header-main}}
-      {{#> level level--modifier="pf-m-gutter"}}
+      {{#> split split--modifier="pf-m-gutter pf-m-wrap"}}
         {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
           Getting started
         {{/card-title}}
@@ -55,7 +55,7 @@ import './Card.css'
             {{/label-group-list}}
           {{/label-group-main}}
         {{/label-group}}
-      {{/level}}
+      {{/split}}
     {{/card-header-main}}
   {{/card-header}}
 {{/card}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -15,46 +15,48 @@ import './Card.css'
     {{#> card-actions}}
       {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab-right-aligned") dropdown-toggle--IsPlain="true"}}
     {{/card-actions}}
-    {{#> level level--modifier="pf-m-gutter"}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        Getting started
-      {{/card-title}}
-      {{#> label-group label-group--id="label-group-basic"}}
-        {{#> label-group-main}}
-          {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
-            {{#> label-group-list-item}}
-              {{#> label label--modifier="pf-m-blue pf-m-compact"}}
-                {{#> label-icon}}
-                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
-                {{/label-icon}}
-                Set up your cluster
-              {{/label}}
-            {{/label-group-list-item}}
-            {{#> label-group-list-item}}
-              {{#> label label--modifier="pf-m-purple pf-m-compact"}}
-                {{#> label-icon}}
-                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
-                {{/label-icon}}
-                Guided tours
-              {{/label}}
-            {{/label-group-list-item}}
-            {{#> label-group-list-item}}
-              {{#> label label--modifier="pf-m-green pf-m-compact"}}
-                {{#> label-icon}}
-                  <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
-                {{/label-icon}}
-                Quick starts
-              {{/label}}
-            {{/label-group-list-item}}
-            {{#> label-group-list-item}}
-              {{#> label label--IsOverflow="true" label--modifier="pf-m-compact"}}
-                1 more
-              {{/label}}
-            {{/label-group-list-item}}
-          {{/label-group-list}}
-        {{/label-group-main}}
-      {{/label-group}}
-    {{/level}}
+    {{#> card-header-main}}
+      {{#> level level--modifier="pf-m-gutter"}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          Getting started
+        {{/card-title}}
+        {{#> label-group label-group--id="label-group-basic"}}
+          {{#> label-group-main}}
+            {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
+              {{#> label-group-list-item}}
+                {{#> label label--modifier="pf-m-blue pf-m-compact"}}
+                  {{#> label-icon}}
+                    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                  {{/label-icon}}
+                  Set up your cluster
+                {{/label}}
+              {{/label-group-list-item}}
+              {{#> label-group-list-item}}
+                {{#> label label--modifier="pf-m-purple pf-m-compact"}}
+                  {{#> label-icon}}
+                    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                  {{/label-icon}}
+                  Guided tours
+                {{/label}}
+              {{/label-group-list-item}}
+              {{#> label-group-list-item}}
+                {{#> label label--modifier="pf-m-green pf-m-compact"}}
+                  {{#> label-icon}}
+                    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                  {{/label-icon}}
+                  Quick starts
+                {{/label}}
+              {{/label-group-list-item}}
+              {{#> label-group-list-item}}
+                {{#> label label--IsOverflow="true" label--modifier="pf-m-compact"}}
+                  1 more
+                {{/label}}
+              {{/label-group-list-item}}
+            {{/label-group-list}}
+          {{/label-group-main}}
+        {{/label-group}}
+      {{/level}}
+    {{/card-header-main}}
   {{/card-header}}
 {{/card}}
 ```
@@ -67,9 +69,11 @@ import './Card.css'
     {{#> card-actions}}
       {{> dropdown dropdown--id=(concat card--id "-dropdown-kebab-right-aligned") dropdown-toggle--IsPlain="true"}}
     {{/card-actions}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      Getting started
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        Getting started
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-expandable-content}}
     {{#> card-body}}
@@ -531,9 +535,11 @@ import './Card.css'
 ```hbs
 {{#> card}}
   {{#> card-header}}
-    {{#> title titleType="h2" title--modifier="pf-m-lg"}}
-      Status
-    {{/title}}
+    {{#> card-header-main}}
+      {{#> title titleType="h2" title--modifier="pf-m-lg"}}
+        Status
+      {{/title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     {{#> tabs tabs--id="status-tabs" tabs--modifier="pf-m-fill"}}
@@ -749,11 +755,13 @@ import './Card.css'
 {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="utilization-card-3-example"}}
     {{#> card-header card-header--modifier="pf-u-align-items-flex-start"}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
-        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-          Recommendations
-        {{/title}}
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
+          {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+            Recommendations
+          {{/title}}
+        {{/card-title}}
+      {{/card-header-main}}
       {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
         {{#> select select--id=(concat card--id '-select-dropdown') select-menu--modifier="pf-m-align-right" select-toggle--modifier="pf-m-plain"}}
           Filter
@@ -800,20 +808,24 @@ import './Card.css'
 ```hbs
 {{#> card card--id="nested-cards-toggle-right-example"}}
   {{#> card-header}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-        Hardware Monitor
-      {{/title}}
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+          Hardware Monitor
+        {{/title}}
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card card--id=(concat card--id '-group-1') card--modifier="pf-m-plain pf-m-expanded"}}
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 1
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 1
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
     {{#> card-expandable-content}}
       {{#> card-body}}
@@ -824,21 +836,25 @@ import './Card.css'
   {{#> card card--id=(concat card--id '-group-2') card--modifier="pf-m-plain"}}
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 2
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 2
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
   {{/card}}
   {{#> card card--id=(concat card--id '-group-3') card--modifier="pf-m-plain"}}
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 3
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 3
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
   {{/card}}
 {{/card}}
@@ -848,20 +864,24 @@ import './Card.css'
 ```hbs
 {{#> card card--id="nested-cards-example"}}
   {{#> card-header}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-        Hardware Monitor
-      {{/title}}
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+          Hardware Monitor
+        {{/title}}
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card card--id=(concat card--id '-group-1') card--modifier="pf-m-plain pf-m-expanded"}}
     {{#> card-header}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 1
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 1
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
     {{#> card-expandable-content}}
       {{#> card-body}}
@@ -872,21 +892,25 @@ import './Card.css'
   {{#> card card--id=(concat card--id '-group-2') card--modifier="pf-m-plain"}}
     {{#> card-header}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 2
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 2
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
   {{/card}}
   {{#> card card--id=(concat card--id '-group-3') card--modifier="pf-m-plain"}}
     {{#> card-header}}
       {{> card-header-toggle}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-        <span class="pf-u-font-weight-light">
-          CPU 3
-        </span>
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+          <span class="pf-u-font-weight-light">
+            CPU 3
+          </span>
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
   {{/card}}
 {{/card}}
@@ -896,11 +920,13 @@ import './Card.css'
 ```hbs
 {{#> card card--id="with-accordion-example"}}
   {{#> card-header}}
-    {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-      {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-        Hardware Monitor
-      {{/title}}
-    {{/card-title}}
+    {{#> card-header-main}}
+      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+          Hardware Monitor
+        {{/title}}
+      {{/card-title}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     {{#> accordion}}
@@ -953,7 +979,7 @@ import './Card.css'
 {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="trend-card-1-example"}}
     {{#> card-header}}
-      {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+      {{#> card-header-main}}
         {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
           {{#> title title--modifier="pf-m-2xl"}}
             1,050,765 IOPS
@@ -962,7 +988,7 @@ import './Card.css'
         <span class="pf-u-color-200">
           Workload
         </span>
-      {{/l-flex}}
+      {{/card-header-main}}
       {{#> card-actions card-actions--modifier="pf-m-no-offset" card-actions--attribute='style="padding-top: 1px;"'}}
         {{#> select select--id=(concat card--id '-select-dropdown') select-menu--modifier="pf-m-align-right" select-toggle--modifier="pf-m-plain"}}
           Filter
@@ -981,23 +1007,25 @@ import './Card.css'
 {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="trend-card-2-example"}}
     {{#> card-header}}
-      {{#> l-flex l-flex--modifier="pf-m-align-items-center"}}
-        {{#> l-flex-item l-flex-item--modifier="pf-m-flex-none"}}
-          {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
-            {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
-              {{#> title title--modifier="pf-m-2xl"}}
-                842 TB
-              {{/title}}
-            {{/card-title}}
-            <span class="pf-u-color-200">
-              Storage capacity
-            </span>
-          {{/l-flex}}
-        {{/l-flex-item}}
-        {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
-          {{> card-demo--chart}}
-        {{/l-flex-item}}
-      {{/l-flex}}
+      {{#> card-header-main card-header-main}}
+        {{#> l-flex l-flex--modifier="pf-m-align-items-center"}}
+          {{#> l-flex-item l-flex-item--modifier="pf-m-flex-none"}}
+            {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
+              {{#> card-title card-title--attribute=(concat 'id="' card--id '-title"')}}
+                {{#> title title--modifier="pf-m-2xl"}}
+                  842 TB
+                {{/title}}
+              {{/card-title}}
+              <span class="pf-u-color-200">
+                Storage capacity
+              </span>
+            {{/l-flex}}
+          {{/l-flex-item}}
+          {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
+            {{> card-demo--chart}}
+          {{/l-flex-item}}
+        {{/l-flex}}
+      {{/card-header-main}}
     {{/card-header}}
     {{#> card-footer}}
       {{#> l-flex}}
@@ -1021,11 +1049,13 @@ import './Card.css'
           Most recent
         {{/select}}
       {{/card-actions}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
-        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-          Activity
-        {{/title}}
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
+          {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+            Activity
+          {{/title}}
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
     {{#> card-body}}
       {{#> description-list}}
@@ -1095,11 +1125,13 @@ import './Card.css'
           Status
         {{/select}}
       {{/card-actions}}
-      {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
-        {{#> title title--modifier="pf-m-lg" titleType="h2"}}
-          Events
-        {{/title}}
-      {{/card-title}}
+      {{#> card-header-main}}
+        {{#> card-title card-title--attribute=(concat 'id="' card--id '-title1" style="padding-top: 3px;"')}}
+          {{#> title title--modifier="pf-m-lg" titleType="h2"}}
+            Events
+          {{/title}}
+        {{/card-title}}
+      {{/card-header-main}}
     {{/card-header}}
     {{#> card-body}}
       {{#> description-list}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -1007,7 +1007,7 @@ import './Card.css'
 {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="trend-card-2-example"}}
     {{#> card-header}}
-      {{#> card-header-main card-header-main}}
+      {{#> card-header-main}}
         {{#> l-flex l-flex--modifier="pf-m-align-items-center"}}
           {{#> l-flex-item l-flex-item--modifier="pf-m-flex-none"}}
             {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}


### PR DESCRIPTION
Fixes #4958 by making the `.pf-c-card__header-main` required if there is a `.pf-c-card__header`.

This creates a container so that other items and layouts can be within the header without disturbing the expand icon and actions. Some styling that was specific to title in the header was moved to header-main.

Fixes #3924 by using the correct margin variables.

Pending a design change, it does not directly address having actions wrap below the header main content as requested in #3714, but that would be possible by placing the actions into a layout as desired in the header main.

