### PR TITLE
fix(form-control): update form-control in other components

### DIFF
--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -19,7 +19,7 @@ cssPrefix: pf-v5-c-clipboard-copy
 <br />
 {{#> clipboard-copy clipboard-copy--id="basic-readonly"}}
   {{#> clipboard-copy-group}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is read-only" id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is read-only" id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
@@ -52,7 +52,7 @@ cssPrefix: pf-v5-c-clipboard-copy
     {{#> button button--modifier="pf-m-control pf-m-expanded" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
@@ -69,7 +69,7 @@ cssPrefix: pf-v5-c-clipboard-copy
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>
@@ -85,7 +85,7 @@ cssPrefix: pf-v5-c-clipboard-copy
     {{#> button button--modifier="pf-m-control pf-m-expanded" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-labelledby="' clipboard-copy--id '-toggle ' clipboard-copy--id '-text-input" aria-controls="' clipboard-copy--id '-content"')}}
       {{> clipboard-copy-toggle-icon}}
     {{/button}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{#> button button--modifier="pf-m-control" button--attribute=(concat 'aria-label="Copy to clipboard" id="' clipboard-copy--id '-copy-button" aria-labelledby="' clipboard-copy--id '-copy-button ' clipboard-copy--id '-text-input"')}}
       <i class="fas fa-copy" aria-hidden="true"></i>

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -46,7 +46,7 @@ import './DatePicker.css'
 {{#> date-picker date-picker--id="invalid" helper-text--value="Invalid date" helper-text-item--IsError="true"}}
   {{#> input-group}}
     {{#> input-group-item input-group-item--IsFill=true}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+      {{> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
     {{/input-group-item}}
     {{#> input-group-item}}
       {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}

--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -14,8 +14,9 @@ cssPrefix: pf-v5-c-file-upload
     {{#> input-group}}
       {{#> input-group-item input-group-item--IsFill=true}}
         {{> file-upload-text-input
+          form-control--IsReadonly="true"
           file-upload-text-input--aria-label="Drag and drop a file or upload one"
-          file-upload-text-input--attribute=(concat 'readonly placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')
+          file-upload-text-input--attribute=(concat 'placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')
           }}
       {{/input-group-item}}
       {{#> input-group-item}}
@@ -42,8 +43,9 @@ cssPrefix: pf-v5-c-file-upload
     {{#> input-group}}
       {{#> input-group-item input-group-item--IsFill=true}}
         {{> file-upload-text-input
+          form-control--IsReadonly='true'
           file-upload-text-input--aria-label="Read only filename"
-          file-upload-text-input--attribute=(concat 'readonly value="Read only filename" aria-describedby="' file-upload--id '-browse"')
+          file-upload-text-input--attribute=(concat 'value="Read only filename" aria-describedby="' file-upload--id '-browse"')
           }}
       {{/input-group-item}}
       {{#> input-group-item}}
@@ -58,7 +60,7 @@ cssPrefix: pf-v5-c-file-upload
       {{/input-group-item}}
     {{/input-group}}
   {{/file-upload-file-select}}
-  {{#> file-upload-file-details file-upload-file-details--aria-label="Text area" file-upload-file-details--attribute='readonly'}}Ssh-Rsa AAh3zJFkzjjakCJialksjfB3zJFkzzAAhhMskjjakCJialksjfB3z89z3zJFkz3 +kzMAjsauoox88aaZXphBx4fczJFkzMAjsauoox88aaZXphBx4fczJFkzMAjsauoox88aaZXphBx4fc
+  {{#> file-upload-file-details file-upload-file-details--aria-label="Text area" form-control--IsReadonly='true'}}Ssh-Rsa AAh3zJFkzjjakCJialksjfB3zJFkzzAAhhMskjjakCJialksjfB3z89z3zJFkz3 +kzMAjsauoox88aaZXphBx4fczJFkzMAjsauoox88aaZXphBx4fczJFkzMAjsauoox88aaZXphBx4fc
   {{/file-upload-file-details}}
 {{/file-upload}}
 ```
@@ -70,8 +72,9 @@ cssPrefix: pf-v5-c-file-upload
     {{#> input-group}}
       {{#> input-group-item input-group-item--IsFill=true}}
         {{> file-upload-text-input
+          form-control--IsReadonly='true'
           file-upload-text-input--aria-label="Read only filename"
-          file-upload-text-input--attribute=(concat 'readonly value="Sample.txt" aria-describedby="' file-upload--id '-browse"')
+          file-upload-text-input--attribute=(concat 'value="Sample.txt" aria-describedby="' file-upload--id '-browse"')
           }}
       {{/input-group-item}}
       {{#> input-group-item}}
@@ -97,7 +100,10 @@ cssPrefix: pf-v5-c-file-upload
   {{#> file-upload-file-select}}
     {{#> input-group}}
       {{#> input-group-item input-group-item--IsFill=true}}
-        {{> file-upload-text-input file-upload-text-input--aria-label="Drag and drop a file or upload one" file-upload-text-input--attribute=(concat 'readonly placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')}}
+        {{> file-upload-text-input
+          form-control--IsReadonly='true' 
+          file-upload-text-input--aria-label="Drag and drop a file or upload one"
+          file-upload-text-input--attribute=(concat 'placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')}}
       {{/input-group-item}}
       {{#> input-group-item}}
         {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
@@ -125,8 +131,9 @@ cssPrefix: pf-v5-c-file-upload
         {{#> input-group}}
           {{#> input-group-item input-group-item--IsFill=true}}
             {{> file-upload-text-input
+              form-control--IsRequired='true'
               file-upload-text-input--aria-label="File upload error"
-              file-upload-text-input--attribute=(concat 'required value="Sample.png"  aria-describedby="' file-upload--id '-browse"')
+              file-upload-text-input--attribute=(concat 'value="Sample.png"  aria-describedby="' file-upload--id '-browse"')
               }}
           {{/input-group-item}}
           {{#> input-group-item}}
@@ -141,7 +148,10 @@ cssPrefix: pf-v5-c-file-upload
           {{/input-group-item}}
         {{/input-group}}
       {{/file-upload-file-select}}
-      {{#> file-upload-file-details file-upload-file-details--attribute='aria-describedby="textAreaHelperText1" aria-invalid="true"' file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
+      {{#> file-upload-file-details 
+        form-control--IsError='true'
+        file-upload-file-details--attribute='aria-describedby="textAreaHelperText1" aria-invalid="true"' 
+        file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
     {{/file-upload}}
     {{#> form-helper-text}}
       {{> helper-text helper-text--value="We don't support this file type. Try again with a different file type." helper-text-item--id='textAreaHelperText1' helper-text-item--IsError=true}}
@@ -157,8 +167,9 @@ cssPrefix: pf-v5-c-file-upload
     {{#> input-group}}
       {{#> input-group-item input-group-item--IsFill=true}}
         {{> file-upload-text-input
+          form-control--IsReadonly='true'
           file-upload-text-input--aria-label="Read only filename"
-          file-upload-text-input--attribute=(concat 'readonly name="file-upload-loading" value="Sample.png" aria-describedby="' file-upload--id '-browse"')
+          file-upload-text-input--attribute=(concat 'name="file-upload-loading" value="Sample.png" aria-describedby="' file-upload--id '-browse"')
         }}
       {{/input-group-item}}
       {{#> input-group-item}}

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -17,7 +17,7 @@ cssPrefix: pf-v5-c-form
       {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=form-group--id}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -33,7 +33,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id=(concat form--id '-info')}}
@@ -79,7 +79,7 @@ cssPrefix: pf-v5-c-form
       {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form-group--id)}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -96,7 +96,7 @@ cssPrefix: pf-v5-c-form
         {{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-section--id '-input" name="' form-section--id '-input" required')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-section--id '-input" name="' form-section--id '-input"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group}}
@@ -106,7 +106,7 @@ cssPrefix: pf-v5-c-form
         {{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-section--id '-input-2" name="' form-section--id '-input-2" required')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-section--id '-input-2" name="' form-section--id '-input-2"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
   {{/form-section}}
@@ -121,7 +121,7 @@ cssPrefix: pf-v5-c-form
         {{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-section--id '-input" name="' form-section--id '-input" required')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-section--id '-input" name="' form-section--id '-input"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group}}
@@ -131,7 +131,7 @@ cssPrefix: pf-v5-c-form
         {{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-section--id '-input-2" name="' form-section--id '-input-2" required')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-section--id '-input-2" name="' form-section--id '-input-2"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
   {{/form-section}}
@@ -148,7 +148,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='This is helper text.'}}
     {{/form-group-control}}
@@ -160,7 +160,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control form-control--modifier="pf-m-warning" controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control form-control--IsWarning='true' controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='This is helper text for a warning input.' helper-text-item--IsWarning=true}}
     {{/form-group-control}}
@@ -172,7 +172,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='This is helper text for an invalid input.' helper-text-item--IsError=true}}
     {{/form-group-control}}
@@ -184,7 +184,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsSuccess='true' form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='This is helper text for success input.' helper-text-item--IsSuccess=true}}
     {{/form-group-control}}
@@ -196,7 +196,7 @@ cssPrefix: pf-v5-c-form
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="textarea" form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="textarea" form-control--modifier='pf-m-resize-both' form-control--IsError='true' form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='This is helper text with an icon.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
     {{/form-group-control}}
@@ -220,7 +220,7 @@ cssPrefix: pf-v5-c-form
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -268,7 +268,7 @@ cssPrefix: pf-v5-c-form
           {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
         {{/form-group-control}}
       {{/form-group}}
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
@@ -277,7 +277,7 @@ cssPrefix: pf-v5-c-form
           {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
         {{/form-group-control}}
       {{/form-group}}
     {{/form-field-group-body}}
@@ -324,7 +324,7 @@ cssPrefix: pf-v5-c-form
           {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
         {{/form-group-control}}
       {{/form-group}}
       {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
@@ -333,7 +333,7 @@ cssPrefix: pf-v5-c-form
           {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
         {{/form-group-control}}
       {{/form-group}}
       {{#> form-field-group form-field-group--id=(concat form--id '-field-group-3') form-field-group--IsExpandable=reset}}
@@ -351,7 +351,7 @@ cssPrefix: pf-v5-c-form
               {{> form-group-label-help form-group-label-help--aria-label="More information for label 1 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
             {{/form-group-control}}
           {{/form-group}}
           {{#> form-group form-group--id=(concat form-field-group--id "-label2")}}
@@ -360,7 +360,7 @@ cssPrefix: pf-v5-c-form
               {{> form-group-label-help form-group-label-help--aria-label="More information for label 2 field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
             {{/form-group-label}}
             {{#> form-group-control}}
-              {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
             {{/form-group-control}}
           {{/form-group}}
         {{/form-field-group-body}}

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -13,7 +13,7 @@ cssPrefix: pf-v5-c-form-control
 ```hbs
 {{> form-control controlType="input" input="true" form-control--attribute='type="text" value="Standard" id="input-standard" aria-label="Standard input example"'}}
 <br>
-{{> form-control controlType="input" input="true" form-control--IsPlaceholder="true" form-control--attribute='type="text" placeholder="Placeholder" id="input-placeholder" aria-label="Placeholder input example"'}}
+{{> form-control controlType="input" input="true" form-control--attribute='type="text" placeholder="Placeholder" id="input-placeholder" aria-label="Placeholder input example"'}}
 <br>
 {{> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute='type="text" value="Readonly" id="input-readonly" aria-label="Readonly input example"'}}
 <br>

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -147,6 +147,11 @@
     // stylelint-enable
   }
 
+  // Where there is support for :has, make sure the height is consistent. Height cannot be set for form elements that contain a text area.
+  &:not(:has(textarea)) {
+    height: var(--#{$form-control}--Height);
+  }
+
   > ::placeholder {
     color: var(--#{$form-control}--m-placeholder--Color); // TODO update to set --#{$form-control}--Color in breaking change - also look for any other place to do that in this component
   }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -147,11 +147,6 @@
     // stylelint-enable
   }
 
-  // Where there is support for :has, make sure the height is consistent. Height cannot be set for form elements that contain a text area.
-  &:not(:has(textarea)) {
-    height: var(--#{$form-control}--Height);
-  }
-
   > ::placeholder {
     color: var(--#{$form-control}--m-placeholder--Color); // TODO update to set --#{$form-control}--Color in breaking change - also look for any other place to do that in this component
   }

--- a/src/patternfly/components/InlineEdit/examples/InlineEdit.md
+++ b/src/patternfly/components/InlineEdit/examples/InlineEdit.md
@@ -197,7 +197,7 @@ Inline edit **action-group** contains save and cancel actions and is only visibl
   {{/inline-edit-value}}
   {{#> inline-edit-group}}
     {{#> inline-edit-input}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required value="Invalid state" aria-invalid="true" aria-label="Error state input example"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute=(concat 'value="Invalid state" aria-invalid="true" aria-label="Error state input example"')}}
       {{/form-control}}
     {{/inline-edit-input}}
     {{#> inline-edit-group inline-edit-group--modifier="pf-m-action-group pf-m-icon-group"}}
@@ -252,7 +252,7 @@ Inline edit **action-group** contains save and cancel actions and is only visibl
             Text input disabled, description content
           {{/inline-edit-value}}
           {{#> inline-edit-input}}
-            {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Text input disabled, description content" id="' inline-edit--id inline-edit--row 'text-input-disabled"  aria-label="Disabled text input" disabled')}}
+            {{> form-control controlType="input" input="true" form-control--IsDisabled='true' form-control--attribute=(concat 'type="text" value="Text input disabled, description content" id="' inline-edit--id inline-edit--row 'text-input-disabled" aria-label="Disabled text input"')}}
           {{/inline-edit-input}}
         {{/table-td}}
         {{#> table-td table-td--data-label="Checkboxes"}}
@@ -331,7 +331,7 @@ Inline edit **action-group** contains save and cancel actions and is only visibl
             Text input disabled, description content
           {{/inline-edit-value}}
           {{#> inline-edit-input}}
-            {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Text input disabled, description content" id="' inline-edit--id inline-edit--row 'text-input-disabled"  aria-label="Disabled text input" disabled')}}
+            {{> form-control controlType="input" input="true" form-control--IsDisabled='true' form-control--attribute=(concat 'type="text" value="Text input disabled, description content" id="' inline-edit--id inline-edit--row 'text-input-disabled" aria-label="Disabled text input"')}}
           {{/inline-edit-input}}
         {{/table-td}}
         {{#> table-td table-td--data-label="Checkboxes"}}
@@ -433,155 +433,5 @@ All accessibility requirements for inputs apply to elements within inline edit.
 | `.pf-m-valid` | `.pf-v5-c-inline-edit__action` | Modifies the action button state. |
 | `.pf-m-enable-editable` | `.pf-v5-c-inline-edit__action` | Exposes an inline edit action by default. |
 
-
-<!--
-### Bulk edit dl (default)
-```hbs
-{{#> inline-edit inline-edit--type="form" inline-edit--id="bulk-edit-dl-example-default"}}
-  {{#> inline-edit-dl}}{{/inline-edit-dl}}
-{{/inline-edit}}
-```
-
-### Bulk edit dl (active)
-```hbs
-{{#> inline-edit inline-edit--type="form" inline-edit--id="bulk-edit-dl-example-active" inline-edit--modifier="pf-m-inline-editable"}}
-  {{#> inline-edit-dl}}{{/inline-edit-dl}}
-{{/inline-edit}}
-```
-
-### Inline edit dl example
-```hbs
-{{#> list list--type="dl" list--modifier="pf-m-2-col" list--attribute=(concat 'aria-label="Inline edit description list example"')}}
-  <div>
-    <dt>Name</dt>
-    <dd>main</dd>
-  </div>
-  {{#> inline-edit inline-edit--id="inline-edit-dl-example-1"}}
-    <dt>
-      {{#> inline-edit-group}}
-        {{#> inline-edit-label}}
-          Description
-        {{/inline-edit-label}}
-        {{#> inline-edit-toggle}}
-          {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' inline-edit--id '-edit-button" aria-label="Edit" aria-labelledby="' inline-edit--id '-edit-button"')}}
-            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
-          {{/button}}
-        {{/inline-edit-toggle}}
-      {{/inline-edit-group}}
-    </dt>
-    <dd>
-      {{#> inline-edit-value}}
-        test cluster
-      {{/inline-edit-value}}
-      {{#> inline-edit-input}}
-        {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Text input description content" id="' inline-edit--id '-input"')}}
-      {{/inline-edit-input}}
-    </dd>
-  {{/inline-edit}}
-
-  {{#> inline-edit inline-edit--id="inline-edit-dl-example-2" inline-edit--modifier="pf-m-inline-editable"}}
-    <dt>
-      {{#> inline-edit-group}}
-        {{#> inline-edit-label}}
-          Description (editable)
-        {{/inline-edit-label}}
-        {{#> inline-edit-toggle}}
-          {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' inline-edit--id '-edit-button" aria-label="Edit" aria-labelledby="' inline-edit--id '-label ' inline-edit--id '-edit-button"')}}
-            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
-          {{/button}}
-        {{/inline-edit-toggle}}
-      {{/inline-edit-group}}
-    </dt>
-    <dd>
-      {{#> inline-edit-value}}
-        Text input description content
-      {{/inline-edit-value}}
-      {{#> inline-edit-input}}
-        {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Text input description content" id="' inline-edit--id '-input"')}}
-      {{/inline-edit-input}}
-    </dd>
-  {{/inline-edit}}
-
-  <div>
-    <dt>Tags</dt>
-    <dd>
-      {{#> chip chip--type="div" chip--modifier="pf-m-read-only"}}
-        {{#> chip-content}}
-          {{#> chip-text}}
-            alertmanager=main
-          {{/chip-text}}
-        {{/chip-content}}
-      {{/chip}}
-    </dd>
-  </div>
-
-  {{#> inline-edit inline-edit--id="inline-edit-dl-example-3"}}
-    <dt>
-      {{#> inline-edit-group}}
-        {{#> inline-edit-label}}
-          Value
-        {{/inline-edit-label}}
-        {{#> inline-edit-toggle}}
-          {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' inline-edit--id '-edit-button" aria-label="Edit" aria-labelledby="' inline-edit--id '-label ' inline-edit--id '-edit-button"')}}
-            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
-          {{/button}}
-        {{/inline-edit-toggle}}
-      {{/inline-edit-group}}
-    </dt>
-    <dd>
-      {{#> inline-edit-value}}
-        True
-      {{/inline-edit-value}}
-      {{#> inline-edit-group inline-edit-group--attribute='role="radiogroup" aria-label="Radio group example"' inline-edit-group--modifier="pf-m-column"}}
-        {{#> inline-edit-input}}
-          {{#> radio}}
-            {{#> radio-input radio-input--attribute=(concat 'id="' inline-edit--id '-radio1" name="' inline-edit--id '-input"')}}{{/radio-input}}
-            {{#> radio-label radio-label--attribute=(concat 'for="' inline-edit--id '-radio1"')}}True{{/radio-label}}
-          {{/radio}}
-        {{/inline-edit-input}}
-        {{#> inline-edit-input}}
-          {{#> radio}}
-            {{#> radio-input radio-input--attribute=(concat 'id="' inline-edit--id '-radio2" name="' inline-edit--id '-input"')}}{{/radio-input}}
-            {{#> radio-label radio-label--attribute=(concat 'for="' inline-edit--id '-radio2"')}}False{{/radio-label}}
-          {{/radio}}
-        {{/inline-edit-input}}
-      {{/inline-edit-group}}
-    </dd>
-  {{/inline-edit}}
-
-  {{#> inline-edit inline-edit--id="inline-edit-dl-example-4" inline-edit--modifier="pf-m-inline-editable"}}
-    <dt>
-      {{#> inline-edit-group}}
-        {{#> inline-edit-label}}
-          Value
-        {{/inline-edit-label}}
-        {{#> inline-edit-toggle}}
-          {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'id="' inline-edit--id '-edit-button" aria-label="Edit" aria-labelledby="' inline-edit--id '-label ' inline-edit--id '-edit-button"')}}
-            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
-          {{/button}}
-        {{/inline-edit-toggle}}
-      {{/inline-edit-group}}
-    </dt>
-    <dd>
-      {{#> inline-edit-value}}
-        True
-      {{/inline-edit-value}}
-      {{#> inline-edit-group inline-edit-group--attribute='role="radiogroup" aria-label="Radio group example"' inline-edit-group--modifier="pf-m-column"}}
-        {{#> inline-edit-input}}
-          {{#> radio}}
-            {{#> radio-input radio-input--attribute=(concat 'id="' inline-edit--id '-radio1" name="' inline-edit--id '-input"')}}{{/radio-input}}
-            {{#> radio-label radio-label--attribute=(concat 'for="' inline-edit--id '-radio1"')}}True{{/radio-label}}
-          {{/radio}}
-        {{/inline-edit-input}}
-        {{#> inline-edit-input}}
-          {{#> radio}}
-            {{#> radio-input radio-input--attribute=(concat 'id="' inline-edit--id '-radio2" name="' inline-edit--id '-input"')}}{{/radio-input}}
-            {{#> radio-label radio-label--attribute=(concat 'for="' inline-edit--id '-radio2"')}}False{{/radio-label}}
-          {{/radio}}
-        {{/inline-edit-input}}
-      {{/inline-edit-group}}
-    </dd>
-  {{/inline-edit}}
-{{/list}}
 ```
 -->

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -16,7 +16,7 @@ Use the input group to extend form controls by adding text, buttons, selects, et
     {{/button}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsFill=true}}
-    {{> form-control controlType="textarea" form-control--attribute='name="textarea1" id="textarea1" aria-label="Textarea with buttons" aria-describedby="textAreaButton1"'}}
+    {{> form-control controlType="textarea" form-control--modifier="pf-m-resize-both" form-control--attribute='name="textarea1" id="textarea1" aria-label="Textarea with buttons" aria-describedby="textAreaButton1"'}}
   {{/input-group-item}}
   {{#> input-group-item}}
     {{#> button button--modifier="pf-m-control"}}
@@ -27,7 +27,7 @@ Use the input group to extend form controls by adding text, buttons, selects, et
 <br>
 {{#> input-group}}
   {{#> input-group-item input-group-item--IsFill=true}}
-    {{> form-control controlType="textarea" form-control--attribute='name="textarea2" id="textarea2" aria-label="Textarea with button" aria-describedby="textAreaButton2"'}}
+    {{> form-control controlType="textarea" form-control--modifier="pf-m-resize-both" form-control--attribute='name="textarea2" id="textarea2" aria-label="Textarea with button" aria-describedby="textAreaButton2"'}}
   {{/input-group-item}}
   {{#> input-group-item}}
     {{#> button button--modifier="pf-m-control" button--attribute='id="textAreaButton2"'}}
@@ -48,7 +48,7 @@ Use the input group to extend form controls by adding text, buttons, selects, et
     {{/button}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsFill=true}}
-    {{> form-control controlType="textarea" form-control--attribute='name="textarea3" id="textarea3" aria-label="Textarea with buttons" aria-describedby="textAreaButton3"'}}
+    {{> form-control controlType="textarea" form-control--modifier="pf-m-resize-both" form-control--attribute='name="textarea3" id="textarea3" aria-label="Textarea with buttons" aria-describedby="textAreaButton3"'}}
   {{/input-group-item}}
   {{#> input-group-item}}
     {{#> button button--modifier="pf-m-control"}}
@@ -99,7 +99,7 @@ Use the input group to extend form controls by adding text, buttons, selects, et
     {{> input-group-text input-group-text--HasAtIcon=true}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsFill=true}}
-    {{> form-control controlType="input" input=true form-control--attribute='required type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example"'}}
+    {{> form-control controlType="input" input=true form-control--IsError='true' form-control--attribute='required type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example"'}}
   {{/input-group-item}}
 {{/input-group}}
 <br>

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -99,7 +99,7 @@ Use the input group to extend form controls by adding text, buttons, selects, et
     {{> input-group-text input-group-text--HasAtIcon=true}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsFill=true}}
-    {{> form-control controlType="input" input=true form-control--IsError='true' form-control--attribute='required type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example"'}}
+    {{> form-control controlType="input" input=true form-control--IsError='true' form-control--IsRequired='true' form-control--attribute='type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example"'}}
   {{/input-group-item}}
 {{/input-group}}
 <br>

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -34,10 +34,6 @@
   --#{$input-group}__item--m-disabled--BorderBottomColor: transparent;
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--#{$pf-global}--disabled-color--300);
 
-  // Form control
-  --#{$input-group}--c-form-control--invalid--ZIndex: var(--#{$pf-global}--ZIndex--xs);
-  --#{$input-group}--c-form-control--MarginRight: 0;
-
   display: flex;
   width: 100%;
 }

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -23,7 +23,7 @@ wrapperTag: div
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> check}}
@@ -97,12 +97,12 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
             {{#> input-group}}
-              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="password" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
               {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
                 <i class="fas fa-eye" aria-hidden="true"></i>
               {{/button}}
@@ -147,12 +147,12 @@ wrapperTag: div
           {{/form-helper-text}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
             {{#> input-group}}
-              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
               {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Hide password"'}}
                 <i class="fas fa-eye-slash" aria-hidden="true"></i>
               {{/button}}
@@ -191,11 +191,11 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> check}}

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -19,11 +19,11 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> check}}
@@ -58,11 +58,11 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="invalid-login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" id="invalid-login-demo-form-username" name="invalid-login-demo-form-username" aria-invalid="true"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute='type="text" id="invalid-login-demo-form-username" name="invalid-login-demo-form-username" aria-invalid="true"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="invalid-login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required type="password" id="invalid-login-demo-form-password" name="invalid-login-demo-form-password" aria-invalid="true"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute='type="password" id="invalid-login-demo-form-password" name="invalid-login-demo-form-password" aria-invalid="true"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> check}}
@@ -97,12 +97,12 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
             {{#> input-group}}
-              {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
               {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
                 <i class="fas fa-eye" aria-hidden="true"></i>
               {{/button}}
@@ -147,12 +147,12 @@ wrapperTag: div
           {{/form-helper-text}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
             {{#> input-group}}
-              {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
+              {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-password" name="login-demo-form-password" value="abcd1234"'}}{{/form-control}}
               {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Hide password"'}}
                 <i class="fas fa-eye-slash" aria-hidden="true"></i>
               {{/button}}
@@ -191,11 +191,11 @@ wrapperTag: div
           {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-            {{#> form-control controlType="input" input="true" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
           {{/form-group}}
           {{#> form-group}}
             {{#> check}}

--- a/src/patternfly/components/NumberInput/examples/NumberInput.md
+++ b/src/patternfly/components/NumberInput/examples/NumberInput.md
@@ -192,7 +192,7 @@ cssPrefix: pf-v5-c-number-input
       {{/button}}
     {{/input-group-item}}
     {{#> input-group-item input-group-item--IsFill=true}}
-      {{> form-control controlType="input" input="true" form-control--modifier="pf-m-warning"  form-control--attribute=(concat 'type="number" value="90" name="' number-input--id '-name" aria-label="Number input"')}}
+      {{> form-control controlType="input" input="true" form-control--IsWarning='true'  form-control--attribute=(concat 'type="number" value="90" name="' number-input--id '-name" aria-label="Number input"')}}
     {{/input-group-item}}
     {{#> input-group-item}}
       {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Plus"'}}

--- a/src/patternfly/components/NumberInput/examples/NumberInput.md
+++ b/src/patternfly/components/NumberInput/examples/NumberInput.md
@@ -144,7 +144,7 @@ cssPrefix: pf-v5-c-number-input
       {{/button}}
     {{/input-group-item}}
     {{#> input-group-item input-group-item--IsFill=true}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="number" value="100" name="' number-input--id '-name" aria-label="Number input" disabled')}}
+      {{> form-control controlType="input" input="true" form-control--IsDisabled='true' form-control--attribute=(concat 'type="number" value="100" name="' number-input--id '-name" aria-label="Number input"')}}
     {{/input-group-item}}
     {{#> input-group-item}}
       {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Plus" disabled'}}

--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -31,9 +31,12 @@
 
   .#{$form-control} {
     width: var(--#{$number-input}--c-form-control--Width);
-    text-align: right;
 
-    @extend %pf-v5-remove-num-arrows;
+    > :is(input) {
+      text-align: right;
+
+      @extend %pf-v5-remove-num-arrows;
+    }
   }
 }
 

--- a/src/patternfly/components/Pagination/pagination-nav-content.hbs
+++ b/src/patternfly/components/Pagination/pagination-nav-content.hbs
@@ -14,7 +14,7 @@
   {{#unless pagination--IsCompact}}
     {{#> pagination-nav-page-select}}
       {{#if pagination-nav-content--IsDisabled}}
-        {{> form-control input="true" controlType="input" form-control--attribute='disabled aria-label="Current page" type="number" min="1" max="4" value="1"'}}
+        {{> form-control input="true" controlType="input" form-control--IsDisabled='true' form-control--attribute='aria-label="Current page" type="number" min="1" max="4" value="1"'}}
       {{else}}
         {{> form-control input="true" controlType="input" form-control--attribute='aria-label="Current page" type="number" min="1" max="4" value="1"'}}
       {{/if}}

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -179,6 +179,10 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
         display: block;
       }
 
+      .#{$pagination}__nav-page-select {
+        display: inline-flex;
+      }
+
       .#{$options-menu} {
         position: relative;
       }
@@ -260,7 +264,9 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   .#{$form-control} {
     width: var(--#{$pagination}__nav-page-select--c-form-control--Width);
 
-    @extend %pf-v5-remove-num-arrows;
+    > :is(input) {
+      @extend %pf-v5-remove-num-arrows;
+    }
   }
 }
 

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -1,13 +1,15 @@
 {{#if select--IsDisabled}}
   {{#> form-control controlType="input"
     input="true"
+    form-control--IsDisabled='true'
     form-control--modifier="pf-v5-c-select__toggle-typeahead"
-    form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '" disabled')}}
+    form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
   {{/form-control}}
 {{else}}
   {{#if select--IsInvalid}}
     {{#> form-control controlType="input"
       input="true"
+      form-control--IsError='true'
       form-control--modifier="pf-v5-c-select__toggle-typeahead"
       form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
     {{/form-control}}

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -9,7 +9,6 @@
   {{#if select--IsInvalid}}
     {{#> form-control controlType="input"
       input="true"
-      form-control--IsError='true'
       form-control--modifier="pf-v5-c-select__toggle-typeahead"
       form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
     {{/form-control}}

--- a/src/patternfly/components/Wizard/__wizard-form.hbs
+++ b/src/patternfly/components/Wizard/__wizard-form.hbs
@@ -4,7 +4,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 1{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-field2"}}
@@ -12,7 +12,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 2{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
     {{#> form-group form-group--id="-field3"}}
@@ -20,7 +20,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 3{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
     {{#> form-group form-group--id="-field4"}}
@@ -28,7 +28,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 4{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
     {{#> form-group form-group--id="-field5"}}
@@ -36,7 +36,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 5{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
     {{#> form-group form-group--id="-field6"}}
@@ -44,7 +44,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 6{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
     {{#> form-group form-group--id="-field7"}}
@@ -52,7 +52,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Field 7{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-label--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -28,7 +28,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input=true form-control--IsError="true" form-control--IsRequired="true" form-control--attribute=(concat 'type="text" value="patternfly@patternfly.com" id="' form-group--id '" name="' form-group--id )}}{{/form-control}}
+      {{#> form-control controlType="input" input='true' form-control--IsRequired='true' form-control--attribute=(concat 'type="text" value="patternfly@patternfly.com" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id=(concat form--id '-phone')}}
@@ -38,7 +38,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input=true form-control--IsError="true" form-control--IsRequired form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input=true form-control--IsError='true' form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true}}
     {{/form-group-control}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -16,7 +16,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input=true form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input=true form-control--IsError="true" form-control--IsRequired="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true}}
     {{/form-group-control}}
@@ -28,7 +28,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input=true form-control--attribute=(concat 'type="text" value="patternfly@patternfly.com" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input=true form-control--IsError="true" form-control--IsRequired="true" form-control--attribute=(concat 'type="text" value="patternfly@patternfly.com" id="' form-group--id '" name="' form-group--id )}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id=(concat form--id '-phone')}}
@@ -38,7 +38,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input=true form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input=true form-control--IsError="true" form-control--IsRequired form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true}}
     {{/form-group-control}}

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -16,7 +16,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true}}
     {{/form-group-control}}
@@ -28,7 +28,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="patternfly.com" id="' form-group--id '" name="' form-group--id '" required')}}
+      {{#> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'type="text" value="patternfly.com" id="' form-group--id '" name="' form-group--id '" required')}}
       {{/form-control}}
     {{/form-group-control}}
     {{> form-helper-text helper-text--value='Enter a valid email address: example@gmail.com' helper-text-item--IsError=true}}
@@ -39,7 +39,7 @@
         State of residence
       {{/form-label}}
     {{/form-group-label}}
-    {{#> form-control controlType="select" form-control--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
+    {{#> form-control controlType="select" form-control--IsError="true" form-control--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
         <option value="">Select a state</option>
         <option value="Option 1">CA</option>
         <option value="Option 2">FL</option>

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -16,7 +16,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsError="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Required field' helper-text-item--IsError=true}}
     {{/form-group-control}}
@@ -28,7 +28,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'type="text" value="patternfly.com" id="' form-group--id '" name="' form-group--id '" required')}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" value="patternfly.com" id="' form-group--id '" name="' form-group--id '"')}}
       {{/form-control}}
     {{/form-group-control}}
     {{> form-helper-text helper-text--value='Enter a valid email address: example@gmail.com' helper-text-item--IsError=true}}
@@ -39,7 +39,7 @@
         State of residence
       {{/form-label}}
     {{/form-group-label}}
-    {{#> form-control controlType="select" form-control--IsError="true" form-control--attribute='required aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
+    {{#> form-control controlType="select" form-control--IsError='true' form-control--IsRequired='true' form-control--attribute='aria-invalid="true" id="select-group-error" name="select-group-error" aria-label="Error state select group example"'}}
         <option value="">Select a state</option>
         <option value="Option 1">CA</option>
         <option value="Option 2">FL</option>

--- a/src/patternfly/demos/Button/button-template-form.hbs
+++ b/src/patternfly/demos/Button/button-template-form.hbs
@@ -6,7 +6,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" value="johndoe" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" value="johndoe"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--id="-password"}}
@@ -16,7 +16,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="password" value="p@ssw0rd" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="password" value="p@ssw0rd" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -13,7 +13,7 @@ subsection: forms
       {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required="true"}}Full name{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{> form-helper-text helper-text--value='Include your middle name if you have one.'}}
     {{/form-group-control}}
   {{/form-group}}
@@ -31,7 +31,7 @@ subsection: forms
       {{> form-group-label-help form-group-label-help--aria-label="More information for phone number field"  form-group-label-help--aria-describedby=form-group--id}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="tel" placeholder="Example, (555) 555-5555" id="' form-group--id '" name="' form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="tel" placeholder="Example, (555) 555-5555" id="' form-group--id '" name="' form-group--id '" placeholder="555-555-5555"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--IsCheckGroup="true" form-group--id="-contact"}}
@@ -95,7 +95,7 @@ subsection: forms
       {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required="true"}}Full name{{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
       {{> form-helper-text helper-text--value='Include your middle name if you have one.'}}
     {{/form-group-control}}
@@ -162,7 +162,7 @@ subsection: forms
         {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required="true"}}Full name{{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
         {{> form-helper-text helper-text helper-text--value='Include your middle name if you have one.'}}
       {{/form-group-control}}
     {{/form-group}}
@@ -171,7 +171,7 @@ subsection: forms
         {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required="true"}}Job title{{/form-label}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group form-group--id=(concat form--id '-phone')}}
@@ -297,7 +297,7 @@ subsection: forms
         {{> form-group-label-help form-group-label-help--aria-label="More information for client id field" form-group-label-help--aria-describedby=form-group--id}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group form-group--id=(concat form--id '-name')}}
@@ -306,7 +306,7 @@ subsection: forms
         {{> form-group-label-help form-group-label-help--aria-label="More information for full name field" form-group-label-help--aria-describedby=form-group--id}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group form-group--id=(concat form--id '-description')}}
@@ -315,7 +315,7 @@ subsection: forms
         {{> form-group-label-help form-group-label-help--aria-label="More information for description field" form-group-label-help--aria-describedby=form-group--id}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
   {{/form-section}}
@@ -329,7 +329,7 @@ subsection: forms
         {{> form-group-label-help form-group-label-help--aria-label="More information for root URL field" form-group-label-help--aria-describedby=form-group--id}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
     {{#> form-group form-group--id=(concat form-section--id '-uris')}}
@@ -340,7 +340,7 @@ subsection: forms
       {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
         {{#> input-group}}
           {{#> input-group-item input-group-item--IsFill=true}}
-            {{> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '-input-1" name="' form-group--id '-input-1" aria-labelledby="' form-group--id ' ' form-group--id '-input-1"')}}
+            {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '-input-1" name="' form-group--id '-input-1" aria-labelledby="' form-group--id ' ' form-group--id '-input-1"')}}
           {{/input-group-item}}
           {{#> input-group-item input-group-item--IsPlain=true}}
             {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
@@ -350,7 +350,7 @@ subsection: forms
         {{/input-group}}
         {{#> input-group}}
           {{#> input-group-item input-group-item--IsFill=true}}
-            {{> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '-input-2" name="' form-group--id '-input-2" aria-labelledby="' form-group--id ' ' form-group--id '-input-2"')}}
+            {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '-input-2" name="' form-group--id '-input-2" aria-labelledby="' form-group--id ' ' form-group--id '-input-2"')}}
           {{/input-group-item}}
           {{#> input-group-item input-group-item--IsPlain=true}}
             {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
@@ -360,7 +360,7 @@ subsection: forms
         {{/input-group}}
         {{#> input-group}}
           {{#> input-group-item input-group-item--IsFill=true}}
-            {{> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '-input-3" name="' form-group--id '-input-3" aria-labelledby="' form-group--id ' ' form-group--id '-input-3"')}}
+            {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '-input-3" name="' form-group--id '-input-3" aria-labelledby="' form-group--id ' ' form-group--id '-input-3"')}}
           {{/input-group-item}}
           {{#> input-group-item input-group-item--IsPlain=true}}
             {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
@@ -382,7 +382,7 @@ subsection: forms
         {{> form-group-label-help form-group-label-help--aria-label="More information for home URL field" form-group-label-help--aria-describedby=form-group--id}}
       {{/form-group-label}}
       {{#> form-group-control}}
-        {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
+        {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
       {{/form-group-control}}
     {{/form-group}}
   {{/form-section}}
@@ -399,7 +399,7 @@ subsection: forms
       {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=form-group--id}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
     {{/form-group-control}}
   {{/form-group}}
 
@@ -530,7 +530,7 @@ subsection: forms
                   {{#> form-group-control form-group-control--modifier="pf-m-stack"}}
                     {{#> input-group}}
                       {{#> input-group-item input-group-item--IsFill=true}}
-                        {{> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '-input-1" name="' form-group--id '-input-1" aria-labelledby="' form-group--id ' ' form-group--id '-title"')}}
+                        {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '-input-1" name="' form-group--id '-input-1" aria-labelledby="' form-group--id ' ' form-group--id '-title"')}}
                         {{!-- {{#> form-helper-text form-helper-text--attribute=(concat 'id="' form--id form-group--id '-helper" aria-live="polite"')}} --}}
                         {{!-- Required. A list of node selector terms. The terms are ORed. --}}
                         {{!-- {{/form-helper-text}} --}}
@@ -609,7 +609,7 @@ subsection: forms
           {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') }}Path{{/form-label}}
         {{/form-group-label}}
         {{#> form-group-control}}
-          {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" placeholder="/" id="' form-group--id '" name="' form-group--id '" required')}}{{/form-control}}
+          {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" placeholder="/" id="' form-group--id '" name="' form-group--id '"')}}{{/form-control}}
           {{> form-helper-text helper-text--value='Path that the router watches to route traffic to the service.'}}
         {{/form-group-control}}
       {{/form-group}}

--- a/src/patternfly/demos/HelperText/examples/HelperText.md
+++ b/src/patternfly/demos/HelperText/examples/HelperText.md
@@ -14,7 +14,7 @@ section: components
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
+      {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
         {{> helper-text helper-text--value='This is helper text on a form field.'}}
       {{/form-helper-text}}
@@ -27,7 +27,7 @@ section: components
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-warning" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsWarning='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
         {{> helper-text helper-text--value='This is helper text for a warning.' helper-text-item--IsWarning=true}}
       {{/form-helper-text}}
@@ -40,7 +40,7 @@ section: components
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
           {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
@@ -57,7 +57,7 @@ section: components
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
+      {{#> form-control controlType="input" input="true" form-control--IsSuccess='true' form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
         {{> helper-text helper-text--value='This is dynamic helper text with an icon showing success.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
       {{/form-helper-text}}

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -179,7 +179,7 @@ section: components
             {{> form-group-label-help form-group-label-help--aria-label="More information for name field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
           {{/form-group-label}}
           {{#> form-group-control}}
-            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
           {{/form-group-control}}
         {{/form-group}}
         {{#> form-group form-group--id="-email"}}
@@ -190,7 +190,7 @@ section: components
             {{> form-group-label-help form-group-label-help--aria-label="More information for email field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
           {{/form-group-label}}
           {{#> form-group-control}}
-            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
           {{/form-group-control}}
         {{/form-group}}
         {{#> form-group form-group--id="-address"}}
@@ -201,7 +201,7 @@ section: components
             {{> form-group-label-help form-group-label-help--aria-label="More information for address field" form-group-label-help--aria-describedby=(concat form--id form-group--id)}}
           {{/form-group-label}}
           {{#> form-group-control}}
-            {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" required')}}{{/form-control}}
+            {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '"')}}{{/form-control}}
           {{/form-group-control}}
         {{/form-group}}
       {{/form}}

--- a/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
+++ b/src/patternfly/demos/PasswordGenerator/examples/PasswordGenerator.md
@@ -21,7 +21,7 @@ section: components
     {{#> form-group-control}}
       {{#> input-group}}
         {{#> input-group-item input-group-item--IsFill=true}}
-          {{> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="password" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
+          {{> form-control controlType="input" input="true"  form-control--IsRequired='true' form-control--attribute=(concat 'type="password" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
         {{/input-group-item}}
         {{#> input-group-item}}
           {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -20,7 +20,7 @@ section: components
     {{#> form-group-control}}
       {{#> input-group}}
         {{#> input-group-item input-group-item--IsFill=true}}
-          {{> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
+          {{> form-control controlType="input" input="true"  form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="" placeholder="Password"')}}
         {{/input-group-item}}
         {{#> input-group-item}}
           {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
@@ -55,7 +55,7 @@ section: components
     {{#> form-group-control}}
       {{#> input-group}}
         {{#> input-group-item input-group-item--IsFill=true}}
-          {{> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$RedHat78" placeholder="Password"')}}
+          {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$RedHat78" placeholder="Password"')}}
         {{/input-group-item}}
         {{#> input-group-item}}
           {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
@@ -91,7 +91,7 @@ section: components
     {{#> form-group-control}}
       {{#> input-group}}
         {{#> input-group-item input-group-item--IsFill=true}}
-          {{> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can3Read" placeholder="Password"')}}
+          {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can3Read" placeholder="Password"')}}
         {{/input-group-item}}
         {{#> input-group-item}}
           {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}
@@ -127,7 +127,7 @@ section: components
     {{#> form-group-control}}
       {{#> input-group}}
         {{#> input-group-item input-group-item--IsFill=true}}
-          {{> form-control controlType="input" input="true"  form-control--attribute=(concat 'required type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can8Read3Pass@Word" placeholder="Password"')}}
+          {{> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute=(concat 'type="text" id="' form--id form-group--id '" name="' form--id form-group--id '" aria-label="Password input" value="Marie$Can8Read3Pass@Word" placeholder="Password"')}}
         {{/input-group-item}}
         {{#> input-group-item}}
           {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Show password"'}}

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -60,7 +60,7 @@ import './Toolbar.css'
                   {{/date-picker}}
                   {{#> date-picker date-picker--id=(concat toolbar--id "-invalid") helper-text--value="Max: 08/10/2022" helper-text--IsError="true"}}
                     {{#> input-group}}
-                      {{> form-control controlType="input" input="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
+                      {{> form-control controlType="input" input="true" form-control--IsError='true' form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
                       {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Toggle date picker"'}}
                         <i class="fas fa-calendar-alt" aria-hidden="true"></i>
                       {{/button}}


### PR DESCRIPTION
Fixes #5566
Form control height was previously removed, but is necessary in some cases - however this causes a slight difference elsewhere. 

Alert horizontal and stacked forms
Calendar - no update needed
Clipboard copy
Datepicker
File upload - must set form control option (readonly) with the form-element hbs parameter
Form
Inline edit - also removed a large block of commented code that is no longer needed
Input group
Login
Number input
Pagination
Select
Slider - fixed in https://github.com/patternfly/patternfly/pull/5590
Text input group - no change necessary
Basic forms
Helper text
Modal
Password generator
Password strength
Toolbar
Wizard form
