### PR TITLE
feat(Table/DataList): refactored visual affordances

### DIFF
--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -99,8 +99,8 @@
 
 .pf-c-chip__content {
   display: flex;
-  align-items: center;
   column-gap: var(--pf-c-chip__content--ColumnGap);
+  align-items: center;
   font-size: var(--pf-c-chip__content--FontSize);
 }
 

--- a/src/patternfly/components/DataList/data-list-item.hbs
+++ b/src/patternfly/components/DataList/data-list-item.hbs
@@ -1,6 +1,6 @@
-<li class="pf-c-data-list__item{{#if data-list-item--modifier}} {{data-list-item--modifier}}{{/if}}{{#if data-list-item--expanded}} pf-m-expanded{{/if}}{{#if data-list-item--IsSelectable}} pf-m-selectable{{/if}}{{#if data-list-item--IsSelected}} pf-m-selected{{/if}}"
+<li class="pf-c-data-list__item{{#if data-list-item--modifier}} {{data-list-item--modifier}}{{/if}}{{#if data-list-item--expanded}} pf-m-expanded{{/if}}{{#if data-list-item--IsClickable}} pf-m-clickable{{/if}}{{#if data-list-item--IsSelected}} pf-m-selected{{/if}}"
   aria-labelledby="{{data-list--id}}-{{data-list-item--id}}"
-  {{#if data-list-item--IsSelectable}}
+  {{#if data-list-item--IsClickable}}
     tabindex="0"
   {{/if}}
   {{#if data-list-item--attribute}}

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -19,16 +19,15 @@
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-data-list__item--m-selectable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-data-list__item--m-selectable--hover--ZIndex: calc(var(--pf-c-data-list__item--m-selected--ZIndex) + 1);
-  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-data-list__item--m-selectable--focus--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-data-list__item--m-selectable--active--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
+  --pf-c-data-list__item--m-clickable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
+  --pf-c-data-list__item--m-clickable--hover--ZIndex: calc(var(--pf-c-data-list__item--m-selected--ZIndex) + 1);
+  --pf-c-data-list__item--m-clickable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-data-list__item--m-clickable--focus--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-data-list__item--m-clickable--active--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--BorderBottomColor: var(--pf-global--BorderColor--300);
   --pf-c-data-list__item--BorderBottomWidth: #{pf-size-prem(8px)};
-  --pf-c-data-list__item--m-selectable--hover--item--BorderTopColor: var(--pf-c-data-list__item--BorderBottomColor);
-  --pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth: var(--pf-c-data-list__item--BorderBottomWidth);
+  --pf-c-data-list__item--m-clickable--hover--item--BorderTopColor: var(--pf-c-data-list__item--BorderBottomColor);
+  --pf-c-data-list__item--m-clickable--hover--item--BorderTopWidth: var(--pf-c-data-list__item--BorderBottomWidth);
   --pf-c-data-list__item--sm--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-data-list__item--sm--BorderBottomColor: var(--pf-global--BorderColor--100);
 
@@ -39,7 +38,7 @@
 
   // list item border left
   --pf-c-data-list__item--before--BackgroundColor: transparent;
-  --pf-c-data-list__item--before--Width: var(--pf-global--BorderWidth--lg);
+  --pf-c-data-list__item--before--Width: calc(2 * var(--pf-global--BorderWidth--lg));
   --pf-c-data-list__item--before--Transition: var(--pf-global--Transition);
   --pf-c-data-list__item--before--Top: 0;
   --pf-c-data-list__item--before--sm--Top: calc(var(--pf-c-data-list__item--BorderBottomWidth) * -1);
@@ -122,8 +121,6 @@
   --pf-c-data-list__item-action__action--MarginBottom: calc(var(--pf-global--spacer--form-element) * -1);
 
   // expandable content
-  --pf-c-data-list__expandable-content--BorderTopWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-data-list__expandable-content--BorderTopColor: var(--pf-global--BorderColor--100);
   --pf-c-data-list__expandable-content--MarginRight: calc(var(--pf-c-data-list__expandable-content-body--PaddingRight) * -1);
   --pf-c-data-list__expandable-content--MarginLeft: calc(var(--pf-c-data-list__expandable-content-body--PaddingLeft) * -1);
   --pf-c-data-list__expandable-content--MaxHeight: #{pf-size-prem(600px)};
@@ -247,14 +244,14 @@
     transition: var(--pf-c-data-list__item--before--Transition);
   }
 
-  &.pf-m-selectable {
+  &.pf-m-clickable {
     cursor: pointer;
-    outline-offset: var(--pf-c-data-list__item--m-selectable--OutlineOffset);
+    outline-offset: var(--pf-c-data-list__item--m-clickable--OutlineOffset);
 
     &:hover,
     &:focus {
       position: relative;
-      z-index: var(--pf-c-data-list__item--m-selectable--hover--ZIndex);
+      z-index: var(--pf-c-data-list__item--m-clickable--hover--ZIndex);
 
       // stylelint-disable selector-not-notation
       // update to single :not() in breaking change
@@ -263,22 +260,22 @@
 
         // stylelint-disable
         + .pf-c-data-list__item {
-          border-top: var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopWidth) solid var(--pf-c-data-list__item--m-selectable--hover--item--BorderTopColor);
+          border-top: var(--pf-c-data-list__item--m-clickable--hover--item--BorderTopWidth) solid var(--pf-c-data-list__item--m-clickable--hover--item--BorderTopColor);
         }
         // stylelint-enable
       }
     }
 
     &:hover {
-      box-shadow: var(--pf-c-data-list__item--m-selectable--hover--BoxShadow);
+      box-shadow: var(--pf-c-data-list__item--m-clickable--hover--BoxShadow);
     }
 
     &:focus {
-      box-shadow: var(--pf-c-data-list__item--m-selectable--focus--BoxShadow);
+      box-shadow: var(--pf-c-data-list__item--m-clickable--focus--BoxShadow);
     }
 
     &:active {
-      box-shadow: var(--pf-c-data-list__item--m-selectable--active--BoxShadow);
+      box-shadow: var(--pf-c-data-list__item--m-clickable--active--BoxShadow);
     }
   }
 
@@ -305,11 +302,6 @@
 
   &.pf-m-expanded {
     --pf-c-data-list__toggle-icon--Rotate: var(--pf-c-data-list__item--m-expanded__toggle-icon--Rotate);
-    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
-
-    &.pf-m-selectable:not(.pf-m-selected) {
-      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
-    }
   }
 }
 
@@ -465,10 +457,13 @@
 .pf-c-data-list__expandable-content {
   max-height: var(--pf-c-data-list__expandable-content--MaxHeight);
   overflow-y: auto;
-  border-top: var(--pf-c-data-list__expandable-content--BorderTopWidth) solid var(--pf-c-data-list__expandable-content--BorderTopColor);
 
   .pf-c-data-list__expandable-content-body {
     padding: var(--pf-c-data-list__expandable-content-body--PaddingTop) var(--pf-c-data-list__expandable-content-body--PaddingRight) var(--pf-c-data-list__expandable-content-body--PaddingBottom) var(--pf-c-data-list__expandable-content-body--PaddingLeft);
+
+    // > .pf-c-data-list {
+    //   border-top-width: 0;
+    // }
 
     &.pf-m-no-padding {
       padding: 0;

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -7,6 +7,7 @@
   --pf-c-data-list--BorderTopWidth: var(--pf-global--spacer--sm);
   --pf-c-data-list--sm--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-data-list--sm--BorderTopColor: var(--pf-global--BorderColor--100);
+  --pf-c-data-list--MarginLeft: var(--pf-global--spacer--md);
 
   @media screen and (min-width: $pf-global--breakpoint--sm) {
     --pf-c-data-list--BorderTopColor: var(--pf-c-data-list--sm--BorderTopColor);
@@ -461,9 +462,17 @@
   .pf-c-data-list__expandable-content-body {
     padding: var(--pf-c-data-list__expandable-content-body--PaddingTop) var(--pf-c-data-list__expandable-content-body--PaddingRight) var(--pf-c-data-list__expandable-content-body--PaddingBottom) var(--pf-c-data-list__expandable-content-body--PaddingLeft);
 
-    // > .pf-c-data-list {
-    //   border-top-width: 0;
-    // }
+    > .pf-c-data-list {
+      margin-left: var(--pf-c-data-list--MarginLeft);
+    }
+
+    .pf-c-data-list__item-row {
+      --pf-c-data-list__item-row--PaddingLeft: 0;
+    }
+
+    .pf-c-data-list__expandable-content-body {
+      --pf-c-data-list__expandable-content-body--PaddingLeft: 0;
+    }
 
     &.pf-m-no-padding {
       padding: 0;

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -466,6 +466,10 @@
       margin-left: var(--pf-c-data-list--MarginLeft);
     }
 
+    .pf-c-data-list__item:last-child {
+      border-bottom: 0;
+    }
+
     .pf-c-data-list__item-row {
       --pf-c-data-list__item-row--PaddingLeft: 0;
     }

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -753,10 +753,10 @@ When a list item includes more than one block of content, it can be difficult fo
 | -- | -- | -- |
 | `.pf-m-flex-{1, 2, 3, 4, 5}` | `.pf-c-data-list__cell` | Percentage based modifier for `.pf-c-data-list__cell` widths. |
 
-### Selectable rows
+### Clickable rows
 ```hbs
-{{#> data-list data-list--id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
-  {{#> data-list-item data-list-item--id="item-1" data-list-item--IsSelectable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
+{{#> data-list data-list--id="data-list-clickable-rows" data-list--attribute='aria-label="Clickable rows data list example"'}}
+  {{#> data-list-item data-list-item--id="item-1" data-list-item--IsClickable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -766,7 +766,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-2" data-list-item--IsSelectable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
+  {{#> data-list-item data-list-item--id="item-2" data-list-item--IsClickable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -776,7 +776,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-3" data-list-item--IsSelectable="true"}}
+  {{#> data-list-item data-list-item--id="item-3" data-list-item--IsClickable="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -791,17 +791,17 @@ When a list item includes more than one block of content, it can be difficult fo
 ### Accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `tabindex="0"` | `.pf-c-data-list__item.pf-m-selectable` | Inserts the selectable row into the tab order of the page so that it is focusable. **Required** |
+| `tabindex="0"` | `.pf-c-data-list__item.pf-m-clickable` | Inserts the clickable row into the tab order of the page so that it is focusable. **Required** |
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-selectable` | `.pf-c-data-list__item` | Modifies a data list item so that it is selectable. |
+| `.pf-m-clickable` | `.pf-c-data-list__item` | Modifies a data list item so that it is clickable. |
 | `.pf-m-selected` | `.pf-c-data-list__item` | Modifies a data list item for the selected state. |
 
-### Selectable expandable rows
+### Clickable expandable rows
 ```hbs
-{{#> data-list data-list--id="data-list-selectable-expandable-rows" data-list-item--IsSelectable="true" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--id="item-1" data-list-item--expanded="true"}}
+{{#> data-list data-list--id="data-list-clickable-expandable-rows" data-list-item--IsClickable="true" data-list--attribute='aria-label="Clickable, expandable data list example"'}}
+  {{#> data-list-item data-list-item--id="item-1" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle1 ' data-list--id '-item1" id="' data-list--id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content1"')}}{{/data-list-toggle}}
@@ -812,7 +812,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content1" aria-label="Selectable expandable row primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content1" aria-label="Clickable expandable row primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
@@ -830,7 +830,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content2" aria-label="Selectable expandable row secondary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content2" aria-label="Clickable expandable row secondary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
@@ -848,7 +848,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content3" aria-label="Selectable expandable row tertiary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content3" aria-label="Clickable expandable row tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
@@ -867,7 +867,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content4" aria-label="Selectable expandable row quaternary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content4" aria-label="Clickable expandable row quaternary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -756,21 +756,21 @@ When a list item includes more than one block of content, it can be difficult fo
 ### Clickable rows
 ```hbs
 {{#> data-list data-list--id="data-list-clickable-rows" data-list--attribute='aria-label="Clickable rows data list example"'}}
-  {{#> data-list-item data-list-item--id="item-1" data-list-item--IsClickable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
+  {{#> data-list-item data-list-item--id="item-1" data-list-item--IsClickable="true" data-list-item--IsSelected="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content (clicked)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--id="item-2" data-list-item--IsClickable="true" data-list-item--IsSelected="true" data-list-item--expanded="true"}}
+  {{#> data-list-item data-list-item--id="item-2" data-list-item--IsClickable="true"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Secondary content (selected)</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Secondary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -808,7 +808,7 @@ When a list item includes more than one block of content, it can be difficult fo
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content (selected, expanded)</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Primary content (clicked and expanded)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -844,7 +844,7 @@ When a list item includes more than one block of content, it can be difficult fo
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Tertiary content (not selected, expanded)</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Tertiary content (expanded)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -862,7 +862,7 @@ When a list item includes more than one block of content, it can be difficult fo
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{data-list--id}}-{{data-list-item--id}}">Quaternary content (selected)</span>
+          <span id="{{data-list--id}}-{{data-list-item--id}}">Quaternary content</span>
         {{/data-list-cell}}
 
       {{/data-list-item-content}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -1827,9 +1827,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 | -- | -- | -- |
 | `.pf-m-compact` | `.pf-c-table` | Modifies for a compact table. |
 
-## Clickable and selected
+## Clickable
 
-### Clickable and selected example
+### Clickable example
 ```hbs
 {{#> table table--id="table-clickable" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="Clickable and selectable table example"'}}
   {{#> table-thead}}
@@ -1843,21 +1843,13 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
   {{/table-thead}}
   {{#> wrapper table-tr--IsClickable="true" table-tr--basic--title="Clickable"}}
     {{> table-tr--basic table-tr--basic--index="1"}}
-    {{> table-tr--basic table-tr--basic--index="2" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
+    {{> table-tr--basic table-tr--basic--index="2" table-tr--IsSelected="true" table-tr--basic--title="<b>Clicked</b>"}}
     {{> table-tr--basic table-tr--basic--index="3"}}
-    {{> table-tr--basic table-tr--basic--index="4"}}
-    {{> table-tr--basic table-tr--basic--index="5" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
-    {{> table-tr--basic table-tr--basic--index="6" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
-    {{> table-tr--basic table-tr--basic--index="7" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
-    {{> table-tr--basic table-tr--basic--index="8"}}
-    {{> table-tr--basic table-tr--basic--index="9"}}
-    {{> table-tr--basic table-tr--basic--index="10" table-tr--basic--IsExpanded="true" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
-    {{> table-tr--basic table-tr--basic--index="11"}}
   {{/wrapper}}
 {{/table}}
 ```
 
-### Expandable, clickable, and selected example
+### Clickable and expandable example
 ```hbs
 {{#> table table--id="table-expandable-clickable" table--grid="true" table--modifier="pf-m-grid-lg" table--expandable="true" table--attribute='aria-label="Expandable and clickable table example"'}}
   {{#> table-thead}}
@@ -1877,26 +1869,11 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
-  {{#> wrapper table-tbody--IsClickable="true" table-tbody--expandable--title="Clickable"}}
+  {{#> wrapper table-tbody--IsClickable="true" table-tbody--expandable--title="Clickable and not expanded"}}
     {{> table-tbody--expandable table-tbody--expandable--index="1"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="2" table-tbody--IsSelected="true" table-tbody--expandable--title="<i>Selected and not expanded</i>"}}
+    {{> table-tbody--expandable table-tbody--expandable--index="2" table-tbody--expandable--IsExpanded="true" table-tbody--IsSelected="true" table-tbody--expandable--title="<b>Clicked and expanded</b>"}}
     {{> table-tbody--expandable table-tbody--expandable--index="3"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="4"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="5" table-tbody--IsSelected="true" table-tbody--expandable--title="<i>Selected and not expanded</i>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="6" table-tbody--IsSelected="true" table-tbody--expandable--title="<i>Selected and not expanded</i>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="7" table-tbody--IsSelected="true" table-tbody--expandable--title="<i>Selected and not expanded</i>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="8"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="9"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="10"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="11" table-tbody--expandable--IsExpanded="true" table-tbody--IsSelected="true" table-tbody--expandable--title="<b>Expanded and selected</b>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="12"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="13" table-tbody--expandable--IsExpanded="true" table-tbody--IsSelected="true" table-tbody--expandable--title="<b>Expanded and selected</b>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="15" table-tbody--expandable--IsExpanded="true" table-tbody--IsSelected="true"  table-tbody--expandable--title="<b>Expanded and selected</b>"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="14" table-tbody--expandable--IsExpanded="true" table-tbody--expandable--title="Expanded and not selected"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="16"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="17" table-tbody--expandable--IsExpanded="true" table-tbody--expandable--title="Expanded and not selected"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="18"}}
-    {{> table-tbody--expandable table-tbody--expandable--index="19"}}
+    {{> table-tbody--expandable table-tbody--expandable--index="4" table-tbody--expandable--IsExpanded="true" table-tbody--expandable--title="Clickable and expanded"}}
   {{/wrapper}}
 {{/table}}
 ```

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -1827,11 +1827,11 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 | -- | -- | -- |
 | `.pf-m-compact` | `.pf-c-table` | Modifies for a compact table. |
 
-## Hoverable and selected
+## Clickable and selected
 
-### Hoverable and selected example
+### Clickable and selected example
 ```hbs
-{{#> table table--id="table-hoverable" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="Hoverable and selectable table example"'}}
+{{#> table table--id="table-clickable" table--grid="true" table--modifier="pf-m-grid-lg" table--attribute='aria-label="Clickable and selectable table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
       {{> table--check table--check--IsThead="true"}}
@@ -1841,7 +1841,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
-  {{#> wrapper table-tr--IsHoverable="true" table-tr--basic--title="Hoverable"}}
+  {{#> wrapper table-tr--IsClickable="true" table-tr--basic--title="Clickable"}}
     {{> table-tr--basic table-tr--basic--index="1"}}
     {{> table-tr--basic table-tr--basic--index="2" table-tr--IsSelected="true" table-tr--basic--title="<b>Selected</b>"}}
     {{> table-tr--basic table-tr--basic--index="3"}}
@@ -1857,9 +1857,9 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{/table}}
 ```
 
-### Expandable, hoverable, and selected example
+### Expandable, clickable, and selected example
 ```hbs
-{{#> table table--id="table-expandable-hoverable" table--grid="true" table--modifier="pf-m-grid-lg" table--expandable="true" table--attribute='aria-label="Expandable and hoverable table example"'}}
+{{#> table table--id="table-expandable-clickable" table--grid="true" table--modifier="pf-m-grid-lg" table--expandable="true" table--attribute='aria-label="Expandable and clickable table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
       {{> table-td table-td--IsEmpty="true"}}
@@ -1877,7 +1877,7 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
       {{> table-td table-td--IsEmpty="true"}}
     {{/table-tr}}
   {{/table-thead}}
-  {{#> wrapper table-tbody--IsHoverable="true" table-tbody--expandable--title="Hoverable"}}
+  {{#> wrapper table-tbody--IsClickable="true" table-tbody--expandable--title="Clickable"}}
     {{> table-tbody--expandable table-tbody--expandable--index="1"}}
     {{> table-tbody--expandable table-tbody--expandable--index="2" table-tbody--IsSelected="true" table-tbody--expandable--title="<i>Selected and not expanded</i>"}}
     {{> table-tbody--expandable table-tbody--expandable--index="3"}}
@@ -1901,15 +1901,15 @@ Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.p
 {{/table}}
 ```
 
-### Hoverable accessibility
+### Clickable accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `tabindex="0"` | `.pf-c-table tbody.pf-m-hoverable` | Inserts the hoverable table element into the tab order of the page so that it is focusable. **Required** |
+| `tabindex="0"` | `.pf-c-table tbody.pf-m-clickable` | Inserts the clickable table element into the tab order of the page so that it is focusable. **Required** |
 
-### Hoverable and selected usage
+### Clickable and selected usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-hoverable` | `.pf-c-table tbody`, `.pf-c-table tr` | Modifies a tbody or tr table element to be hoverable. |
+| `.pf-m-clickable` | `.pf-c-table tbody`, `.pf-c-table tr` | Modifies a tbody or tr table element to be clickable. |
 | `.pf-m-selected` | `.pf-c-table tbody`, `.pf-c-table tr` | Modifies a selectable tbody or tr table element to be selected. |
 
 ## Tree table

--- a/src/patternfly/components/Table/table-tbody.hbs
+++ b/src/patternfly/components/Table/table-tbody.hbs
@@ -1,12 +1,12 @@
 <tbody class="
-  {{~#if table-tbody--IsHoverable}} pf-m-hoverable{{/if}}
+  {{~#if table-tbody--IsClickable}} pf-m-clickable{{/if}}
   {{~#if table-tbody--IsSelected}} pf-m-selected{{/if}}
   {{~#if table-tbody--IsExpanded}} pf-m-expanded{{/if}}
   {{#if table-tbody--modifier}} {{table-tbody--modifier}}{{/if}}"
   {{#if table--grid}}
     role="rowgroup"
   {{/if}}
-  {{#if table-tbody--IsHoverable}}
+  {{#if table-tbody--IsClickable}}
     tabindex="0"
   {{/if}}
   {{#if table-tbody--attribute}}

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -3,7 +3,7 @@
   {{#if table-tr--IsControlRow}} pf-c-table__control-row{{/if}}
   {{#if table-tr--IsExpanded}} pf-m-expanded{{/if}}
   {{#if table-tr--details--IsExpanded}} pf-m-tree-view-details-expanded{{/if}}
-  {{#if table-tr--IsHoverable}} pf-m-hoverable{{/if}}
+  {{~#if table-tr--IsClickable}} pf-m-clickable{{/if}}
   {{#if table-tr--IsSelected}} pf-m-selected{{/if}}
   {{#if table-tr--IsBorderRow}} pf-m-border-row{{/if}}
   {{#if table-tr--HasNoInset}} pf-m-no-inset{{/if}}
@@ -35,7 +35,7 @@
       role="row"
     {{/if}}
   {{/unless}}
-  {{#if table-tr--IsHoverable}}
+  {{#if table-tr--IsClickable}}
     tabindex="0"
   {{/if}}
   {{#if table-tr--IsBorderRow}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -246,50 +246,50 @@
   // Modifier - expandable row expanded
   --pf-c-table__expandable-row--m-expanded--BorderBottomColor: var(--pf-global--BorderColor--100);
 
-  // tr hoverable
-  --pf-c-table--tr--m-hoverable--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
-  --pf-c-table--tr--m-hoverable--BackgroundColor: transparent;
-  --pf-c-table--tr--m-hoverable--BoxShadow: none;
-  --pf-c-table--tr--m-hoverable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-table--tr--m-hoverable--hover--BoxShadow: var(--pf-c-table--tr--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tr--m-hoverable--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tr--m-hoverable--focus--BoxShadow: var(--pf-c-table--tr--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tr--m-hoverable--focus--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tr--m-hoverable--active--BoxShadow: var(--pf-c-table--tr--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tr--m-hoverable--active--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tr--m-hoverable--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
+  // tr clickable
+  --pf-c-table--tr--m-clickable--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
+  --pf-c-table--tr--m-clickable--BackgroundColor: transparent;
+  --pf-c-table--tr--m-clickable--BoxShadow: none;
+  --pf-c-table--tr--m-clickable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
+  --pf-c-table--tr--m-clickable--hover--BoxShadow: var(--pf-c-table--tr--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tr--m-clickable--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tr--m-clickable--focus--BoxShadow: var(--pf-c-table--tr--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tr--m-clickable--focus--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tr--m-clickable--active--BoxShadow: var(--pf-c-table--tr--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tr--m-clickable--active--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tr--m-clickable--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
 
   // tr selected
   --pf-c-table--tr--m-selected--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
   --pf-c-table--tr--m-selected--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-table--tr--m-selected--BoxShadow: var(--pf-c-table--tr--m-selected--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-table--tr--m-selected--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-table--tr--m-selected--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
+  --pf-c-table--tr--m-selected--after--BorderLeftWidth: calc(2 * var(--pf-c-table__expandable-row--after--border-width--base));
   --pf-c-table--tr--m-selected--after--BorderLeftColor: var(--pf-global--active-color--100);
   --pf-c-table--tr--m-selected--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-table--tr--m-selected--hover--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-table--tr--m-selected--tr--m-selected--hover--BoxShadow: var(--pf-c-table--tr--m-selected--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
 
-  // tbody hoverable
-  --pf-c-table--tbody--m-hoverable--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
-  --pf-c-table--tbody--m-hoverable--BoxShadow: none;
-  --pf-c-table--tbody--m-hoverable--BackgroundColor: transparent;
-  --pf-c-table--tbody--m-hoverable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-table--tbody--m-hoverable--hover--BoxShadow: var(--pf-c-table--tbody--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tbody--m-hoverable--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tbody--m-hoverable--focus--BoxShadow: var(--pf-c-table--tbody--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tbody--m-hoverable--focus--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tbody--m-hoverable--active--BoxShadow: var(--pf-c-table--tbody--m-hoverable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-table--tbody--m-hoverable--active--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-table--tbody--m-hoverable--m-expanded--BorderColor: var(--pf-global--active-color--400);
-  --pf-c-table--tbody--m-hoverable--m-selected--hover--tr--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
+  // tbody clickable
+  --pf-c-table--tbody--m-clickable--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
+  --pf-c-table--tbody--m-clickable--BoxShadow: none;
+  --pf-c-table--tbody--m-clickable--BackgroundColor: transparent;
+  --pf-c-table--tbody--m-clickable--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
+  --pf-c-table--tbody--m-clickable--hover--BoxShadow: var(--pf-c-table--tbody--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tbody--m-clickable--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tbody--m-clickable--focus--BoxShadow: var(--pf-c-table--tbody--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tbody--m-clickable--focus--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tbody--m-clickable--active--BoxShadow: var(--pf-c-table--tbody--m-clickable--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-table--tbody--m-clickable--active--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-table--tbody--m-clickable--m-expanded--BorderColor: var(--pf-global--active-color--400);
+  --pf-c-table--tbody--m-clickable--m-selected--hover--tr--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
 
   // tbody selected
   --pf-c-table--tbody--m-selected--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-table--tbody--m-selected--BoxShadow--top: var(--pf-c-table--tr--BoxShadow--top--base);
   --pf-c-table--tbody--m-selected--BoxShadow: var(--pf-c-table--tbody--m-selected--BoxShadow--top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-table--tbody--m-selected--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
-  --pf-c-table--tbody--m-selected--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
+  --pf-c-table--tbody--m-selected--after--BorderLeftWidth: calc(2 * var(--pf-c-table__expandable-row--after--border-width--base));
   --pf-c-table--tbody--m-selected--after--BorderLeftColor: var(--pf-global--active-color--100);
   --pf-c-table--tbody--m-selected--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-table--tbody--m-selected--hover--tbody--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-bottom) inset, var(--pf-global--BoxShadow--sm-bottom);
@@ -577,6 +577,10 @@
         vertical-align: top;
       }
     }
+
+    &.pf-m-expanded > :first-child:not(.pf-c-table__control-row) {
+      border-bottom-width: 0;
+    }
   }
   // stylelint-enable
 
@@ -665,34 +669,34 @@
     }
   }
 
-  // tr hoverable
-  tr.pf-m-hoverable {
+  // tr clickable
+  tr.pf-m-clickable {
     cursor: pointer;
-    background-color: var(--pf-c-table--tr--m-hoverable--BackgroundColor);
-    outline-offset: var(--pf-c-table--tr--m-hoverable--OutlineOffset);
-    box-shadow: var(--pf-c-table--tr--m-hoverable--BoxShadow);
+    background-color: var(--pf-c-table--tr--m-clickable--BackgroundColor);
+    outline-offset: var(--pf-c-table--tr--m-clickable--OutlineOffset);
+    box-shadow: var(--pf-c-table--tr--m-clickable--BoxShadow);
 
     &:hover,
     &:focus,
     &:active {
       &:not(.pf-m-selected) + tr.pf-m-selected {
-        box-shadow: var(--pf-c-table--tr--m-hoverable--m-selected--BoxShadow);
+        box-shadow: var(--pf-c-table--tr--m-clickable--m-selected--BoxShadow);
       }
     }
 
     &:hover {
-      --pf-c-table--tr--m-hoverable--BoxShadow: var(--pf-c-table--tr--m-hoverable--hover--BoxShadow);
-      --pf-c-table--tr--m-hoverable--BackgroundColor: var(--pf-c-table--tr--m-hoverable--hover--BackgroundColor);
+      --pf-c-table--tr--m-clickable--BoxShadow: var(--pf-c-table--tr--m-clickable--hover--BoxShadow);
+      --pf-c-table--tr--m-clickable--BackgroundColor: var(--pf-c-table--tr--m-clickable--hover--BackgroundColor);
     }
 
     &:focus {
-      --pf-c-table--tr--m-hoverable--BoxShadow: var(--pf-c-table--tr--m-hoverable--focus--BoxShadow);
-      --pf-c-table--tr--m-hoverable--BackgroundColor: var(--pf-c-table--tr--m-hoverable--focus--BackgroundColor);
+      --pf-c-table--tr--m-clickable--BoxShadow: var(--pf-c-table--tr--m-clickable--focus--BoxShadow);
+      --pf-c-table--tr--m-clickable--BackgroundColor: var(--pf-c-table--tr--m-clickable--focus--BackgroundColor);
     }
 
     &:active {
-      --pf-c-table--tr--m-hoverable--BoxShadow: var(--pf-c-table--tr--m-hoverable--active--BoxShadow);
-      --pf-c-table--tr--m-hoverable--BackgroundColor: var(--pf-c-table--tr--m-hoverable--active--BackgroundColor);
+      --pf-c-table--tr--m-clickable--BoxShadow: var(--pf-c-table--tr--m-clickable--active--BoxShadow);
+      --pf-c-table--tr--m-clickable--BackgroundColor: var(--pf-c-table--tr--m-clickable--active--BackgroundColor);
     }
   }
 
@@ -723,38 +727,38 @@
     --pf-c-table--cell--first-last-child--PaddingLeft: var(--pf-c-table--tr--m-first-cell-offset-reset--cell--PaddingLeft);
   }
 
-  // tbody hoverable
-  tbody.pf-m-hoverable {
+  // tbody clickable
+  tbody.pf-m-clickable {
     cursor: pointer;
-    background-color: var(--pf-c-table--tbody--m-hoverable--BackgroundColor);
-    outline-offset: var(--pf-c-table--tbody--m-hoverable--OutlineOffset);
-    box-shadow: var(--pf-c-table--tbody--m-hoverable--BoxShadow);
+    background-color: var(--pf-c-table--tbody--m-clickable--BackgroundColor);
+    outline-offset: var(--pf-c-table--tbody--m-clickable--OutlineOffset);
+    box-shadow: var(--pf-c-table--tbody--m-clickable--BoxShadow);
 
     &.pf-m-expanded:not(.pf-m-selected) {
-      --pf-c-table__expandable-row--after--BorderColor: var(--pf-c-table--tbody--m-hoverable--m-expanded--BorderColor);
+      --pf-c-table__expandable-row--after--BorderColor: var(--pf-c-table--tbody--m-clickable--m-expanded--BorderColor);
     }
 
     &:hover,
     &:focus,
     &:active {
       &:not(.pf-m-selected) + tbody.pf-m-selected {
-        box-shadow: var(--pf-c-table--tbody--m-hoverable--m-selected--hover--tr--BoxShadow);
+        box-shadow: var(--pf-c-table--tbody--m-clickable--m-selected--hover--tr--BoxShadow);
       }
     }
 
     &:hover {
-      --pf-c-table--tbody--m-hoverable--BoxShadow: var(--pf-c-table--tbody--m-hoverable--hover--BoxShadow);
-      --pf-c-table--tbody--m-hoverable--BackgroundColor: var(--pf-c-table--tbody--m-hoverable--hover--BackgroundColor);
+      --pf-c-table--tbody--m-clickable--BoxShadow: var(--pf-c-table--tbody--m-clickable--hover--BoxShadow);
+      --pf-c-table--tbody--m-clickable--BackgroundColor: var(--pf-c-table--tbody--m-clickable--hover--BackgroundColor);
     }
 
     &:focus {
-      --pf-c-table--tbody--m-hoverable--BoxShadow: var(--pf-c-table--tbody--m-hoverable--focus--BoxShadow);
-      --pf-c-table--tbody--m-hoverable--BackgroundColor: var(--pf-c-table--tbody--m-hoverable--focus--BackgroundColor);
+      --pf-c-table--tbody--m-clickable--BoxShadow: var(--pf-c-table--tbody--m-clickable--focus--BoxShadow);
+      --pf-c-table--tbody--m-clickable--BackgroundColor: var(--pf-c-table--tbody--m-clickable--focus--BackgroundColor);
     }
 
     &:active {
-      --pf-c-table--tbody--m-hoverable--BoxShadow: var(--pf-c-table--tbody--m-hoverable--active--BoxShadow);
-      --pf-c-table--tbody--m-hoverable--BackgroundColor: var(--pf-c-table--tbody--m-hoverable--active--BackgroundColor);
+      --pf-c-table--tbody--m-clickable--BoxShadow: var(--pf-c-table--tbody--m-clickable--active--BoxShadow);
+      --pf-c-table--tbody--m-clickable--BackgroundColor: var(--pf-c-table--tbody--m-clickable--active--BackgroundColor);
     }
   }
 
@@ -1236,12 +1240,13 @@
   }
 }
 
+// REMOVE
 // stylelint-disable
-.pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child,
-.pf-c-table__expandable-row.pf-m-expanded > :first-child,
-.pf-c-table tbody.pf-m-expanded > tr > :not(.pf-c-table__compound-expansion-toggle) {
-  --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
-}
+// .pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child,
+// .pf-c-table__expandable-row.pf-m-expanded > :first-child,
+// .pf-c-table tbody.pf-m-expanded > tr > :not(.pf-c-table__compound-expansion-toggle) {
+//   --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
+// }
 // stylelint-enable
 
 // Nested table

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1240,15 +1240,6 @@
   }
 }
 
-// REMOVE
-// stylelint-disable
-// .pf-c-table__compound-expansion-toggle.pf-m-expanded:first-child,
-// .pf-c-table__expandable-row.pf-m-expanded > :first-child,
-// .pf-c-table tbody.pf-m-expanded > tr > :not(.pf-c-table__compound-expansion-toggle) {
-//   --pf-c-table__expandable-row--after--BorderLeftWidth: var(--pf-c-table__expandable-row--after--border-width--base);
-// }
-// stylelint-enable
-
 // Nested table
 // ==================================================================
 .pf-c-table .pf-c-table {


### PR DESCRIPTION
Closes #5347 

- Updated "hoverable"/"selectable" verbiage to "clickable". This includes class names, example text, etc. (several updates made will simply be lines with this update)
- To provide the additional ask of the border for indented datalist items, I removed some left padding and then added a left margin to the `pf-c-data-list` element instead.

Question regarding these components scss files: would the `*-grid.scss` files also need to be updated? It didn't look like the files were interfering with updates made in the `<component>.scss` file, but wanted to double check