### PR TITLE
chore(page): default page to full viewport height

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -254,7 +254,7 @@ import './Page.css'
 
 ## Documentation
 ### Overview
-This component provides the basic chrome for a page, including sidebar, header, and main areas. To make the page component take up the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component.
+This component provides the basic chrome for a page, including sidebar, header, and main areas.
 
 ### Accessibility
 | Attribute | Applied to | Outcome |
@@ -271,7 +271,6 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-page` | `<div>` |   Declares the page component. |
-| `.pf-m-full-height` | `.pf-c-page` |   Sets the page to be full height. Eliminates the need to ensure that all ancestors of `.pf-c-page` have height of 100% set. |
 | `.pf-c-page__header` | `<header>` |   Declares the page header. |
 | `.pf-c-page__header-brand` | `<div>` |   Creates a header container to nest the brand component. |
 | `.pf-c-page__header-brand-toggle` | `<div>` |   Creates a container to nest the sidebar toggle. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -203,7 +203,9 @@ $pf-c-page--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
     "main";
   grid-template-rows: max-content 1fr;
   grid-template-columns: 1fr;
-    height: 100%;
+  height: 100vh;
+  height: 100dvh;
+  max-height: 100%;
   background-color: var(--pf-c-page--BackgroundColor);
 
   @media (min-width: $pf-global--breakpoint--xl) {
@@ -212,13 +214,6 @@ $pf-c-page--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
       "nav main";
     grid-template-columns: max-content 1fr;
     }
-
-  // full height
-  &.pf-m-full-height {
-    height: 100vh;
-    height: 100dvh;
-    max-height: 100%;
-  }
 }
 
 // Header

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -11,12 +11,6 @@ wrapperTag: div
 {{> page-template page-template--id="page-demo-basic"}}
 ```
 
-### Full height page
-Using the `.pf-m-full-height` modifier class on the page component eliminates the need to ensure that the `<html>` and `<body>` tags, and any other ancestors of `.pf-c-page`, have height set to 100%.
-```hbs isFullscreen
-{{> page-template page-template--id="page-demo-full-height" page-template--modifier="pf-m-full-height"}}
-```
-
 ### Multiple sidebar body elements
 ```hbs isFullscreen
 {{> page-template page-template--id="multiple-sidebar-body-elements-demo"}}
@@ -142,6 +136,3 @@ Using the `.pf-m-full-height` modifier class on the page component eliminates th
   {{/page-main-section}}
 {{/inline}}
 ```
-
-## Documentation
-To make the page component fill the full height of the viewport, it is recommended to add `height: 100%;` to all ancestor elements of the page component. Alternatively, use the `.pf-m-full-height` modifier class on the page component.


### PR DESCRIPTION
Fixes #5448 
Removes `.pf-m-full-height` for a page in lieu of defaulting the page to be 100vh/dvh with a max-height so it doesn't overrun the space it's allocated if it's within another layout.

This will need a follow-on issue on .org to limit the width of all the page examples (this is currently done just for a couple of the examples).