### PR TITLE
Reorganize pages in workspace

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ---
 id: Release notes
-section: developer-resources
+section: get-started
 releaseNoteTOC: true
 ---
 ## 2023.01 release notes (2023-01-25)

--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -5,7 +5,7 @@ module.exports = {
   hasVersionSwitcher: false,
   hasDarkThemeSwitcher: true,
   sideNavItems: [
-    { section: 'get-started'},
+    { section: 'get-started' },
     { section: 'developer-resources' },
     { section: 'components' },
     { section: 'layouts' },

--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -5,7 +5,7 @@ module.exports = {
   hasVersionSwitcher: false,
   hasDarkThemeSwitcher: true,
   sideNavItems: [
-    { section: 'get-started'}
+    { section: 'get-started'},
     { section: 'developer-resources' },
     { section: 'components' },
     { section: 'layouts' },

--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -5,11 +5,12 @@ module.exports = {
   hasVersionSwitcher: false,
   hasDarkThemeSwitcher: true,
   sideNavItems: [
+    { section: 'get-started'}
     { section: 'developer-resources' },
     { section: 'components' },
     { section: 'layouts' },
-    { section: 'utilities' },
-    { section: 'demos' },
+    { section: 'utility-classes' },
+    { section: 'patterns' },
     { section: 'extensions' }
   ],
   topNavItems: [

--- a/src/patternfly/components/AppLauncher/examples/application-launcher.md
+++ b/src/patternfly/components/AppLauncher/examples/application-launcher.md
@@ -1,6 +1,7 @@
 ---
 id: Application launcher
 section: components
+subsection: menus
 cssPrefix: pf-c-app-launcher
 ---
 

--- a/src/patternfly/components/Check/examples/Check.md
+++ b/src/patternfly/components/Check/examples/Check.md
@@ -1,6 +1,7 @@
 ---
 id: Checkbox
 section: components
+subsection: forms
 cssPrefix: pf-c-check
 ---
 

--- a/src/patternfly/components/ContextSelector/examples/context-selector.md
+++ b/src/patternfly/components/ContextSelector/examples/context-selector.md
@@ -1,6 +1,7 @@
 ---
 id: Context selector
 section: components
+subsection: menus
 cssPrefix: pf-c-context-selector
 ---
 import './context-selector.css'

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -2,7 +2,7 @@
 id: 'Date picker'
 beta: true
 section: components
-Subsection: date-and-time
+subsection: date-and-time
 cssPrefix: pf-c-date-picker
 ---
 

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -2,6 +2,7 @@
 id: 'Date picker'
 beta: true
 section: components
+Subsection: date-and-time
 cssPrefix: pf-c-date-picker
 ---
 

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -1,6 +1,7 @@
 ---
 id: Dropdown
 section: components
+subsection: menus
 cssPrefix: pf-c-dropdown
 ---
 

--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -1,6 +1,7 @@
 ---
-id: File upload
+id: Text file upload
 section: components
+subsection: file-upload
 cssPrefix: pf-c-file-upload
 ---
 

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -1,6 +1,7 @@
 ---
 id: Form
 section: components
+subsection: forms
 cssPrefix: pf-c-form
 ---
 

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -1,6 +1,7 @@
 ---
 id: Form control
 section: components
+subsection: forms
 cssPrefix: pf-c-form-control
 ---
 

--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -1,6 +1,7 @@
 ---
 id: Menu
 section: components
+subsection: menus
 cssPrefix: pf-c-menu
 ---
 

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -1,6 +1,7 @@
 ---
 id: 'Menu toggle'
 section: components
+subsection: menus
 cssPrefix: pf-c-menu-toggle
 ---
 

--- a/src/patternfly/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/src/patternfly/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -1,6 +1,7 @@
 ---
-id: 'File upload - multiple'
+id: 'Multiple file upload'
 section: components
+subsection: file-upload
 cssPrefix: pf-c-multiple-file-upload
 ---
 

--- a/src/patternfly/components/OptionsMenu/examples/options-menu.md
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu.md
@@ -1,6 +1,7 @@
 ---
 id: Options menu
 section: components
+subsection: menus
 cssPrefix: pf-c-options-menu
 ---
 

--- a/src/patternfly/components/Radio/examples/Radio.md
+++ b/src/patternfly/components/Radio/examples/Radio.md
@@ -1,6 +1,7 @@
 ---
 id: Radio
 section: components
+subsection: forms
 cssPrefix: pf-c-radio
 ---
 

--- a/src/patternfly/components/Select/examples/Select.md
+++ b/src/patternfly/components/Select/examples/Select.md
@@ -1,6 +1,7 @@
 ---
 id: Select
 section: components
+subsection: menus
 cssPrefix: pf-c-select
 ---
 

--- a/src/patternfly/demos/CardView/examples/CardView.md
+++ b/src/patternfly/demos/CardView/examples/CardView.md
@@ -1,6 +1,6 @@
 ---
 id: 'Card view'
-section: demos
+section: patterns
 ---
 
 ## Examples

--- a/src/patternfly/demos/Dashboard/examples/Dashboard.md
+++ b/src/patternfly/demos/Dashboard/examples/Dashboard.md
@@ -1,7 +1,7 @@
 ---
 id: 'Dashboard'
 beta: true
-section: demos
+section: patterns
 cssPrefix: pf-d-dashboard
 ---
 

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -1,6 +1,7 @@
 ---
 id: Form
 section: components
+subsection: forms
 ---
 
 ## Demos

--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -1,6 +1,6 @@
 ---
 id: 'Password generator'
-section: demos
+section: components
 ---
 
 ## Examples

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -1,6 +1,6 @@
 ---
 id: 'Password strength'
-section: demos
+section: components
 ---
 
 ## Examples

--- a/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
+++ b/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
@@ -1,6 +1,6 @@
 ---
 id: Primary-detail
-section: demos
+section: patterns
 wrapperTag: div
 ---
 

--- a/src/patternfly/utilities/Accessibility/examples/Accessibility.md
+++ b/src/patternfly/utilities/Accessibility/examples/Accessibility.md
@@ -1,6 +1,6 @@
 ---
 id: Accessibility
-section: utilities
+section: utility-classes
 ---
 
 ## Examples

--- a/src/patternfly/utilities/Alignment/examples/Alignment.md
+++ b/src/patternfly/utilities/Alignment/examples/Alignment.md
@@ -1,6 +1,6 @@
 ---
 id: Alignment
-section: utilities
+section: utility-classes
 ---
 
 import './Alignment.css'

--- a/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
+++ b/src/patternfly/utilities/BackgroundColor/examples/BackgroundColor.md
@@ -1,6 +1,6 @@
 ---
 id: Background color
-section: utilities
+section: utility-classes
 ---
 
 ## Examples

--- a/src/patternfly/utilities/BoxShadow/examples/box-shadow.md
+++ b/src/patternfly/utilities/BoxShadow/examples/box-shadow.md
@@ -1,6 +1,6 @@
 ---
 id: Box shadow
-section: utilities
+section: utility-classes
 ---
 
 import './box-shadow.css'

--- a/src/patternfly/utilities/Display/examples/Display.md
+++ b/src/patternfly/utilities/Display/examples/Display.md
@@ -1,6 +1,6 @@
 ---
 id: Display
-section: utilities
+section: utility-classes
 ---
 
 import './Display.css'

--- a/src/patternfly/utilities/Flex/examples/Flex.md
+++ b/src/patternfly/utilities/Flex/examples/Flex.md
@@ -1,6 +1,6 @@
 ---
 id: Flex
-section: utilities
+section: utility-classes
 ---
 
 import './Flex.css'

--- a/src/patternfly/utilities/Float/examples/Float.md
+++ b/src/patternfly/utilities/Float/examples/Float.md
@@ -1,6 +1,6 @@
 ---
 id: Float
-section: utilities
+section: utility-classes
 ---
 
 import './Float.css'

--- a/src/patternfly/utilities/Sizing/examples/Sizing.md
+++ b/src/patternfly/utilities/Sizing/examples/Sizing.md
@@ -1,6 +1,6 @@
 ---
 id: Sizing
-section: utilities
+section: utility-classes
 ---
 
 import './Sizing.css'

--- a/src/patternfly/utilities/Spacing/examples/Spacing.md
+++ b/src/patternfly/utilities/Spacing/examples/Spacing.md
@@ -1,6 +1,6 @@
 ---
 id: Spacing
-section: utilities
+section: utility-classes
 ---
 
 import './Spacing.css'

--- a/src/patternfly/utilities/Text/examples/Text.md
+++ b/src/patternfly/utilities/Text/examples/Text.md
@@ -1,6 +1,6 @@
 ---
 id: Text
-section: utilities
+section: utility-classes
 ---
 
 import './Text.css'


### PR DESCRIPTION
Make the following changes to workspace organization:
- Rename primary sections
- Move release notes to 'Get started'
- Change 'Demos' to 'Patterns' and move Password generator and Password strength to 'Components'
- Change 'Utilities' to 'Utility classes'
- Groups Dropdown, Menu, Menu toggle, and Select into a new category named "Menu"
- Groups Checkbox, Form, Form control, and Radio into a new category named "Forms"
- Groups Text file upload and Multiple file upload into a new category named "File upload"

Closes #5414