### PR TITLE
feat(Button): extended inline styling

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -144,12 +144,6 @@
   --#{$button}--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
   --#{$button}--m-plain--disabled--BackgroundColor: transparent;
 
-    // Plain compact button
-    --#{$button}--m-plain--m-compact--PaddingTop: 0;
-    --#{$button}--m-plain--m-compact--PaddingRight: 0;
-    --#{$button}--m-plain--m-compact--PaddingBottom: 0;
-    --#{$button}--m-plain--m-compact--PaddingLeft: 0;
-
   // Control Button
   --#{$button}--m-control--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
   --#{$button}--m-control--Color: var(--#{$pf-global}--Color--100);
@@ -565,13 +559,8 @@
     color: var(--#{$button}--m-plain--Color);
     background-color: var(--#{$button}--m-plain--BackgroundColor);
 
-    &.pf-m-compact {
-      --#{$button}--PaddingTop: var(--#{$button}--m-plain--m-compact--PaddingTop);
-      --#{$button}--PaddingRight: var(--#{$button}--m-plain--m-compact--PaddingRight);
-      --#{$button}--PaddingBottom: var(--#{$button}--m-plain--m-compact--PaddingBottom);
-      --#{$button}--PaddingLeft: var(--#{$button}--m-plain--m-compact--PaddingLeft);
-  
-      line-height: 1;
+    &.pf-m-no-padding {
+      padding: 0;
     }
 
     &:hover {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -143,12 +143,12 @@
   --#{$button}--m-plain--active--Color: var(--#{$pf-global}--Color--100);
   --#{$button}--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
   --#{$button}--m-plain--disabled--BackgroundColor: transparent;
-  --#{$button}--m-plain--m-inline--FontSize: inherit;
-  --#{$button}--m-plain--m-inline--PaddingTop: 0;
-  --#{$button}--m-plain--m-inline--PaddingRight: var(--#{$pf-global}--spacer--sm);;
-  --#{$button}--m-plain--m-inline--PaddingBottom: 0;
-  --#{$button}--m-plain--m-inline--PaddingLeft: var(--#{$pf-global}--spacer--sm);;
-  --#{$button}--m-plain--m-inline--LineHeight: normal;
+
+    // Plain compact button
+    --#{$button}--m-plain--m-compact--PaddingTop: 0;
+    --#{$button}--m-plain--m-compact--PaddingRight: 0;
+    --#{$button}--m-plain--m-compact--PaddingBottom: 0;
+    --#{$button}--m-plain--m-compact--PaddingLeft: 0;
 
   // Control Button
   --#{$button}--m-control--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
@@ -565,13 +565,13 @@
     color: var(--#{$button}--m-plain--Color);
     background-color: var(--#{$button}--m-plain--BackgroundColor);
 
-    &.pf-m-inline {
-      padding-block-start: var(--#{$button}--m-plain--m-inline--PaddingTop);
-      padding-block-end: var(--#{$button}--m-plain--m-inline--PaddingBottom);
-      padding-inline-start: var(--#{$button}--m-plain--m-inline--PaddingLeft);
-      padding-inline-end: var(--#{$button}--m-plain--m-inline--PaddingRight);
-      font-size: var(--#{$button}--m-plain--m-inline--FontSize);
-      line-height: var(--#{$button}--m-plain--m-inline--LineHeight);
+    &.pf-m-compact {
+      --#{$button}--PaddingTop: var(--#{$button}--m-plain--m-compact--PaddingTop);
+      --#{$button}--PaddingRight: var(--#{$button}--m-plain--m-compact--PaddingRight);
+      --#{$button}--PaddingBottom: var(--#{$button}--m-plain--m-compact--PaddingBottom);
+      --#{$button}--PaddingLeft: var(--#{$button}--m-plain--m-compact--PaddingLeft);
+  
+      line-height: 1;
     }
 
     &:hover {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -143,6 +143,12 @@
   --#{$button}--m-plain--active--Color: var(--#{$pf-global}--Color--100);
   --#{$button}--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
   --#{$button}--m-plain--disabled--BackgroundColor: transparent;
+  --#{$button}--m-plain--m-inline--FontSize: inherit;
+  --#{$button}--m-plain--m-inline--PaddingTop: 0;
+  --#{$button}--m-plain--m-inline--PaddingRight: var(--#{$pf-global}--spacer--sm);;
+  --#{$button}--m-plain--m-inline--PaddingBottom: 0;
+  --#{$button}--m-plain--m-inline--PaddingLeft: var(--#{$pf-global}--spacer--sm);;
+  --#{$button}--m-plain--m-inline--LineHeight: normal;
 
   // Control Button
   --#{$button}--m-control--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
@@ -558,6 +564,12 @@
 
     color: var(--#{$button}--m-plain--Color);
     background-color: var(--#{$button}--m-plain--BackgroundColor);
+
+    &.pf-m-inline {
+      padding: var(--#{$button}--m-plain--m-inline--PaddingTop) var(--#{$button}--m-plain--m-inline--PaddingRight) var(--#{$button}--m-plain--m-inline--PaddingBottom) var(--#{$button}--m-plain--m-inline--PaddingLeft);
+      font-size: var(--#{$button}--m-plain--m-inline--FontSize);
+      line-height: var(--#{$button}--m-plain--m-inline--LineHeight);
+    }
 
     &:hover {
       --#{$button}--m-plain--Color: var(--#{$button}--m-plain--hover--Color);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -566,7 +566,10 @@
     background-color: var(--#{$button}--m-plain--BackgroundColor);
 
     &.pf-m-inline {
-      padding: var(--#{$button}--m-plain--m-inline--PaddingTop) var(--#{$button}--m-plain--m-inline--PaddingRight) var(--#{$button}--m-plain--m-inline--PaddingBottom) var(--#{$button}--m-plain--m-inline--PaddingLeft);
+      padding-block-start: var(--#{$button}--m-plain--m-inline--PaddingTop);
+      padding-block-end: var(--#{$button}--m-plain--m-inline--PaddingBottom);
+      padding-inline-start: var(--#{$button}--m-plain--m-inline--PaddingLeft);
+      padding-inline-end: var(--#{$button}--m-plain--m-inline--PaddingRight);
       font-size: var(--#{$button}--m-plain--m-inline--FontSize);
       line-height: var(--#{$button}--m-plain--m-inline--LineHeight);
     }

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -64,6 +64,20 @@ import './Button.css'
 {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
   <i class="fas fa-times" aria-hidden="true"></i>
 {{/button}}
+
+<span style="font-size: 12px;">
+  <span>Inline plain button</span>
+  {{#> button button--modifier="pf-m-plain pf-m-inline" button--attribute='aria-label="Remove"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+</span>
+
+<span style="font-size: 24px;">
+  <span>Inline plain button</span>
+  {{#> button button--modifier="pf-m-plain pf-m-inline" button--attribute='aria-label="Remove"'}}
+    <i class="fas fa-times" aria-hidden="true"></i>
+  {{/button}}
+</span>
 <br><br>
 {{#> button button--modifier="pf-m-control"}}
   Control

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -411,7 +411,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
-| `.pf-m-no-padding` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. |
+| `.pf-m-no-padding` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. Should only be used when the button is inline within a sentence or block of text. Multiple plain buttons without padding should not be placed adjacent to one another without spacing between them. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-v5-c-button` | Creates a block level button. |
 | `.pf-m-control` | `.pf-v5-c-button` | Modifies for control styles. **Note:** This modifier should only be used when using buttons in the Input Group or Clipboard Copy components. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -66,8 +66,8 @@ import './Button.css'
   <i class="fas fa-times" aria-hidden="true"></i>
 {{/button}}
 <br>
-<span>Compact plain button: </span>
-{{#> button button--modifier="pf-m-plain pf-m-compact" button--attribute='aria-label="Remove"'}}
+<span>No padding plain button: </span>
+{{#> button button--modifier="pf-m-plain pf-m-no-padding" button--attribute='aria-label="Remove"'}}
   <i class="fas fa-times" aria-hidden="true"></i>
 {{/button}}
 <br><br>
@@ -411,7 +411,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
-| `.pf-m-compact` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. |
+| `.pf-m-no-padding` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-v5-c-button` | Creates a block level button. |
 | `.pf-m-control` | `.pf-v5-c-button` | Modifies for control styles. **Note:** This modifier should only be used when using buttons in the Input Group or Clipboard Copy components. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -411,7 +411,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
-| `.pf-m-no-padding` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. Should only be used when the button is inline within a sentence or block of text. Multiple plain buttons without padding should not be placed adjacent to one another without spacing between them. |
+| `.pf-m-no-padding` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. This modifier should only be used when the button is inline within a sentence or block of text. Adjacent plain buttons without padding should always have spacing between them. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-v5-c-button` | Creates a block level button. |
 | `.pf-m-control` | `.pf-v5-c-button` | Modifies for control styles. **Note:** This modifier should only be used when using buttons in the Input Group or Clipboard Copy components. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -61,23 +61,15 @@ import './Button.css'
 {{/button}}
 <br>
 <br>
+<span>Default plain button: </span>
 {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
   <i class="fas fa-times" aria-hidden="true"></i>
 {{/button}}
-
-<span style="font-size: 12px;">
-  <span>Inline plain button</span>
-  {{#> button button--modifier="pf-m-plain pf-m-inline" button--attribute='aria-label="Remove"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
-</span>
-
-<span style="font-size: 24px;">
-  <span>Inline plain button</span>
-  {{#> button button--modifier="pf-m-plain pf-m-inline" button--attribute='aria-label="Remove"'}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
-</span>
+<br>
+<span>Compact plain button: </span>
+{{#> button button--modifier="pf-m-plain pf-m-compact" button--attribute='aria-label="Remove"'}}
+  <i class="fas fa-times" aria-hidden="true"></i>
+{{/button}}
 <br><br>
 {{#> button button--modifier="pf-m-control"}}
   Control
@@ -86,11 +78,11 @@ import './Button.css'
 {{#> button button--modifier="pf-m-control" button--attribute='aria-label="Copy input"'}}
   <i class="fas fa-copy" aria-hidden="true"></i>
 {{/button}}
+```
 
-<br>
-<br>
-<br>
+### Small buttons
 
+```hbs
 {{#> button button--modifier="pf-m-primary pf-m-small"}}
   Primary
 {{/button}}
@@ -137,7 +129,6 @@ import './Button.css'
   Control
 {{/button}}
 ```
-
 ### Disabled
 ```hbs
 {{#> button button--modifier="pf-m-primary" button--attribute="disabled"}}
@@ -420,6 +411,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-warning` | `.pf-v5-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v5-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
 | `.pf-m-plain` | `.pf-v5-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
+| `.pf-m-compact` | `.pf-v5-c-button.pf-m-plain` | Modifies a plain button to remove padding. |
 | `.pf-m-inline` | `.pf-v5-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-v5-c-button` | Creates a block level button. |
 | `.pf-m-control` | `.pf-v5-c-button` | Modifies for control styles. **Note:** This modifier should only be used when using buttons in the Input Group or Clipboard Copy components. |


### PR DESCRIPTION
Closes #5351 

@mceledonia @mcoker This draft currently only extends inline support to the plain button. I did try seeing what similar styling might look like for other button variants, for example the primary variant:

![Inline primary example](https://github.com/patternfly/patternfly/assets/70952936/a1665d63-776e-4e2a-9dfc-d10f61274fc1)

One thing to note is that with the Tabs component's action buttons (close and help), the icon becomes a little bigger than it currently is (can be fixed by adding a font size CSS var for pf-v5-c-tabs__item-action), and the outline on focus gets a little overlapped on the top and bottom:

![Tabs action button outline](https://github.com/patternfly/patternfly/assets/70952936/8568db0a-011b-4d99-b449-fa51e88ea2d5)


 We could use the current outline offset in the Tabs css (-0.1875rem), though that might make it feel cramped using `--pf-v5-global--FontSize--xs` (worse if the font size is custom and smaller than this):

![Tabs action buttons outline with offset](https://github.com/patternfly/patternfly/assets/70952936/3d8d3ada-a2e9-4ae5-8bf1-87e6045e3e6c)

This is also assuming we'd want to move the button styling out of the Tabs scss. If not, then it's a bit simpler to keep the `pf-v5-c-tabs__item-action .pf-v5-c-button` block and add the outline offset there.

