### PR TITLE
fix(table): updated table paddings and templates

### DIFF
--- a/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
@@ -1,7 +1,7 @@
 {{#> table table--IsTree-view="true"}}
   {{#> table-thead table-tr--expanded="true"}}
     {{#> table-tr newcontext table-tr--tree--HasActions=table-tr--tree--HasActions}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="{{pfv}}table__tree-view-title-header-cell"}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--modifier=(concat pfv 'table__tree-view-title-header-cell')}}
         Name
       {{/table-th}}
       {{#> table-th table-th--attribute='scope="col"'}}
@@ -20,12 +20,14 @@
   {{/table-thead}}
 
   {{#if table--HasNoPosinset}}
-    {{> table-tr--tree table-tr--tree--index="1" table-tr--tree--title='Level 1, leaf 1'}}
-    {{> table-tr--tree table-tr--tree--index="2" table-tr--tree--title='Level 1, leaf 2'}}
-    {{> table-tr--tree table-tr--tree--index="3" table-tr--tree--title='Level 1, leaf 3'}}
-    {{> table-tr--tree table-tr--tree--index="4" table-tr--tree--title='Level 1, leaf 4'}}
-    {{> table-tr--tree table-tr--tree--index="5" table-tr--tree--title='Level 1, leaf 5'}}
-    {{> table-tr--tree table-tr--tree--index="6" table-tr--tree--title='Level 1, leaf 6'}}
+    {{#> table-tbody}}
+      {{> table-tr--tree table-tr--tree--index="1" table-tr--tree--title='Level 1, leaf 1'}}
+      {{> table-tr--tree table-tr--tree--index="2" table-tr--tree--title='Level 1, leaf 2'}}
+      {{> table-tr--tree table-tr--tree--index="3" table-tr--tree--title='Level 1, leaf 3'}}
+      {{> table-tr--tree table-tr--tree--index="4" table-tr--tree--title='Level 1, leaf 4'}}
+      {{> table-tr--tree table-tr--tree--index="5" table-tr--tree--title='Level 1, leaf 5'}}
+      {{> table-tr--tree table-tr--tree--index="6" table-tr--tree--title='Level 1, leaf 6'}}
+    {{/table-tbody}}
   {{else}}
     {{#> table-tbody table--IsTree-view--level="1" table--IsTree-view--setsize="1" table--IsTree-view--posinset="1"}}
       {{> table-tr--tree table-tr--tree--index="1" table-tr--expanded="true" table-tr--tree--title=(concat 'Level ' table--IsTree-view--level ' all folders')}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1305,7 +1305,6 @@
   // Thead
   thead:where(.#{$table}__thead) {
     th:where(.#{$table}__th),
-    td:where(.#{$table}__td),
     .#{$table}__toggle {
       --#{$table}--cell--PaddingTop: var(--#{$table}--m-compact__th--PaddingTop);
       --#{$table}--cell--PaddingBottom: var(--#{$table}--m-compact__th--PaddingBottom);


### PR DESCRIPTION
closes #5576 

@mcoker 

> Tree with no children or indentation example 
Fix: https://patternfly-pr-5579.surge.sh/components/table#tree-with-no-children-or-indentation

> Compact example - thead is taller than it needs to be due to an issue with the checkbox td cell in the thead.
Fix: https://patternfly-pr-5579.surge.sh/components/table#compact-example

