### PR TITLE
feat(Nav): added top and bottom padding to nav list

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -993,6 +993,8 @@
 
 // Subnav
 .#{$nav}__subnav {
+  --#{$nav}__list--PaddingTop: 0;
+  --#{$nav}__list--PaddingBottom: 0;
   --#{$nav}__link--PaddingTop: var(--#{$nav}__subnav__link--PaddingTop);
   --#{$nav}__link--PaddingRight: var(--#{$nav}__subnav__link--PaddingRight);
   --#{$nav}__link--PaddingBottom: var(--#{$nav}__subnav__link--PaddingBottom);
@@ -1021,11 +1023,6 @@
     --#{$nav}__link--PaddingLeft: var(--#{$nav}__subnav__subnav__link--PaddingLeft);
     --#{$nav}__subnav--PaddingLeft: var(--#{$nav}__subnav__subnav--PaddingLeft);
   }
-
-  > .#{$nav}__list {
-    --#{$nav}__list--PaddingTop: 0;
-  }
-
 
   // remove at breaking change - not used
   &.pf-m-flyout {
@@ -1100,7 +1097,7 @@
     --#{$nav}__section--MarginTop: 0;
   }
 
-  > .#{$nav}__list {
+  &:not(:last-child) {
     --#{$nav}__list--PaddingBottom: 0;
   }
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,7 +30,7 @@
 
   // List
   --#{$nav}__list--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$nav}__list--PaddingBottom: var(--#{$pf-global}--spacer--md);
+  --#{$nav}__list--PaddingBottom: var(--#{$pf-global}--spacer--sm);
 
   // Item
   --#{$nav}__item--MarginTop: 0;
@@ -178,7 +178,7 @@
   --#{$nav}--m-horizontal-subnav__link--m-current--after--BorderLeftWidth: var(--#{$pf-global}--BorderWidth--sm);
 
   // Subnav
-  --#{$nav}__subnav--PaddingBottom: var(--#{$pf-global}--spacer--md);
+  --#{$nav}__subnav--PaddingBottom: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__subnav--xl--PaddingLeft: var(--#{$nav}__link--PaddingLeft);
   --#{$nav}__subnav__link--MarginTop: 0;
   --#{$nav}__subnav__link--PaddingTop: var(--#{$pf-global}--spacer--sm);
@@ -1012,6 +1012,7 @@
   --#{$nav}--c-divider--PaddingLeft: var(--#{$nav}__subnav--c-divider--PaddingLeft);
 
   max-height: var(--#{$nav}__subnav--MaxHeight);
+  padding-bottom: var(--#{$nav}__subnav--PaddingBottom);
   padding-left: var(--#{$nav}__subnav--PaddingLeft);
   transition: var(--#{$nav}--Transition);
 
@@ -1019,6 +1020,10 @@
     --#{$nav}__link--FontSize: var(--#{$nav}__subnav__subnav__link--FontSize);
     --#{$nav}__link--PaddingLeft: var(--#{$nav}__subnav__subnav__link--PaddingLeft);
     --#{$nav}__subnav--PaddingLeft: var(--#{$nav}__subnav__subnav--PaddingLeft);
+  }
+
+  > .#{$nav}__list {
+    --#{$nav}__list--PaddingTop: 0;
   }
 
 
@@ -1093,6 +1098,10 @@
 
   &.pf-m-no-title {
     --#{$nav}__section--MarginTop: 0;
+  }
+
+  > .#{$nav}__list {
+    --#{$nav}__list--PaddingBottom: 0;
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,8 +29,8 @@
   --#{$nav}--m-light__subnav__link--m-current--after--BorderColor: var(--#{$pf-global}--active-color--100);
 
   // List
-  --#{$nav}__list--PaddingTop: var(--pf-global--spacer--sm);
-  --#{$nav}__list--PaddingBottom: var(--pf-global--spacer--md);
+  --#{$nav}__list--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__list--PaddingBottom: var(--#{$pf-global}--spacer--md);
 
   // Item
   --#{$nav}__item--MarginTop: 0;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -28,6 +28,10 @@
   --#{$nav}--m-light__subnav__link--active--after--BorderColor: var(--#{$pf-global}--BorderColor--dark-100);
   --#{$nav}--m-light__subnav__link--m-current--after--BorderColor: var(--#{$pf-global}--active-color--100);
 
+  // List
+  --#{$nav}__list--PaddingTop: var(--pf-global--spacer--sm);
+  --#{$nav}__list--PaddingBottom: var(--pf-global--spacer--md);
+
   // Item
   --#{$nav}__item--MarginTop: 0;
   --#{$nav}__item--m-current--not--m-expanded__link--BackgroundColor: var(--#{$pf-global}--BackgroundColor--dark-400);
@@ -524,6 +528,9 @@
     overflow: hidden;
 
     .#{$nav}__list {
+      --#{$nav}__list--PaddingTop: 0;
+      --#{$nav}__list--PaddingBottom: 0;
+      
       flex: 1;
       max-width: 100%;
       overflow-x: auto;
@@ -731,13 +738,14 @@
 .#{$nav}__list {
   position: relative;
   display: block;
+  padding-top: var(--#{$nav}__list--PaddingTop);
+  padding-bottom: var(--#{$nav}__list--PaddingBottom);
 }
 
 // Borders
 .#{$nav}__item {
   position: relative;
-  margin-top: var(--#{$nav}__item--MarginTop);
-
+  
   &.pf-m-expandable {
     --#{$nav}__link--before--BorderBottomWidth: 0;
 
@@ -751,6 +759,10 @@
     }
   }
 
+  &:not(:first-child) {
+    margin-top: var(--#{$nav}__item--MarginTop);
+  }
+  
   .#{$nav}__item {
     &:not(.pf-m-expanded) .#{$nav}__toggle-icon {
       transform: rotate(0);
@@ -1000,7 +1012,6 @@
   --#{$nav}--c-divider--PaddingLeft: var(--#{$nav}__subnav--c-divider--PaddingLeft);
 
   max-height: var(--#{$nav}__subnav--MaxHeight);
-  padding-bottom: var(--#{$nav}__subnav--PaddingBottom);
   padding-left: var(--#{$nav}__subnav--PaddingLeft);
   transition: var(--#{$nav}--Transition);
 


### PR DESCRIPTION
Closes #5406 

Looks like styles for `.pf-c-nav__item` are being applied twice, which is pre-existing behavior. From the Core v5 surge:

![Core v5 nav item styling from devtools](https://user-images.githubusercontent.com/70952936/233709576-c3c0e7fc-3056-4210-93e1-c347bc353102.png)

From this PR's surge:

![PR nav item styling from devtools](https://user-images.githubusercontent.com/70952936/233709764-a424b8c1-05de-4c03-876d-f86e3ef56b2c.png)
