### PR TITLE
feat(table): added support for sticky column on right

### DIFF
--- a/src/patternfly/components/Table/examples/Table.css
+++ b/src/patternfly/components/Table/examples/Table.css
@@ -9,6 +9,10 @@
   top: -18px;
 }
 
+#ws-core-c-table-sticky-header .ws-preview-html {
+  height: 300px;
+}
+
 #ws-core-c-table-sticky-columns-and-header .ws-preview-html {
   height: 600px;
 }

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3343,8 +3343,9 @@ For sticky columns to function correctly, the parent table's width must be contr
 | `.pf-m-sticky-header` | `.pf-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll. |
 | `.pf-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
-| `.pf-c-table__sticky-left` | `<th>`, `<td>` | Initiates a sticky, left-hand table cell. |
-| `.pf-c-table__sticky-right` | `<th>`, `<td>` | Initiates a sticky, right-hand table cell. |
+| `.pf-c-table__sticky-cell` | `<th>`, `<td>` | Initiates a sticky table cell. |
+| `.pf-m-right` | `.pf-c-table__sticky-cell` | Initiates a sticky, right-hand table cell. |
+| `.pf-m-left` | `.pf-c-table__sticky-cell` | Initiates a sticky, left-hand table cell. |
 
 
 ## Nested column headers

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3187,143 +3187,150 @@ There are a few ways this can be handled:
 
 ### Sticky header
 ```hbs
-{{#> table table--id="table-sticky-header" table--grid="true" table--modifier="pf-m-grid-md pf-m-sticky-header" table--attribute='aria-label="This is a table with sticky header cells"'}}
-  {{#> table-thead}}
-    {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Repositories
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Branches
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Pull requests
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Workspaces
-      {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"'}}
-        Last commit
-      {{/table-th}}
-    {{/table-tr}}
-  {{/table-thead}}
+<div class="pf-c-scroll-inner-wrapper">
+  {{#> table table--id="table-sticky-header" table--grid="true" table--modifier="pf-m-grid-md pf-m-sticky-header" table--attribute='aria-label="This is a table with sticky header cells"'}}
+    {{#> table-thead}}
+      {{#> table-tr}}
+        {{#> table-th table-th--attribute='scope="col"'}}
+          Repositories
+        {{/table-th}}
+        {{#> table-th table-th--attribute='scope="col"'}}
+          Branches
+        {{/table-th}}
+        {{#> table-th table-th--attribute='scope="col"'}}
+          Pull requests
+        {{/table-th}}
+        {{#> table-th table-th--attribute='scope="col"'}}
+          Workspaces
+        {{/table-th}}
+        {{#> table-th table-th--attribute='scope="col"'}}
+          Last commit
+        {{/table-th}}
+      {{/table-tr}}
+    {{/table-thead}}
 
-  {{#> table-tbody}}
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="Repository name"}}
-        Repository 1
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Branches"}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Pull requests"}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Last commit"}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
+    {{#> table-tbody}}
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 1
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
 
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="Repository name"}}
-        Repository 2
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Branches"}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Pull requests"}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Last commit"}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 2
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
 
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="Repository name"}}
-        Repository 3
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Branches"}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Pull requests"}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Last commit"}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 3
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
 
-    {{#> table-tr}}
-      {{#> table-td table-td--data-label="Repository name"}}
-        Repository 4
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Branches"}}
-        10
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Pull requests"}}
-        25
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
-        5
-      {{/table-td}}
-      {{#> table-td table-td--data-label="Last commit"}}
-        2 days ago
-      {{/table-td}}
-    {{/table-tr}}
-  {{/table-tbody}}
-{{/table}}
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 4
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+    {{/table-tbody}}
+  {{/table}}
+</div>
 ```
 
 ### Sticky column
-
 ```hbs
 <div class="pf-c-scroll-inner-wrapper">
   {{> table--scrollable
       table--scrollable--id="sticky-column-example"
-      table--scrollable--Column1IsStickyColumn="true"
+      table--scrollable--Column1IsStickyColumn=true
       table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate pf-m-border-right"
-      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate"
-      }}
+      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate"}}
 </div>
 ```
 
 ### Multiple sticky columns
-
 ```hbs
 <div class="pf-c-scroll-inner-wrapper">
   {{> table--scrollable
       table--scrollable--id="sticky-multi-column-example"
-      table--scrollable--Column1IsStickyColumn="true"
-      table--scrollable--Column2IsStickyColumn="true"
+      table--scrollable--Column1IsStickyColumn=true
+      table--scrollable--Column2IsStickyColumn=true
       table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate"
-      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"
-      }}
+      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"}}
 </div>
 ```
 
 ### Sticky columns and header
-
 ```hbs
 <div class="pf-c-scroll-outer-wrapper">
   <div class="pf-c-scroll-inner-wrapper">
     {{> table--scrollable table--scrollable--id="sticky-header-columns-example"
         table--scrollable--modifier="pf-m-sticky-header"
-        table--scrollable--Column1IsStickyColumn="true"
-        table--scrollable--Column2IsStickyColumn="true"
+        table--scrollable--Column1IsStickyColumn=true
+        table--scrollable--Column2IsStickyColumn=true
         table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate"
-        table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"
-        }}
+        table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"}}
   </div>
+</div>
+```
+
+### Sticky right column
+
+```hbs
+<div class="pf-c-scroll-inner-wrapper">
+  {{> table--scrollable
+      table--scrollable--id="sticky-right-column-example"
+      table--scrollable--ColumnLastIsStickyColumn=true
+      table--scrollable--th--modifier--cell-9-modifier="pf-m-truncate pf-m-border-left"}}
 </div>
 ```
 
@@ -3336,7 +3343,8 @@ For sticky columns to function correctly, the parent table's width must be contr
 | `.pf-m-sticky-header` | `.pf-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll. |
 | `.pf-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
-| `.pf-c-table__sticky-column` | `<th>`, `<td>` | Initiates a sticky table cell. |
+| `.pf-c-table__sticky-left` | `<th>`, `<td>` | Initiates a sticky, left-hand table cell. |
+| `.pf-c-table__sticky-right` | `<th>`, `<td>` | Initiates a sticky, right-hand table cell. |
 
 
 ## Nested column headers

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -1,7 +1,7 @@
 .pf-c-table {
   --pf-c-table__sticky-cell--MinWidth--base: #{pf-size-prem(200px)};
   --pf-c-table__sticky-cell--MinWidth: var(--pf-c-table__sticky-cell--MinWidth--base);
-  --pf-c-table__sticky-cell--ZIndex: var(--pf-global--ZIndex--md);
+  --pf-c-table__sticky-cell--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-table__sticky-cell--Top: 0;
   --pf-c-table__sticky-cell--Right: auto;
   --pf-c-table__sticky-cell--Left: auto;

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -1,55 +1,50 @@
 .pf-c-table {
-  --pf-c-table__sticky--cell-min-width--base: #{pf-size-prem(200px)};
-  --pf-c-table__sticky--cell--MinWidth: var(--pf-c-table__sticky--cell-min-width--base);
-  --pf-c-table__sticky--cell--ZIndex: var(--pf-global--ZIndex--md);
-  --pf-c-table__sticky--cell--Top: 0;
-  --pf-c-table__sticky--cell--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table__sticky--cell--m-border-right--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__sticky--cell--m-border-right--before--BorderRightColor: var(--pf-global--BorderColor--100);
-  --pf-c-table__sticky--cell--m-border-left--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__sticky--cell--m-border-left--before--BorderLeftColor: var(--pf-global--BorderColor--100);
-  --pf-c-table--m-sticky-header--thead__sticky--cell--ZIndex: calc(var(--pf-c-table__sticky--cell--ZIndex) + 1);
-  --pf-c-table__sticky-left--Left: 0;
-  --pf-c-table__sticky-right--Right: 0;
+  --pf-c-table__sticky-cell--MinWidth--base: #{pf-size-prem(200px)};
+  --pf-c-table__sticky-cell--MinWidth: var(--pf-c-table__sticky-cell--MinWidth--base);
+  --pf-c-table__sticky-cell--ZIndex: var(--pf-global--ZIndex--md);
+  --pf-c-table__sticky-cell--Top: 0;
+  --pf-c-table__sticky-cell--Right: auto;
+  --pf-c-table__sticky-cell--Left: auto;
+  --pf-c-table__sticky-cell--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table__sticky-cell--m-border-right--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__sticky-cell--m-border-right--before--BorderRightColor: var(--pf-global--BorderColor--100);
+  --pf-c-table__sticky-cell--m-border-left--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__sticky-cell--m-border-left--before--BorderLeftColor: var(--pf-global--BorderColor--100);
+  --pf-c-table__sticky-cell--m-right--Right: 0;
+  --pf-c-table__sticky-cell--m-left--Left: 0;
+  --pf-c-table--m-sticky-header__sticky-cell--ZIndex: calc(var(--pf-c-table__sticky-cell--ZIndex) + 1);
 
-  .pf-c-table__sticky-left,
-  .pf-c-table__sticky-right {
+  .pf-c-table__sticky-cell {
+    --pf-c-table--cell--Overflow: visible;
+    --pf-c-table--m-sticky-header--cell--ZIndex: var(--pf-c-table--m-sticky-header__sticky-cell--ZIndex);
+
     position: sticky;
-    z-index: var(--pf-c-table__sticky--cell--ZIndex);
-    min-width: var(--pf-c-table__sticky--cell--MinWidth);
-    background-color: var(--pf-c-table__sticky--cell--BackgroundColor);
+    right: var(--pf-c-table__sticky-cell--Right);
+    left: var(--pf-c-table__sticky-cell--Left);
+    z-index: var(--pf-c-table__sticky-cell--ZIndex);
+    min-width: var(--pf-c-table__sticky-cell--MinWidth);
+    background-color: var(--pf-c-table__sticky-cell--BackgroundColor);
     background-clip: padding-box;
 
     &.pf-m-border-right::before {
-      --pf-c-table--cell--m-border-right--before--BorderRightWidth: var(--pf-c-table__sticky--cell--m-border-right--before--BorderRightWidth);
-      --pf-c-table--cell--m-border-right--before--BorderRightColor: var(--pf-c-table__sticky--cell--m-border-right--before--BorderRightColor);
+      --pf-c-table--cell--m-border-right--before--BorderRightWidth: var(--pf-c-table__sticky-cell--m-border-right--before--BorderRightWidth);
+      --pf-c-table--cell--m-border-right--before--BorderRightColor: var(--pf-c-table__sticky-cell--m-border-right--before--BorderRightColor);
     }
 
     &.pf-m-border-left::before {
-      --pf-c-table--cell--m-border-left--before--BorderLeftWidth: var(--pf-c-table__sticky--cell--m-border-left--before--BorderLeftWidth);
-      --pf-c-table--cell--m-border-left--before--BorderLeftColor: var(--pf-c-table__sticky--cell--m-border-left--before--BorderLeftColor);
+      --pf-c-table--cell--m-border-left--before--BorderLeftWidth: var(--pf-c-table__sticky-cell--m-border-left--before--BorderLeftWidth);
+      --pf-c-table--cell--m-border-left--before--BorderLeftColor: var(--pf-c-table__sticky-cell--m-border-left--before--BorderLeftColor);
     }
-  }
 
-  &.pf-m-sticky-header {
-    --pf-c-table--cell--Overflow: visible;
-
-    thead {
-      .pf-c-table__sticky-left,
-      .pf-c-table__sticky-right {
-        z-index: var(--pf-c-table--m-sticky-header--thead__sticky--cell--ZIndex);
-      }
+    &.pf-m-right {
+      --pf-c-table__sticky-cell--Right: var(--pf-c-table__sticky-cell--m-right--Right);
     }
+
+    &.pf-m-left {
+      --pf-c-table__sticky-cell--Left: var(--pf-c-table__sticky-cell--m-left--Left);
+    }
+
   }
-}
-
-
-.pf-c-table__sticky-left {
-  left: var(--pf-c-table__sticky-left--Left);
-}
-
-.pf-c-table__sticky-right {
-  right: var(--pf-c-table__sticky-right--Right);
 }
 
 .pf-c-scroll-outer-wrapper {

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -1,7 +1,6 @@
 .pf-c-table {
   --pf-c-table__sticky-column--cell-min-width--base: #{pf-size-prem(200px)};
   --pf-c-table__sticky-column--MinWidth: var(--pf-c-table__sticky-column--cell-min-width--base);
-  --pf-c-table__sticky-column--Left: 0;
   --pf-c-table__sticky-column--ZIndex: var(--pf-global--ZIndex--md);
   --pf-c-table__sticky-column--Top: 0;
   --pf-c-table__sticky-column--BackgroundColor: var(--pf-global--BackgroundColor--100);
@@ -13,11 +12,20 @@
 
   .pf-c-table__sticky-column {
     position: sticky;
-    left: var(--pf-c-table__sticky-column--Left);
+    right: var(--pf-c-table__sticky-column--Right, revert);
+    left: var(--pf-c-table__sticky-column--Left, revert);
     z-index: var(--pf-c-table__sticky-column--ZIndex);
     min-width: var(--pf-c-table__sticky-column--MinWidth);
     background-color: var(--pf-c-table__sticky-column--BackgroundColor);
     background-clip: padding-box;
+
+    &:where(:first-child) {
+      --pf-c-table__sticky-column--Left: 0;
+    }
+
+    &:where(:last-child) {
+      --pf-c-table__sticky-column--Right: 0;
+    }
 
     &.pf-m-border-right::before {
       --pf-c-table--cell--m-border-right--before--BorderRightWidth: var(--pf-c-table__sticky-column--m-border-right--before--BorderRightWidth);

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -2,7 +2,6 @@
   --pf-c-table__sticky-cell--MinWidth--base: #{pf-size-prem(200px)};
   --pf-c-table__sticky-cell--MinWidth: var(--pf-c-table__sticky-cell--MinWidth--base);
   --pf-c-table__sticky-cell--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-table__sticky-cell--Top: 0;
   --pf-c-table__sticky-cell--Right: auto;
   --pf-c-table__sticky-cell--Left: auto;
   --pf-c-table__sticky-cell--BackgroundColor: var(--pf-global--BackgroundColor--100);

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -1,40 +1,33 @@
 .pf-c-table {
-  --pf-c-table__sticky-column--cell-min-width--base: #{pf-size-prem(200px)};
-  --pf-c-table__sticky-column--MinWidth: var(--pf-c-table__sticky-column--cell-min-width--base);
-  --pf-c-table__sticky-column--ZIndex: var(--pf-global--ZIndex--md);
-  --pf-c-table__sticky-column--Top: 0;
-  --pf-c-table__sticky-column--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table__sticky-column--m-border-right--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__sticky-column--m-border-right--before--BorderRightColor: var(--pf-global--BorderColor--100);
-  --pf-c-table__sticky-column--m-border-left--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-table__sticky-column--m-border-left--before--BorderLeftColor: var(--pf-global--BorderColor--100);
-  --pf-c-table--m-sticky-header--thead__sticky-column--ZIndex: calc(var(--pf-c-table__sticky-column--ZIndex) + 1);
+  --pf-c-table__sticky--cell-min-width--base: #{pf-size-prem(200px)};
+  --pf-c-table__sticky--cell--MinWidth: var(--pf-c-table__sticky--cell-min-width--base);
+  --pf-c-table__sticky--cell--ZIndex: var(--pf-global--ZIndex--md);
+  --pf-c-table__sticky--cell--Top: 0;
+  --pf-c-table__sticky--cell--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table__sticky--cell--m-border-right--before--BorderRightWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__sticky--cell--m-border-right--before--BorderRightColor: var(--pf-global--BorderColor--100);
+  --pf-c-table__sticky--cell--m-border-left--before--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-table__sticky--cell--m-border-left--before--BorderLeftColor: var(--pf-global--BorderColor--100);
+  --pf-c-table--m-sticky-header--thead__sticky--cell--ZIndex: calc(var(--pf-c-table__sticky--cell--ZIndex) + 1);
+  --pf-c-table__sticky-left--Left: 0;
+  --pf-c-table__sticky-right--Right: 0;
 
-  .pf-c-table__sticky-column {
+  .pf-c-table__sticky-left,
+  .pf-c-table__sticky-right {
     position: sticky;
-    right: var(--pf-c-table__sticky-column--Right, revert);
-    left: var(--pf-c-table__sticky-column--Left, revert);
-    z-index: var(--pf-c-table__sticky-column--ZIndex);
-    min-width: var(--pf-c-table__sticky-column--MinWidth);
-    background-color: var(--pf-c-table__sticky-column--BackgroundColor);
+    z-index: var(--pf-c-table__sticky--cell--ZIndex);
+    min-width: var(--pf-c-table__sticky--cell--MinWidth);
+    background-color: var(--pf-c-table__sticky--cell--BackgroundColor);
     background-clip: padding-box;
 
-    &:where(:first-child) {
-      --pf-c-table__sticky-column--Left: 0;
-    }
-
-    &:where(:last-child) {
-      --pf-c-table__sticky-column--Right: 0;
-    }
-
     &.pf-m-border-right::before {
-      --pf-c-table--cell--m-border-right--before--BorderRightWidth: var(--pf-c-table__sticky-column--m-border-right--before--BorderRightWidth);
-      --pf-c-table--cell--m-border-right--before--BorderRightColor: var(--pf-c-table__sticky-column--m-border-right--before--BorderRightColor);
+      --pf-c-table--cell--m-border-right--before--BorderRightWidth: var(--pf-c-table__sticky--cell--m-border-right--before--BorderRightWidth);
+      --pf-c-table--cell--m-border-right--before--BorderRightColor: var(--pf-c-table__sticky--cell--m-border-right--before--BorderRightColor);
     }
 
     &.pf-m-border-left::before {
-      --pf-c-table--cell--m-border-left--before--BorderLeftWidth: var(--pf-c-table__sticky-column--m-border-left--before--BorderLeftWidth);
-      --pf-c-table--cell--m-border-left--before--BorderLeftColor: var(--pf-c-table__sticky-column--m-border-left--before--BorderLeftColor);
+      --pf-c-table--cell--m-border-left--before--BorderLeftWidth: var(--pf-c-table__sticky--cell--m-border-left--before--BorderLeftWidth);
+      --pf-c-table--cell--m-border-left--before--BorderLeftColor: var(--pf-c-table__sticky--cell--m-border-left--before--BorderLeftColor);
     }
   }
 
@@ -42,11 +35,21 @@
     --pf-c-table--cell--Overflow: visible;
 
     thead {
-      .pf-c-table__sticky-column {
-        z-index: var(--pf-c-table--m-sticky-header--thead__sticky-column--ZIndex);
+      .pf-c-table__sticky-left,
+      .pf-c-table__sticky-right {
+        z-index: var(--pf-c-table--m-sticky-header--thead__sticky--cell--ZIndex);
       }
     }
   }
+}
+
+
+.pf-c-table__sticky-left {
+  left: var(--pf-c-table__sticky-left--Left);
+}
+
+.pf-c-table__sticky-right {
+  right: var(--pf-c-table__sticky-right--Right);
 }
 
 .pf-c-scroll-outer-wrapper {

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -2,7 +2,8 @@
   {{~#if table-th--compound-expansion-toggle}} pf-c-table__compound-expansion-toggle{{/if}}
   {{~#if table-th--sortable}} pf-c-table__sort{{/if}}
   {{~#if table-th--IsSortable}} pf-c-table__sort{{/if}}
-  {{~#if table-th--IsStickyColumn}} pf-c-table__sticky-column{{/if}}
+  {{~#if table-th--IsStickyLeft}} pf-c-table__sticky-left{{/if}}
+  {{~#if table-th--IsStickyRight}} pf-c-table__sticky-right{{/if}}
   {{~#if table-th--toggle}} pf-c-table__toggle{{/if}}
   {{~#if table-th--check}} pf-c-table__check{{/if}}
   {{~#if table-th--action}} pf-c-table__action{{/if}}

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -1,18 +1,18 @@
 <th class="{{#if table-th--modifier}} {{table-th--modifier}}{{/if}}
-  {{~#if table-th--compound-expansion-toggle}} pf-c-table__compound-expansion-toggle{{/if}}
-  {{~#if table-th--sortable}} pf-c-table__sort{{/if}}
-  {{~#if table-th--IsSortable}} pf-c-table__sort{{/if}}
-  {{~#if table-th--IsStickyLeft}} pf-c-table__sticky-left{{/if}}
-  {{~#if table-th--IsStickyRight}} pf-c-table__sticky-right{{/if}}
-  {{~#if table-th--toggle}} pf-c-table__toggle{{/if}}
-  {{~#if table-th--check}} pf-c-table__check{{/if}}
-  {{~#if table-th--action}} pf-c-table__action{{/if}}
-  {{~#if table-th--icon}} pf-c-table__icon{{/if}}
-  {{~#if table-th--sortable-wrap}} pf-m-wrap{{/if}}
-  {{~#if table-th--selected}} pf-m-selected{{/if}}
-  {{~#if table-th--IsColumnHelp}} pf-m-help{{/if}}
-  {{~#if table-th--IsFavorite}} pf-m-favorite{{/if}}"
-  {{~#if table--grid}}
+  {{#if table-th--compound-expansion-toggle}} pf-c-table__compound-expansion-toggle{{/if}}
+  {{#if table-th--sortable}} pf-c-table__sort{{/if}}
+  {{#if table-th--IsSortable}} pf-c-table__sort{{/if}}
+  {{#if table-th--IsStickyLeft}} pf-c-table__sticky-cell pf-m-left{{/if}}
+  {{#if table-th--IsStickyRight}} pf-c-table__sticky-cell pf-m-right{{/if}}
+  {{#if table-th--toggle}} pf-c-table__toggle{{/if}}
+  {{#if table-th--check}} pf-c-table__check{{/if}}
+  {{#if table-th--action}} pf-c-table__action{{/if}}
+  {{#if table-th--icon}} pf-c-table__icon{{/if}}
+  {{#if table-th--sortable-wrap}} pf-m-wrap{{/if}}
+  {{#if table-th--selected}} pf-m-selected{{/if}}
+  {{#if table-th--IsColumnHelp}} pf-m-help{{/if}}
+  {{#if table-th--IsFavorite}} pf-m-favorite{{/if}}"
+  {{#if table--grid}}
     {{#if table-th--isRowHeader}}
       role="rowheader"
     {{else}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -306,6 +306,9 @@
   // Striped
   --pf-c-table--m-striped__tr--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
 
+  // Sticky
+  --pf-c-table--m-sticky-header--cell--ZIndex: var(--pf-global--ZIndex--xs);
+
   @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-table--cell--first-last-child--PaddingRight: var(--pf-c-table--cell--first-last-child--xl--PaddingRight);
     --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-c-table--cell--first-last-child--xl--PaddingLeft);
@@ -330,7 +333,7 @@
       border-bottom: 0;
 
       > * {
-        z-index: var(--pf-global--ZIndex--xs); // set z-index here to allow sticky column to override
+        z-index: var(--pf-c-table--m-sticky-header--cell--ZIndex); // set z-index here to allow sticky column to override
       }
     }
 

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -1,11 +1,19 @@
 {{#> table-tr}}
   {{#if table--scrollable--Column1IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 100px;"'}}
+    {{> table--scrollable--th
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier
+        table--scrollable--th--content=cell-1--content
+        table-th--IsStickyLeft=true
+        table-th--attribute='style="--pf-c-table__sticky--cell--MinWidth: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-1--content}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--IsStickyColumn="true" table-th--attribute='style="--pf-c-table__sticky-column--MinWidth: 80px; --pf-c-table__sticky-column--Left: 100px;"'}}
+    {{> table--scrollable--th
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier
+        table--scrollable--th--content=cell-2--content
+        table-th--IsStickyLeft=true
+        table-th--attribute='style="--pf-c-table__sticky--cell--MinWidth: 80px; --pf-c-table__sticky-left--Left: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}
@@ -15,5 +23,14 @@
   {{> table--scrollable--td table--scrollable--td--content=cell-6--content}}
   {{> table--scrollable--td table--scrollable--td--content=cell-7--content}}
   {{> table--scrollable--td table--scrollable--td--content=cell-8--content}}
-  {{> table--scrollable--td table--scrollable--td--content=cell-9--content}}
+
+  {{#if table--scrollable--ColumnLastIsStickyColumn}}
+    {{> table--scrollable--th
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
+        table--scrollable--th--content=cell-9--content
+        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 150px;"'
+        table-th--IsStickyRight=true}}
+  {{else}}
+    {{> table--scrollable--td table--scrollable--td--content=cell-9--content table--scrollable--td--icon=cell-9--icon}}
+  {{/if}}
 {{/table-tr}}

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -4,7 +4,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier
         table--scrollable--th--content=cell-1--content
         table-th--IsStickyLeft=true
-        table-th--attribute='style="--pf-c-table__sticky--cell--MinWidth: 100px;"'}}
+        table-th--attribute='style="--pf-c-table__sticky-cell--MinWidth: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-1--content}}
   {{/if}}
@@ -13,7 +13,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier
         table--scrollable--th--content=cell-2--content
         table-th--IsStickyLeft=true
-        table-th--attribute='style="--pf-c-table__sticky--cell--MinWidth: 80px; --pf-c-table__sticky-left--Left: 100px;"'}}
+        table-th--attribute='style="--pf-c-table__sticky-cell--MinWidth: 80px; --pf-c-table__sticky-cell--Left: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}
@@ -28,7 +28,7 @@
     {{> table--scrollable--th
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
         table--scrollable--th--content=cell-9--content
-        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 150px;"'
+        table-th--attribute='scope="col" style="--pf-c-table__sticky-cell--MinWidth: 150px;"'
         table-th--IsStickyRight=true}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-9--content table--scrollable--td--icon=cell-9--icon}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -1,13 +1,18 @@
 {{#> table-tr}}
   {{#if table--scrollable--Column1IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier table--scrollable--th--content=cell-1--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true"}}
+    {{> table--scrollable--th
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier
+        table--scrollable--th--content=cell-1--content
+        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 100px;"'
+        table-th--sortable=true
+        table-th--IsStickyLeft=true}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--sortable="true"}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--sortable=true}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-column--MinWidth: 120px; --pf-c-table__sticky-column--Left: 100px;"' table-th--sortable="true" table-th--IsStickyColumn="true"}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 120px; --pf-c-table__sticky-left--Left: 100px;"' table-th--sortable=true table-th--IsStickyLeft=true}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable="true"}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable=true}}
   {{/if}}
   {{> table--scrollable--th table--scrollable--th--content=cell-3--content table--scrollable--th--icon=cell-3--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-4--content table--scrollable--th--icon=cell-4--icon}}
@@ -15,5 +20,14 @@
   {{> table--scrollable--th table--scrollable--th--content=cell-6--content table--scrollable--th--icon=cell-6--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-7--content table--scrollable--th--icon=cell-7--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-8--content table--scrollable--th--icon=cell-8--icon}}
-  {{> table--scrollable--th table--scrollable--th--content=cell-9--content table--scrollable--th--icon=cell-9--icon}}
+
+  {{#if table--scrollable--ColumnLastIsStickyColumn}}
+    {{> table--scrollable--th
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
+        table--scrollable--th--content=cell-9--content
+        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 150px;"'
+        table-th--IsStickyRight=true}}
+  {{else}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-9--content table--scrollable--th--icon=cell-9--icon}}
+  {{/if}}
 {{/table-tr}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -3,14 +3,14 @@
     {{> table--scrollable--th
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier
         table--scrollable--th--content=cell-1--content
-        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 100px;"'
+        table-th--attribute='scope="col" style="--pf-c-table__sticky-cell--MinWidth: 100px;"'
         table-th--sortable=true
         table-th--IsStickyLeft=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--sortable=true}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 120px; --pf-c-table__sticky-left--Left: 100px;"' table-th--sortable=true table-th--IsStickyLeft=true}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-c-table__sticky-cell--MinWidth: 120px; --pf-c-table__sticky-cell--Left: 100px;"' table-th--sortable=true table-th--IsStickyLeft=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--sortable=true}}
   {{/if}}
@@ -25,7 +25,7 @@
     {{> table--scrollable--th
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
         table--scrollable--th--content=cell-9--content
-        table-th--attribute='scope="col" style="--pf-c-table__sticky--cell--MinWidth: 150px;"'
+        table-th--attribute='scope="col" style="--pf-c-table__sticky-cell--MinWidth: 150px;"'
         table-th--IsStickyRight=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-9--content table--scrollable--th--icon=cell-9--icon}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -190,7 +190,10 @@ import './Table.css'
     <div class="pf-c-scroll-outer-wrapper">
       {{> toolbar-template toolbar--id=(concat page--id '-toolbar') toolbar-template--HasBulkSelect="true" toolbar-template--HasToggleGroup="true" toolbar-template--HasSearchFilter="true" toolbar-template--HasSortButton="true" toolbar-template--HasOverflowMenu="true"}}
       <div class="pf-c-scroll-inner-wrapper">
-        {{> table--scrollable table--scrollable--id="sticky-first-column-demo-table" table--scrollable--Column1IsStickyColumn="true" table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"}}
+        {{> table--scrollable
+            table--scrollable--id="sticky-first-column-demo-table"
+            table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"
+            table--scrollable--Column1IsStickyColumn=true}}
       </div>
       {{> table-pagination-footer}}
     </div>
@@ -207,7 +210,12 @@ import './Table.css'
     <div class="pf-c-scroll-outer-wrapper">
       {{> toolbar-template toolbar--id=(concat page--id '-toolbar') toolbar-template--HasBulkSelect="true" toolbar-template--HasToggleGroup="true" toolbar-template--HasSearchFilter="true" toolbar-template--HasSortButton="true" toolbar-template--HasOverflowMenu="true"}}
       <div class="pf-c-scroll-inner-wrapper">
-        {{> table--scrollable table--scrollable--id="sticky-multiple-columns-demo-table" table--scrollable--Column1IsStickyColumn="true" table--scrollable--Column2IsStickyColumn="true" table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"}}
+        {{>
+            table--scrollable
+            table--scrollable--id="sticky-multiple-columns-demo-table"
+            table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"
+            table--scrollable--Column1IsStickyColumn=true
+            table--scrollable--Column2IsStickyColumn=true}}
       </div>
       {{> table-pagination-footer}}
     </div>
@@ -224,7 +232,32 @@ import './Table.css'
     <div class="pf-c-scroll-outer-wrapper">
       {{> toolbar-template toolbar--id=(concat page--id '-toolbar') toolbar-template--HasBulkSelect="true" toolbar-template--HasToggleGroup="true" toolbar-template--HasSearchFilter="true" toolbar-template--HasSortButton="true" toolbar-template--HasOverflowMenu="true"}}
       <div class="pf-c-scroll-inner-wrapper">
-        {{> table--scrollable table--scrollable--id="sticky-header-and-multiple-columns-demo-table" table--scrollable--modifier="pf-m-sticky-header" table--scrollable--Column1IsStickyColumn="true" table--scrollable--Column2IsStickyColumn="true" table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"}}
+        {{> table--scrollable
+            table--scrollable--id="sticky-header-and-multiple-columns-demo-table"
+            table--scrollable--modifier="pf-m-sticky-header"
+            table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"
+            table--scrollable--Column1IsStickyColumn=true
+            table--scrollable--Column2IsStickyColumn=true}}
+      </div>
+      {{> table-pagination-footer}}
+    </div>
+  {{/page-main-section}}
+{{/inline}}
+```
+
+### Sticky header and last column
+```hbs isFullscreen
+{{> page-template page-template--id="sticky-header-and-multiple columns-demo"}}
+
+{{#*inline "page-template-section"}}
+  {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl pf-m-overflow-scroll" page-main-section--IsLimitWidths="true"}}
+    <div class="pf-c-scroll-outer-wrapper">
+      {{> toolbar-template toolbar--id=(concat page--id '-toolbar') toolbar-template--HasBulkSelect="true" toolbar-template--HasToggleGroup="true" toolbar-template--HasSearchFilter="true" toolbar-template--HasSortButton="true" toolbar-template--HasOverflowMenu="true"}}
+      <div class="pf-c-scroll-inner-wrapper">
+        {{> table--scrollable
+            table--scrollable--id="sticky-right-column-example"
+            table--scrollable--th--modifier--cell-9-modifier="pf-m-truncate pf-m-border-left"
+            table--scrollable--ColumnLastIsStickyColumn=true}}
       </div>
       {{> table-pagination-footer}}
     </div>


### PR DESCRIPTION
closes #5391

This PR adds `right: var(--pf-c-table__sticky-column--Right, revert);` to support righthand sticky column. If the table cell is the first child, `--pf-c-table__sticky-column--Left` is set to `0`. If the table cell is the last child, `--pf-c-table__sticky-column--Right` is set to `0`. There are no other instances in which either value should be `0`. 

