### PR TITLE
fix(menu): keep description from wrapping mid-word

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -667,7 +667,7 @@
 .#{$menu}__item-description {
   font-size: var(--#{$menu}__item-description--FontSize);
   color: var(--#{$menu}__item-description--Color);
-  word-break: break-all;
+  word-break: break-word;
 }
 
 // General icon


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5786