### PR TITLE
chore(Badge): added flex styling

### DIFF
--- a/src/patternfly/components/Badge/badge.scss
+++ b/src/patternfly/components/Badge/badge.scss
@@ -7,6 +7,7 @@
   --pf-c-badge--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-badge--Color: var(--pf-global--Color--dark-100);
   --pf-c-badge--MinWidth: var(--pf-global--spacer--xl);
+  --pf-c-badge--Gap: var(--pf-global--spacer--sm);
 
   // Modifiers
   --pf-c-badge--m-read--BackgroundColor: var(--pf-global--BackgroundColor--200);
@@ -14,7 +15,10 @@
   --pf-c-badge--m-unread--BackgroundColor: var(--pf-global--primary-color--100);
   --pf-c-badge--m-unread--Color: var(--pf-global--Color--light-100);
 
-  display: inline-block;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--pf-c-badge--Gap);
+  justify-content: center;
   min-width: var(--pf-c-badge--MinWidth);
   padding-right: var(--pf-c-badge--PaddingRight);
   padding-left: var(--pf-c-badge--PaddingLeft);


### PR DESCRIPTION
Closes #5479 

@srambach added flex-wrap and justify-content so that wrapping more closely matches the current behavior of a Badge:

![Badges with flex styling](https://user-images.githubusercontent.com/70952936/231870692-944e10bc-2c3c-4ca4-95d2-5a5164bc4812.png)
