### PR TITLE
fix(table): reverts "right align table action cells"

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1010,10 +1010,6 @@
   vertical-align: middle;
 }
 
-.pf-c-table__action {
-  text-align: right;
-}
-
 // Inline edit
 .pf-c-table__inline-edit-action {
   --pf-c-table--cell--PaddingLeft: 0;


### PR DESCRIPTION
Reverts patternfly/patternfly#4717

#4717 was an old PR and accidentally opened against main, needs to come out since this is a breaking change intended for v5