### PR TITLE
chore(select): fixed text in HTML example to show multiple checks can be selected

### DIFF
--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -403,6 +403,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-secondary` | `.pf-v5-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-v5-c-button` | Modifies for tertiary styles. |
 | `.pf-m-danger` | `.pf-v5-c-button` | Modifies for danger styles. |
+| `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -403,7 +403,6 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-secondary` | `.pf-v5-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-v5-c-button` | Modifies for tertiary styles. |
 | `.pf-m-danger` | `.pf-v5-c-button` | Modifies for danger styles. |
-| `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |

--- a/src/patternfly/components/Select/__select-menu-descriptive.hbs
+++ b/src/patternfly/components/Select/__select-menu-descriptive.hbs
@@ -16,11 +16,6 @@
       {{/select-menu-item}}
     </li>
     <li role="presentation">
-      {{#> select-menu-item select-menu-item--IsSelected="true"}}
-        Menu item selected
-      {{/select-menu-item}}
-    </li>
-    <li role="presentation">
       {{#> select-menu-item select-menu-item--Description="This is a description."}}
         Menu item description
       {{/select-menu-item}}
@@ -30,6 +25,11 @@
         {{#> select-menu-item-main}}
           Menu item description disabled
         {{/select-menu-item-main}}
+      {{/select-menu-item}}
+    </li>
+    <li role="presentation">
+      {{#> select-menu-item select-menu-item--Description="This is a description." select-menu-item--IsSelected="true"}}
+        Menu item description selected
       {{/select-menu-item}}
     </li>
     <li role="presentation">

--- a/src/patternfly/components/Select/__select-menu-descriptive.hbs
+++ b/src/patternfly/components/Select/__select-menu-descriptive.hbs
@@ -33,12 +33,7 @@
       {{/select-menu-item}}
     </li>
     <li role="presentation">
-      {{#> select-menu-item select-menu-item--Description="This is a description." select-menu-item--IsSelected="true"}}
-        Menu item description selected
-      {{/select-menu-item}}
-    </li>
-    <li role="presentation">
-      {{#> select-menu-item select-menu-item--Description="This is a really long description that describes the menu item. This is a really long description that describes the menu item." select-menu-item--IsSelected="true"}}
+      {{#> select-menu-item select-menu-item--Description="This is a really long description that describes the menu item. This is a really long description that describes the menu item."}}
         Menu item long description
       {{/select-menu-item}}
     </li>

--- a/src/patternfly/components/Select/deprecated/Select.css
+++ b/src/patternfly/components/Select/deprecated/Select.css
@@ -30,7 +30,8 @@
 }
 
 #ws-html-deprecated-c-select-multi-with-typeahead-chip-group-expanded,
-#ws-html-deprecated-c-select-menu-footer {
+#ws-html-deprecated-c-select-menu-footer,
+#ws-html-deprecated-c-select-checkbox-item-description {
   min-height: 365px;
 }
 
@@ -46,8 +47,7 @@
   min-height: 120px;
 }
 
-#ws-html-deprecated-c-select-item-description,
-#ws-html-deprecated-c-select-checkbox-item-description {
+#ws-html-deprecated-c-select-item-description {
   min-height: 400px;
 }
 

--- a/src/patternfly/components/Select/deprecated/Select.md
+++ b/src/patternfly/components/Select/deprecated/Select.md
@@ -114,13 +114,13 @@ The single select should be used when the user is selecting an option from a lis
 
 ### Single with typeahead expanded
 ```hbs
-{{#> select select-toggle--type="div" select--id="select-single-typeahead-expanded" select--IsExpanded="true" select--IsTypeahead="true" select-toggle--type="div" select--IsCurrentlyTyping="true" select--ItemIsSelected="true" select-typeahead--Placeholder="New"}}
+{{#> select select-toggle--type="div" select--id="select-single-typeahead-expanded" select--IsExpanded="true" select--IsTypeahead="true" select-toggle--type="div" select--IsCurrentlyTyping="true" select--ItemIsSelected="true" select-typeahead--Placeholder="Choose a state" select-typeahead--Value="New"}}
 {{/select}}
 ```
 
 ### Single with typeahead expanded and selected
 ```hbs
-{{#> select select-toggle--type="div" select--id="select-single-typeahead-expanded-selected" select--ItemIsSelected="true" select--IsExpanded="true" select--IsTypeahead="true" select-toggle--type="div" select-typeahead--Placeholder="New Mexico"}}
+{{#> select select-toggle--type="div" select--id="select-single-typeahead-expanded-selected" select--ItemIsSelected="true" select--IsExpanded="true" select--IsTypeahead="true" select-toggle--type="div" select-typeahead--Placeholder="Choose a state" select-typeahead--Value="New Mexico"}}
 {{/select}}
 ```
 
@@ -174,7 +174,7 @@ The single select typeahead should be used when the user is selecting one option
 
 ### Multi with typeahead (chip group collapsed)
 ```hbs
-{{#> select select-toggle--type="div" select--id="select-multi-typeahead-expanded-selected" select--IsMultiSelect="true" select--IsExpanded="true" select--IsTypeahead="true" select--ItemIsSelected="true" select--IsCurrentlyTyping="true" select-typeahead--Placeholder="New"}}
+{{#> select select-toggle--type="div" select--id="select-multi-typeahead-expanded-selected" select--IsMultiSelect="true" select--IsExpanded="true" select--IsTypeahead="true" select--ItemIsSelected="true" select--IsCurrentlyTyping="true" select-typeahead--Placeholder="Choose states" select-typeahead--Value="New"}}
 {{/select}}
 ```
 

--- a/src/patternfly/components/Select/deprecated/Select.md
+++ b/src/patternfly/components/Select/deprecated/Select.md
@@ -217,35 +217,35 @@ The multiselect should be used when the user is selecting multiple items from a 
 
 ### Checkbox expanded
 ```hbs
-{{#> select select--id="select-checkbox-expanded" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-expanded" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" }}
   Filter
 {{/select}}
 ```
 
 ### Checkbox expanded and selected with groups
 ```hbs
-{{#> select select--id="select-checkbox-expanded-selected" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-expanded-selected" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true"}}
   Filter by status
 {{/select}}
 ```
 
 ### Checkbox expanded and selected with groups and filter
 ```hbs
-{{#> select select--id="select-checkbox-expanded-selected-filter-example" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsFilterable="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-expanded-selected-filter-example" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsFilterable="true"}}
   Filter by status
 {{/select}}
 ```
 
 ### Checkbox expanded without badge
 ```hbs
-{{#> select select--id="select-checkbox-without-badge" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsNoBadge="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-without-badge" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsNoBadge="true" }}
   Filter
 {{/select}}
 ```
 
 ### Checkbox with counts
 ```hbs
-{{#> select select--id="select-checkbox-counts" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--HasCounts="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-counts" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--HasCounts="true" }}
   Filter
 {{/select}}
 ```
@@ -355,7 +355,7 @@ The plain select variation should be used when you do not want a border applied 
 
 ### Checkbox item description
 ```hbs
-{{#> select select--id="select-checkbox-description" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsMultiSelect="true"}}
+{{#> select select--id="select-checkbox-description" select--IsCheckboxSelect="true" select--IsExpanded="true"}}
   Filter
 {{/select}}
 ```

--- a/src/patternfly/components/Select/deprecated/Select.md
+++ b/src/patternfly/components/Select/deprecated/Select.md
@@ -217,35 +217,35 @@ The multiselect should be used when the user is selecting multiple items from a 
 
 ### Checkbox expanded
 ```hbs
-{{#> select select--id="select-checkbox-expanded" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true"}}
+{{#> select select--id="select-checkbox-expanded" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsMultiSelect="true"}}
   Filter
 {{/select}}
 ```
 
 ### Checkbox expanded and selected with groups
 ```hbs
-{{#> select select--id="select-checkbox-expanded-selected" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true"}}
+{{#> select select--id="select-checkbox-expanded-selected" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsMultiSelect="true"}}
   Filter by status
 {{/select}}
 ```
 
 ### Checkbox expanded and selected with groups and filter
 ```hbs
-{{#> select select--id="select-checkbox-expanded-selected-filter-example" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsFilterable="true"}}
+{{#> select select--id="select-checkbox-expanded-selected-filter-example" select--IsCheckboxSelect="true" select--IsChecked="true" select--IsExpanded="true" select--HasGroups="true" select--IsFilterable="true" select--IsMultiSelect="true"}}
   Filter by status
 {{/select}}
 ```
 
 ### Checkbox expanded without badge
 ```hbs
-{{#> select select--id="select-checkbox-without-badge" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsNoBadge="true"}}
+{{#> select select--id="select-checkbox-without-badge" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsNoBadge="true" select--IsMultiSelect="true"}}
   Filter
 {{/select}}
 ```
 
 ### Checkbox with counts
 ```hbs
-{{#> select select--id="select-checkbox-counts" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--HasCounts="true"}}
+{{#> select select--id="select-checkbox-counts" select--IsChecked="true" select--IsCheckboxSelect="true" select--IsExpanded="true" select--HasCounts="true" select--IsMultiSelect="true"}}
   Filter
 {{/select}}
 ```
@@ -355,7 +355,7 @@ The plain select variation should be used when you do not want a border applied 
 
 ### Checkbox item description
 ```hbs
-{{#> select select--id="select-checkbox-description" select--IsCheckboxSelect="true" select--IsExpanded="true"}}
+{{#> select select--id="select-checkbox-description" select--IsCheckboxSelect="true" select--IsExpanded="true" select--IsMultiSelect="true"}}
   Filter
 {{/select}}
 ```

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -3,20 +3,20 @@
     input="true"
     form-control--IsDisabled='true'
     form-control--modifier="pf-v5-c-select__toggle-typeahead"
-    form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
+    form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
   {{/form-control}}
 {{else}}
   {{#if select--IsInvalid}}
     {{#> form-control controlType="input"
       input="true"
       form-control--modifier="pf-v5-c-select__toggle-typeahead"
-      form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
+      form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
     {{/form-control}}
   {{else}}
     {{#> form-control controlType="input"
       input="true"
       form-control--modifier="pf-v5-c-select__toggle-typeahead"
-      form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
+      form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" value="' select-typeahead--Value '" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
     {{/form-control}}
   {{/if}}
 {{/if}}

--- a/src/patternfly/components/Select/select.hbs
+++ b/src/patternfly/components/Select/select.hbs
@@ -12,11 +12,11 @@
   {{/if}}>
   {{!-- hidden spans for a11y --}}
   {{#unless select--HasCustomLabel}}
-    {{#if select--IsMultiSelect}}
+    {{#ifAny select--IsMultiSelect select--IsCheckboxSelect}}
       <span id="{{select--id}}-label" hidden>{{#if select-typeahead--Placeholder}} {{select-typeahead--Placeholder}}{{else}}Choose many{{/if}}</span>
     {{else}}
       <span id="{{select--id}}-label" hidden>{{#if select-typeahead--Placeholder}} {{select-typeahead--Placeholder}}{{else}}Choose one{{/if}}</span>
-    {{/if}}
+    {{/ifAny}}
   {{/unless}}
 
   {{#if select--IsCustom}}


### PR DESCRIPTION
Fixed some of the hidden labels in the HTML examples on Select page. Some were saying to choose one when multiple could be selected. Adjusted to reflect that.

Closes: [#5653](https://github.com/patternfly/patternfly/issues/5653) 