### PR TITLE
fix(MenuToggle): updated spacing of toggle icon

### DIFF
--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -152,11 +152,13 @@
 
   // Split button, controls, check
   --#{$menu-toggle}__button--BackgroundColor: transparent;
+  --#{$menu-toggle}__button--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$menu-toggle}__button--PaddingRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginLeft: var(--#{$pf-global}--spacer--sm);
 
   // Typeahead
-  --#{$menu-toggle}--m-typeahead__controls--MarginRight: var(--#{$pf-global}--spacer--md);
+  --#{$menu-toggle}--m-typeahead__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}--m-typeahead__controls--MarginLeft: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight: var(--#{$pf-global}--spacer--sm);
 
@@ -503,6 +505,8 @@
   --#{$menu-toggle}__controls--MarginRight: var(--#{$menu-toggle}__button__controls--MarginRight);
   --#{$menu-toggle}__controls--MarginLeft: var(--#{$menu-toggle}__button__controls--MarginLeft);
 
+  padding-right: var(--#{$menu-toggle}__button--PaddingRight);
+  padding-left: var(--#{$menu-toggle}__button--PaddingLeft);
   color: inherit;
   background-color: var(--#{$menu-toggle}__button--BackgroundColor);
   border: 0;


### PR DESCRIPTION
Closes #5604

@mcarrano Updated some styling for the MenuToggle. You can copy+paste the following code into an example to compare a FormSelect against a MenuToggle typeahead (the markup of a MenuToggle typeahead should be similar to React's Select typeahead)

<details>
<summary>Code to copy</summary>

```

<div class="pf-v5-c-form-control pf-m-placeholder">
  <select
    class
    id="select-selectable-placeholder"
    name="select-selectable-placeholder"
    aria-label="Selectable placeholder select example"
  >
    <option value selected>Selectable placeholder</option>
    <option value="Mr">Mr</option>
    <option value="Miss">Miss</option>
    <option value="Mrs">Mrs</option>
    <option value="Ms">Ms</option>
    <option value="Dr">Dr</option>
    <option value="Other">Other</option>
  </select>
  <div class="pf-v5-c-form-control__utilities">
    <div class="pf-v5-c-form-control__toggle-icon">
      <i class="fas fa-caret-down" aria-hidden="true"></i>
    </div>
  </div>
</div>
<br />
<div class="pf-v5-c-menu-toggle pf-m-typeahead pf-m-full-width">
  <div class="pf-v5-c-text-input-group pf-m-plain">
    <div class="pf-v5-c-text-input-group__main">
      <span class="pf-v5-c-text-input-group__text">
        <input
          class="pf-v5-c-text-input-group__text-input"
          type="text"
          value
          aria-label="Type to filter"
        />
      </span>
    </div>
  </div>
  <button
    class="pf-v5-c-menu-toggle__button"
    type="button"
    aria-expanded="false"
    id="typeahead-example-toggle-button"
    aria-label="Menu toggle"
  >
    <span class="pf-v5-c-menu-toggle__controls">
      <span class="pf-v5-c-menu-toggle__toggle-icon">
        <i class="fas fa-caret-down" aria-hidden="true"></i>
      </span>
    </span>
  </button>
</div>

```

</details>