### PR TITLE
fix(form-control): updated readonly, disabled colors

### DIFF
--- a/src/patternfly/components/FormControl/themes/dark/form-control.scss
+++ b/src/patternfly/components/FormControl/themes/dark/form-control.scss
@@ -8,9 +8,9 @@
     --pf-c-form-control--BorderBottomColor: var(--pf-global--BorderColor--400);
     --pf-c-form-control--BorderLeftColor: transparent;
     --pf-c-form-control--BackgroundColor: var(--pf-global--BackgroundColor--400);
-    --pf-c-form-control--disabled--Color: var(--pf-global--disabled-color--300);
+    --pf-c-form-control--disabled--Color: var(--pf-global--palette--black-300);
     --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
-    --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--disabled-color--200);
 
     color: var(--pf-global--Color--100);
 
@@ -21,10 +21,6 @@
 
     &[readonly] {
       border-bottom-color: var(--pf-global--palette--black-700); // should be a var?
-    }
-
-    &:disabled {
-      color: var(--pf-global--palette--black-100); // global var
     }
   }
 }

--- a/src/patternfly/sass-utilities/themes/dark/scss-variables.scss
+++ b/src/patternfly/sass-utilities/themes/dark/scss-variables.scss
@@ -25,7 +25,7 @@ $pf-global--link--Color--hover: $pf-color-blue-200;
 $pf-global--link--Color--visited: $pf-color-purple-300;
 $pf-global--disabled-color--100: $pf-color-black-400; // disabled text on regular background color
 $pf-global--disabled-color--200: $pf-color-black-500; // disabled background color
-$pf-global--disabled-color--300: $pf-color-black-200; // disabled text on disabled background color
+$pf-global--disabled-color--300: $pf-color-black-200; // disabled text on disabled background color - except form elements
 
 // icons
 $pf-global--icon--Color--light: $pf-color-black-300;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5361

@mceledonia @lboehling this updates the form control/text input. What about other things - buttons (specifically control buttons, which match form control styles), menu toggles - anything else? 

FWIW here is a readonly and disabled text input after our disabled buttons:

<img width="901" alt="Screenshot 2023-02-27 at 7 06 45 PM" src="https://user-images.githubusercontent.com/35148959/221725900-96a29ed6-a8de-4557-b28b-c0089dc167f5.png">

And some menu toggles, with a readonly and disabled text input after the disabled menu toggle example

<img width="1196" alt="Screenshot 2023-02-27 at 7 07 27 PM" src="https://user-images.githubusercontent.com/35148959/221725995-ac71dfe1-a453-406f-8b75-2dc1f94a513f.png">
