### PR TITLE
feat(form control): remove background icons

### DIFF
--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -36,7 +36,7 @@ import './FormControl.css'
 Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control pf-c-form-control-select">` in order to display properly with PatternFly styling. Using the [PatternFly Select component](/components/menus/select) is preferred.
 
 ```hbs
-{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control-select--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
   <option value="" selected>Selectable placeholder</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>
@@ -46,7 +46,7 @@ Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control pf-c-
   <option value="Other">Other</option>
 {{/form-control-select}}
 <br>
-{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-non-selectable-placeholder" name="select-non-selectable-placeholder" aria-label="Non-selectable placeholder select example"'}}
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control-select--attribute='id="select-non-selectable-placeholder" name="select-non-selectable-placeholder" aria-label="Non-selectable placeholder select example"'}}
   <option value="" selected disabled>Non-selectable placeholder</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -30,17 +30,13 @@ import './FormControl.css'
 {{> form-control controlType="input" input="true" form-control--attribute='required type="text" value="Error" id="input-error" aria-invalid="true" aria-label="Error state input example"'}}
 <br><br>
 {{> form-control controlType="input" input="true" form-control--IsExpanded="true" form-control--attribute='type="text" value="Expanded" id="input-expanded" aria-label="Expanded input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar" form-control--attribute='type="text" value="Calendar" id="input-calendar" name="input-calendar" aria-label="Calendar input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-clock" form-control--attribute='type="text" value="Clock" id="input-clock" name="input-clock" aria-label="Clock input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon" form-control--attribute='type="text" value="Custom icon" id="input-custom-icon" name="custom-icon" aria-label="Custom icon input example"'}}
 ```
 
 ### Select
+Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in order to display properly with PatternFly styling. In addition, `'pf-m-disabled`/`.pf-m-error` must be added to the wrapper for disabled/invalid select inputs. Using the [PatternFly Select component](/components/menus/select) is preferred.
+
 ```hbs
-{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
   <option value="" selected>Selectable placeholder</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>
@@ -48,9 +44,9 @@ import './FormControl.css'
   <option value="Ms">Ms</option>
   <option value="Dr">Dr</option>
   <option value="Other">Other</option>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='id="select-non-selectable-placeholder" name="select-non-selectable-placeholder" aria-label="Non-selectable placeholder select example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-non-selectable-placeholder" name="select-non-selectable-placeholder" aria-label="Non-selectable placeholder select example"'}}
   <option value="" selected disabled>Non-selectable placeholder</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>
@@ -58,9 +54,9 @@ import './FormControl.css'
   <option value="Ms">Ms</option>
   <option value="Dr">Dr</option>
   <option value="Other">Other</option>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--attribute='id="select-group" name="select-group" aria-label="Select group example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--attribute='id="select-group" name="select-group" aria-label="Select group example"'}}
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
     <option value="Option 2" selected>Option groups (second option selected)</option>
@@ -69,9 +65,9 @@ import './FormControl.css'
     <option value="Option 3">The third option</option>
     <option value="Option 4">The fourth option</option>
   </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-success" form-control--attribute='id="select-group-success" name="select-group-success" aria-label="Success state select group example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--modifier="pf-m-success" form-control-select--attribute='id="select-group-success" name="select-group-success" aria-label="Success state select group example"'}}
   <option value="">Valid option</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
@@ -81,9 +77,9 @@ import './FormControl.css'
     <option value="Option 3">The third option</option>
     <option value="Option 4">The fourth option</option>
   </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-warning" form-control--attribute='id="select-group-warning" name="select-group-warning" aria-label="Warning state select group example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--modifier="pf-m-warning" form-control-select--attribute='id="select-group-warning" name="select-group-warning" aria-label="Warning state select group example"'}}
   <option value="">Warning option</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
@@ -93,9 +89,9 @@ import './FormControl.css'
     <option value="Option 3">The third option</option>
     <option value="Option 4">The fourth option</option>
   </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--modifier="pf-m-error" form-control-select--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
   <option value="">Invalid option</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
@@ -105,9 +101,9 @@ import './FormControl.css'
     <option value="Option 3">The third option</option>
     <option value="Option 4">The fourth option</option>
   </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-placeholder" form-control--attribute='disabled id="select-disabled" name="select-disabled" aria-label="Disabled select example"'}}
+{{/form-control-select}}
+<br>
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder pf-m-disabled" form-control-select--attribute='disabled id="select-disabled" name="select-disabled" aria-label="Disabled select example"'}}
   <option value="" selected>Disabled</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>
@@ -115,7 +111,7 @@ import './FormControl.css'
   <option value="Ms">Ms</option>
   <option value="Dr">Dr</option>
   <option value="Other">Other</option>
-{{/form-control}}
+{{/form-control-select}}
 ```
 
 ### Textarea
@@ -157,73 +153,6 @@ Resizes horizontally
 {{/form-control}}
 ```
 
-### Icon sprite
-**Note:** The icons for the success, invalid, calendar, etc varations in form control elemements are applied as background images to the form element. By default, the image URLs for these icons are data URIs. However, there may be cases where data URIs are not ideal, such as in an application with a content security policy that disallows data URIs for security reasons. The `.pf-m-icon-sprite` variation changes the icon source to an external SVG file that serves as a sprite for all of the supported icons.
-
-
-```hbs
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-success pf-m-icon-sprite" form-control--attribute='type="text" value="Success" id="input-success-sprite" aria-label="Success state input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-warning pf-m-icon-sprite" form-control--attribute='type="text" value="Warning" id="input-warning-sprite" aria-label="Warning state input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon-sprite" form-control--attribute='required type="text" value="Error" id="input-error-sprite" aria-invalid="true" aria-label="Error state input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-search pf-m-icon-sprite" form-control--attribute='type="search" value="Search" id="input-search-sprite" name="search-input" aria-label="Search input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-calendar pf-m-icon-sprite" form-control--attribute='type="text" value="Calendar" id="input-calendar-sprite" name="input-calendar" aria-label="Calendar input example"'}}
-<br><br>
-{{> form-control controlType="input" input="true" form-control--modifier="pf-m-icon pf-m-clock pf-m-icon-sprite" form-control--attribute='type="text" value="Clock" id="input-clock-sprite" name="input-clock" aria-label="Clock input example"'}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-success pf-m-icon-sprite" form-control--attribute='id="select-group-success-sprite" name="select-group-success" aria-label="Success state select group example"'}}
-  <option value="">Valid option</option>
-  <optgroup label="Group 1">
-    <option value="Option 1">The first option</option>
-    <option value="Option 2">The second option</option>
-  </optgroup>
-  <optgroup label="Group 2">
-    <option value="Option 3">The third option</option>
-    <option value="Option 4">The fourth option</option>
-  </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-warning pf-m-icon-sprite" form-control--attribute='id="select-group-warning-sprite" name="select-group-warning" aria-label="Warning state select group example"'}}
-  <option value="">Warning option</option>
-  <optgroup label="Group 1">
-    <option value="Option 1">The first option</option>
-    <option value="Option 2">The second option</option>
-  </optgroup>
-  <optgroup label="Group 2">
-    <option value="Option 3">The third option</option>
-    <option value="Option 4">The fourth option</option>
-  </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="select" form-control--modifier="pf-m-icon-sprite" form-control--attribute='required aria-invalid="true" id="select-group-error-sprite" name="select-group-error" aria-label="Error state select group example"'}}
-  <option value="">Invalid option</option>
-  <optgroup label="Group 1">
-    <option value="Option 1">The first option</option>
-    <option value="Option 2">The second option</option>
-  </optgroup>
-  <optgroup label="Group 2">
-    <option value="Option 3">The third option</option>
-    <option value="Option 4">The fourth option</option>
-  </optgroup>
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="textarea" form-control--modifier="pf-m-success pf-m-icon-sprite" form-control--attribute='name="textarea-success" id="textarea-success-sprite" aria-label="Success state textarea example"'}}
-Success
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="textarea" form-control--modifier="pf-m-warning pf-m-icon-sprite" form-control--attribute='name="textarea-warning" id="textarea-warning-sprite" aria-label="Warning state textarea example"'}}
-Warning
-{{/form-control}}
-<br><br>
-{{#> form-control controlType="textarea" form-control--modifier="pf-m-icon-sprite" form-control--attribute='required name="textarea-error" id="textarea-error-sprite" aria-label="Error state textarea example" aria-invalid="true"'}}
-Error
-{{/form-control}}
-
-```
-
 ## Documentation
 
 ### Accessibility
@@ -237,15 +166,14 @@ Error
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
+| `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input or textarea. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
-| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. |
-| `.pf-m-warning` | `.pf-c-form-control` | Modifies a form control for the warning state. |
-| `.pf-m-icon-sprite` | `.pf-c-form-control` | Modifies form control element to use an external SVG sprite instead of embedded data URIs for icons. For use with apps whose content security policies disallow the use of data URIs. |
-| `.pf-m-icon` | `input.pf-c-form-control` | Modifies a form control text input to be able to specify a custom SVG background via `--pf-c-form-control--m-icon--BackgroundUrl`, and other optional vars for other background properties.
-| `.pf-m-calendar` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the calendar icon. |
-| `.pf-m-clock` | `.pf-c-form-control.pf-m-icon` | Modifies a form control to support the clock icon. |
+| `.pf-m-success` | `.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form control for the success state. |
+| `.pf-m-warning` | `.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form control for the warning state. |
 | `.pf-m-expanded` | `input.pf-c-form-control` | Modifies a form control for the expanded state. This is used when clicking in the text input toggles something open/closed. |
-| `.pf-m-placeholder` | `select.pf-c-form-control` | Modifies a form select for placeholder styles. This modifier is set programatically based on the chosen option. |
+| `.pf-m-placeholder` | `select.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form select for placeholder styles. This modifier is set programatically based on the chosen option. |
 | `.pf-m-plain` | `input[readonly].pf-c-form-control`, `textarea[readonly].pf-c-form-control` | Modifies an `<input>` or `<textarea>` with a `readonly` attribute to be presented as normal text. |
+| `.pf-c-form-control-select` | `<div>` |  Wrapper for a select. **Required for select form controls**  |
+| `.pf-m-error` | `.pf-c-form-control-select` | Modifies a form control select for the invalid state. Always use with `aria-invalid="true"` on the `<select>`.|
+| `.pf-m-disabled` | `.pf-c-form-control-select` | Modifies a form control select for the disabled state. Always use with `disabled` on the `<select>`.|

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -33,7 +33,7 @@ import './FormControl.css'
 ```
 
 ### Select
-Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in order to display properly with PatternFly styling. In addition, `'pf-m-disabled`/`.pf-m-error` must be added to the wrapper for disabled/invalid select inputs. Using the [PatternFly Select component](/components/menus/select) is preferred.
+Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in order to display properly with PatternFly styling. Using the [PatternFly Select component](/components/menus/select) is preferred.
 
 ```hbs
 {{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
@@ -91,7 +91,7 @@ Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in
   </optgroup>
 {{/form-control-select}}
 <br>
-{{#> form-control-select form-control-select--modifier="pf-m-error" form-control-select--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
+{{#> form-control-select form-control-select--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
   <option value="">Invalid option</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
@@ -103,7 +103,7 @@ Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in
   </optgroup>
 {{/form-control-select}}
 <br>
-{{#> form-control-select form-control-select--modifier="pf-m-placeholder pf-m-disabled" form-control-select--attribute='disabled id="select-disabled" name="select-disabled" aria-label="Disabled select example"'}}
+{{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control-select--attribute='disabled id="select-disabled" name="select-disabled" aria-label="Disabled select example"'}}
   <option value="" selected>Disabled</option>
   <option value="Mr">Mr</option>
   <option value="Miss">Miss</option>
@@ -175,5 +175,3 @@ Resizes horizontally
 | `.pf-m-placeholder` | `select.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form select for placeholder styles. This modifier is set programatically based on the chosen option. |
 | `.pf-m-plain` | `input[readonly].pf-c-form-control`, `textarea[readonly].pf-c-form-control` | Modifies an `<input>` or `<textarea>` with a `readonly` attribute to be presented as normal text. |
 | `.pf-c-form-control-select` | `<div>` |  Wrapper for a select. **Required for select form controls**  |
-| `.pf-m-error` | `.pf-c-form-control-select` | Modifies a form control select for the invalid state. Always use with `aria-invalid="true"` on the `<select>`.|
-| `.pf-m-disabled` | `.pf-c-form-control-select` | Modifies a form control select for the disabled state. Always use with `disabled` on the `<select>`.|

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -33,7 +33,7 @@ import './FormControl.css'
 ```
 
 ### Select
-Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control">` in order to display properly with PatternFly styling. Using the [PatternFly Select component](/components/menus/select) is preferred.
+Note: An HTML `<select>` must be wrapped in `<div class="pf-c-form-control pf-c-form-control-select">` in order to display properly with PatternFly styling. Using the [PatternFly Select component](/components/menus/select) is preferred.
 
 ```hbs
 {{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute='id="select-selectable-placeholder" name="select-selectable-placeholder" aria-label="Selectable placeholder select example"'}}
@@ -169,9 +169,9 @@ Resizes horizontally
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input or textarea. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized vertically along the y-axis. |
 | `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `textarea.pf-c-form-control` element so it can only be resized horizontally along the x-axis. |
-| `.pf-m-success` | `.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form control for the success state. |
-| `.pf-m-warning` | `.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form control for the warning state. |
+| `.pf-m-success` | `.pf-c-form-control`, `pf-c-form-control > select` | Modifies a form control for the success state. |
+| `.pf-m-warning` | `.pf-c-form-control`, `pf-c-form-control > select` | Modifies a form control for the warning state. |
 | `.pf-m-expanded` | `input.pf-c-form-control` | Modifies a form control for the expanded state. This is used when clicking in the text input toggles something open/closed. |
-| `.pf-m-placeholder` | `select.pf-c-form-control`, `pf-c-form-control-select` | Modifies a form select for placeholder styles. This modifier is set programatically based on the chosen option. |
+| `.pf-m-placeholder` | `select.pf-c-form-control`, `pf-c-form-control > select` | Modifies a form select for placeholder styles. This modifier is set programatically based on the chosen option. |
 | `.pf-m-plain` | `input[readonly].pf-c-form-control`, `textarea[readonly].pf-c-form-control` | Modifies an `<input>` or `<textarea>` with a `readonly` attribute to be presented as normal text. |
-| `.pf-c-form-control-select` | `<div>` |  Wrapper for a select. **Required for select form controls**  |
+| `.pf-c-form-control.pf-c-form-control-select` | `<div>` |  Wrapper for a select. **Required for select form controls**  |

--- a/src/patternfly/components/FormControl/form-control-select.hbs
+++ b/src/patternfly/components/FormControl/form-control-select.hbs
@@ -1,0 +1,7 @@
+<div class="pf-c-form-control pf-c-form-control-select{{#if form-control-select--IsExpanded}} pf-m-expanded{{/if}}{{#if form-control-select--modifier}} {{form-control-select--modifier}}{{/if}}">
+  <select class=""
+    {{#if form-control-select--attribute}}
+      {{{form-control-select--attribute}}}
+    {{/if}}
+  {{#if input}}>{{else}}>{{#if @partial-block}}{{> @partial-block}}{{/if}}</select>{{/if}}
+</div>

--- a/src/patternfly/components/FormControl/form-control-select.hbs
+++ b/src/patternfly/components/FormControl/form-control-select.hbs
@@ -1,5 +1,5 @@
-<div class="pf-c-form-control pf-c-form-control-select{{#if form-control-select--IsExpanded}} pf-m-expanded{{/if}}{{#if form-control-select--modifier}} {{form-control-select--modifier}}{{/if}}">
-  <select class=""
+<div class="pf-c-form-control pf-c-form-control-select">
+  <select class="pf-c-form-control {{#if form-control-select--IsExpanded}} pf-m-expanded{{/if}}{{#if form-control-select--modifier}} {{form-control-select--modifier}}{{/if}}"
     {{#if form-control-select--attribute}}
       {{{form-control-select--attribute}}}
     {{/if}}

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -179,7 +179,9 @@
     border-bottom-width: var(--pf-c-form-control--m-warning--BorderBottomWidth);
   }
 
-  @at-root select#{&} {
+  // Wrapper to style a select input
+  // Replace with &:has(select) when there is enough support
+  &.pf-c-form-control-select {
     --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--PaddingRight);
     --pf-c-form-control--PaddingLeft: var(--pf-c-form-control__select--PaddingLeft);
 
@@ -199,7 +201,20 @@
       border-right: 5px solid transparent;
       border-left: 5px solid transparent;
       transform: translate(-100%, -50%);
-   }
+    }
+
+    &.pf-m-disabled {
+      --pf-c-form-control--BackgroundColor: var(--pf-c-form-control--disabled--BackgroundColor);
+      --pf-c-form-control--Color: var(--pf-c-form-control--disabled--Color);
+      --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--disabled--BorderColor);
+    }
+
+    &.pf-m-error {
+      --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--invalid--BorderBottomColor);
+
+      padding-bottom: var(--pf-c-form-control--invalid--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
+      border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth);
+    }
 
     // Firefox's select text has additional padding
     // stylelint-disable-next-line
@@ -208,20 +223,34 @@
       --pf-c-form-control--PaddingLeft: calc(var(--pf-c-form-control__select--PaddingLeft) - 4px);
     }
 
-    &.pf-m-placeholder {
-      color: var(--pf-c-form-control--placeholder--Color);
+    &.pf-m-placeholder select {
+      --pf-c-form-control--Color: var(--pf-c-form-control--placeholder--Color);
 
-      * {
-        color: var(--pf-c-form-control--placeholder--child--Color);
-
-        // stylelint-disable max-nesting-depth
-        &:disabled {
-          color: revert;
-        }
-        // stylelint-enable
+      &:disabled {
+        --pf-c-form-control--BackgroundColor: var(--pf-c-form-control--disabled--BackgroundColor);
+        
+        color: revert;
       }
     }
   }
+
+  & select {
+    width: 100%; 
+    color: var(--pf-c-form-control--Color); 
+    background-color: transparent;
+    background-image: none;
+    border: none;
+    // stylelint-disable
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    // stylelint-enable
+
+    &:active, &:focus {
+      outline: none;
+      box-shadow: none;
+    }
+}
 
   @at-root textarea#{&} {
     width: var(--pf-c-form-control--textarea--Width);

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -69,11 +69,10 @@
   --pf-c-form-control--invalid--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--invalid--BorderBottomWidth));
   --pf-c-form-control--invalid--BorderBottomColor: var(--pf-global--danger-color--100);
 
-  // TODO 
-  // Select -- rename __select to --select in a breaking change release
-  --pf-c-form-control__select--PaddingRight: calc(var(--pf-global--spacer--lg) + var(--pf-c-form-control--BorderWidth) + var(--pf-c-form-control--BorderWidth));
-  --pf-c-form-control__select--PaddingLeft: calc(var(--pf-global--spacer--sm) - var(--pf-c-form-control--BorderWidth));
-  --pf-c-form-control__select--BackgroundPositionX: calc(100% - var(--pf-global--spacer--md) + 1px);
+  // Select
+  --pf-c-form-control--select--PaddingRight: calc(var(--pf-global--spacer--lg) + var(--pf-c-form-control--BorderWidth) + var(--pf-c-form-control--BorderWidth));
+  --pf-c-form-control--select--PaddingLeft: calc(var(--pf-global--spacer--sm) - var(--pf-c-form-control--BorderWidth));
+  --pf-c-form-control--select--BackgroundPositionX: calc(100% - var(--pf-global--spacer--md) + 1px);
 
   // Textarea
   --pf-c-form-control--textarea--Width: var(--pf-c-form-control--Width);
@@ -182,16 +181,13 @@
   // Wrapper to style a select input
   // Replace with &:has(select) when there is enough support
   &.pf-c-form-control-select {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--PaddingRight);
-    --pf-c-form-control--PaddingLeft: var(--pf-c-form-control__select--PaddingLeft);
-
     position: relative;
     cursor: pointer;
 
     &::after {
       position: absolute;
       top: 50%;
-      left: var(--pf-c-form-control__select--BackgroundPositionX);
+      left: var(--pf-c-form-control--select--BackgroundPositionX);
       width: 0;
       height: 0;
       margin-top: var(--pf-c-form-control--BorderWidth);
@@ -201,26 +197,6 @@
       border-right: 5px solid transparent;
       border-left: 5px solid transparent;
       transform: translate(-100%, -50%);
-    }
-
-    &.pf-m-disabled {
-      --pf-c-form-control--BackgroundColor: var(--pf-c-form-control--disabled--BackgroundColor);
-      --pf-c-form-control--Color: var(--pf-c-form-control--disabled--Color);
-      --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--disabled--BorderColor);
-    }
-
-    &.pf-m-error {
-      --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--invalid--BorderBottomColor);
-
-      padding-bottom: var(--pf-c-form-control--invalid--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-      border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth);
-    }
-
-    // Firefox's select text has additional padding
-    // stylelint-disable-next-line
-    @-moz-document url-prefix() {
-      --pf-c-form-control--PaddingRight: calc(var(--pf-c-form-control__select--PaddingRight) - 1px);
-      --pf-c-form-control--PaddingLeft: calc(var(--pf-c-form-control__select--PaddingLeft) - 4px);
     }
 
     &.pf-m-placeholder select {
@@ -235,22 +211,18 @@
   }
 
   & select {
-    width: 100%; 
-    color: var(--pf-c-form-control--Color); 
-    background-color: transparent;
-    background-image: none;
-    border: none;
+    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--select--PaddingRight);
+    --pf-c-form-control--PaddingLeft: var(--pf-c-form-control--select--PaddingLeft);
+
+    position: absolute;
+    inset: 0;
+
     // stylelint-disable
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
     // stylelint-enable
-
-    &:active, &:focus {
-      outline: none;
-      box-shadow: none;
-    }
-}
+  }
 
   @at-root textarea#{&} {
     width: var(--pf-c-form-control--textarea--Width);

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -1,30 +1,3 @@
-// Input - success
-$pf-c-form-control--success--Color: $pf-global--success-color--100 !default;
-$pf-c-form-control--success--Coordinates: "M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z" !default;
-
-// Input - warning
-$pf-c-form-control--m-warning--Color: $pf-global--warning-color--100 !default;
-$pf-c-form-control--m-warning--Coordinates: "M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" !default;
-
-// Input - invalid
-$pf-c-form-control--invalid--Color: $pf-global--danger-color--100 !default;
-$pf-c-form-control--invalid--Coordinates: "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" !default;
-$pf-c-form-control__select--Coordinates: "M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z" !default;
-$pf-c-form-control__select--ViewBox: "320" !default;
-
-// Input - search
-// Remove at breaking change
-$pf-c-form-control--m-search--Color: $pf-global--icon--Color--light !default;
-$pf-c-form-control--m-search--Coordinates: "M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z" !default;
-
-// Calendar
-$pf-c-form-control--m-calendar--Color: $pf-global--icon--Color--light !default;
-$pf-c-form-control--m-calendar--Coordinates: "M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z" !default;
-
-// Clock
-$pf-c-form-control--m-clock--Color: $pf-global--icon--Color--light !default;
-$pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z" !default;
-
 .pf-c-form-control {
   // Component
   --pf-c-form-control--Color: var(--pf-global--Color--100);
@@ -85,133 +58,36 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   --pf-c-form-control--success--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-form-control--success--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--success--BorderBottomWidth));
   --pf-c-form-control--success--BorderBottomColor: var(--pf-global--success-color--100);
-  --pf-c-form-control--success--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-form-control--success--BackgroundPositionX: calc(100% - var(--pf-c-form-control--PaddingLeft));
-  --pf-c-form-control--success--BackgroundPositionY: center;
-  --pf-c-form-control--success--BackgroundPosition: var(--pf-c-form-control--success--BackgroundPositionX) var(--pf-c-form-control--success--BackgroundPositionY);
-  --pf-c-form-control--success--BackgroundSizeX: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--success--BackgroundSizeY: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--success--BackgroundSize: var(--pf-c-form-control--success--BackgroundSizeX) var(--pf-c-form-control--success--BackgroundSizeY);
-  --pf-c-form-control--success--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--success--Coordinates, $svg-color: $pf-c-form-control--success--Color)};
 
   // Input m-warning
   --pf-c-form-control--m-warning--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-form-control--m-warning--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--m-warning--BorderBottomWidth));
   --pf-c-form-control--m-warning--BorderBottomColor: var(--pf-global--warning-color--100);
-  --pf-c-form-control--m-warning--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-form-control--m-warning--BackgroundPositionX: calc(100% - calc(var(--pf-c-form-control--PaddingLeft) - #{pf-size-prem(1px)}));
-  --pf-c-form-control--m-warning--BackgroundPositionY: center;
-  --pf-c-form-control--m-warning--BackgroundPosition: var(--pf-c-form-control--m-warning--BackgroundPositionX) var(--pf-c-form-control--m-warning--BackgroundPositionY);
-  --pf-c-form-control--m-warning--BackgroundSizeX: #{pf-size-prem(20px)};
-  --pf-c-form-control--m-warning--BackgroundSizeY: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--m-warning--BackgroundSize: var(--pf-c-form-control--m-warning--BackgroundSizeX) var(--pf-c-form-control--m-warning--BackgroundSizeY);
-  --pf-c-form-control--m-warning--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--m-warning--Coordinates, $svg-color: $pf-c-form-control--m-warning--Color)};
 
   // Input invalid
   --pf-c-form-control--invalid--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-form-control--invalid--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--invalid--BorderBottomWidth));
   --pf-c-form-control--invalid--BorderBottomColor: var(--pf-global--danger-color--100);
-  --pf-c-form-control--invalid--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-form-control--invalid--BackgroundPositionX: calc(100% - var(--pf-c-form-control--PaddingLeft));
-  --pf-c-form-control--invalid--BackgroundPositionY: center;
-  --pf-c-form-control--invalid--BackgroundPosition: var(--pf-c-form-control--invalid--BackgroundPositionX) var(--pf-c-form-control--invalid--BackgroundPositionY);
-  --pf-c-form-control--invalid--BackgroundSizeX: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--invalid--BackgroundSizeY: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--invalid--BackgroundSize: var(--pf-c-form-control--invalid--BackgroundSizeX) var(--pf-c-form-control--invalid--BackgroundSizeY);
-  --pf-c-form-control--invalid--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--invalid--Coordinates, $svg-color: $pf-c-form-control--invalid--Color)};
-  --pf-c-form-control--invalid--exclamation--Background: var(--pf-c-form-control--invalid--BackgroundUrl) var(--pf-c-form-control--invalid--BackgroundPosition) / var(--pf-c-form-control--invalid--BackgroundSize) no-repeat;
-  --pf-c-form-control--invalid--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--invalid--exclamation--Background); // remove in breaking change
 
-  // Input m-search
-  // Remove at breaking change
-  --pf-c-form-control--m-search--PaddingLeft: var(--pf-global--spacer--xl);
-  --pf-c-form-control--m-search--BackgroundPosition: var(--pf-c-form-control--PaddingRight);
-  --pf-c-form-control--m-search--BackgroundSize: var(--pf-c-form-control--FontSize) var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--m-search--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--m-search--Coordinates, $svg-color: $pf-c-form-control--m-search--Color)};
-
-  // Input m-icon
-  --pf-c-form-control--m-icon--PaddingRight: calc(var(--pf-c-form-control--inset--base) + var(--pf-c-form-control--m-icon--BackgroundSizeX) + var(--pf-c-form-control--m-icon--icon--spacer));
-  --pf-c-form-control--m-icon--BackgroundUrl: none;
-  --pf-c-form-control--m-icon--BackgroundPositionX: calc(100% - var(--pf-c-form-control--inset--base));
-  --pf-c-form-control--m-icon--BackgroundPositionY: center;
-  --pf-c-form-control--m-icon--BackgroundSizeX: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--m-icon--BackgroundSizeY: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--m-icon--icon--spacer: var(--pf-global--spacer--sm);
-  --pf-c-form-control--m-icon--icon--PaddingRight: calc(var(--pf-c-form-control--inset--base) + var(--pf-c-form-control--invalid--BackgroundSizeX) + var(--pf-c-form-control--m-icon--icon--spacer) + var(--pf-c-form-control--m-icon--BackgroundSizeX) + var(--pf-c-form-control--m-icon--icon--spacer));
-  --pf-c-form-control--m-icon--icon--BackgroundPositionX: calc(var(--pf-c-form-control--m-icon--BackgroundPositionX) - var(--pf-c-form-control--m-icon--icon--spacer) - var(--pf-c-form-control--invalid--BackgroundSizeX));
-  --pf-c-form-control--m-icon--invalid--BackgroundUrl: var(--pf-c-form-control--invalid--BackgroundUrl), var(--pf-c-form-control--m-icon--BackgroundUrl);
-  --pf-c-form-control--m-icon--invalid--BackgroundPosition: var(--pf-c-form-control--invalid--BackgroundPosition), var(--pf-c-form-control--m-icon--icon--BackgroundPositionX) var(--pf-c-form-control--m-icon--BackgroundPositionY);
-  --pf-c-form-control--m-icon--invalid--BackgroundSize: var(--pf-c-form-control--invalid--BackgroundSize), var(--pf-c-form-control--m-icon--BackgroundSizeX) var(--pf-c-form-control--m-icon--BackgroundSizeY);
-  --pf-c-form-control--m-icon--success--BackgroundUrl: var(--pf-c-form-control--success--BackgroundUrl), var(--pf-c-form-control--m-icon--BackgroundUrl);
-  --pf-c-form-control--m-icon--success--BackgroundPosition: var(--pf-c-form-control--success--BackgroundPosition), var(--pf-c-form-control--m-icon--icon--BackgroundPositionX) var(--pf-c-form-control--m-icon--BackgroundPositionY);
-  --pf-c-form-control--m-icon--success--BackgroundSize: var(--pf-c-form-control--success--BackgroundSize), var(--pf-c-form-control--m-icon--BackgroundSizeX) var(--pf-c-form-control--m-icon--BackgroundSizeY);
-  --pf-c-form-control--m-icon--m-warning--BackgroundUrl: var(--pf-c-form-control--m-warning--BackgroundUrl), var(--pf-c-form-control--m-icon--BackgroundUrl);
-  --pf-c-form-control--m-icon--m-warning--BackgroundPosition: var(--pf-c-form-control--m-warning--BackgroundPosition), var(--pf-c-form-control--m-icon--icon--BackgroundPositionX) var(--pf-c-form-control--m-icon--BackgroundPositionY);
-  --pf-c-form-control--m-icon--m-warning--BackgroundSize: var(--pf-c-form-control--m-warning--BackgroundSize), var(--pf-c-form-control--m-icon--BackgroundSizeX) var(--pf-c-form-control--m-icon--BackgroundSizeY);
-
-  // Input m-calendar
-  --pf-c-form-control--m-calendar--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--m-calendar--Coordinates, $svg-color: $pf-c-form-control--m-calendar--Color)};
-
-  // Input m-clock
-  --pf-c-form-control--m-clock--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--m-clock--Coordinates, $svg-color: $pf-c-form-control--m-clock--Color)};
-
+  // TODO 
   // Select -- rename __select to --select in a breaking change release
   --pf-c-form-control__select--PaddingRight: calc(var(--pf-global--spacer--lg) + var(--pf-c-form-control--BorderWidth) + var(--pf-c-form-control--BorderWidth));
   --pf-c-form-control__select--PaddingLeft: calc(var(--pf-global--spacer--sm) - var(--pf-c-form-control--BorderWidth));
-  --pf-c-form-control__select--BackgroundUrl: #{pf-bg-svg($pf-c-form-control__select--Coordinates, $pf-c-form-control__select--ViewBox)};
-  --pf-c-form-control__select--BackgroundSize: .625em; // Calculated from react-icon SVG viewbox
   --pf-c-form-control__select--BackgroundPositionX: calc(100% - var(--pf-global--spacer--md) + 1px);
-  --pf-c-form-control__select--BackgroundPositionY: center;
-  --pf-c-form-control__select--BackgroundPosition: var(--pf-c-form-control__select--BackgroundPositionX) var(--pf-c-form-control__select--BackgroundPositionY);
-
-  // Select success
-  --pf-c-form-control__select--success--PaddingRight: var(--pf-global--spacer--3xl);
-  --pf-c-form-control__select--success--BackgroundPosition: calc(var(--pf-c-form-control__select--BackgroundPositionX) - var(--pf-global--spacer--lg));
-
-  // Select warning
-  --pf-c-form-control__select--m-warning--PaddingRight: var(--pf-global--spacer--3xl);
-  --pf-c-form-control__select--m-warning--BackgroundPosition: calc(var(--pf-c-form-control__select--BackgroundPositionX) - var(--pf-global--spacer--lg) + #{pf-size-prem(1px)});
-
-  // Select invalid
-  --pf-c-form-control__select--invalid--PaddingRight: var(--pf-global--spacer--3xl);
-  --pf-c-form-control__select--invalid--BackgroundPosition: calc(var(--pf-c-form-control__select--BackgroundPositionX) - var(--pf-global--spacer--lg));
 
   // Textarea
   --pf-c-form-control--textarea--Width: var(--pf-c-form-control--Width);
   --pf-c-form-control--textarea--Height: auto;
 
-  // Textarea success
-  --pf-c-form-control--textarea--success--BackgroundPositionY: var(--pf-c-form-control--PaddingLeft); // update to use --pf-c-form-control--inset--base at breaking change
-
-  // Textarea warning
-  --pf-c-form-control--textarea--m-warning--BackgroundPositionY: var(--pf-c-form-control--PaddingLeft); // update to use --pf-c-form-control--inset--base at breaking change
-
-  // Textarea invalid
-  --pf-c-form-control--textarea--invalid--BackgroundPositionY: var(--pf-c-form-control--PaddingLeft); // update to use --pf-c-form-control--inset--base at breaking change
-
-  // Icon sprite
-  --pf-c-form-control--m-icon-sprite--success--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#success");
-  --pf-c-form-control--m-icon-sprite--m-warning--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#warning");
-  --pf-c-form-control--m-icon-sprite--invalid--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#invalid");
-  --pf-c-form-control--m-icon-sprite__select--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#select");
-  --pf-c-form-control--m-icon-sprite--m-search--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#search");
-  --pf-c-form-control--m-icon-sprite--m-calendar--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#calendar");
-  --pf-c-form-control--m-icon-sprite--m-clock--BackgroundUrl: url("#{$pf-global--image-path}/status-icon-sprite.svg#clock");
-  --pf-c-form-control--m-icon-sprite__select--BackgroundSize: var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--m-icon-sprite__select--BackgroundPositionX: calc(100% - var(--pf-global--spacer--md) + 7px);
-  --pf-c-form-control--m-icon-sprite__select--success--BackgroundPosition: calc(100% - var(--pf-global--spacer--md) + 1px - var(--pf-global--spacer--lg));
-  --pf-c-form-control--m-icon-sprite__select--m-warning--BackgroundPosition: calc(100% - var(--pf-global--spacer--md) - var(--pf-global--spacer--lg) + #{pf-size-prem(1px)});
-  --pf-c-form-control--m-icon-sprite__select--invalid--BackgroundPosition: calc(100% - var(--pf-global--spacer--md) - var(--pf-global--spacer--lg));
-
   // This component always needs to be light
   @include pf-t-light("--pf-c-form-control--Color");
 
+  position: relative;
   width: var(--pf-c-form-control--Width);
   padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
   font-size: var(--pf-c-form-control--FontSize);
   line-height: var(--pf-c-form-control--LineHeight);
   background-color: var(--pf-c-form-control--BackgroundColor);
-  background-repeat: no-repeat;
   border: var(--pf-c-form-control--BorderWidth) solid;
   border-color: var(--pf-c-form-control--BorderTopColor) var(--pf-c-form-control--BorderRightColor) var(--pf-c-form-control--BorderBottomColor) var(--pf-c-form-control--BorderLeftColor);
   border-radius: var(--pf-c-form-control--BorderRadius);
@@ -283,141 +159,53 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   }
 
   &[aria-invalid="true"] {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--invalid--PaddingRight);
     --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--invalid--BorderBottomColor);
 
     padding-bottom: var(--pf-c-form-control--invalid--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-    background-image: var(--pf-c-form-control--invalid--BackgroundUrl);
-    background-position: var(--pf-c-form-control--invalid--BackgroundPosition);
-    background-size: var(--pf-c-form-control--invalid--BackgroundSize);
     border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth);
-
-    &.pf-m-icon {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control--m-icon--icon--PaddingRight);
-
-      background-image: var(--pf-c-form-control--m-icon--invalid--BackgroundUrl);
-      background-position: var(--pf-c-form-control--m-icon--invalid--BackgroundPosition);
-      background-size: var(--pf-c-form-control--m-icon--invalid--BackgroundSize);
-    }
   }
 
   &.pf-m-success {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--success--PaddingRight);
     --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--success--BorderBottomColor);
 
     padding-bottom: var(--pf-c-form-control--success--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-    background-image: var(--pf-c-form-control--success--BackgroundUrl);
-    background-position: var(--pf-c-form-control--success--BackgroundPosition);
-    background-size: var(--pf-c-form-control--success--BackgroundSize);
     border-bottom-width: var(--pf-c-form-control--success--BorderBottomWidth);
-
-    &.pf-m-icon {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control--m-icon--icon--PaddingRight);
-
-      background-image: var(--pf-c-form-control--m-icon--success--BackgroundUrl);
-      background-position: var(--pf-c-form-control--m-icon--success--BackgroundPosition);
-      background-size: var(--pf-c-form-control--m-icon--success--BackgroundSize);
-    }
   }
 
   &.pf-m-warning {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--m-warning--PaddingRight);
     --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--m-warning--BorderBottomColor);
 
     padding-bottom: var(--pf-c-form-control--m-warning--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-    background-image: var(--pf-c-form-control--m-warning--BackgroundUrl);
-    background-position: var(--pf-c-form-control--m-warning--BackgroundPosition);
-    background-size: var(--pf-c-form-control--m-warning--BackgroundSize);
     border-bottom-width: var(--pf-c-form-control--m-warning--BorderBottomWidth);
-
-    &.pf-m-icon {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control--m-icon--icon--PaddingRight);
-
-      background-image: var(--pf-c-form-control--m-icon--m-warning--BackgroundUrl);
-      background-position: var(--pf-c-form-control--m-icon--m-warning--BackgroundPosition);
-      background-size: var(--pf-c-form-control--m-icon--m-warning--BackgroundSize);
-    }
-  }
-
-  // Remove at breaking change
-  &.pf-m-search {
-    --pf-c-form-control--PaddingLeft: var(--pf-c-form-control--m-search--PaddingLeft);
-
-    background-image: var(--pf-c-form-control--m-search--BackgroundUrl);
-    background-position: var(--pf-c-form-control--m-search--BackgroundPosition);
-    background-size: var(--pf-c-form-control--m-search--BackgroundSize);
-  }
-
-  &.pf-m-icon {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--m-icon--PaddingRight);
-
-    background-image: var(--pf-c-form-control--m-icon--BackgroundUrl);
-    background-position: var(--pf-c-form-control--m-icon--BackgroundPositionX) var(--pf-c-form-control--m-icon--BackgroundPositionY);
-    background-size: var(--pf-c-form-control--m-icon--BackgroundSizeX) var(--pf-c-form-control--m-icon--BackgroundSizeY);
-
-    &.pf-m-calendar {
-      --pf-c-form-control--m-icon--BackgroundUrl: var(--pf-c-form-control--m-calendar--BackgroundUrl);
-    }
-
-    &.pf-m-clock {
-      --pf-c-form-control--m-icon--BackgroundUrl: var(--pf-c-form-control--m-clock--BackgroundUrl);
-    }
-  }
-
-  &.pf-m-icon-sprite {
-    --pf-c-form-control--success--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--success--BackgroundUrl);
-    --pf-c-form-control--m-warning--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--m-warning--BackgroundUrl);
-    --pf-c-form-control--invalid--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--invalid--BackgroundUrl);
-    --pf-c-form-control__select--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite__select--BackgroundUrl);
-    --pf-c-form-control--m-search--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--m-search--BackgroundUrl);
-    --pf-c-form-control--m-calendar--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--m-calendar--BackgroundUrl);
-    --pf-c-form-control--m-clock--BackgroundUrl: var(--pf-c-form-control--m-icon-sprite--m-clock--BackgroundUrl);
-    --pf-c-form-control__select--BackgroundSize: var(--pf-c-form-control--m-icon-sprite__select--BackgroundSize);
-    --pf-c-form-control__select--BackgroundPositionX: var(--pf-c-form-control--m-icon-sprite__select--BackgroundPositionX);
-    --pf-c-form-control__select--success--BackgroundPosition: var(--pf-c-form-control--m-icon-sprite__select--success--BackgroundPosition);
-    --pf-c-form-control__select--m-warning--BackgroundPosition: var(--pf-c-form-control--m-icon-sprite__select--m-warning--BackgroundPosition);
-    --pf-c-form-control__select--invalid--BackgroundPosition: var(--pf-c-form-control--m-icon-sprite__select--invalid--BackgroundPosition);
   }
 
   @at-root select#{&} {
     --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--PaddingRight);
     --pf-c-form-control--PaddingLeft: var(--pf-c-form-control__select--PaddingLeft);
 
-    background-image: var(--pf-c-form-control__select--BackgroundUrl);
-    background-position: var(--pf-c-form-control__select--BackgroundPosition);
-    background-size: var(--pf-c-form-control__select--BackgroundSize);
+    position: relative;
+    cursor: pointer;
+
+    &::after {
+      position: absolute;
+      top: 50%;
+      left: var(--pf-c-form-control__select--BackgroundPositionX);
+      width: 0;
+      height: 0;
+      margin-top: var(--pf-c-form-control--BorderWidth);
+      pointer-events: none;
+      content: "";
+      border-top: 6px solid var(--pf-c-form-control--Color);
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent;
+      transform: translate(-100%, -50%);
+   }
 
     // Firefox's select text has additional padding
     // stylelint-disable-next-line
     @-moz-document url-prefix() {
       --pf-c-form-control--PaddingRight: calc(var(--pf-c-form-control__select--PaddingRight) - 1px);
       --pf-c-form-control--PaddingLeft: calc(var(--pf-c-form-control__select--PaddingLeft) - 4px);
-    }
-
-    &[aria-invalid="true"] {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--invalid--PaddingRight);
-      --pf-c-form-control--invalid--BackgroundPosition: var(--pf-c-form-control__select--invalid--BackgroundPosition); // drop this declaration and use the __select var directly in the background-position below in breaking change release
-
-      background-image: var(--pf-c-form-control__select--BackgroundUrl), var(--pf-c-form-control--invalid--BackgroundUrl);
-      background-position: var(--pf-c-form-control__select--BackgroundPosition), var(--pf-c-form-control--invalid--BackgroundPosition);
-      background-size: var(--pf-c-form-control__select--BackgroundSize), var(--pf-c-form-control--invalid--BackgroundSize);
-    }
-
-    &.pf-m-success {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--success--PaddingRight);
-      --pf-c-form-control--success--BackgroundPosition: var(--pf-c-form-control__select--success--BackgroundPosition); // drop this declaration and use the __select var directly in the background-position below in breaking change release
-
-      background-image: var(--pf-c-form-control__select--BackgroundUrl), var(--pf-c-form-control--success--BackgroundUrl);
-      background-position: var(--pf-c-form-control__select--BackgroundPosition), var(--pf-c-form-control--success--BackgroundPosition);
-      background-size: var(--pf-c-form-control__select--BackgroundSize), var(--pf-c-form-control--success--BackgroundSize);
-    }
-
-    &.pf-m-warning {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--m-warning--PaddingRight);
-
-      background-image: var(--pf-c-form-control__select--BackgroundUrl), var(--pf-c-form-control--m-warning--BackgroundUrl);
-      background-position: var(--pf-c-form-control__select--BackgroundPosition), var(--pf-c-form-control__select--m-warning--BackgroundPosition);
-      background-size: var(--pf-c-form-control__select--BackgroundSize), var(--pf-c-form-control--m-warning--BackgroundSize);
     }
 
     &.pf-m-placeholder {
@@ -436,10 +224,6 @@ $pf-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 248 
   }
 
   @at-root textarea#{&} {
-    --pf-c-form-control--success--BackgroundPositionY: var(--pf-c-form-control--textarea--success--BackgroundPositionY);
-    --pf-c-form-control--invalid--BackgroundPositionY: var(--pf-c-form-control--textarea--invalid--BackgroundPositionY);
-    --pf-c-form-control--m-warning--BackgroundPositionY: var(--pf-c-form-control--textarea--m-warning--BackgroundPositionY);
-
     width: var(--pf-c-form-control--textarea--Width);
     height: var(--pf-c-form-control--textarea--Height);
     vertical-align: bottom;

--- a/src/patternfly/components/FormControl/themes/dark/form-control.scss
+++ b/src/patternfly/components/FormControl/themes/dark/form-control.scss
@@ -2,7 +2,6 @@
 
 @mixin pf-theme-dark-form-control() {
   .pf-c-form-control {
-    --pf-c-form-control__select--BackgroundUrl: #{pf-bg-svg($pf-c-form-control__select--Coordinates, $pf-c-form-control__select--ViewBox, $pf-global--Color--100)};
     --pf-c-form-control--BorderTopColor: transparent;
     --pf-c-form-control--BorderRightColor: transparent;
     --pf-c-form-control--BorderBottomColor: var(--pf-global--BorderColor--400);

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -39,13 +39,13 @@
         State of residence
       {{/form-label}}
     {{/form-group-label}}
-    {{#> form-control controlType="select" form-control--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
+    {{#> form-control-select form-control-select--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
         <option value="">Select a state</option>
         <option value="Option 1">CA</option>
         <option value="Option 2">FL</option>
         <option value="Option 3">MA</option>
         <option value="Option 4">NY</option>
-    {{/form-control}}
+    {{/form-control-select}}
     {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true form-helper-text--id=(concat form-group--id '-form-email-helper-state')}}
   {{/form-group}}
   {{#> form-group form-group--IsCheckGroup=true form-group--id=(concat form--id '-check-group')}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -212,7 +212,7 @@ subsection: forms
           {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"')}}State{{/form-label}}
         {{/form-group-label}}
         {{#> form-group-control}}
-        {{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '"')}}
+        {{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control-select--attribute=(concat 'id="' form-group--id '" name="' form-group--id '"')}}
             <option value="" selected>Select one</option>
             <option value="AL">Alabama</option>
             <option value="AK">Alaska</option>

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -212,7 +212,7 @@ subsection: forms
           {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"')}}State{{/form-label}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="select" form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '"')}}
+        {{#> form-control-select form-control-select--modifier="pf-m-placeholder" form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '"')}}
             <option value="" selected>Select one</option>
             <option value="AL">Alabama</option>
             <option value="AK">Alaska</option>
@@ -264,7 +264,7 @@ subsection: forms
             <option value="WV">West Virginia</option>
             <option value="WI">Wisconsin</option>
             <option value="WY">Wyoming</option>
-          {{/form-control}}
+          {{/form-control-select}}
         {{/form-group-control}}
       {{/form-group}}
     {{/grid}}


### PR DESCRIPTION
This removes icons from the background of form control elements. Status icons will be replaced with required icons in helper text from this pr https://github.com/patternfly/patternfly/pull/5443

Native `select` elements were being restyled with a background image to replace the caret. This replaces the caret with a styled :after element but now requires a wrapper around the select to accomplish this.

The icon, clock, and calendar variants are removed. The time picker should be updated to use a form control group.

There is a related issue to replace the icon on the text input within the number input with helper text https://github.com/patternfly/patternfly/issues/5466

Fixes #5439 