### PR TITLE
fix(calendar-month): updated year width to not truncate

### DIFF
--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -8,7 +8,7 @@
 
   // header
   --pf-c-calendar-month__header--MarginBottom: var(--pf-global--spacer--md);
-  --pf-c-calendar-month__header-year--Width: 8ch;
+  --pf-c-calendar-month__header-year--Width: 8.5ch;
   --pf-c-calendar-month__header-nav-control--MarginRight: 0;
   --pf-c-calendar-month__header-nav-control--MarginLeft: 0;
   --pf-c-calendar-month__header-nav-control--m-prev-month--MarginRight: 0; // remove in breaking change


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5222

You can see the year truncate if you set the year to "0000" in chrome. This just bumps the size a bit for cases where that might trigger.