### PR TITLE
fix(empty-state): cleaned up CSS

### DIFF
--- a/src/patternfly/components/EmptyState/empty-state-actions.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-actions.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-empty-state__actions{{#if empty-state-actions--modifier}} {{empty-state-actions--modifier}}{{/if}}"
+  {{#if empty-state-actions--attribute}}
+    {{{empty-state-actions--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/EmptyState/empty-state-footer.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-footer.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-empty-state__footer{{#if empty-state-footer--modifier}} {{empty-state-footer--modifier}}{{/if}}"
+  {{#if empty-state-footer--attribute}}
+    {{{empty-state-footer--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/EmptyState/empty-state-header.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-empty-state__header{{#if empty-state-header--modifier}} {{empty-state-header--modifier}}{{/if}}"
+  {{#if empty-state-header--attribute}}
+    {{{empty-state-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/EmptyState/empty-state-icon.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-icon.hbs
@@ -1,14 +1,13 @@
-{{#if @partial-block}}
   <div class="pf-c-empty-state__icon{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
     {{#if empty-state-icon--attribute}}
       {{{empty-state-icon--attribute}}}
     {{/if}}>
-    {{> @partial-block}}
-  </div>
-{{else}}
-<i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}} pf-c-empty-state__icon{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
-  aria-hidden="true"
-  {{#if empty-state-icon--attribute}}
-    {{{empty-state-icon--attribute}}}
-  {{/if}}></i>
-{{/if}}
+    {{#if @partial-block}}
+      {{> @partial-block}}
+    {{else}}
+      <i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}}{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
+      aria-hidden="true"
+      {{#if empty-state-icon--attribute}}
+        {{{empty-state-icon--attribute}}}
+      {{/if}}></i>
+  </div>{{/if}}

--- a/src/patternfly/components/EmptyState/empty-state-icon.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-icon.hbs
@@ -1,13 +1,14 @@
-  <div class="pf-c-empty-state__icon{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
+<div class="pf-c-empty-state__icon{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
+  {{#if empty-state-icon--attribute}}
+    {{{empty-state-icon--attribute}}}
+  {{/if}}>
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{else}}
+    <i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}}{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
+    aria-hidden="true"
     {{#if empty-state-icon--attribute}}
       {{{empty-state-icon--attribute}}}
-    {{/if}}>
-    {{#if @partial-block}}
-      {{> @partial-block}}
-    {{else}}
-      <i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}}{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
-      aria-hidden="true"
-      {{#if empty-state-icon--attribute}}
-        {{{empty-state-icon--attribute}}}
-      {{/if}}></i>
-  </div>{{/if}}
+    {{/if}}></i>
+  {{/if}}
+</div>

--- a/src/patternfly/components/EmptyState/empty-state-icon.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-icon.hbs
@@ -5,10 +5,7 @@
   {{#if @partial-block}}
     {{> @partial-block}}
   {{else}}
-    <i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}}{{#if empty-state-icon--modifier}} {{empty-state-icon--modifier}}{{/if}}"
-    aria-hidden="true"
-    {{#if empty-state-icon--attribute}}
-      {{{empty-state-icon--attribute}}}
-    {{/if}}></i>
+    <i class="fas fa-{{#if empty-state-icon--type}} fa-{{empty-state-icon--type}}{{else}}cubes{{/if}}"
+    aria-hidden="true"></i>
   {{/if}}
 </div>

--- a/src/patternfly/components/EmptyState/empty-state-primary.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-primary.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-empty-state__primary{{#if empty-state-primary--modifier}} {{empty-state-primary--modifier}}{{/if}}"
-  {{#if empty-state-primary--attribute}}
-    {{{empty-state-primary--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/EmptyState/empty-state-secondary.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-secondary.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-empty-state__secondary{{#if empty-state-secondary--modifier}} {{empty-state-secondary--modifier}}{{/if}}"
-  {{#if empty-state-secondary--attribute}}
-    {{{empty-state-secondary--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/EmptyState/empty-state-title-text.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-title-text.hbs
@@ -1,0 +1,6 @@
+<{{#if empty-state-title-text--element}}{{empty-state-title-text--element}}{{else}}h1{{/if}} class="pf-c-empty-state__title-text{{#if empty-state-title-text--modifier}} {{empty-state-title-text--modifier}}{{/if}}"
+  {{#if empty-state-title-text--attribute}}
+    {{{empty-state-title-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</{{#if empty-state-title-text--element}}{{empty-state-title-text--element}}{{else}}h1{{/if}}>

--- a/src/patternfly/components/EmptyState/empty-state-title.hbs
+++ b/src/patternfly/components/EmptyState/empty-state-title.hbs
@@ -1,6 +1,6 @@
-<h1 class="pf-c-empty-state__title{{#if empty-state-title--modifier}} {{empty-state-title--modifier}}{{/if}}"
+<div class="pf-c-empty-state__title{{#if empty-state-title--modifier}} {{empty-state-title--modifier}}{{/if}}"
   {{#if empty-state-title--attribute}}
     {{{empty-state-title--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</h1>
+</div>

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -22,6 +22,15 @@
   --pf-c-empty-state--m-xl__icon--MarginBottom: var(--pf-global--spacer--xl);
   --pf-c-empty-state--m-xl__icon--FontSize: #{pf-size-prem(100px)};
 
+  // Title text
+  --pf-c-empty-state__title-text--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
+  --pf-c-empty-state__title-text--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-empty-state__title-text--FontWeight: var(--pf-global--FontWeight--normal);
+  --pf-c-empty-state__title-text--LineHeight: var(--pf-global--LineHeight--md);
+  --pf-c-empty-state--m-xs__title-text--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-empty-state--m-xl__title-text--FontSize: var(--pf-global--FontSize--4xl);
+  --pf-c-empty-state--m-xl__title-text--LineHeight: var(--pf-global--LineHeight--sm);
+
   // Body
   --pf-c-empty-state__body--MarginTop: var(--pf-global--spacer--md);
   --pf-c-empty-state__body--Color: var(--pf-global--Color--200);
@@ -51,6 +60,7 @@
     --pf-c-empty-state--PaddingRight: var(--pf-c-empty-state--m-xs--PaddingRight);
     --pf-c-empty-state--PaddingBottom: var(--pf-c-empty-state--m-xs--PaddingBottom);
     --pf-c-empty-state--PaddingLeft: var(--pf-c-empty-state--m-xs--PaddingLeft);
+    --pf-c-empty-state__title-text--FontSize: var(--pf-c-empty-state--m-xs__title-text--FontSize);
     --pf-c-empty-state__content--MaxWidth: var(--pf-c-empty-state--m-xs__content--MaxWidth);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xs__icon--MarginBottom);
     --pf-c-empty-state__body--MarginTop: var(--pf-c-empty-state--m-xs__body--MarginTop);
@@ -71,6 +81,8 @@
     --pf-c-empty-state--body--FontSize: var(--pf-c-empty-state--m-xl__body--FontSize);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xl__icon--MarginBottom);
     --pf-c-empty-state__icon--FontSize: var(--pf-c-empty-state--m-xl__icon--FontSize);
+    --pf-c-empty-state__title-text--FontSize: var(--pf-c-empty-state--m-xl__title-text--FontSize);
+    --pf-c-empty-state__title-text--LineHeight: var(--pf-c-empty-state--m-xl__title-text--LineHeight);
   }
 
   &.pf-m-full-height {
@@ -87,6 +99,13 @@
   font-size: var(--pf-c-empty-state__icon--FontSize);
   line-height: 1;
   color: var(--pf-c-empty-state__icon--Color);
+}
+
+.pf-c-empty-state__title-text {
+  font-family: var(--pf-c-empty-state__title-text--FontFamily);
+  font-size: var(--pf-c-empty-state__title-text--FontSize);
+  font-weight: var(--pf-c-empty-state__title-text--FontWeight);
+  line-height: var(--pf-c-empty-state__title-text--LineHeight);
 }
 
 .pf-c-empty-state__body {

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -31,19 +31,15 @@
   --pf-c-empty-state--m-xl__body--FontSize: var(--pf-global--FontSize--xl);
   --pf-c-empty-state--m-xl__body--MarginTop: var(--pf-global--spacer--lg);
 
-  // Primary actions
-  --pf-c-empty-state__primary--RowGap: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__primary--ColumnGap: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__primary--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state__primary--secondary--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-empty-state--m-xs__primary--MarginTop: var(--pf-global--spacer--md);
+  // Footer
+  --pf-c-empty-state__footer--RowGap: var(--pf-global--spacer--sm);
+  --pf-c-empty-state__footer--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--m-xs__footer--MarginTop: var(--pf-global--spacer--md);
 
-  // Secondary actions
-  --pf-c-empty-state__secondary--RowGap: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__secondary--ColumnGap: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__secondary--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state--m-xs__secondary--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-empty-state--m-xl__secondary--MarginTop: var(--pf-global--spacer--md);
+  // Actions
+  --pf-c-empty-state__actions--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__actions--ColumnGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__actions--MarginTop: 0;
 
   display: flex;
   align-items: center;
@@ -60,8 +56,7 @@
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xs__icon--MarginBottom);
     --pf-c-empty-state__body--MarginTop: var(--pf-c-empty-state--m-xs__body--MarginTop);
     --pf-c-empty-state--body--FontSize: var(--pf-c-empty-state--m-xs__body--FontSize);
-    --pf-c-empty-state__primary--MarginTop: var(--pf-c-empty-state--m-xs__primary--MarginTop);
-    --pf-c-empty-state__secondary--MarginTop: var(--pf-c-empty-state--m-xs__secondary--MarginTop);
+    --pf-c-empty-state__footer--MarginTop: var(--pf-c-empty-state--m-xs__footer--MarginTop);
   }
 
   &.pf-m-sm {
@@ -77,7 +72,6 @@
     --pf-c-empty-state--body--FontSize: var(--pf-c-empty-state--m-xl__body--FontSize);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xl__icon--MarginBottom);
     --pf-c-empty-state__icon--FontSize: var(--pf-c-empty-state--m-xl__icon--FontSize);
-    --pf-c-empty-state__secondary--MarginTop: var(--pf-c-empty-state--m-xl__secondary--MarginTop);
   }
 
   &.pf-m-full-height {
@@ -102,22 +96,17 @@
   color: var(--pf-c-empty-state__body--Color);
 }
 
-.pf-c-empty-state__primary {
+.pf-c-empty-state__footer {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--pf-c-empty-state__primary--RowGap) var(--pf-c-empty-state__primary--ColumnGap);
-  margin-top: var(--pf-c-empty-state__primary--MarginTop);
-
-  + .pf-c-empty-state__secondary {
-    margin-top: var(--pf-c-empty-state__primary--secondary--MarginTop);
-  }
+  flex-direction: column;
+  align-items: center;
+  row-gap: var(--pf-c-empty-state__footer--RowGap);
+  margin-top: var(--pf-c-empty-state__footer--MarginTop);
 }
 
-.pf-c-empty-state__secondary {
+.pf-c-empty-state__actions {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: var(--pf-c-empty-state__secondary--RowGap) var(--pf-c-empty-state__secondary--ColumnGap);
-  margin-top: var(--pf-c-empty-state__secondary--MarginTop);
+  gap: var(--pf-c-empty-state__actions--RowGap) var(--pf-c-empty-state__actions--ColumnGap);
 }

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -3,38 +3,47 @@
   --pf-c-empty-state--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-empty-state--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-empty-state--PaddingLeft: var(--pf-global--spacer--xl);
-  --pf-c-empty-state__content--MaxWidth: none;
-  --pf-c-empty-state__icon--MarginBottom: var(--pf-global--spacer--lg);
-  --pf-c-empty-state__icon--FontSize: var(--pf-global--icon--FontSize--xl);
-  --pf-c-empty-state__icon--Color: var(--pf-global--icon--Color--light);
-  --pf-c-empty-state__content--c-title--m-lg--FontSize: var(--pf-global--FontSize--xl);
-  --pf-c-empty-state__body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-empty-state__body--Color: var(--pf-global--Color--200);
-  --pf-c-empty-state__primary--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state__primary--secondary--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-empty-state__secondary--MarginTop: var(--pf-global--spacer--xl);
-  --pf-c-empty-state__secondary--MarginBottom: calc(var(--pf-global--spacer--xs) * -1);
-  --pf-c-empty-state__secondary--child--MarginRight: calc(var(--pf-global--spacer--xs) / 2);
-  --pf-c-empty-state__secondary--child--MarginBottom: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__secondary--child--MarginLeft: calc(var(--pf-global--spacer--xs) / 2);
-  --pf-c-empty-state--m-xs__content--MaxWidth: #{pf-size-prem(350px)};
-  --pf-c-empty-state--m-xs__body--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-empty-state--m-xs--button--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-empty-state--m-xs--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-empty-state--m-xs--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-empty-state--m-xs--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-empty-state--m-xs--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-c-empty-state--m-xs__icon--MarginBottom: var(--pf-global--spacer--md);
-  --pf-c-empty-state--m-xs__body--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-empty-state--m-xs__primary--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-empty-state--m-xs__secondary--MarginTop: var(--pf-global--spacer--md);
+
+  // Content
+  --pf-c-empty-state__content--MaxWidth: none;
+  --pf-c-empty-state--m-xs__content--MaxWidth: #{pf-size-prem(350px)};
   --pf-c-empty-state--m-sm__content--MaxWidth: #{pf-size-prem(400px)};
   --pf-c-empty-state--m-lg__content--MaxWidth: #{pf-size-prem(600px)};
-  --pf-c-empty-state--m-xl__body--FontSize: var(--pf-global--FontSize--xl);
-  --pf-c-empty-state--m-xl__body--MarginTop: var(--pf-global--spacer--lg);
+
+  // Icon
+  --pf-c-empty-state__icon--MarginBottom: var(--pf-global--spacer--lg);
+  --pf-c-empty-state__icon--FontSize: var(--pf-global--icon--FontSize--xl);
+  --pf-c-empty-state__icon--Color: var(--pf-global--icon--Color--light);
+  --pf-c-empty-state--m-xs__icon--MarginBottom: var(--pf-global--spacer--md);
   --pf-c-empty-state--m-xl__icon--MarginBottom: var(--pf-global--spacer--xl);
   --pf-c-empty-state--m-xl__icon--FontSize: #{pf-size-prem(100px)};
-  --pf-c-empty-state--m-xl--c-button__secondary--MarginTop: var(--pf-global--spacer--md);
+
+  // Body
+  --pf-c-empty-state__body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-empty-state__body--Color: var(--pf-global--Color--200);
+  --pf-c-empty-state--body--FontSize: var(--pf-global--FontSize--md);
+  --pf-c-empty-state--m-xs__body--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-empty-state--m-xs__body--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-empty-state--m-xl__body--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-empty-state--m-xl__body--MarginTop: var(--pf-global--spacer--lg);
+
+  // Primary actions
+  --pf-c-empty-state__primary--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__primary--ColumnGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__primary--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-empty-state__primary--secondary--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-empty-state--m-xs__primary--MarginTop: var(--pf-global--spacer--md);
+
+  // Secondary actions
+  --pf-c-empty-state__secondary--RowGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__secondary--ColumnGap: var(--pf-global--spacer--xs);
+  --pf-c-empty-state__secondary--MarginTop: var(--pf-global--spacer--xl);
+  --pf-c-empty-state--m-xs__secondary--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-empty-state--m-xl__secondary--MarginTop: var(--pf-global--spacer--md);
 
   display: flex;
   align-items: center;
@@ -50,16 +59,9 @@
     --pf-c-empty-state__content--MaxWidth: var(--pf-c-empty-state--m-xs__content--MaxWidth);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xs__icon--MarginBottom);
     --pf-c-empty-state__body--MarginTop: var(--pf-c-empty-state--m-xs__body--MarginTop);
+    --pf-c-empty-state--body--FontSize: var(--pf-c-empty-state--m-xs__body--FontSize);
     --pf-c-empty-state__primary--MarginTop: var(--pf-c-empty-state--m-xs__primary--MarginTop);
     --pf-c-empty-state__secondary--MarginTop: var(--pf-c-empty-state--m-xs__secondary--MarginTop);
-
-    .pf-c-empty-state__body {
-      font-size: var(--pf-c-empty-state--m-xs__body--FontSize);
-    }
-
-    .pf-c-button {
-      --pf-c-button--FontSize: var(--pf-c-empty-state--m-xs--button--FontSize);
-    }
   }
 
   &.pf-m-sm {
@@ -72,13 +74,10 @@
 
   &.pf-m-xl {
     --pf-c-empty-state__body--MarginTop: var(--pf-c-empty-state--m-xl__body--MarginTop);
+    --pf-c-empty-state--body--FontSize: var(--pf-c-empty-state--m-xl__body--FontSize);
     --pf-c-empty-state__icon--MarginBottom: var(--pf-c-empty-state--m-xl__icon--MarginBottom);
     --pf-c-empty-state__icon--FontSize: var(--pf-c-empty-state--m-xl__icon--FontSize);
-    --pf-c-empty-state--c-button__secondary--MarginTop: var(--pf-c-empty-state--m-xl--c-button__secondary--MarginTop);
-
-    .pf-c-empty-state__body {
-      font-size: var(--pf-c-empty-state--m-xl__body--FontSize);
-    }
+    --pf-c-empty-state__secondary--MarginTop: var(--pf-c-empty-state--m-xl__secondary--MarginTop);
   }
 
   &.pf-m-full-height {
@@ -88,25 +87,26 @@
 
 .pf-c-empty-state__content {
   max-width: var(--pf-c-empty-state__content--MaxWidth);
-
-  > .pf-c-title.pf-m-lg {
-    font-size: var(--pf-c-empty-state__content--c-title--m-lg--FontSize);
-  }
 }
 
 .pf-c-empty-state__icon {
   margin-bottom: var(--pf-c-empty-state__icon--MarginBottom);
   font-size: var(--pf-c-empty-state__icon--FontSize);
+  line-height: 1;
   color: var(--pf-c-empty-state__icon--Color);
 }
 
 .pf-c-empty-state__body {
   margin-top: var(--pf-c-empty-state__body--MarginTop);
+  font-size: var(--pf-c-empty-state--body--FontSize);
   color: var(--pf-c-empty-state__body--Color);
 }
 
-@at-root .pf-c-empty-state__content > .pf-c-button.pf-m-primary,
 .pf-c-empty-state__primary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--pf-c-empty-state__primary--RowGap) var(--pf-c-empty-state__primary--ColumnGap);
   margin-top: var(--pf-c-empty-state__primary--MarginTop);
 
   + .pf-c-empty-state__secondary {
@@ -118,12 +118,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  gap: var(--pf-c-empty-state__secondary--RowGap) var(--pf-c-empty-state__secondary--ColumnGap);
   margin-top: var(--pf-c-empty-state__secondary--MarginTop);
-  margin-bottom: var(--pf-c-empty-state__secondary--MarginBottom);
-
-  > * {
-    margin-right: var(--pf-c-empty-state__secondary--child--MarginRight);
-    margin-bottom: var(--pf-c-empty-state__secondary--child--MarginBottom);
-    margin-left: var(--pf-c-empty-state__secondary--child--MarginLeft);
-  }
 }

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -39,7 +39,6 @@
   // Actions
   --pf-c-empty-state__actions--RowGap: var(--pf-global--spacer--xs);
   --pf-c-empty-state__actions--ColumnGap: var(--pf-global--spacer--xs);
-  --pf-c-empty-state__actions--MarginTop: 0;
 
   display: flex;
   align-items: center;

--- a/src/patternfly/components/EmptyState/examples/EmptyState.md
+++ b/src/patternfly/components/EmptyState/examples/EmptyState.md
@@ -9,89 +9,113 @@ cssPrefix: pf-c-empty-state
 ### Basic
 ```hbs
 {{#> empty-state}}
-  {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
-    Empty state
-  {{/title}}
+  {{#> empty-state-header}}
+    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{#> empty-state-title}}
+      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+        Empty state
+      {{/title}}
+    {{/empty-state-title}}
+  {{/empty-state-header}}
+
   {{#> empty-state-body}}
     This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> empty-state-primary}}
-    {{#> button button--modifier="pf-m-primary"}}
-      Primary action
-    {{/button}}
-  {{/empty-state-primary}}
-  {{#> empty-state-secondary}}
-    {{#> button button--modifier="pf-m-link"}}
-      Multiple
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action buttons
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Can
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Go here
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      In the secondary
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action area
-    {{/button}}
-  {{/empty-state-secondary}}
+
+  {{#> empty-state-footer}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-primary"}}
+        Primary action
+      {{/button}}
+    {{/empty-state-actions}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-link"}}
+        Multiple
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action buttons
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Can
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Go here
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        In the second
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action area
+      {{/button}}
+    {{/empty-state-actions}}
+  {{/empty-state-footer}}
 {{/empty-state}}
 ```
 
 ### Extra small
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-xs"}}
-  {{#> title titleType="h1" title--modifier="pf-m-md"}}
-    Empty state
-  {{/title}}
+  {{#> empty-state-header}}
+    {{#> empty-state-title}}
+      {{#> title titleType="h1" title--modifier="pf-m-md"}}
+        Empty state
+      {{/title}}
+    {{/empty-state-title}}
+  {{/empty-state-header}}
+
   {{#> empty-state-body}}
     This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> empty-state-secondary}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      Multiple
-    {{/button}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      Action buttons
-    {{/button}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      Can
-    {{/button}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      Go here
-    {{/button}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      In the secondary
-    {{/button}}
-    {{#> button button--modifier="pf-m-link pf-m-small"}}
-      Action area
-    {{/button}}
-  {{/empty-state-secondary}}
+
+  {{#> empty-state-footer}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        Multiple
+      {{/button}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        Action buttons
+      {{/button}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        Can
+      {{/button}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        Go here
+      {{/button}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        In the
+      {{/button}}
+      {{#> button button--modifier="pf-m-link pf-m-small"}}
+        Action area
+      {{/button}}
+    {{/empty-state-actions}}
+  {{/empty-state-footer}}
 {{/empty-state}}
 ```
 
 ### Small
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-sm"}}
-  {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
-    Empty state
-  {{/title}}
+  {{#> empty-state-header}}
+    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{#> empty-state-title}}
+      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+        Empty state
+      {{/title}}
+    {{/empty-state-title}}
+  {{/empty-state-header}}
+
   {{#> empty-state-body}}
     This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-    {{#> empty-state-primary}}
+
+  {{#> empty-state-footer}}
+    {{#> empty-state-actions}}
     {{#> button button--modifier="pf-m-primary"}}
       Primary action
     {{/button}}
-  {{/empty-state-primary}}
-  {{#> empty-state-secondary}}
+  {{/empty-state-actions}}
+
+  {{#> empty-state-actions}}
     {{#> button button--modifier="pf-m-link"}}
       Multiple
     {{/button}}
@@ -105,86 +129,104 @@ cssPrefix: pf-c-empty-state
       Go here
     {{/button}}
     {{#> button button--modifier="pf-m-link"}}
-      In the secondary
+      In the second
     {{/button}}
     {{#> button button--modifier="pf-m-link"}}
       Action area
     {{/button}}
-  {{/empty-state-secondary}}
+  {{/empty-state-actions}}
+  {{/empty-state-footer}}
 {{/empty-state}}
 ```
 
 ### Large
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-lg"}}
-  {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
-    Empty state
-  {{/title}}
+  {{#> empty-state-header}}
+    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{#> empty-state-title}}
+      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+        Empty state
+      {{/title}}
+    {{/empty-state-title}}
+  {{/empty-state-header}}
+
   {{#> empty-state-body}}
     This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> empty-state-primary}}
-    {{#> button button--modifier="pf-m-primary"}}
-      Primary action
-    {{/button}}
-  {{/empty-state-primary}}
-  {{#> empty-state-secondary}}
-    {{#> button button--modifier="pf-m-link"}}
-      Multiple
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action buttons
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Can
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Go here
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      In the secondary
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action area
-    {{/button}}
-  {{/empty-state-secondary}}
+
+  {{#> empty-state-footer}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-primary"}}
+        Primary action
+      {{/button}}
+    {{/empty-state-actions}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-link"}}
+        Multiple
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action buttons
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Can
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Go here
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        In the second
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action area
+      {{/button}}
+    {{/empty-state-actions}}
+  {{/empty-state-footer}}
 {{/empty-state}}
 ```
 
 ### Extra large
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-xl"}}
-  {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-4xl"}}
-    Empty state
-  {{/title}}
-  {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
-  {{/empty-state-body}}
-  {{#> empty-state-primary}}
-    {{#> button button--modifier="pf-m-primary"}}
-      Primary action
-    {{/button}}
-  {{/empty-state-primary}}
-{{/empty-state}}
-```
+  {{#> empty-state-header}}
+    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{#> empty-state-title}}
+      {{#> title titleType="h1" title--modifier="pf-m-4xl"}}
+        Empty state
+      {{/title}}
+    {{/empty-state-title}}
+  {{/empty-state-header}}
 
-### With primary element
-```hbs
-{{#> empty-state}}
-  {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-lg"}}
-    Empty State
-  {{/title}}
   {{#> empty-state-body}}
     This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> empty-state-primary}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action buttons
-    {{/button}}
-  {{/empty-state-primary}}
+  {{#> empty-state-footer}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-primary"}}
+        Primary action
+      {{/button}}
+    {{/empty-state-actions}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-link"}}
+        Multiple
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action buttons
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Can
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Go here
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        In the second
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action area
+      {{/button}}
+    {{/empty-state-actions}}
+  {{/empty-state-footer}}
 {{/empty-state}}
 ```
 
@@ -199,11 +241,12 @@ cssPrefix: pf-c-empty-state
 | -- | -- | -- |
 | `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. The empty state centers its content (`.pf-c-empty-state__content`) vertically and horizontally. **Required** |
 | `.pf-c-empty-state__content` | `<div>` |  Creates the content container. **Required** |
+| `.pf-c-empty-state__header` | `<div>` |  Creates the header container. **Required** |
+| `.pf-c-empty-state__title` | `<div>` |  Creates the empty state title container. |
 | `.pf-c-empty-state__icon` | `<div>` |  Creates the empty state icon container. |
-| `.pf-c-title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Creates the empty state title. **Required** |
 | `.pf-c-empty-state__body` | `<div>` |  Creates the empty state body content. There can be more than one `.pf-c-empty-state__body` elements. |
-| `.pf-c-empty-state__primary` | `<div>` |  Container for primary actions. **Required if there is a primary action** |
-| `.pf-c-empty-state__secondary` | `<div>` |  Container secondary actions. **Required if there is a secondary action** |
+| `.pf-c-empty-state__footer` | `<div>` |  Container for actions. **Required** |
+| `.pf-c-empty-state__actions` | `<div>` |  Container for actions. **Required** |
 | `.pf-m-xs` | `.pf-c-empty-state` | Modifies the empty state for a extra small variation and max-width. |
 | `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width. |
 | `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width. |

--- a/src/patternfly/components/EmptyState/examples/EmptyState.md
+++ b/src/patternfly/components/EmptyState/examples/EmptyState.md
@@ -10,11 +10,11 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state}}
   {{#> empty-state-header}}
-    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{> empty-state-icon}}
     {{#> empty-state-title}}
-      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+      {{#> empty-state-title-text}}
         Empty state
-      {{/title}}
+      {{/empty-state-title-text}}
     {{/empty-state-title}}
   {{/empty-state-header}}
 
@@ -57,9 +57,9 @@ cssPrefix: pf-c-empty-state
 {{#> empty-state empty-state--modifier="pf-m-xs"}}
   {{#> empty-state-header}}
     {{#> empty-state-title}}
-      {{#> title titleType="h1" title--modifier="pf-m-md"}}
+      {{#> empty-state-title-text}}
         Empty state
-      {{/title}}
+      {{/empty-state-title-text}}
     {{/empty-state-title}}
   {{/empty-state-header}}
 
@@ -96,11 +96,11 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-sm"}}
   {{#> empty-state-header}}
-    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{> empty-state-icon}}
     {{#> empty-state-title}}
-      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+      {{#> empty-state-title-text}}
         Empty state
-      {{/title}}
+      {{/empty-state-title-text}}
     {{/empty-state-title}}
   {{/empty-state-header}}
 
@@ -110,31 +110,31 @@ cssPrefix: pf-c-empty-state
 
   {{#> empty-state-footer}}
     {{#> empty-state-actions}}
-    {{#> button button--modifier="pf-m-primary"}}
-      Primary action
-    {{/button}}
-  {{/empty-state-actions}}
+      {{#> button button--modifier="pf-m-primary"}}
+        Primary action
+      {{/button}}
+    {{/empty-state-actions}}
 
-  {{#> empty-state-actions}}
-    {{#> button button--modifier="pf-m-link"}}
-      Multiple
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action buttons
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Can
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Go here
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      In the second
-    {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
-      Action area
-    {{/button}}
-  {{/empty-state-actions}}
+    {{#> empty-state-actions}}
+      {{#> button button--modifier="pf-m-link"}}
+        Multiple
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action buttons
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Can
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Go here
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        In the second
+      {{/button}}
+      {{#> button button--modifier="pf-m-link"}}
+        Action area
+      {{/button}}
+    {{/empty-state-actions}}
   {{/empty-state-footer}}
 {{/empty-state}}
 ```
@@ -143,11 +143,11 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-lg"}}
   {{#> empty-state-header}}
-    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{> empty-state-icon}}
     {{#> empty-state-title}}
-      {{#> title titleType="h1" title--modifier="pf-m-xl"}}
+      {{#> empty-state-title-text}}
         Empty state
-      {{/title}}
+      {{/empty-state-title-text}}
     {{/empty-state-title}}
   {{/empty-state-header}}
 
@@ -189,11 +189,11 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-xl"}}
   {{#> empty-state-header}}
-    {{#> empty-state-icon}}{{/empty-state-icon}}
+    {{> empty-state-icon}}
     {{#> empty-state-title}}
-      {{#> title titleType="h1" title--modifier="pf-m-4xl"}}
+      {{#> empty-state-title-text}}
         Empty state
-      {{/title}}
+      {{/empty-state-title-text}}
     {{/empty-state-title}}
   {{/empty-state-header}}
 
@@ -242,13 +242,14 @@ cssPrefix: pf-c-empty-state
 | `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. The empty state centers its content (`.pf-c-empty-state__content`) vertically and horizontally. **Required** |
 | `.pf-c-empty-state__content` | `<div>` |  Creates the content container. **Required** |
 | `.pf-c-empty-state__header` | `<div>` |  Creates the header container. **Required** |
-| `.pf-c-empty-state__title` | `<div>` |  Creates the empty state title container. |
+| `.pf-c-empty-state__title` | `<div>` |  Creates the empty state title container. **Required** |
+| `.pf-c-empty-state__title-text` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`, `<div>` |  Creates the empty state title text container. |
 | `.pf-c-empty-state__icon` | `<div>` |  Creates the empty state icon container. |
 | `.pf-c-empty-state__body` | `<div>` |  Creates the empty state body content. There can be more than one `.pf-c-empty-state__body` elements. |
-| `.pf-c-empty-state__footer` | `<div>` |  Container for actions. **Required** |
+| `.pf-c-empty-state__footer` | `<div>` |  Creates the footer container. **Required** |
 | `.pf-c-empty-state__actions` | `<div>` |  Container for actions. **Required** |
-| `.pf-m-xs` | `.pf-c-empty-state` | Modifies the empty state for a extra small variation and max-width. |
+| `.pf-m-xs` | `.pf-c-empty-state` | Modifies the empty state for an extra small variation and max-width. |
 | `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width. |
 | `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width. |
-| `.pf-m-xl` | `.pf-c-empty-state` | Modifies the empty state for an x-large variation and max-width. |
+| `.pf-m-xl` | `.pf-c-empty-state` | Modifies the empty state for an extra large variation and max-width. |
 | `.pf-m-full-height` | `.pf-c-empty-state` | Modifies the empty state to be `height: 100%`. If you need the empty state content to be centered vertically, you can use this modifier to make the empty state fill the height of its container, and center `.pf-c-empty-state__content`. **Note:** this modifier requires the parent of `.pf-c-empty-state` have an implicit or explicit `height` defined.  |

--- a/src/patternfly/components/EmptyState/examples/EmptyState.md
+++ b/src/patternfly/components/EmptyState/examples/EmptyState.md
@@ -10,15 +10,17 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state}}
   {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-lg"}}
+  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
     Empty state
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> button button--modifier="pf-m-primary"}}
-    Primary action
-  {{/button}}
+  {{#> empty-state-primary}}
+    {{#> button button--modifier="pf-m-primary"}}
+      Primary action
+    {{/button}}
+  {{/empty-state-primary}}
   {{#> empty-state-secondary}}
     {{#> button button--modifier="pf-m-link"}}
       Multiple
@@ -49,25 +51,25 @@ cssPrefix: pf-c-empty-state
     Empty state
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
   {{#> empty-state-secondary}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       Multiple
     {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       Action buttons
     {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       Can
     {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       Go here
     {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       In the secondary
     {{/button}}
-    {{#> button button--modifier="pf-m-link"}}
+    {{#> button button--modifier="pf-m-link pf-m-small"}}
       Action area
     {{/button}}
   {{/empty-state-secondary}}
@@ -78,15 +80,17 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-sm"}}
   {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-lg"}}
+  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
     Empty state
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> button button--modifier="pf-m-primary"}}
-    Primary action
-  {{/button}}
+    {{#> empty-state-primary}}
+    {{#> button button--modifier="pf-m-primary"}}
+      Primary action
+    {{/button}}
+  {{/empty-state-primary}}
   {{#> empty-state-secondary}}
     {{#> button button--modifier="pf-m-link"}}
       Multiple
@@ -114,15 +118,17 @@ cssPrefix: pf-c-empty-state
 ```hbs
 {{#> empty-state empty-state--modifier="pf-m-lg"}}
   {{#> empty-state-icon}}{{/empty-state-icon}}
-  {{#> title titleType="h1" title--modifier="pf-m-lg"}}
+  {{#> title titleType="h1" title--modifier="pf-m-xl"}}
     Empty state
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> button button--modifier="pf-m-primary"}}
-    Primary action
-  {{/button}}
+  {{#> empty-state-primary}}
+    {{#> button button--modifier="pf-m-primary"}}
+      Primary action
+    {{/button}}
+  {{/empty-state-primary}}
   {{#> empty-state-secondary}}
     {{#> button button--modifier="pf-m-link"}}
       Multiple
@@ -154,11 +160,13 @@ cssPrefix: pf-c-empty-state
     Empty state
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
-  {{#> button button--modifier="pf-m-primary"}}
-    Primary action
-  {{/button}}
+  {{#> empty-state-primary}}
+    {{#> button button--modifier="pf-m-primary"}}
+      Primary action
+    {{/button}}
+  {{/empty-state-primary}}
 {{/empty-state}}
 ```
 
@@ -170,7 +178,7 @@ cssPrefix: pf-c-empty-state
     Empty State
   {{/title}}
   {{#> empty-state-body}}
-    This represents an the empty state pattern in PatternFly 4. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
+    This represents an the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs.
   {{/empty-state-body}}
   {{#> empty-state-primary}}
     {{#> button button--modifier="pf-m-link"}}
@@ -191,12 +199,11 @@ cssPrefix: pf-c-empty-state
 | -- | -- | -- |
 | `.pf-c-empty-state` | `<div>` |  Initiates an empty state component. The empty state centers its content (`.pf-c-empty-state__content`) vertically and horizontally. **Required** |
 | `.pf-c-empty-state__content` | `<div>` |  Creates the content container. **Required** |
-| `.pf-c-empty-state__icon` | `<i>`, `<div>` |  Creates the empty state icon or icon container when used as a `<div>`. |
+| `.pf-c-empty-state__icon` | `<div>` |  Creates the empty state icon container. |
 | `.pf-c-title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Creates the empty state title. **Required** |
-| `.pf-c-empty-state__body` | `<div>` |  Creates the empty state body content. You can have more than one `.pf-c-empty-state__body` elements. |
-| `.pf-c-button.pf-m-primary` | `<button>` |  Creates the primary action button. |
-| `.pf-c-empty-state__primary` | `<div>` |  Container for primary actions. Can be used in lieu of using `.pf-c-button.pf-m-primary`. |
-| `.pf-c-empty-state__secondary` | `<div>` |  Container secondary actions. |
+| `.pf-c-empty-state__body` | `<div>` |  Creates the empty state body content. There can be more than one `.pf-c-empty-state__body` elements. |
+| `.pf-c-empty-state__primary` | `<div>` |  Container for primary actions. **Required if there is a primary action** |
+| `.pf-c-empty-state__secondary` | `<div>` |  Container secondary actions. **Required if there is a secondary action** |
 | `.pf-m-xs` | `.pf-c-empty-state` | Modifies the empty state for a extra small variation and max-width. |
 | `.pf-m-sm` | `.pf-c-empty-state` | Modifies the empty state for a small max-width. |
 | `.pf-m-lg` | `.pf-c-empty-state` | Modifies the empty state for a large max-width. |


### PR DESCRIPTION
Fixes #5138 
[Empty state page](https://patternfly-pr-5307.surge.sh/components/empty-state)

- Body text font size is properly controlled with variables
- The icon must be contained in the icon container
- Title size is driven by the modifier on the title rather than empty state overrides
- Button size is determined by the button modifier rather than empty state overrides
- __primary/__secondary containers are now required if there are primary/secondary actions
- __primary and __secondary containers use flex/gap to space contents
- Rearranged variables for clarity
- Removed Patternfly "4" from example text