### PR TITLE
fix(icons): update global icon font sizes

### DIFF
--- a/src/patternfly/components/Icon/icon.scss
+++ b/src/patternfly/components/Icon/icon.scss
@@ -1,40 +1,39 @@
 // @debug $icon; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
 .#{$icon} {
-  // Size
-  --#{$icon}--Width: var(--#{$pf-global}--icon--FontSize--md);
-  --#{$icon}--Height: var(--#{$pf-global}--icon--FontSize--md);
-
-  // When inline, use the parent's size
+  // Sizes
+  --#{$icon}--Width: 1em;
+  --#{$icon}--Height: 1em;
+  --#{$icon}--m-sm--Width: var(--#{$pf-global}--icon--FontSize--sm);
+  --#{$icon}--m-sm--Height: var(--#{$pf-global}--icon--FontSize--sm);
+  --#{$icon}--m-md--Width: var(--#{$pf-global}--icon--FontSize--md);
+  --#{$icon}--m-md--Height: var(--#{$pf-global}--icon--FontSize--md);
+  --#{$icon}--m-lg--Width: var(--#{$pf-global}--icon--FontSize--lg);
+  --#{$icon}--m-lg--Height: var(--#{$pf-global}--icon--FontSize--lg);
+  --#{$icon}--m-xl--Width: var(--#{$pf-global}--icon--FontSize--xl);
+  --#{$icon}--m-xl--Height: var(--#{$pf-global}--icon--FontSize--xl);
   --#{$icon}--m-inline--Width: 1em;
   --#{$icon}--m-inline--Height: 1em;
 
-  // Size modifiers
-  --#{$icon}--m-sm--Width: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$icon}--m-md--Width: var(--#{$pf-global}--icon--FontSize--md);
-  --#{$icon}--m-lg--Width: var(--#{$pf-global}--icon--FontSize--lg);
-  --#{$icon}--m-xl--Width: var(--#{$pf-global}--icon--FontSize--xl);
-  --#{$icon}--m-sm--Height: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$icon}--m-md--Height: var(--#{$pf-global}--icon--FontSize--md);
-  --#{$icon}--m-lg--Height: var(--#{$pf-global}--icon--FontSize--lg);
-  --#{$icon}--m-xl--Height: var(--#{$pf-global}--icon--FontSize--xl);
+  // Content
+  --#{$icon}__content--svg--VerticalAlign: -.125em;
 
-  // Content variables
-  --#{$icon}__content--Color: var(--#{$pf-global}--icon--Color--dark);
-
-  // Content status
+  // Content color
+  --#{$icon}__content--Color: initial;
   --#{$icon}__content--m-danger--Color: var(--#{$pf-global}--danger-color--100);
   --#{$icon}__content--m-warning--Color: var(--#{$pf-global}--warning-color--100);
   --#{$icon}__content--m-success--Color: var(--#{$pf-global}--success-color--100);
   --#{$icon}__content--m-info--Color: var(--#{$pf-global}--info-color--100);
   --#{$icon}__content--m-custom--Color: var(--#{$pf-global}--custom-color--100);
-  --#{$icon}__content--FontSize: var(--#{$pf-global}--icon--FontSize--md);
+  --#{$icon}--m-inline__content--Color: initial;
+
+  // Content sizes
+  --#{$icon}__content--FontSize: 1em;
+  --#{$icon}--m-sm__content--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
+  --#{$icon}--m-md__content--FontSize: var(--#{$pf-global}--icon--FontSize--md);
+  --#{$icon}--m-lg__content--FontSize: var(--#{$pf-global}--icon--FontSize--lg);
+  --#{$icon}--m-xl__content--FontSize: var(--#{$pf-global}--icon--FontSize--xl);
   --#{$icon}--m-inline__content--FontSize: 1em;
-  --#{$icon}__content--svg--VerticalAlign: -.125em;
-  --#{$icon}--m-sm--content--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$icon}--m-md--content--FontSize: var(--#{$pf-global}--icon--FontSize--md);
-  --#{$icon}--m-lg--content--FontSize: var(--#{$pf-global}--icon--FontSize--lg);
-  --#{$icon}--m-xl--content--FontSize: var(--#{$pf-global}--icon--FontSize--xl);
 
   position: relative;
   display: inline-flex;
@@ -48,7 +47,7 @@
     --#{$icon}--Width: var(--#{$icon}--m-inline--Width);
     --#{$icon}--Height: var(--#{$icon}--m-inline--Height);
     --#{$icon}__content--FontSize: var(--#{$icon}--m-inline__content--FontSize);
-    --#{$icon}__content--Color: currentcolor;
+    --#{$icon}__content--Color: var(--#{$icon}--m-inline__content--Color);
 
     line-height: 1;
 
@@ -61,25 +60,25 @@
   &.pf-m-sm {
     --#{$icon}--Width: var(--#{$icon}--m-sm--Width);
     --#{$icon}--Height: var(--#{$icon}--m-sm--Height);
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-sm--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-sm__content--FontSize);
   }
 
   &.pf-m-md {
     --#{$icon}--Width: var(--#{$icon}--m-md--Width);
     --#{$icon}--Height: var(--#{$icon}--m-md--Height);
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-md--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-md__content--FontSize);
   }
 
   &.pf-m-lg {
     --#{$icon}--Width: var(--#{$icon}--m-lg--Width);
     --#{$icon}--Height: var(--#{$icon}--m-lg--Height);
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-lg--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-lg__content--FontSize);
   }
 
   &.pf-m-xl {
     --#{$icon}--Width: var(--#{$icon}--m-xl--Width);
     --#{$icon}--Height: var(--#{$icon}--m-xl--Height);
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-xl--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-xl__content--FontSize);
   }
 
   &.pf-m-in-progress {
@@ -99,25 +98,25 @@
 
   // Size modifiers
   &.pf-m-sm {
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-sm--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-sm__content--FontSize);
   }
 
   &.pf-m-md {
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-md--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-md__content--FontSize);
   }
 
   &.pf-m-lg {
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-lg--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-lg__content--FontSize);
   }
 
   &.pf-m-xl {
-    --#{$icon}__content--FontSize: var(--#{$icon}--m-xl--content--FontSize);
+    --#{$icon}__content--FontSize: var(--#{$icon}--m-xl__content--FontSize);
   }
 }
 
 // Content element
 .#{$icon}__content {
-  color: var(--#{$icon}__content--Color);
+  color: var(--#{$icon}__content--Color, inherit);
   opacity: var(--#{$icon}__content--Opacity, 1);
 
   // Status modifiers

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -186,8 +186,8 @@ $pf-v5-global--BorderRadius--sm:        3px !default;
 $pf-v5-global--BorderRadius--lg:        30em !default; // This is a sufficiently large number to ensure in most cases that the ends are evenly rounded.
 
 // Icons
-$pf-v5-global--icon--Color--light: $pf-color-black-600 !default;
-$pf-v5-global--icon--Color--dark: $pf-color-black-900 !default;
+$pf-v5-global--icon--Color--light: $pf-v5-color-black-600 !default;
+$pf-v5-global--icon--Color--dark: $pf-v5-color-black-900 !default;
 $pf-v5-global--icon--FontSize--sm: pf-font-prem(12px) !default;
 $pf-v5-global--icon--FontSize--md: pf-font-prem(16px) !default;
 $pf-v5-global--icon--FontSize--lg: pf-font-prem(24px) !default;

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -186,10 +186,10 @@ $pf-v5-global--BorderRadius--sm:        3px !default;
 $pf-v5-global--BorderRadius--lg:        30em !default; // This is a sufficiently large number to ensure in most cases that the ends are evenly rounded.
 
 // Icons
-$pf-v5-global--icon--Color--light: $pf-v5-color-black-600 !default;
-$pf-v5-global--icon--Color--dark: $pf-v5-color-black-900 !default;
-$pf-v5-global--icon--FontSize--sm: pf-font-prem(10px) !default;
-$pf-v5-global--icon--FontSize--md: pf-font-prem(18px) !default;
+$pf-v5-global--icon--Color--light: $pf-color-black-600 !default;
+$pf-v5-global--icon--Color--dark: $pf-color-black-900 !default;
+$pf-v5-global--icon--FontSize--sm: pf-font-prem(12px) !default;
+$pf-v5-global--icon--FontSize--md: pf-font-prem(16px) !default;
 $pf-v5-global--icon--FontSize--lg: pf-font-prem(24px) !default;
 $pf-v5-global--icon--FontSize--xl: pf-font-prem(54px) !default;
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5265

----

@mceledonia @andrew-ronaldson @mmenestr @lboehling 

A couple of questions
* By default, SVGs and font-based icons (font awesome, pficons in core) will inherit their size based on whatever the text size is where the icon is used. So their default size is `1em` basically. **What is the use case for these icon specific sizes?** As in, when would you want to use an icon-specific size versus making the icon match whatever the text size is? I can see if you have a standalone icon in a thing like a big icon in a card, or like the empty state icon. But if you have an icon beside a title (or any other kind of text)... would you ever want that icon to be a different size than the title? Should it be an option for the icon to match whatever the text size is?
  * One thing I'm thinking about is how our current global font-size vars for text are `--xs: 12px`, `--sm: 14px`, and  `--md: 16px`. But our icon font-sizes are `--sm: 12px` and `--md: 16px`. So if you wanted to make an icon match the 14px global font-size, you can't do that using icon size global vars. Should you be able to do that? 
* Our icon component currently sizes the icon inside of it using the default font-size (16px) when there is no size modifier passed. You can then override the icon size using one of the values provided by the icon component - those values are based off of the global vars for icon sizes. Personally I think the icon component should deliver an icon as `1em` by default, if no size modifier is passed, so it's as big/small as the font-size is where the icon is used. I imagine that's the most common use case? WDYT?