### PR TITLE
feat(helper-text): make icon required for status

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -186,19 +186,7 @@ cssPrefix: pf-c-form
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
-      {{> form-helper-text helper-text--value='This is helper text for success input.' helper-text-item--IsSuccess=true}}
-    {{/form-group-control}}
-  {{/form-group}}
-  {{#> form-group form-group--id=(concat form--id '-info')}}
-    {{#> form-group-label}}
-      {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"')}}
-        Information
-      {{/form-label}}
-    {{/form-group-label}}
-    {{#> form-group-control}}
-      {{#> form-control controlType="textarea" form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
-      {{/form-control}}
-      {{> form-helper-text helper-text--value='This is helper text with an icon.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+      {{> form-helper-text helper-text--value='This is helper text for success input.' helper-text-item--IsSuccess="true"}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -10,7 +10,7 @@ import './FormControl.css'
 ## Examples
 ### Input
 
-**Note:** In webkit browsers, inputs with status icons that are autocompleted will have their icons removed by the user agent stylesheet. If the field does not need to use autocomplete, turn it off with `autocomplete="off"` to avoid the problem. Otherwise, use [helper text](/components/helper-text/html-demos)  instead to ensure that the status will remain visible if the field is autocompleted.
+**Note:** Inputs with a status variant or invalid state should also have [helper text](/components/helper-text/html-demos) to ensure that the status is properly conveyed to the user. See the [form component](/components/forms/form#help-text) for examples.
 
 ```hbs
 {{> form-control controlType="input" input="true" form-control--attribute='type="text" value="Standard" id="input-standard" aria-label="Standard input example"'}}
@@ -230,7 +230,7 @@ Error
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `id` | `.pf-c-form-control` | Provides an `id` value that can be used with the `for` attribute on an associated `<label>` element to provide an accessible label for the form control element.
-| `aria-invalid="true"` | `.pf-c-form-control` | Indicates that the form control is in the error state and applies error state styling. |
+| `aria-invalid="true"` | `.pf-c-form-control` | Indicates that the form control is in the error state and applies error state styling. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
 | `aria-label="descriptive text"` | `.pf-c-form-control` | Provides an accessible label for assistive technology. |
 | `aria-expanded="true"` | `.pf-c-form-control.pf-m-expanded` | Indicates that clicking in the form control has toggled something else to be expanded. |
 
@@ -240,8 +240,8 @@ Error
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
-| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. |
-| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. |
+| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
+| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
 | `.pf-m-icon-sprite` | `.pf-c-form-control` | Modifies form control element to use an external SVG sprite instead of embedded data URIs for icons. For use with apps whose content security policies disallow the use of data URIs. |
 | `.pf-m-icon` | `input.pf-c-form-control` | Modifies a form control text input to be able to specify a custom SVG background via `--pf-c-form-control--m-icon--BackgroundUrl`, and other optional vars for other background properties.
 | `.pf-m-calendar` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the calendar icon. |

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -240,8 +240,8 @@ Error
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
-| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. **Always use [helper text](/components/helper-text/html-demos) with this.**|
-| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. **Always use [helper text](/components/helper-text/html-demos) with this.**|
+| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. **Always use [helper text](/components/helper-text) with this.**|
+| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. **Always use [helper text](/components/helper-text) with this.**|
 | `.pf-m-icon-sprite` | `.pf-c-form-control` | Modifies form control element to use an external SVG sprite instead of embedded data URIs for icons. For use with apps whose content security policies disallow the use of data URIs. |
 | `.pf-m-icon` | `input.pf-c-form-control` | Modifies a form control text input to be able to specify a custom SVG background via `--pf-c-form-control--m-icon--BackgroundUrl`, and other optional vars for other background properties.
 | `.pf-m-calendar` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the calendar icon. |

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -230,7 +230,7 @@ Error
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
 | `id` | `.pf-c-form-control` | Provides an `id` value that can be used with the `for` attribute on an associated `<label>` element to provide an accessible label for the form control element.
-| `aria-invalid="true"` | `.pf-c-form-control` | Indicates that the form control is in the error state and applies error state styling. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
+| `aria-invalid="true"` | `.pf-c-form-control` | Indicates that the form control is in the error state and applies error state styling. **Always use [helper text](/components/helper-text/html-demos) with this.**|
 | `aria-label="descriptive text"` | `.pf-c-form-control` | Provides an accessible label for assistive technology. |
 | `aria-expanded="true"` | `.pf-c-form-control.pf-m-expanded` | Indicates that clicking in the form control has toggled something else to be expanded. |
 
@@ -240,8 +240,8 @@ Error
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
-| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
-| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. **Always use [helper text](/components/helper-text/html-demos) this with this.**|
+| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. **Always use [helper text](/components/helper-text/html-demos) with this.**|
+| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. **Always use [helper text](/components/helper-text/html-demos) with this.**|
 | `.pf-m-icon-sprite` | `.pf-c-form-control` | Modifies form control element to use an external SVG sprite instead of embedded data URIs for icons. For use with apps whose content security policies disallow the use of data URIs. |
 | `.pf-m-icon` | `input.pf-c-form-control` | Modifies a form control text input to be able to specify a custom SVG background via `--pf-c-form-control--m-icon--BackgroundUrl`, and other optional vars for other background properties.
 | `.pf-m-calendar` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the calendar icon. |

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -34,7 +34,7 @@ cssPrefix: pf-c-helper-text
 
 ### Dynamic
 ```hbs
-{{#> helper-text-wrapper helper-text-item--IsDynamic=true helper-text-item--HasIcon=true}}
+{{#> helper-text-wrapper helper-text-item--IsDynamic=true }}
   {{> helper-text helper-text--value="This is default helper text"}}
   {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true}}
   {{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true}}
@@ -45,7 +45,7 @@ cssPrefix: pf-c-helper-text
 
 ### Dynamic list
 ```hbs
-{{#> helper-text helper-text-item--IsDynamic=true helper-text-item--HasIcon=true}}
+{{#> helper-text helper-text-item--IsDynamic=true}}
   {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsSuccess=true}}
   {{> helper-text-item helper-text--value='Cannot contain any variation of the word "redhat"' helper-text-item--IsError=true}}
   {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols' helper-text-item--IsSuccess=true}}
@@ -57,7 +57,7 @@ cssPrefix: pf-c-helper-text
 | -- | -- | -- |
 | `.pf-c-helper-text` | `<div>`, `<ul>` |  Initiates the helper text component. **Required** |
 | `.pf-c-helper-text__item` | `<div>`, `<li>` |  Initiates a helper text item. **Required** |
-| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon. **Required when used in `.pf-c-helper-text__item.pf-m-dynamic`, `.pf-c-helper-text__item.pf-m-warning`, `.pf-c-helper-text__item.pf-m-error`, and `.pf-c-helper-text__item.pf-m-success`** |
+| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon. **Required when using `.pf-c-helper-text__item` with `.pf-c-helper-text__item.pf-m-dynamic`, `.pf-c-helper-text__item.pf-m-warning`, `.pf-c-helper-text__item.pf-m-error`, and `.pf-c-helper-text__item.pf-m-success`** |
 | `.pf-c-helper-text__item-text` | `<span>` |  Initiates a helper text item text. **Required** |
 | `.pf-m-dynamic` | `.pf-c-helper-text__item` |  Modifies a helper text item to be dynamic. For use when the item changes state as the form field the text is associated with is updated. |
 | `.pf-m-indeterminate` | `.pf-c-helper-text__item` |  Modifies a helper text item for indeterminate state styles. |

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -18,9 +18,9 @@ cssPrefix: pf-c-helper-text
 ```hbs
 {{> helper-text helper-text--value="This is default helper text" helper-text-item--HasIcon=true}}
 {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is error helper text" helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+{{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true }}
+{{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true}}
+{{> helper-text helper-text--value="This is error helper text" helper-text-item--IsError=true }}
 ```
 
 ### Multiple static
@@ -57,7 +57,7 @@ cssPrefix: pf-c-helper-text
 | -- | -- | -- |
 | `.pf-c-helper-text` | `<div>`, `<ul>` |  Initiates the helper text component. **Required** |
 | `.pf-c-helper-text__item` | `<div>`, `<li>` |  Initiates a helper text item. **Required** |
-| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon. **Required when used in `.pf-c-helper-text__item.pf-m-dynamic`** |
+| `.pf-c-helper-text__item-icon` | `<span>` |  Initiates a helper text item icon. **Required when used in `.pf-c-helper-text__item.pf-m-dynamic`, `.pf-c-helper-text__item.pf-m-warning`, `.pf-c-helper-text__item.pf-m-error`, and `.pf-c-helper-text__item.pf-m-success`** |
 | `.pf-c-helper-text__item-text` | `<span>` |  Initiates a helper text item text. **Required** |
 | `.pf-m-dynamic` | `.pf-c-helper-text__item` |  Modifies a helper text item to be dynamic. For use when the item changes state as the form field the text is associated with is updated. |
 | `.pf-m-indeterminate` | `.pf-c-helper-text__item` |  Modifies a helper text item for indeterminate state styles. |

--- a/src/patternfly/components/HelperText/helper-text-item-icon.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-icon.hbs
@@ -2,21 +2,19 @@
   {{#if helper-text-item-icon--attribute}}
     {{{helper-text-item-icon--attribute}}}
   {{/if}}>
-  {{#if helper-text-item--HasIcon}}
-    {{#if helper-text-item--IsIndeterminate}}
-      <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
-    {{else if helper-text-item--IsWarning}}
-      <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
-    {{else if helper-text-item--IsSuccess}}
-      <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
-    {{else if helper-text-item--IsError}}
-      <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-    {{else}}
-      <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
-    {{/if}}
+  {{#if helper-text-item--IsIndeterminate}}
+    <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
+  {{else if helper-text-item--IsWarning}}
+    <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
+  {{else if helper-text-item--IsSuccess}}
+    <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
+  {{else if helper-text-item--IsError}}
+    <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+  {{else if helper-text-item-icon--type}}
+    <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
   {{else if @partial-block}}
     {{> @partial-block}}
   {{else}}
-    <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
+    <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
   {{/if}}
 </span>

--- a/src/patternfly/components/HelperText/helper-text-item.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item.hbs
@@ -12,7 +12,7 @@
   {{#if helper-text-item--attribute}}
     {{{helper-text-item--attribute}}}
   {{/if}}>
-  {{#if helper-text-item--HasIcon}}
+  {{#if (concat helper-text-item--HasIcon helper-text-item--IsWarning helper-text-item--IsError helper-text-item--IsSuccess helper-text-item--IsDynamic)}}
     {{> helper-text-item-icon}}
   {{/if}}
   {{#if helper-text--value}}

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -16,7 +16,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
@@ -55,7 +55,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="invalid-login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" id="invalid-login-demo-form-username" name="invalid-login-demo-form-username" aria-invalid="true"'}}{{/form-control}}
@@ -94,7 +94,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
@@ -138,7 +138,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-helper-text form-helper-text--modifier="pf-m-error pf-m-hidden"}}
             {{#> form-helper-text-icon}}
               <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
@@ -188,7 +188,7 @@ wrapperTag: div
       {{> __login-main-header __login-main-header--HasLangaugeSelector="true"}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -50,7 +50,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true}}
       {{#> check}}
         {{#> check-input check-input--attribute='type="checkbox" id="alt-checkbox1" name="alt-checkbox1"'}}{{/check-input}}
         {{#> check-label check-label--attribute='for="alt-checkbox1"'}}Follow up via email.{{/check-label}}

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -53,7 +53,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required='true'}}
         How can we contact you?
       {{/form-label}}
-      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--HasIcon=true helper-text-item--IsError=true}}
+      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true}}
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
       {{#> check}}

--- a/src/patternfly/demos/HelperText/examples/HelperText.md
+++ b/src/patternfly/demos/HelperText/examples/HelperText.md
@@ -43,9 +43,9 @@ section: components
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='This criteria has not been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
-          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='This criteria has not been met.' helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
+          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -59,7 +59,7 @@ section: components
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
-        {{> helper-text helper-text--value='This is dynamic helper text with an icon showing success.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+        {{> helper-text helper-text--value='This is dynamic helper text with an icon showing success.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -30,9 +30,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true  helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -65,9 +65,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -85,7 +85,7 @@ section: components
         {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
-        {{> helper-text helper-text--value='Weak' helper-text-item--HasIcon=true helper-text-item--IsError=true}}
+        {{> helper-text helper-text--value='Weak' helper-text-item--IsError=true}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
@@ -101,9 +101,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -121,7 +121,7 @@ section: components
         {{> form-group-label-help form-group-label-help--aria-label="More information for password field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
-        {{> helper-text helper-text--value="Strong" helper-text-item--HasIcon=true helper-text-item--IsSuccess=true}}
+        {{> helper-text helper-text--value="Strong" helper-text-item--IsSuccess=true}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
@@ -137,9 +137,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -58,14 +58,14 @@ import './Toolbar.css'
                       {{/button}}
                     {{/input-group}}
                   {{/date-picker}}
-                  {{#> date-picker date-picker--id=(concat toolbar--id "-invalid") helper-text--value="Max: 08/10/2022" helper-text--IsError="true"}}
+                  {{#> date-picker date-picker--id=(concat toolbar--id "-invalid") helper-text--value="Max: 08/10/2022" helper-text-item--IsError="true"}}
                     {{#> input-group}}
                       {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
                       {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
                         <i class="fas fa-calendar-alt" aria-hidden="true"></i>
                       {{/button}}
                     {{/input-group}}
-                    {{> date-picker-helper-text helper-text--value="MM/DD/YYYY" helper-text--IsError=false}}
+                    {{> date-picker-helper-text helper-text--value="MM/DD/YYYY" }}
                   {{/date-picker}}
                 {{/input-group}}
               {{/toolbar-item}}


### PR DESCRIPTION
Fixes #5438 

Whenever there is a status on helper text, it now adds the icon in the handlebars.
Removes `helper-text--HasIcon` in uses of helper-text where there is already a status specified, as it is no longer needed
Removes the separate example in Form.md for helper text with an icon, since it's always there
In FormControl.md, the explanatory text at the beginning is updated, but the examples do not include the helper text, but points to the Form examples to show how.