### PR TITLE
fix(core): darkened circle icon to match dark theme

### DIFF
--- a/src/patternfly/components/Switch/examples/Switch.md
+++ b/src/patternfly/components/Switch/examples/Switch.md
@@ -105,7 +105,7 @@ cssPrefix: pf-v5-c-switch
 {{#> switch switch--attribute='for="switch-with-icon-disabled-1"'}}
   {{#> switch-input switch-input--id="switch-with-icon-disabled-1" switch-input--attribute='disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}
-    {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}
+    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
 <br/>
@@ -114,7 +114,7 @@ cssPrefix: pf-v5-c-switch
   {{#> switch-input switch-input--id="switch-with-icon-disabled-2" switch-input--attribute='disabled'}}
   {{/switch-input}}
   {{#> switch-toggle}}
-    {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}
+    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
 ```

--- a/src/patternfly/components/Switch/examples/Switch.md
+++ b/src/patternfly/components/Switch/examples/Switch.md
@@ -108,7 +108,7 @@ cssPrefix: pf-v5-c-switch
 {{#> switch switch--attribute='for="switch-with-icon-disabled-1"'}}
   {{#> switch-input switch-input--id="switch-with-icon-1" switch-input--attribute='disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}
-    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
+    {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}
   {{/switch-toggle}}
 {{/switch}}
 <br/>
@@ -117,7 +117,7 @@ cssPrefix: pf-v5-c-switch
   {{#> switch-input switch-input--id="switch-with-icon-2" switch-input--attribute='disabled'}}
   {{/switch-input}}
   {{#> switch-toggle}}
-    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
+    {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}
   {{/switch-toggle}}
 {{/switch}}
 ```

--- a/src/patternfly/components/Switch/examples/Switch.md
+++ b/src/patternfly/components/Switch/examples/Switch.md
@@ -100,9 +100,6 @@ cssPrefix: pf-v5-c-switch
   {{#> switch-label switch-label--id="switch-disabled-2-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--id="switch-disabled-2-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
-
-
-
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-with-icon-disabled-1"'}}

--- a/src/patternfly/components/Switch/examples/Switch.md
+++ b/src/patternfly/components/Switch/examples/Switch.md
@@ -100,6 +100,26 @@ cssPrefix: pf-v5-c-switch
   {{#> switch-label switch-label--id="switch-disabled-2-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--id="switch-disabled-2-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
+
+
+
+<br/>
+<br/>
+{{#> switch switch--attribute='for="switch-with-icon-disabled-1"'}}
+  {{#> switch-input switch-input--id="switch-with-icon-1" switch-input--attribute='disabled checked'}}{{/switch-input}}
+  {{#> switch-toggle}}
+    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
+  {{/switch-toggle}}
+{{/switch}}
+<br/>
+<br/>
+{{#> switch switch--attribute='for="switch-with-icon-disabled-2"'}}
+  {{#> switch-input switch-input--id="switch-with-icon-2" switch-input--attribute='disabled'}}
+  {{/switch-input}}
+  {{#> switch-toggle}}
+    {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
+  {{/switch-toggle}}
+{{/switch}}
 ```
 
 ## Documentation

--- a/src/patternfly/components/Switch/examples/Switch.md
+++ b/src/patternfly/components/Switch/examples/Switch.md
@@ -103,7 +103,7 @@ cssPrefix: pf-v5-c-switch
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-with-icon-disabled-1"'}}
-  {{#> switch-input switch-input--id="switch-with-icon-1" switch-input--attribute='disabled checked'}}{{/switch-input}}
+  {{#> switch-input switch-input--id="switch-with-icon-disabled-1" switch-input--attribute='disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}
   {{/switch-toggle}}
@@ -111,7 +111,7 @@ cssPrefix: pf-v5-c-switch
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-with-icon-disabled-2"'}}
-  {{#> switch-input switch-input--id="switch-with-icon-2" switch-input--attribute='disabled'}}
+  {{#> switch-input switch-input--id="switch-with-icon-disabled-2" switch-input--attribute='disabled'}}
   {{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon-disabled}}{{/switch-toggle-icon-disabled}}

--- a/src/patternfly/components/Switch/switch-toggle-icon-disabled.hbs
+++ b/src/patternfly/components/Switch/switch-toggle-icon-disabled.hbs
@@ -1,0 +1,6 @@
+<span class="{{pfv}}switch__toggle-icon-disabled{{#if switch-toggle-icon-disabled--modifier}} {{switch-toggle-icon-disabled--modifier}}{{/if}}"
+  {{#if switch-toggle-icon-disabled--attribute}}
+    {{{switch-toggle-icon-disabled--attribute}}}
+  {{/if}}>
+  <i class="fas fa-check" aria-hidden="true"></i>
+</span>

--- a/src/patternfly/components/Switch/switch-toggle-icon-disabled.hbs
+++ b/src/patternfly/components/Switch/switch-toggle-icon-disabled.hbs
@@ -1,6 +1,0 @@
-<span class="{{pfv}}switch__toggle-icon-disabled{{#if switch-toggle-icon-disabled--modifier}} {{switch-toggle-icon-disabled--modifier}}{{/if}}"
-  {{#if switch-toggle-icon-disabled--attribute}}
-    {{{switch-toggle-icon-disabled--attribute}}}
-  {{/if}}>
-  <i class="fas fa-check" aria-hidden="true"></i>
-</span>

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -11,6 +11,8 @@
   --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--Color--light-100);
   --#{$switch}__toggle-icon--Left: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
+  
+  // Switch icon disabled
   --#{$switch}__toggle-icon-disabled--FontSize: calc(var(--#{$switch}--FontSize) * .625); // We don't use an icon font-size here because this value allows the icon to scale relative to the switch's font-size.
   --#{$switch}__toggle-icon-disabled--Color: var(--pf-v5-global--palette--black-150);
   --#{$switch}__toggle-icon-disabled--Left: calc(var(--#{$switch}--FontSize) * .4);

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -11,6 +11,10 @@
   --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--Color--light-100);
   --#{$switch}__toggle-icon--Left: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
+  --#{$switch}__toggle-icon-disabled--FontSize: calc(var(--#{$switch}--FontSize) * .625); // We don't use an icon font-size here because this value allows the icon to scale relative to the switch's font-size.
+  --#{$switch}__toggle-icon-disabled--Color: var(--pf-v5-global--palette--black-150);
+  --#{$switch}__toggle-icon-disabled--Left: calc(var(--#{$switch}--FontSize) * .4);
+  --#{$switch}__toggle-icon-disabled--Offset: #{pf-size-prem(2px)};
 
   // Switch
   --#{$switch}--LineHeight: var(--#{$pf-global}--LineHeight--md);
@@ -18,6 +22,7 @@
 
   // Switch input
   --#{$switch}__input--checked__toggle--BackgroundColor: var(--#{$pf-global}--primary-color--100);
+  --#{$switch}__input--checked__toggle--before--TranslateX: calc(100% + var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__input--checked__toggle--before--TranslateX: calc(100% + var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__input--checked__label--Color: var(--#{$pf-global}--Color--dark-100);
   --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--disabled-color--100);
@@ -33,6 +38,7 @@
   --#{$switch}__toggle--BackgroundColor: var(--#{$pf-global}--palette--black-500);
   --#{$switch}__toggle--BorderRadius: var(--#{$switch}__toggle--Height);
   --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon--Offset));
+  --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon-disabled--Offset));
   --#{$switch}__toggle--before--Height: var(--#{$switch}__toggle--before--Width);
   --#{$switch}__toggle--before--Top: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
   --#{$switch}__toggle--before--Left: var(--#{$switch}__toggle--before--Top);
@@ -41,6 +47,7 @@
   --#{$switch}__toggle--before--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$switch}__toggle--before--Transition: transform .25s ease 0s;
   --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon--Offset) + var(--#{$switch}__toggle--before--Width));
+  --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon-disabled--Offset) + var(--#{$switch}__toggle--before--Width));
 
   // Switch label
   --#{$switch}__label--Color: var(--#{$pf-global}--Color--dark-100);
@@ -163,6 +170,17 @@
   align-items: center;
   font-size: var(--#{$switch}__toggle-icon--FontSize);
   color: var(--#{$switch}__toggle-icon--Color);
+}
+
+.#{$switch}__toggle-icon-disabled {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--#{$switch}__toggle-icon-disabled--Left);
+  display: flex;
+  align-items: center;
+  font-size: var(--#{$switch}__toggle-icon-disabled--FontSize);
+  color: var(--#{$switch}__toggle-icon-disabled--Color);
 }
 
 .#{$switch}__label {

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -11,6 +11,7 @@
   --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--Color--light-100);
   --#{$switch}__toggle-icon--Left: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
+  --#{$switch}__input--disabled__toggle-icon--Color: var(--#{$pf-global}--palette--black-150);
 
   // Switch
   --#{$switch}--LineHeight: var(--#{$pf-global}--LineHeight--md);
@@ -121,6 +122,8 @@
     }
 
     ~ .#{$switch}__toggle {
+      --#{$switch}__toggle-icon--Color: var(--#{$switch}__input--disabled__toggle-icon--Color);
+
       cursor: not-allowed;
       background-color: var(--#{$switch}__input--disabled__toggle--BackgroundColor);
 

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -11,12 +11,6 @@
   --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--Color--light-100);
   --#{$switch}__toggle-icon--Left: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
-  
-  // Switch icon disabled
-  --#{$switch}__toggle-icon-disabled--FontSize: calc(var(--#{$switch}--FontSize) * .625); // We don't use an icon font-size here because this value allows the icon to scale relative to the switch's font-size.
-  --#{$switch}__toggle-icon-disabled--Color: var(--pf-v5-global--palette--black-150);
-  --#{$switch}__toggle-icon-disabled--Left: calc(var(--#{$switch}--FontSize) * .4);
-  --#{$switch}__toggle-icon-disabled--Offset: #{pf-size-prem(2px)};
 
   // Switch
   --#{$switch}--LineHeight: var(--#{$pf-global}--LineHeight--md);
@@ -24,7 +18,6 @@
 
   // Switch input
   --#{$switch}__input--checked__toggle--BackgroundColor: var(--#{$pf-global}--primary-color--100);
-  --#{$switch}__input--checked__toggle--before--TranslateX: calc(100% + var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__input--checked__toggle--before--TranslateX: calc(100% + var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__input--checked__label--Color: var(--#{$pf-global}--Color--dark-100);
   --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--disabled-color--100);
@@ -40,7 +33,6 @@
   --#{$switch}__toggle--BackgroundColor: var(--#{$pf-global}--palette--black-500);
   --#{$switch}__toggle--BorderRadius: var(--#{$switch}__toggle--Height);
   --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon--Offset));
-  --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon-disabled--Offset));
   --#{$switch}__toggle--before--Height: var(--#{$switch}__toggle--before--Width);
   --#{$switch}__toggle--before--Top: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
   --#{$switch}__toggle--before--Left: var(--#{$switch}__toggle--before--Top);
@@ -49,7 +41,6 @@
   --#{$switch}__toggle--before--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$switch}__toggle--before--Transition: transform .25s ease 0s;
   --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon--Offset) + var(--#{$switch}__toggle--before--Width));
-  --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon-disabled--Offset) + var(--#{$switch}__toggle--before--Width));
 
   // Switch label
   --#{$switch}__label--Color: var(--#{$pf-global}--Color--dark-100);
@@ -172,17 +163,6 @@
   align-items: center;
   font-size: var(--#{$switch}__toggle-icon--FontSize);
   color: var(--#{$switch}__toggle-icon--Color);
-}
-
-.#{$switch}__toggle-icon-disabled {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: var(--#{$switch}__toggle-icon-disabled--Left);
-  display: flex;
-  align-items: center;
-  font-size: var(--#{$switch}__toggle-icon-disabled--FontSize);
-  color: var(--#{$switch}__toggle-icon-disabled--Color);
 }
 
 .#{$switch}__label {

--- a/src/patternfly/components/Switch/themes/dark/switch.scss
+++ b/src/patternfly/components/Switch/themes/dark/switch.scss
@@ -3,8 +3,9 @@
 @mixin pf-v5-theme-dark-switch() {
   .#{$switch} {
     --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--BackgroundColor--100);
+    --#{$switch}__toggle-icon-disabled--Color: var(--#{$pf-global}--Color--100);
     --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--Color--100);
-    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--Color--100);
     --#{$switch}__toggle--before--BoxShadow: none;
   }
 }

--- a/src/patternfly/components/Switch/themes/dark/switch.scss
+++ b/src/patternfly/components/Switch/themes/dark/switch.scss
@@ -6,5 +6,6 @@
     --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--Color--100);
     --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--disabled-color--100);
     --#{$switch}__toggle--before--BoxShadow: none;
+    --#{$switch}__input--disabled__toggle-icon--Color: var(--#{$pf-global}--disabled-color--100);
   }
 }

--- a/src/patternfly/components/Switch/themes/dark/switch.scss
+++ b/src/patternfly/components/Switch/themes/dark/switch.scss
@@ -3,7 +3,6 @@
 @mixin pf-v5-theme-dark-switch() {
   .#{$switch} {
     --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--BackgroundColor--100);
-    --#{$switch}__toggle-icon-disabled--Color: var(--#{$pf-global}--disabled-color--100);
     --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--Color--100);
     --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--disabled-color--100);
     --#{$switch}__toggle--before--BoxShadow: none;

--- a/src/patternfly/components/Switch/themes/dark/switch.scss
+++ b/src/patternfly/components/Switch/themes/dark/switch.scss
@@ -3,9 +3,9 @@
 @mixin pf-v5-theme-dark-switch() {
   .#{$switch} {
     --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--BackgroundColor--100);
-    --#{$switch}__toggle-icon-disabled--Color: var(--#{$pf-global}--Color--100);
+    --#{$switch}__toggle-icon-disabled--Color: var(--#{$pf-global}--disabled-color--100);
     --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--Color--100);
-    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--Color--100);
+    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--disabled-color--100);
     --#{$switch}__toggle--before--BoxShadow: none;
   }
 }

--- a/src/patternfly/components/Switch/themes/dark/switch.scss
+++ b/src/patternfly/components/Switch/themes/dark/switch.scss
@@ -4,7 +4,7 @@
   .#{$switch} {
     --#{$switch}__toggle-icon--Color: var(--#{$pf-global}--BackgroundColor--100);
     --#{$switch}__input--not-checked__label--Color: var(--#{$pf-global}--Color--100);
-    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--disabled-color--100);
+    --#{$switch}__input--disabled__toggle--before--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
     --#{$switch}__toggle--before--BoxShadow: none;
   }
 }


### PR DESCRIPTION
Adjusted the disabled switch in dark mode so that the colors match the other dark mode switches. Also added extra switches to include option with check.
<img width="456" alt="Screenshot 2023-06-07 at 10 30 48 AM" src="https://github.com/patternfly/patternfly/assets/123661468/431623f8-2930-4f1b-881c-c28c3a17514a">

Closes https://github.com/patternfly/patternfly/issues/5622