### PR TITLE
fix(form-control): change divs to spans

### DIFF
--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -172,10 +172,10 @@ Resizes in both directions
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v5-c-form-control` | `<div>` |  Initiates a container for an input, text area or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
-| `.pf-v5-c-form-control__utilities` | `<div>` |  Initiates a container for elements like icons to be associated with the form control.  |
-| `.pf-v5-c-form-control__icon` | `<div>` |  Creates a container for an icon associated with a form control.  |
-| `.pf-v5-c-form-control__toggle-icon` | `<div>` |  Initiates a toggle icon for a form select.  |
+| `.pf-v5-c-form-control` | `<span>` |  Initiates a container for an input, text area or select. For styling of checkboxes or radios see the [checkbox component](/components/checkbox) or [radio component](/components/radio). **Required**  |
+| `.pf-v5-c-form-control__utilities` | `<span>` |  Initiates a container for elements like icons to be associated with the form control.  |
+| `.pf-v5-c-form-control__icon` | `<span>` |  Creates a container for an icon associated with a form control.  |
+| `.pf-v5-c-form-control__toggle-icon` | `<span>` |  Initiates a toggle icon for a form select.  |
 | `.pf-m-resize-vertical` | `.pf-v5-c-form-control` | Modifies a form control element containing a text area so it can only be resized vertically. |
 | `.pf-m-resize-horizontal` | `.pf-v5-c-form-control` | Modifies a form control element containing a text area so it can only be resized horizontally. |
 | `.pf-m-resize-both` | `.pf-v5-c-form-control` | Modifies a `.pf-v5-c-form-control` element containing a text area so it resizes in both directions. |

--- a/src/patternfly/components/FormControl/form-control-icon.hbs
+++ b/src/patternfly/components/FormControl/form-control-icon.hbs
@@ -1,6 +1,6 @@
-<div class="{{pfv}}form-control__icon{{#if form-control-icon--IsStatus}} pf-m-status{{/if}}{{#if form-control-icon--modifier}} {{form-control-icon--modifier}}{{/if}}"
+<span class="{{pfv}}form-control__icon{{#if form-control-icon--IsStatus}} pf-m-status{{/if}}{{#if form-control-icon--modifier}} {{form-control-icon--modifier}}{{/if}}"
   {{#if form-control-icon--attribute}}
     {{{form-control-icon--attribute}}}
   {{/if}}>
   <i class="fas fa-{{form-control--HasIcon}}" aria-hidden="true"></i>
-</div>
+</span>

--- a/src/patternfly/components/FormControl/form-control-select.hbs
+++ b/src/patternfly/components/FormControl/form-control-select.hbs
@@ -10,7 +10,7 @@
   {{#ifAny form-control--HasIcon form-control--IsError form-control--IsSuccess form-control--IsWarning}}
     {{> form-control-template-status}}
   {{/ifAny}}
-  <div class="{{pfv}}form-control__toggle-icon">
+  <span class="{{pfv}}form-control__toggle-icon">
     <i class="fas fa-caret-down" aria-hidden="true"></i>
-  </div>
+  </span>
 {{/form-control-utilities}}

--- a/src/patternfly/components/FormControl/form-control-utilities.hbs
+++ b/src/patternfly/components/FormControl/form-control-utilities.hbs
@@ -1,6 +1,6 @@
-<div class="{{pfv}}form-control__utilities{{#if form-control-utilities--modifier}} {{form-control-utilities--modifier}}{{/if}}"
+<span class="{{pfv}}form-control__utilities{{#if form-control-utilities--modifier}} {{form-control-utilities--modifier}}{{/if}}"
   {{#if form-control-utilities--attribute}}
     {{{form-control-utilities--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</span>

--- a/src/patternfly/components/FormControl/form-control.hbs
+++ b/src/patternfly/components/FormControl/form-control.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}form-control
+<span class="{{pfv}}form-control
   {{#if form-control--IsExpanded}} pf-m-expanded{{/if}}
   {{#if form-control--IsDisabled}} pf-m-disabled{{/if}}
   {{#if form-control--IsReadonly}} pf-m-readonly{{/if}}
@@ -35,4 +35,4 @@
       {{/form-control-utilities}}
     {{/ifAny}}
   {{/ifEquals}}
-</div>
+</span>


### PR DESCRIPTION
Fixes #5701 
Changes all the divs in a form control to be spans to allow a form control to be inside phrasing content.