### PR TITLE
chore(ChipGroup): use gap instead of item margins

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -1,11 +1,24 @@
 .pf-c-chip-group {
   @include pf-t-light; // force the container follow the light theme
 
-  // Chip group list
-  --pf-c-chip-group__list--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
-  --pf-c-chip-group__list--MarginRight: calc(var(--pf-global--spacer--xs) * -1);
+  // Chip group - spaces main and close
+  // column-gap spacer supports legacy chip group
+  --pf-c-chip-group--PaddingTop: 0;
+  --pf-c-chip-group--PaddingRight: 0;
+  --pf-c-chip-group--PaddingBottom: 0;
+  --pf-c-chip-group--PaddingLeft: 0;
+  --pf-c-chip-group--RowGap: var(--pf-global--spacer--sm);
+  --pf-c-chip-group--ColumnGap: var(--pf-global--spacer--sm);
 
-  // Category
+  // Chip group main - spaces the category label and list
+  --pf-c-chip-group__main--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-chip-group__main--ColumnGap: var(--pf-global--spacer--sm);
+
+  // Chip group list - spaces the chips
+  --pf-c-chip-group__list--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-chip-group__list--ColumnGap: var(--pf-global--spacer--xs);
+
+  // Category modifier
   --pf-c-chip-group--m-category--PaddingTop: var(--pf-global--spacer--xs);
   --pf-c-chip-group--m-category--PaddingRight: var(--pf-global--spacer--xs);
   --pf-c-chip-group--m-category--PaddingBottom: var(--pf-global--spacer--xs);
@@ -14,25 +27,29 @@
   --pf-c-chip-group--m-category--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   // Label in group
-  --pf-c-chip-group__label--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-chip-group__label--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-chip-group__label--MaxWidth: 18ch;
 
-  // Chip group close
+  // Chip group close - negative margin stretches height for click area
+  // margin-left supports legacy chip group
   --pf-c-chip-group__close--MarginTop: calc(var(--pf-global--spacer--xs) * -1);
   --pf-c-chip-group__close--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
-
-  // Chip
-  --pf-c-chip-group__list-item--MarginRight: var(--pf-global--spacer--xs);
-  --pf-c-chip-group__list-item--MarginBottom: var(--pf-global--spacer--xs);
+  --pf-c-chip-group__close--MarginLeft: calc(var(--pf-global--spacer--sm) * -1);
 
   max-width: 100%;
+  padding-top: var(--pf-c-chip-group--PaddingTop);
+  padding-right: var(--pf-c-chip-group--PaddingRight);
+  padding-bottom: var(--pf-c-chip-group--PaddingBottom);
+  padding-left: var(--pf-c-chip-group--PaddingLeft);
+  row-gap: var(--pf-c-chip-group--RowGap);
+  column-gap: var(--pf-c-chip-group--ColumnGap);
 
   &.pf-m-category {
-    padding-top: var(--pf-c-chip-group--m-category--PaddingTop);
-    padding-right: var(--pf-c-chip-group--m-category--PaddingRight);
-    padding-bottom: var(--pf-c-chip-group--m-category--PaddingBottom);
-    padding-left: var(--pf-c-chip-group--m-category--PaddingLeft);
+    --pf-c-chip-group--PaddingTop: var(--pf-c-chip-group--m-category--PaddingTop);
+    --pf-c-chip-group--PaddingRight: var(--pf-c-chip-group--m-category--PaddingRight);
+    --pf-c-chip-group--PaddingBottom: var(--pf-c-chip-group--m-category--PaddingBottom);
+    --pf-c-chip-group--PaddingLeft: var(--pf-c-chip-group--m-category--PaddingLeft);
+
     background-color: var(--pf-c-chip-group--m-category--BackgroundColor);
     border-radius: var(--pf-c-chip-group--m-category--BorderRadius);
   }
@@ -44,11 +61,8 @@
   flex-wrap: wrap;
   align-items: baseline;
   min-width: 0;
-}
-
-.pf-c-chip-group__list {
-  margin-right: var(--pf-c-chip-group__list--MarginRight);
-  margin-bottom: var(--pf-c-chip-group__list--MarginBottom);
+  row-gap: var(--pf-c-chip-group__main--RowGap);
+  column-gap: var(--pf-c-chip-group__main--ColumnGap);
 }
 
 .pf-c-chip-group,
@@ -59,18 +73,20 @@
   min-width: 0;
 }
 
+.pf-c-chip-group__list {
+  row-gap: var(--pf-c-chip-group__list--RowGap);
+  column-gap: var(--pf-c-chip-group__list--ColumnGap);
+}
+
 .pf-c-chip-group__list-item {
   display: inline-flex;
   min-width: 0;
-  margin-right: var(--pf-c-chip-group__list-item--MarginRight);
-  margin-bottom: var(--pf-c-chip-group__list-item--MarginBottom);
 }
 
 .pf-c-chip-group__label {
   @include pf-text-overflow;
 
   max-width: var(--pf-c-chip-group__label--MaxWidth);
-  margin-right: var(--pf-c-chip-group__label--MarginRight);
   font-size: var(--pf-c-chip-group__label--FontSize);
 }
 
@@ -79,4 +95,5 @@
   align-self: flex-start;
   margin-top: var(--pf-c-chip-group__close--MarginTop);
   margin-bottom: var(--pf-c-chip-group__close--MarginBottom);
+  margin-left: var(--pf-c-chip-group__close--MarginLeft);
 }


### PR DESCRIPTION
Fixes #5289 

Removes margins within chip group in favor of using gap for spacing.
Some comments included to mark items that can be removed if legacy chip group (without the main container) is removed.
I left a slight difference in spacing between category label and the chips when they wrap because I suspect it was due to lack of row spacing or just oversight? @mceledonia can you let me know which is preferred?
<img width="632" alt="image" src="https://user-images.githubusercontent.com/19825616/208698413-496fd63f-2ed8-4f16-9ebb-38f24109afcd.png">
