### PR TITLE
fix: updated use of flex start/end to be more compatible

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -190,7 +190,7 @@ $pf-v5-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
   position: relative;
   display: inline-flex;
-  align-items: start;
+  align-items: flex-start;
   max-width: 100%;
 
   .#{$divider} {
@@ -755,7 +755,7 @@ $pf-v5-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
     &.pf-m-description {
       flex-direction: column;
-      align-items: start;
+      align-items: flex-start;
     }
 
     .#{$dropdown}__menu-item-main {

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -141,7 +141,7 @@
 
 .#{$label-group}__close {
   display: flex;
-  align-self: start;
+  align-self: flex-start;
   margin-top: var(--#{$label-group}__close--MarginTop);
   margin-right: var(--#{$label-group}__close--MarginRight);
   margin-bottom: var(--#{$label-group}__close--MarginBottom);

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -133,7 +133,7 @@ $pf-v5-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}--GridTemplateRows: auto 1fr;
 
   // Step connector variables
-  --#{$progress-stepper}__step-connector--JustifyContent: start;
+  --#{$progress-stepper}__step-connector--JustifyContent: flex-start;
 
   // Step icon variables
   --#{$progress-stepper}__step-icon--ZIndex: var(--#{$pf-global}--ZIndex--xs);

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -39,7 +39,7 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__main--FlexDirection: column;
   --#{$sidebar}__main--md--FlexDirection: row;
   --#{$sidebar}__main--AlignItems: stretch;
-  --#{$sidebar}__main--md--AlignItems: start;
+  --#{$sidebar}__main--md--AlignItems: flex-start;
   --#{$sidebar}__main--child--MarginTop: 0;
 
   // Gutter
@@ -65,7 +65,7 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-stack--m-panel-right__panel--Order: -1;
 
   // Split
-  --#{$sidebar}--m-split__main--AlignItems: start;
+  --#{$sidebar}--m-split__main--AlignItems: flex-start;
   --#{$sidebar}--m-split__main--FlexDirection: row;
   --#{$sidebar}--m-split__panel--Position: static;
   --#{$sidebar}--m-split__panel--Top: auto;


### PR DESCRIPTION
The element it looks like autoprefixer is warning about was introduced in v5, but it looks like we have the same issue in a few other components, too. autoprefixer likely isn't catching them, I'm guessing, because either they aren't using/processing those component styles and/or the offending values are used in custom properties (css vars) and I don't know if autoprefixer can go as far as to trace the value of vars back through the CSS and see if the value is used on/in a flex layout.

IMO this isn't a showstopper since it's pre-existing in other places, and AFAIK no one has flagged it on any of the other components. But we should at least update it for good measure since it is also in violation of the browser support we currently have documented - Safari only supports the current value in versions >= 15.4.

----

fixes https://github.com/patternfly/patternfly/issues/5804

Dropdown:
* The first use of `start` was introduced in v5 - https://github.com/patternfly/patternfly/commit/d3033930db2ca1d4a83960f0e0794ac4551f1abb
* The second use was introduced 3 years ago - https://github.com/patternfly/patternfly/commit/ddb4ff3f6900b8a8065cae89a3feee4bd41fee7f

Label group:
* Introduced in v5 - https://github.com/patternfly/patternfly/commit/763f34722f0bc8bdded6ce41ddb268638db7ebf1

Progress stepper:
* Introduced 2 years ago - https://github.com/patternfly/patternfly/commit/92af87a40838eb9cf80858c2d20f599af6e9d313

Sidebar:
* Introduced 3 years ago - https://github.com/patternfly/patternfly/commit/9690373637ee2b5b202c7ed90a3945feec3a470d
