### PR TITLE
fix(toolbar): revert alignment of chip/filter layout

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -369,7 +369,7 @@ $pf-v5-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2
     --#{$toolbar}--spacer: var(--#{$toolbar}__item--m-search-filter--spacer);
   }
 
-  // Search filter
+  // Chip group
   &.pf-m-chip-group {
     --#{$toolbar}--spacer: var(--#{$toolbar}__item--m-chip-group--spacer);
   }
@@ -499,11 +499,13 @@ $pf-v5-c-toolbar--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2
 
   .#{$toolbar}__item {
     --#{$toolbar}--spacer: var(--#{$toolbar}__item--spacer);
+    --#{$toolbar}__item--AlignSelf: auto;
 
     margin-top: var(--#{$toolbar}__group--m-chip-container__item--MarginTop);
   }
 
   .#{$toolbar}__group {
+    --#{$toolbar}__group--AlignItems: center;
     --#{$toolbar}--spacer: var(--#{$toolbar}__group--spacer);
 
     display: flex;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5767

This just reverts the alignment to what it was before. The label alignment isn't great, but we don't have any open issues against that, so I don't think it's something we need to fix for this release. Assuming it reverts the layout properly, we shouldn't need to test it extensively or worry about inadvertent side effects.