### PR TITLE
fix(Nav): updated spacing for grouped nav

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -89,7 +89,7 @@ import './Navigation.css'
 ### Grouped nav, no titles
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
-  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section one"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -109,7 +109,7 @@ import './Navigation.css'
     {{/nav-list}}
   {{/nav-section}}
   {{> divider}}
-  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section two"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section two"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -134,7 +134,7 @@ import './Navigation.css'
 ### Grouped nav, no titles, no margin top
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
-  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section one"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -153,7 +153,7 @@ import './Navigation.css'
       {{/nav-item}}
     {{/nav-list}}
   {{/nav-section}}
-  {{#> nav-section nav-section--modifier="pf-m-no-title" nav-section--attribute='aria-label="Section two"'}}
+  {{#> nav-section nav-section--attribute='aria-label="Section two"'}}
     {{#> nav-list}}
       {{#> nav-item}}
         {{#> nav-link nav-link--href="#"}}
@@ -785,7 +785,6 @@ The navigation system relies on several different sub-components:
 | `.pf-v5-c-nav__toggle-icon` | `<span>` | Initiates a nav toggle icon wrapper. |
 | `.pf-v5-c-nav__scroll-button` | `<button>` | Initiates a nav scroll button. **Required for horizontal navs** |
 | `.pf-m-horizontal` | `.pf-v5-c-nav` | Modifies nav for the horizontal variation. |
-| `.pf-m-no-title` | `.pf-v5-c-nav__section` | Modifies nav section margin top to 0. |
 | `.pf-m-horizontal-subnav` | `.pf-v5-c-nav` | Modifies nav for the horizontal subnav variation. |
 | `.pf-m-tertiary` | `.pf-v5-c-nav` | Modifies nav for the tertiary variation. |
 | `.pf-m-light` | `.pf-v5-c-nav` | Modifies nav for the light variation. **Note: only for use with vertical navs, and requires `.pf-m-light` on the page component's sidebar element (`.pf-v5-c-page__sidebar`)**. |

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -131,50 +131,6 @@ import './Navigation.css'
 {{/nav}}
 ```
 
-### Grouped nav, no titles, no margin top
-```hbs
-{{#> nav nav--attribute='aria-label="Global"'}}
-  {{#> nav-section nav-section--attribute='aria-label="Section one"'}}
-    {{#> nav-list}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Link 1
-        {{/nav-link}}
-      {{/nav-item}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Link 2
-        {{/nav-link}}
-      {{/nav-item}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Link 3
-        {{/nav-link}}
-      {{/nav-item}}
-    {{/nav-list}}
-  {{/nav-section}}
-  {{#> nav-section nav-section--attribute='aria-label="Section two"'}}
-    {{#> nav-list}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Section 2, link 1
-        {{/nav-link}}
-      {{/nav-item}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-          Current link
-        {{/nav-link}}
-      {{/nav-item}}
-      {{#> nav-item}}
-        {{#> nav-link nav-link--href="#"}}
-          Link 3
-        {{/nav-link}}
-      {{/nav-item}}
-    {{/nav-list}}
-  {{/nav-section}}
-{{/nav}}
-```
-
 ### Expanded
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,8 +29,8 @@
   --#{$nav}--m-light__subnav__link--m-current--after--BorderColor: var(--#{$pf-global}--active-color--100);
 
   // List
-  --#{$nav}__list--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$nav}__list--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__list--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__list--PaddingBottom: var(--#{$pf-global}--spacer--sm);
 
   // Item
   --#{$nav}__item--MarginTop: 0;
@@ -203,7 +203,8 @@
   --#{$nav}__subnav--c-divider--PaddingLeft: var(--#{$pf-global}--spacer--lg);
 
   // Nav section
-  --#{$nav}__section--MarginTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__section--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__section--PaddingBottom: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__item--MarginTop: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__link--PaddingTop: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__link--PaddingRight: var(--#{$pf-global}--spacer--md);
@@ -228,6 +229,7 @@
   --#{$nav}__section-title--PaddingRight: var(--#{$pf-global}--spacer--md);
   --#{$nav}__section-title--PaddingBottom: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section-title--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$nav}__section-title--MarginBottom: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section-title--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
   --#{$nav}__section-title--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
   --#{$nav}__section-title--FontSize: var(--#{$pf-global}--FontSize--sm);
@@ -528,8 +530,8 @@
     overflow: hidden;
 
     .#{$nav}__list {
-      --#{$nav}__list--MarginTop: 0;
-      --#{$nav}__list--MarginBottom: 0;
+      --#{$nav}__list--PaddingTop: 0;
+      --#{$nav}__list--PaddingBottom: 0;
       
       flex: 1;
       max-width: 100%;
@@ -738,8 +740,8 @@
 .#{$nav}__list {
   position: relative;
   display: block;
-  margin-top: var(--#{$nav}__list--MarginTop);
-  margin-bottom: var(--#{$nav}__list--MarginBottom);
+  padding-top: var(--#{$nav}__list--PaddingTop);
+  padding-bottom: var(--#{$nav}__list--PaddingBottom);
 }
 
 // Borders
@@ -993,8 +995,8 @@
 
 // Subnav
 .#{$nav}__subnav {
-  --#{$nav}__list--MarginTop: 0;
-  --#{$nav}__list--MarginBottom: 0;
+  --#{$nav}__list--PaddingTop: 0;
+  --#{$nav}__list--PaddingBottom: 0;
   --#{$nav}__link--PaddingTop: var(--#{$nav}__subnav__link--PaddingTop);
   --#{$nav}__link--PaddingRight: var(--#{$nav}__subnav__link--PaddingRight);
   --#{$nav}__link--PaddingBottom: var(--#{$nav}__subnav__link--PaddingBottom);
@@ -1084,23 +1086,30 @@
   --#{$nav}__link--active--after--BorderLeftWidth: var(--#{$nav}__section__link--active--after--BorderWidth);
   --#{$nav}__link--m-current--after--BorderLeftWidth: var(--#{$nav}__section__link--m-current--after--BorderWidth);
 
+  // Lists
+  --#{$nav}__list--PaddingTop: 0;
+  --#{$nav}__list--PaddingBottom: 0;
+
   // Divider
   --#{$nav}--c-divider--MarginBottom: 0;
 
-  margin-top: var(--#{$nav}__section--MarginTop);
-
-  & + & {
-    --#{$nav}__section--MarginTop: var(--#{$nav}__section--section--MarginTop);
+  &:first-child {
+    padding-top: var(--#{$nav}__section--PaddingTop);
   }
 
-  &.pf-m-no-title {
-    --#{$nav}__section--MarginTop: 0;
+  & + & {
+    margin-top: var(--#{$nav}__section--section--MarginTop);
+  }
+
+  &:last-child {
+    padding-bottom: var(--#{$nav}__section--PaddingTop);
   }
 }
 
 // Section title
 .#{$nav}__section-title {
   padding: var(--#{$nav}__section-title--PaddingTop) var(--#{$nav}__section-title--PaddingRight) var(--#{$nav}__section-title--PaddingBottom) var(--#{$nav}__section-title--PaddingLeft);
+  margin-bottom: var(--#{$nav}__section-title--MarginBottom);
   font-size: var(--#{$nav}__section-title--FontSize);
   color: var(--#{$nav}__section-title--Color);
   border-bottom: var(--#{$nav}__section-title--BorderBottomWidth) solid var(--#{$nav}__section-title--BorderBottomColor);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -203,8 +203,8 @@
   --#{$nav}__subnav--c-divider--PaddingLeft: var(--#{$pf-global}--spacer--lg);
 
   // Nav section
-  --#{$nav}__section--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$nav}__section--PaddingBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__section--first-child--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__section--last-child--PaddingBottom: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__item--MarginTop: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__link--PaddingTop: var(--#{$pf-global}--spacer--sm);
   --#{$nav}__section__link--PaddingRight: var(--#{$pf-global}--spacer--md);
@@ -1094,7 +1094,7 @@
   --#{$nav}--c-divider--MarginBottom: 0;
 
   &:first-child {
-    padding-top: var(--#{$nav}__section--PaddingTop);
+    padding-top: var(--#{$nav}__section--first-child--PaddingTop);
   }
 
   & + & {
@@ -1102,7 +1102,7 @@
   }
 
   &:last-child {
-    padding-bottom: var(--#{$nav}__section--PaddingTop);
+    padding-bottom: var(--#{$nav}__section--last-child--PaddingBottom);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,8 +29,8 @@
   --#{$nav}--m-light__subnav__link--m-current--after--BorderColor: var(--#{$pf-global}--active-color--100);
 
   // List
-  --#{$nav}__list--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$nav}__list--PaddingBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__list--MarginTop: var(--#{$pf-global}--spacer--sm);
+  --#{$nav}__list--MarginBottom: var(--#{$pf-global}--spacer--sm);
 
   // Item
   --#{$nav}__item--MarginTop: 0;
@@ -528,8 +528,8 @@
     overflow: hidden;
 
     .#{$nav}__list {
-      --#{$nav}__list--PaddingTop: 0;
-      --#{$nav}__list--PaddingBottom: 0;
+      --#{$nav}__list--MarginTop: 0;
+      --#{$nav}__list--MarginBottom: 0;
       
       flex: 1;
       max-width: 100%;
@@ -738,8 +738,8 @@
 .#{$nav}__list {
   position: relative;
   display: block;
-  padding-top: var(--#{$nav}__list--PaddingTop);
-  padding-bottom: var(--#{$nav}__list--PaddingBottom);
+  margin-top: var(--#{$nav}__list--MarginTop);
+  margin-bottom: var(--#{$nav}__list--MarginBottom);
 }
 
 // Borders
@@ -993,8 +993,8 @@
 
 // Subnav
 .#{$nav}__subnav {
-  --#{$nav}__list--PaddingTop: 0;
-  --#{$nav}__list--PaddingBottom: 0;
+  --#{$nav}__list--MarginTop: 0;
+  --#{$nav}__list--MarginBottom: 0;
   --#{$nav}__link--PaddingTop: var(--#{$nav}__subnav__link--PaddingTop);
   --#{$nav}__link--PaddingRight: var(--#{$nav}__subnav__link--PaddingRight);
   --#{$nav}__link--PaddingBottom: var(--#{$nav}__subnav__link--PaddingBottom);
@@ -1095,10 +1095,6 @@
 
   &.pf-m-no-title {
     --#{$nav}__section--MarginTop: 0;
-  }
-
-  &:not(:last-child) {
-    --#{$nav}__list--PaddingBottom: 0;
   }
 }
 


### PR DESCRIPTION
Closes #5592 

@mcoker @andrew-ronaldson Tried comparing examples/demos that had screenshots in the previous PR to the local build for this update. Seemed like the local build matched what was expected visually, but some spacing between screenshots was pretty close to call for me.

It seems like the issue was more tied to a section that also had `pf-m-no-title`, so the following also seemed to work:

```
  &.pf-m-no-title {
    --#{$nav}__list--PaddingTop: 0;
    --#{$nav}__section--MarginTop: 0;
  }
```