### PR TITLE
fix(about-modal, background-image): updated to not ship default background image

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box-hero.hbs
+++ b/src/patternfly/components/AboutModalBox/about-modal-box-hero.hbs
@@ -1,6 +1,0 @@
-<div class="{{pfv}}about-modal-box__hero{{#if about-modal-box-hero--modifier}} {{about-modal-box-hero--modifier}}{{/if}}"
-  {{#if about-modal-box-hero--attribute}}
-    {{{about-modal-box-hero--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/AboutModalBox/about-modal-box.hbs
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.hbs
@@ -1,4 +1,5 @@
 <div class="{{pfv}}about-modal-box{{#if about-modal-box--modifier}} {{about-modal-box--modifier}}{{/if}}"
+  style="--{{pfv}}about-modal-box--BackgroundImage: {{ternary about-modal-box--background-image about-modal-box--background-image "url(/assets/images/pfbg-icon.svg)"}}"
   {{#if about-modal-box--attribute}}
     {{{about-modal-box--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -3,7 +3,6 @@
 .#{$about-modal-box} {
   // Component variables
   --#{$about-modal-box}--BackgroundColor: var(--#{$pf-global}--palette--black-1000); // Modal uses a non-standard background color
-  --#{$about-modal-box}--BackgroundImage: url("#{$pf-v5-global--image-path}/pfbg-icon.svg");
   --#{$about-modal-box}--BackgroundPosition: bottom right;
   --#{$about-modal-box}--BackgroundSize--min-width: 200px;
   --#{$about-modal-box}--BackgroundSize--width: 60%;
@@ -54,11 +53,6 @@
   --#{$about-modal-box}__close--c-button--Height: calc(var(--#{$about-modal-box}__close--c-button--FontSize) * 2);
   --#{$about-modal-box}__close--c-button--BackgroundColor: var(--#{$pf-global}--palette--black-1000); // Close button uses a non-standard background color
   --#{$about-modal-box}__close--c-button--hover--BackgroundColor: #{rgba($pf-v5-color-black-1000, .4)};
-
-  // hero image
-  --#{$about-modal-box}__hero--sm--BackgroundImage: url("#{$pf-v5-global--image-path}/pfbg_992@2x.jpg");
-  --#{$about-modal-box}__hero--sm--BackgroundPosition: top left;
-  --#{$about-modal-box}__hero--sm--BackgroundSize: cover;
 
   // Brand img
   --#{$about-modal-box}__brand-image--Height: #{pf-size-prem(40px)};
@@ -116,7 +110,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   background-color: var(--#{$about-modal-box}--BackgroundColor); // Because this component is always dark, set the background color
-  background-image: var(--#{$about-modal-box}--BackgroundImage);
+  background-image: var(--#{$about-modal-box}--BackgroundImage, none);
   background-repeat: no-repeat;
   background-position: var(--#{$about-modal-box}--BackgroundPosition);
   background-size: var(--#{$about-modal-box}--BackgroundSize);
@@ -198,11 +192,11 @@
 
   @media only screen and (min-width: $pf-v5-global--breakpoint--sm) {
     grid-area: 1 / 2;
-    justify-content: center; // center the close over the narrow hero image
+    justify-content: center;
   }
 
   @media only screen and (min-width: $pf-v5-global--breakpoint--lg) {
-    justify-content: flex-end; // align flex end the close over the narrow hero image
+    justify-content: flex-end;
   }
 
   // Close button
@@ -221,21 +215,6 @@
     &:hover {
       --#{$about-modal-box}__close--c-button--BackgroundColor: var(--#{$about-modal-box}__close--c-button--hover--BackgroundColor);
     }
-  }
-}
-
-// Hero
-.#{$about-modal-box}__hero {
-  display: none; // Don't display the hero at the narrowest breakpoint
-
-  @media only screen and (min-width: $pf-v5-global--breakpoint--sm) {
-    display: block;
-    grid-area: hero;
-    background-image: var(--#{$about-modal-box}__hero--sm--BackgroundImage);
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: var(--#{$about-modal-box}__hero--sm--BackgroundPosition);
-    background-size: var(--#{$about-modal-box}__hero--sm--BackgroundSize);
   }
 }
 

--- a/src/patternfly/components/AboutModalBox/examples/AboutModalBox.md
+++ b/src/patternfly/components/AboutModalBox/examples/AboutModalBox.md
@@ -33,17 +33,12 @@ cssPrefix: pf-v5-c-about-modal-box
 ```
 
 ## Documentation
+In order to add a background image, set the `--pf-v5-c-about-modal-box--BackgroundImage` CSS variable to the path of the image. For example: `--pf-v5-c-about-modal-box--BackgroundImage: url(custom/path/image.jpg);`
+
 ### Accessibility
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `aria-label="Close Dialog"` | `.pf-v5-c-modal-box__close .pf-v5-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required** |
-
-### Customizing the background image
-In order to use a custom image, pass a new value to the `--pf-v5-c-about-modal-box--BackgroundImage` CSS variable. For example:
-
-```css
---pf-v5-c-about-modal-box--BackgroundImage: url("custom/image/path");
-```
 
 ### Usage
 | Class | Applied to | Outcome |
@@ -56,3 +51,4 @@ In order to use a custom image, pass a new value to the `--pf-v5-c-about-modal-b
 | `.pf-v5-c-about-modal-box__content` |  `<div>` |  Initiates a modal box content cell. |
 | `.pf-v5-c-about-modal-box__body` |  `<div>` |  Initiates a modal box body cell. |
 | `.pf-v5-c-about-modal-box__strapline` |  `<p>` |  Initiates a modal box strapline cell. |
+| `--pf-v5-c-about-modal-box--BackgroundImage` |  `.pf-v5-c-about-modal-box` |  Sets the background image for the about modal. |

--- a/src/patternfly/components/BackgroundImage/background-image.hbs
+++ b/src/patternfly/components/BackgroundImage/background-image.hbs
@@ -1,4 +1,5 @@
 <div class="{{pfv}}background-image{{#if background-image--modifier}} {{background-image--modifier}}{{/if}}"
+  style="--{{pfv}}background-image--BackgroundImage: {{ternary background-image--background-image background-image--background-image "url(/assets/images/pfbg-icon.svg)"}}"
   {{#if background-image--attribute}}
     {{{background-image--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -2,7 +2,6 @@
 
 .#{$background-image} {
   --#{$background-image}--BackgroundColor: var(--#{$pf-global}--BackgroundColor--dark-100);
-  --#{$background-image}--BackgroundImage: url("#{$pf-v5-global--image-path}/pfbg-icon.svg");
   --#{$background-image}--BackgroundPosition: bottom right;
   --#{$background-image}--BackgroundSize--min-width: 200px;
   --#{$background-image}--BackgroundSize--width: 60%;
@@ -16,7 +15,7 @@
   width: 100%;
   height: 100%;
   background-color: var(--#{$background-image}--BackgroundColor);
-  background-image: var(--#{$background-image}--BackgroundImage);
+  background-image: var(--#{$background-image}--BackgroundImage, none);
   background-repeat: no-repeat;
   background-position: var(--#{$background-image}--BackgroundPosition);
   background-size: var(--#{$background-image}--BackgroundSize);

--- a/src/patternfly/components/BackgroundImage/examples/BackgroundImage.md
+++ b/src/patternfly/components/BackgroundImage/examples/BackgroundImage.md
@@ -13,16 +13,10 @@ cssPrefix: pf-v5-c-background-image
 ## Documentation
 
 ### Overview
-This component puts an image on the background.
-
-### Customizing the background image
-In order to use a custom image, pass a new value to the `--pf-v5-c-background-image--BackgroundImage` CSS variable. For example:
-
-```css
---pf-v5-c-background-image--BackgroundImage: url("custom/image/path");
-```
+In order to set the background image to be used, set the `--pf-v5-c-background-image--BackgroundImage` CSS variable to the path of the image. For example: `--pf-v5-c-background-image--BackgroundImage: url(custom/path/image.jpg);`
 
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v5-c-background-image` | `*` |  A fixed background image is applied to the background of the page. |
+| `.pf-v5-c-background-image` | `*` | A fixed background image is applied to the background of the page. |
+| `--pf-v5-c-background-image--BackgroundImage` | `.pf-v5-c-background-image` | Sets the background image to be used. **Required** |

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -191,13 +191,13 @@ $pf-v5-c-form-control--m-clock--Coordinates: "M256 8C119 8 8 119 8 256s111 248 2
   --#{$form-control}--textarea--invalid--BackgroundPositionY: var(--#{$form-control}--PaddingLeft); // update to use --#{$form-control}--inset--base at breaking change
 
   // Icon sprite
-  --#{$form-control}--m-icon-sprite--success--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#success");
-  --#{$form-control}--m-icon-sprite--m-warning--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#warning");
-  --#{$form-control}--m-icon-sprite--invalid--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#invalid");
-  --#{$form-control}--m-icon-sprite__select--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#select");
-  --#{$form-control}--m-icon-sprite--m-search--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#search");
-  --#{$form-control}--m-icon-sprite--m-calendar--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#calendar");
-  --#{$form-control}--m-icon-sprite--m-clock--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#clock");
+  // --#{$form-control}--m-icon-sprite--success--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#success");
+  // --#{$form-control}--m-icon-sprite--m-warning--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#warning");
+  // --#{$form-control}--m-icon-sprite--invalid--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#invalid");
+  // --#{$form-control}--m-icon-sprite__select--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#select");
+  // --#{$form-control}--m-icon-sprite--m-search--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#search");
+  // --#{$form-control}--m-icon-sprite--m-calendar--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#calendar");
+  // --#{$form-control}--m-icon-sprite--m-clock--BackgroundUrl: url("#{$pf-v5-global--image-path}/status-icon-sprite.svg#clock");
   --#{$form-control}--m-icon-sprite__select--BackgroundSize: var(--#{$form-control}--FontSize);
   --#{$form-control}--m-icon-sprite__select--BackgroundPositionX: calc(100% - var(--#{$pf-global}--spacer--md) + 7px);
   --#{$form-control}--m-icon-sprite__select--success--BackgroundPosition: calc(100% - var(--#{$pf-global}--spacer--md) + 1px - var(--#{$pf-global}--spacer--lg));

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -129,9 +129,6 @@ $fa-font-path: "./assets/fonts/webfonts" !default;
 // FontIcon path
 $pf-v5-global--fonticon-path: "./assets/pficon" !default;
 
-// Imagepath
-$pf-v5-global--image-path: "./assets/images" !default;
-
 // Spacers
 $pf-v5-global--spacer--xs: pf-size-prem(4px) !default;     // Orange
 $pf-v5-global--spacer--sm: pf-size-prem(8px) !default;     // Light green


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5529, fixes https://github.com/patternfly/patternfly/issues/4930

* No longer shipping the PF logo as the default for about modal and background image in the CSS, with approval from @mceledonia 
* Updated docs for ^ to note the var needed to set the background images
* Removed `$pf-global--image-path` as it's no longer necessary
* Updated form control sprite paths to no longer use the global var path so the SCSS will compile - those paths will be removed in https://github.com/patternfly/patternfly/issues/5469