### PR TITLE
fix(modal): add wrapper to close button

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,11 +10,7 @@ import './ModalBox.css'
 ### Basic
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
       Modal title
@@ -32,11 +28,7 @@ import './ModalBox.css'
 ### With help button
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-help-title" aria-describedby="modal-help-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header modal-box-header--modifier="pf-m-help"}}
     {{#> modal-box-header-main}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-help-title"'}}
@@ -60,11 +52,7 @@ import './ModalBox.css'
 ### Small
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute='aria-labelledby="modal-sm-title" aria-describedby="modal-sm-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-sm-title"'}}
       Modal title
@@ -85,11 +73,7 @@ import './ModalBox.css'
 ### Medium
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-md" modal-box--attribute='aria-labelledby="modal-md-title" aria-describedby="modal-md-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-md-title"'}}
       Modal title
@@ -110,11 +94,7 @@ import './ModalBox.css'
 ### Large
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
       Modal title
@@ -135,11 +115,7 @@ import './ModalBox.css'
 ### Without title
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-label="Example of a modal without a title" aria-describedby="modal-no-title-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-body}}
     <span id="modal-no-title-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   {{/modal-box-body}}
@@ -152,11 +128,7 @@ import './ModalBox.css'
 ### With description
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-with-description-title" aria-describedby="modal-with-description-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-with-description-title"'}}
       Modal title
@@ -177,11 +149,7 @@ import './ModalBox.css'
 ### Custom title
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-custom-title" aria-describedby="modal-custom-description"'}}
-  {{#> modal-box-close}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
-  {{/modal-box-close}}
+  {{> modal-box-close}}
   {{#> modal-box-header}}
     {{#> title title--modifier="pf-m-4xl" title--attribute='id="modal-custom-title"'}}Custom title{{/title}}
   {{/modal-box-header}}
@@ -205,11 +173,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="icon"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"')}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"') modal-box-title-icon--type="bullhorn"}}
         Modal with icon title
@@ -229,11 +193,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="default-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsDefaultAlert="true"}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Default alert modal title
@@ -253,11 +213,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="info-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsInfoAlert="true"}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Info alert modal title
@@ -277,11 +233,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="success-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsSuccessAlert="true"}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Success alert modal title
@@ -301,11 +253,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="warning-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsWarningAlert="true"}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Warning alert modal title
@@ -325,11 +273,7 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="danger-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsDangerAlert="true"}}
-    {{#> modal-box-close}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
-    {{/modal-box-close}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Danger alert modal title

--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -10,9 +10,11 @@ import './ModalBox.css'
 ### Basic
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-   <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
       Modal title
@@ -30,9 +32,11 @@ import './ModalBox.css'
 ### With help button
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-help-title" aria-describedby="modal-help-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header modal-box-header--modifier="pf-m-help"}}
     {{#> modal-box-header-main}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-help-title"'}}
@@ -56,9 +60,11 @@ import './ModalBox.css'
 ### Small
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute='aria-labelledby="modal-sm-title" aria-describedby="modal-sm-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-sm-title"'}}
       Modal title
@@ -79,9 +85,11 @@ import './ModalBox.css'
 ### Medium
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-md" modal-box--attribute='aria-labelledby="modal-md-title" aria-describedby="modal-md-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-md-title"'}}
       Modal title
@@ -102,9 +110,11 @@ import './ModalBox.css'
 ### Large
 ```hbs isFullscreen
 {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
       Modal title
@@ -125,9 +135,11 @@ import './ModalBox.css'
 ### Without title
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-label="Example of a modal without a title" aria-describedby="modal-no-title-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
     <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-body}}
     <span id="modal-no-title-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   {{/modal-box-body}}
@@ -140,9 +152,11 @@ import './ModalBox.css'
 ### With description
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-with-description-title" aria-describedby="modal-with-description-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-   <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> modal-box-title modal-box-title--attribute='id="modal-with-description-title"'}}
       Modal title
@@ -163,9 +177,11 @@ import './ModalBox.css'
 ### Custom title
 ```hbs isFullscreen
 {{#> modal-box modal-box--attribute='aria-labelledby="modal-custom-title" aria-describedby="modal-custom-description"'}}
-  {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-   <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+  {{#> modal-box-close}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
     {{#> title title--modifier="pf-m-4xl" title--attribute='id="modal-custom-title"'}}Custom title{{/title}}
   {{/modal-box-header}}
@@ -189,9 +205,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="icon"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"')}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"') modal-box-title-icon--type="bullhorn"}}
         Modal with icon title
@@ -211,9 +229,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="default-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsDefaultAlert="true"}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Default alert modal title
@@ -233,9 +253,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="info-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsInfoAlert="true"}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Info alert modal title
@@ -255,9 +277,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="success-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsSuccessAlert="true"}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Success alert modal title
@@ -277,9 +301,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="warning-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsWarningAlert="true"}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Warning alert modal title
@@ -299,9 +325,11 @@ import './ModalBox.css'
 ```hbs isFullscreen
 {{#> modal-example modal-example--id="danger-alert"}}
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"') modal-box--IsAlert="true" modal-box--IsDangerAlert="true"}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+    {{#> modal-box-close}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"')}}
         Danger alert modal title
@@ -339,6 +367,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | Class | Applied | Outcome |
 | -- | -- | -- |
 | `.pf-c-modal-box` | `<div>` | Initiates a modal box. **Required** |
+| `.pf-c-modal-box__close` | `<div>` | Creates a container for the modal box close button. **Required** if there is a close button. |
 | `.pf-c-button.pf-m-plain` | `<button>` | Initiates a modal box close button. |
 | `.pf-c-modal-box__header` | `<header>` | Initiates a modal box header. **Required** if using a `.pf-c-modal-box__title`. |
 | `.pf-c-modal-box__header-main` | `<div>` | Initiates a modal box header main container. **Required** when `pf-c-modal-box__header-help` is used. |

--- a/src/patternfly/components/ModalBox/modal-box-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-close.hbs
@@ -2,5 +2,11 @@
   {{#if modal-box-close--attribute}}
     {{{modal-box-close--attribute}}}
   {{/if}}>
+  {{#if @partial-block}}
   {{> @partial-block}}
+  {{else}}
+      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
+        <i class="fas fa-times" aria-hidden="true"></i>
+      {{/button}}
+  {{/if}}
 </div>

--- a/src/patternfly/components/ModalBox/modal-box-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-close.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-modal-box__close{{#if modal-box-close--modifier}} {{modal-box-close--modifier}}{{/if}}"
+  {{#if modal-box-close--attribute}}
+    {{{modal-box-close--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -52,9 +52,9 @@
   --pf-c-modal-box__header--body--PaddingTop: var(--pf-global--spacer--md);
 
   // Close
-  --pf-c-modal-box--c-button--Top: calc(var(--pf-global--spacer--lg));
-  --pf-c-modal-box--c-button--Right: var(--pf-global--spacer--md);
-  --pf-c-modal-box--c-button--sibling--MarginRight: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
+  --pf-c-modal-box__close--Top: calc(var(--pf-global--spacer--lg));
+  --pf-c-modal-box__close--Right: var(--pf-global--spacer--md);
+  --pf-c-modal-box__close--sibling--MarginRight: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--sm));
 
   // Footer
   --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--lg);
@@ -114,16 +114,16 @@
   &.pf-m-info {
     --pf-c-modal-box__title-icon--Color: var(--pf-c-modal-box--m-info__title-icon--Color);
   }
+}
 
-  // Close button
-  > .pf-c-button {
-    position: absolute;
-    top: var(--pf-c-modal-box--c-button--Top);
-    right: var(--pf-c-modal-box--c-button--Right);
+// Close button
+.pf-c-modal-box__close {
+  position: absolute;
+  top: var(--pf-c-modal-box__close--Top);
+  right: var(--pf-c-modal-box__close--Right);
 
-    + * {
-      margin-right: var(--pf-c-modal-box--c-button--sibling--MarginRight); // Create room for the close button
-    }
+  + * {
+    margin-right: var(--pf-c-modal-box__close--sibling--MarginRight); // Create room for the close button
   }
 }
 

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -10,9 +10,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-basic-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute=(concat 'aria-labelledby="modal-title-' modal-template--id '" aria-describedby="modal-description-' modal-template--id '"')}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute=(concat 'id="modal-title-' modal-template--id '"')}}
         Overwrite existing file?
@@ -40,9 +38,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-scrollable-content-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute='aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"'}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title  modal-box-title--attribute='id="modal-scroll-title"'}}
         This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
@@ -80,9 +76,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-medium-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-md" modal-box--attribute='aria-labelledby="modal-md-title" aria-describedby="modal-md-description"'}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-md-title"'}}
         This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
@@ -110,9 +104,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-large-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-lg" modal-box--attribute='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-lg-title"'}}
         This is a long header title that will truncate because modal titles should be very short. Use the modal body to provide more info.
@@ -140,9 +132,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-large-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-sm pf-m-align-top" modal-box--attribute='aria-labelledby="modal-top-aligned-title" aria-describedby="modal-top-aligned-description"'}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute='id="modal-top-aligned-title"'}}
         Modal header
@@ -170,9 +160,7 @@ section: components
 
 {{#> modal-template modal-template--id="modal-with-form-example-modal"}}
   {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute=(concat 'aria-labelledby="modal-title-' modal--id '" aria-describedby="modal-description-' modal--id '"') form--id=(concat modal--id '-form')}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute=(concat 'id="modal-title-' modal--id '"')}}
         Create account

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -129,9 +129,7 @@ import './Table.css'
 {{#> backdrop}}
   {{#> bullseye}}
     {{#> modal-box modal-box--attribute='aria-labelledby="modal-title" aria-describedby="modal-description"' modal-box--modifier="pf-m-sm"}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-      {{/button}}
+      {{> modal-box-close}}
       {{#> modal-box-header}}
         {{#> modal-box-title modal-box-title--attribute='id="modal-title"'}}
           Manage columns

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -362,9 +362,7 @@ section: components
 ```hbs isFullscreen
 {{#> modal-template modal-template--id="modal-tabs-example"}}
   {{#> modal-box modal-box--modifier="pf-m-sm" modal-box--attribute=(concat 'aria-labelledby="' modal-template--id '-modal-title" aria-describedby="' modal-template--id '-modal-description"')}}
-    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close dialog"'}}
-      <i class="fas fa-times" aria-hidden="true"></i>
-    {{/button}}
+    {{> modal-box-close}}
     {{#> modal-box-header}}
       {{#> modal-box-title modal-box-title--attribute=(concat 'id="' modal-template--id '-modal-title"')}}
         PatternFly


### PR DESCRIPTION
Fixes #5362 

Breaking change:
- Adds the `pf-c-modal-box__close` wrapper around the close button. Associated CSS variables are renamed.