### PR TITLE
fix(lists): added list role to list elements

### DIFF
--- a/src/patternfly/components/AlertGroup/alert-group.hbs
+++ b/src/patternfly/components/AlertGroup/alert-group.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-alert-group{{#if alert-group--modifier}} {{alert-group--modifier}}{{/if}}"
+  role="list"
   {{#if alert-group--attribute}}
     {{{alert-group--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/AppLauncher/app-launcher-menu.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu.hbs
@@ -1,6 +1,7 @@
 <{{#if app-launcher--IsGrouped}}div{{else}}ul{{/if}} class="pf-c-app-launcher__menu{{#if app-launcher-menu--modifier}} {{app-launcher-menu--modifier}}{{/if}}"
   {{#unless app-launcher--IsGrouped}}
     aria-labelledby="{{app-launcher--id}}-button"
+    role="list"
   {{/unless}}
   {{#unless app-launcher--IsExpanded}}hidden{{/unless}}
   {{#if app-launcher-menu--attribute}}

--- a/src/patternfly/components/AppLauncher/examples/application-launcher.md
+++ b/src/patternfly/components/AppLauncher/examples/application-launcher.md
@@ -72,7 +72,7 @@ import './application-launcher.css'
 {{#> app-launcher app-launcher--id="application-launcher-divided-sections" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link not in group{{/app-launcher-menu-item}}</li>
       </ul>
     {{/app-launcher-group}}
@@ -81,7 +81,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 1
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
       </ul>
@@ -91,7 +91,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 2
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
       </ul>
@@ -105,7 +105,7 @@ import './application-launcher.css'
 {{#> app-launcher app-launcher--id="application-launcher-divided-items" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link not in group{{/app-launcher-menu-item}}</li>
         {{> divider divider--type="li"}}
       </ul>
@@ -114,7 +114,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 1
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
         {{> divider divider--type="li"}}
@@ -124,7 +124,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 2
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
         <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
       </ul>
@@ -138,7 +138,7 @@ import './application-launcher.css'
 {{#> app-launcher app-launcher--id="application-launcher-sections-dividers-icons-links" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
-      <ul>
+      <ul role="list">
         <li>
           {{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}
             {{#> app-launcher-menu-item-icon}}
@@ -154,7 +154,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 1
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>
           {{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-external" app-launcher-menu-item--attribute='href="#" target="_blank"'}}
             {{#> app-launcher-menu-item-icon}}
@@ -180,7 +180,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 2
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         <li>
           {{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-external" app-launcher-menu-item--attribute='href="#" target="_blank"'}}
             {{#> app-launcher-menu-item-icon}}
@@ -216,7 +216,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Favorites
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         {{#> app-launcher-menu-wrapper app-launcher-menu-wrapper--type="li" app-launcher-menu-wrapper--modifier="pf-m-external pf-m-favorite"}}
           {{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-link" app-launcher-menu-item--attribute='href="#" target="_blank"'}}
             {{#> app-launcher-menu-item-icon}}
@@ -248,7 +248,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 1
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         {{#> app-launcher-menu-wrapper app-launcher-menu-wrapper--type="li" app-launcher-menu-wrapper--modifier="pf-m-external"}}
           {{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-link" app-launcher-menu-item--attribute='href="#" target="_blank"'}}
             {{#> app-launcher-menu-item-icon}}
@@ -280,7 +280,7 @@ import './application-launcher.css'
       {{#> app-launcher-group-title}}
         Group 2
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         {{#> app-launcher-menu-wrapper app-launcher-menu-wrapper--type="li" app-launcher-menu-wrapper--modifier="pf-m-external pf-m-favorite"}}
           {{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-link" app-launcher-menu-item--attribute='href="#" target="_blank"'}}
             {{#> app-launcher-menu-item-icon}}

--- a/src/patternfly/components/Breadcrumb/breadcrumb-list.hbs
+++ b/src/patternfly/components/Breadcrumb/breadcrumb-list.hbs
@@ -1,4 +1,5 @@
 <ol class="pf-c-breadcrumb__list{{#if breadcrumb-list--modifier}} {{breadcrumb-list--modifier}}{{/if}}"
+  role="list"
   {{#if breadcrumb-list--attribute}}
     {{{breadcrumb-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/ContextSelector/context-selector-menu-menu.hbs
+++ b/src/patternfly/components/ContextSelector/context-selector-menu-menu.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-context-selector__menu-list{{#if context-selector-menu-list--modifier}} {{context-selector-menu-list--modifier}}{{/if}}"
+  role="list"
   {{#if context-selector-menu-list--attribute}}
     {{{context-selector-menu-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -167,7 +167,6 @@
   font-size: var(--pf-c-data-list--FontSize);
   line-height: var(--pf-c-data-list--LineHeight);
   overflow-wrap: break-word;
-  list-style-type: disc;
   border-top: var(--pf-c-data-list--BorderTopWidth) solid var(--pf-c-data-list--BorderTopColor);
 
   &.pf-m-compact {

--- a/src/patternfly/components/Divider/examples/Divider.md
+++ b/src/patternfly/components/Divider/examples/Divider.md
@@ -17,7 +17,7 @@ import './Divider.css'
 ### li
 
 ```hbs
-<ul>
+<ul role="list">
   <li>List item one</li>
   {{> divider divider--type="li"}}
   <li>List item two</li>

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -131,7 +131,7 @@ cssPrefix: pf-c-helper-text
 
 ### Dynamic list
 ```hbs
-{{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
+{{#> helper-text helper-text--IsList="true"}}
   {{#> helper-text-item helper-text-item--modifier="pf-m-dynamic pf-m-success"}}
     {{> helper-text-item-icon helper-text-item-icon--type="check-circle"}}
     {{#> helper-text-item-text}}Must be at least 14 characters{{/helper-text-item-text}}

--- a/src/patternfly/components/HelperText/helper-text-item.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item.hbs
@@ -1,6 +1,6 @@
-<{{#if helper-text-item--type}}{{helper-text-item--type}}{{else}}div{{/if}} class="pf-c-helper-text__item{{#if helper-text-item--modifier}} {{helper-text-item--modifier}}{{/if}}"
+<{{#if helper-text--IsList}}li{{else}}div{{/if}} class="pf-c-helper-text__item{{#if helper-text-item--modifier}} {{helper-text-item--modifier}}{{/if}}"
   {{#if helper-text-item--attribute}}
     {{{helper-text-item--attribute}}}
   {{/if}}>
   {{>@partial-block}}
-</{{#if helper-text-item--type}}{{helper-text-item--type}}{{else}}div{{/if}}>
+</{{#if helper-text--IsList}}li{{else}}div{{/if}}>

--- a/src/patternfly/components/HelperText/helper-text.hbs
+++ b/src/patternfly/components/HelperText/helper-text.hbs
@@ -1,6 +1,9 @@
-<{{#if helper-text--type}}{{helper-text--type}}{{else}}div{{/if}} class="pf-c-helper-text{{#if helper-text--modifier}} {{helper-text--modifier}}{{/if}}"
+<{{#if helper-text--IsList}}ul{{else}}div{{/if}} class="pf-c-helper-text{{#if helper-text--modifier}} {{helper-text--modifier}}{{/if}}"
+  {{#if helper-text--IsList}}
+    role="list"
+  {{/if}}
   {{#if helper-text--attribute}}
     {{{helper-text--attribute}}}
   {{/if}}>
   {{>@partial-block}}
-</{{#if helper-text--type}}{{helper-text--type}}{{else}}div{{/if}}>
+</{{#if helper-text--IsList}}ul{{else}}div{{/if}}>

--- a/src/patternfly/components/JumpLinks/jump-links-list.hbs
+++ b/src/patternfly/components/JumpLinks/jump-links-list.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-jump-links__list{{#if jump-links-list--modifier}} {{jump-links-list--modifier}}{{/if}}"
+  role="list"
   {{#if jump-links-list--attribute}}
     {{{jump-links-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/List/examples/List.md
+++ b/src/patternfly/components/List/examples/List.md
@@ -62,7 +62,7 @@ cssPrefix: pf-c-list
 
 ### Plain
 ```hbs
-{{#> list list--type="ul" list--modifier="pf-m-plain"}}
+{{#> list list--modifier="pf-m-plain"}}
   <li>Donec blandit a lorem id convallis.</li>
   <li>Integer in volutpat libero.</li>
   <li>Donec a diam tellus.

--- a/src/patternfly/components/List/list.hbs
+++ b/src/patternfly/components/List/list.hbs
@@ -1,4 +1,7 @@
 <{{#if list--type}}{{list--type}}{{else}}ul{{/if}} class="pf-c-list{{#if list--modifier}} {{list--modifier}}{{/if}}"
+  {{#unless list--type}}
+    role="list"
+  {{/unless}}
   {{#if list--attribute}}
     {{{list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/List/list.hbs
+++ b/src/patternfly/components/List/list.hbs
@@ -1,7 +1,5 @@
 <{{#if list--type}}{{list--type}}{{else}}ul{{/if}} class="pf-c-list{{#if list--modifier}} {{list--modifier}}{{/if}}"
-  {{#unless list--type}}
-    role="list"
-  {{/unless}}
+  role="list"
   {{#if list--attribute}}
     {{{list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Login/login-main-footer-links.hbs
+++ b/src/patternfly/components/Login/login-main-footer-links.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-login__main-footer-links{{#if login-main-footer-links--modifier}} {{login-main-footer-grid--modifier}}{{/if}}"
+  role="list"
   {{#if login-main-footer-links--attribute}}
     {{{login-main-footer-links--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload-status-list.hbs
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload-status-list.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-multiple-file-upload__status-list{{#if multiple-file-upload-status-list--modifier}} {{multiple-file-upload-status-list--modifier}}{{/if}}"
+  role="list"
   {{#if multiple-file-upload-status-list--attribute}}
     {{{multiple-file-upload-status-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Nav/nav-list.hbs
+++ b/src/patternfly/components/Nav/nav-list.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-nav__list{{#if nav-list--modifier}} {{nav-list--modifier}}{{/if}}"
+  role="list"
   {{#if nav-list--attribute}}
     {{{nav-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-notification-drawer__list{{#if notification-drawer-list--modifier}} {{notification-drawer-list--modifier}}{{/if}}"
+  role="list"
   {{#if notification-drawer-group--IsGroup}}
     {{#unless notification-drawer-group--IsExpanded}}
       hidden

--- a/src/patternfly/components/ProgressStepper/progress-stepper.hbs
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.hbs
@@ -1,4 +1,5 @@
 <ol class="pf-c-progress-stepper{{#if progress-stepper--modifier}} {{progress-stepper--modifier}}{{/if}}{{#if progress-stepper--IsCenter}} pf-m-center{{/if}}{{#if progress-stepper--IsVertical}} pf-m-vertical{{/if}}{{#if progress-stepper--IsCompact}} pf-m-compact{{/if}}"
+  role="list"
   {{#if progress-stepper--attribute}}
     {{{progress-stepper--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/SimpleList/simple-list-list.hbs
+++ b/src/patternfly/components/SimpleList/simple-list-list.hbs
@@ -1,4 +1,5 @@
 <ul class="pf-c-simple-list__list{{#if simple-list-list--modifier}} {{simple-list-list--modifier}}{{/if}}"
+  role="list"
   {{#if simple-list-list--attribute}}
     {{{simple-list-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Wizard/wizard-nav-list.hbs
+++ b/src/patternfly/components/Wizard/wizard-nav-list.hbs
@@ -1,4 +1,5 @@
 <ol class="pf-c-wizard__nav-list{{#if wizard-nav-list--modifier}} {{wizard-nav-list--modifier}}{{/if}}"
+  role="list"
   {{#if wizard-nav-list--attribute}}
     {{{wizard-nav-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/demos/Masthead/masthead-template-application-launcher.hbs
+++ b/src/patternfly/demos/Masthead/masthead-template-application-launcher.hbs
@@ -7,7 +7,7 @@
       {{#> app-launcher-group-title}}
         Favorites
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         {{#> app-launcher-menu-wrapper app-launcher-menu-wrapper--type="li" app-launcher-menu-wrapper--modifier="pf-m-external pf-m-favorite"}}
           {{#> app-launcher-menu-item}}
             Link 1
@@ -33,7 +33,7 @@
       {{#> app-launcher-group-title}}
         Group 1
       {{/app-launcher-group-title}}
-      <ul>
+      <ul role="list">
         {{#> app-launcher-menu-wrapper app-launcher-menu-wrapper--type="li" app-launcher-menu-wrapper--modifier="pf-m-external"}}
           {{#> app-launcher-menu-item}}
             Link 1


### PR DESCRIPTION
Closes #5262 

Some notes:
- Did not update `log-viewer-list` as it doesn't seem to be used anywhere -- There's a template file called `__log-viewer-dynamic-data` that is used in the HTML examples and which the markup matches React examples. 
- Unrelated to this issue, but related to some usage of lists in Core code, the following components needs to be updated to use the applicable role + match React:
  - Tabs
  - Dropdown
  - OptionsMenu
  - SearchInput (the list for autocomplete examples)
  - OverflowMenu