### PR TITLE
fix(functions): fixed bug with argument order in build-spacer-map

### DIFF
--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -1,7 +1,7 @@
 // Always keep list of spacers and breakpoints up-to-date
 $pf-v5-l-flex--breakpoint-map: build-breakpoint-map();
 $pf-v5-l-flex--spacer-map: build-spacer-map();
-$pf-v5-l-flex--gap-map: build-spacer-map($base: true);
+$pf-v5-l-flex--gap-map: build-spacer-map("base", "none", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl");
 $pf-v5-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $pf-v5-l-flex--spacer-map);
 
 .#{$flex} {

--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -81,26 +81,23 @@
   @return $map;
 }
 
+
 // Build spacer map
 // Based on $pf-v5-global--spacer-map
-@function build-spacer-map($base: false, $map-items...) {
+@function build-spacer-map($map-items...) {
   $map: ();
 
-  @if $base {
-    $map: map-merge($map, ("base": null));
-  }
-  
   @if length($map-items) == 0 {
-    $map: map-merge($map, ("none": 0));
+    $map: ("none": 0);
     $map: map-merge($map, $pf-v5-global--spacer-map);
     $map: map-remove($map, "auto", "0");
   }
 
   @each $spacer in $map-items {
-    @if $spacer == "none" {
-      $map: map-merge($map, ($spacer: 0));
-    } @else if not map-has-key($pf-v5-global--spacer-map, $spacer) {
+    @if not map-has-key($pf-v5-global--spacer-map, $spacer) and $spacer != "none" {
       $map: map-merge($map, ("invalid spacer #{$spacer}": null));
+    } @else if $spacer == "none" {
+      $map: map-merge($map, ($spacer: 0));
     } @else {
       $map: map-merge($map, ($spacer: map-get($pf-v5-global--spacer-map, #{$spacer})));
     }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5560

this update just reverts the change to `build-spacer-map()` in https://github.com/patternfly/patternfly/pull/5516/files#diff-2c8ba30b3fb18dba9e1c5a24069960a79c0e98016bb4409d5c98821a139af90a, and updates the way spacers are passed to `$pf-v5-l-flex--gap-map` in the flex layout.