### PR TITLE
fix(chip): add margin for badge when used in text element

### DIFF
--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -26,6 +26,7 @@
   // chip text
   --#{$chip}__text--Color: var(--#{$pf-global}--Color--100);
   --#{$chip}__text--MaxWidth: 16ch;
+  --#{$chip}__c-badge--MarginLeft: var(--#{$pf-global}--spacer--xs);
 
   // chip actions
   --#{$chip}__actions--FontSize: var(--#{$pf-global}--FontSize--xs);
@@ -92,6 +93,10 @@
   position: relative;
   max-width: var(--#{$chip}__text--MaxWidth);
   color: var(--#{$chip}__text--Color);
+
+  .#{$badge} {
+    margin-left: var(--#{$chip}__c-badge--MarginLeft); // remove in breaking change
+  }
 }
 
 .#{$chip}__icon + .#{$chip}__text,


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5842

I copied the markup from the [react chip example with a badge](https://www.patternfly.org/components/chip/#chip-variants) into the core workspace for this PR

<img width="463" alt="Screenshot 2023-08-14 at 6 33 45 PM" src="https://github.com/patternfly/patternfly/assets/35148959/6ec28838-ce9e-40ca-96ba-251de073268a">
