### PR TITLE
fix(sass): allow non-spacers to be added to a spacer map

### DIFF
--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -94,9 +94,7 @@
   }
 
   @each $spacer in $map-items {
-    @if not map-has-key($pf-v5-global--spacer-map, $spacer) and $spacer != "none" {
-      $map: map-merge($map, ("invalid spacer #{$spacer}": null));
-    } @else if $spacer == "none" {
+    @if $spacer == "none" {
       $map: map-merge($map, ($spacer: 0));
     } @else {
       $map: map-merge($map, ($spacer: map-get($pf-v5-global--spacer-map, #{$spacer})));


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5577

@mattnolting I just removed the conditional that checks to see if the the spacer passed to `build-spacer-map()` exists in the global spacer map, since that will create an unusable item in that map saying it's an invalid spacer. That seems more like a debug statement, since the map should never be used that way. Removing it will add any non-global-spacer value passed to `build-spacer-map()` with a value of `null`, which is what I'm looking for. Below is a `@debug` of the flex map with "base" in that list. WDYT?

```
Debug: ("base": null, "none": 0, "sm": "var(--pf-v5-global--spacer--sm)", "md": "var(--pf-v5-global--spacer--md)", "lg": "var(--pf-v5-global--spacer--lg)", "xl": "var(--pf-v5-global--spacer--xl)", "2xl": "var(--pf-v5-global--spacer--2xl)", "3xl": "var(--pf-v5-global--spacer--3xl)", "4xl": "var(--pf-v5-global--spacer--4xl)")
```

cc @kmcfaul this is for https://github.com/patternfly/patternfly-react/pull/9122#pullrequestreview-1429167800 - it should allow `pf-m-gap/row-gap/column-gap` after this fix is merged.