### PR TITLE
fix: added base, wizard, pagination RTL styles

### DIFF
--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -26,13 +26,20 @@
 
 // RTL helpers
 .#{$pf-prefix}m-dir-rtl {
+  @include pf-v5-rtl("transform-flip");
+
   direction: rtl;
 }
 
-.#{$pf-prefix}m-dir-ltr {
+.#{$pf-prefix}m-dir-ltr,
+.ws-dir-ltr {
+  @include pf-v5-rtl("transform-flip-revert");
+
   direction: ltr;
 }
 
 .#{$pf-prefix}m-rtl-flip-inline {
   @include pf-v5-rtl("flip-inline");
 }
+
+@include pf-v5-rtl("transform-flip");

--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -23,3 +23,16 @@
   --#{$pf-global}--FontFamily--heading: var(--#{$pf-global}--FontFamily--heading--vf);
   --#{$pf-global}--FontFamily--monospace: var(--#{$pf-global}--FontFamily--monospace--vf);
 }
+
+// RTL helpers
+.#{$pf-prefix}m-dir-rtl {
+  direction: rtl;
+}
+
+.#{$pf-prefix}m-dir-ltr {
+  direction: ltr;
+}
+
+.#{$pf-prefix}m-rtl-flip-inline {
+  @include pf-v5-rtl("flip-inline");
+}

--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -282,6 +282,9 @@
   // A11y
   --#{$pf-global}--target-size--MinWidth: #{$pf-v5-global--target-size--MinWidth};
   --#{$pf-global}--target-size--MinHeight: #{$pf-v5-global--target-size--MinHeight};
+
+  // RTL
+  --#{$pf-global}--rtl--transform--flip: 1;
 }
 
 // stylelint-disable no-invalid-position-at-import-rule

--- a/src/patternfly/components/Chip/examples/Chip.md
+++ b/src/patternfly/components/Chip/examples/Chip.md
@@ -576,7 +576,7 @@ The chip group requires the [chip component](#chip-overview). **All single chip 
 
 | Attributes for closable chip group button | Applied to | Outcome |
 | -- | -- | -- |
-| `role="list"` | `.pf-v5-c-chip-group__list` | Indicates that the chip group list is a list element. This role is redundant since `.pf-v5-c-chip-group__list` is a `<ul>` but is required for screen readers to announce the list propertly. **Required** |
+| `role="list"` | `.pf-v5-c-chip-group__list` | Indicates that the chip group list is a list element. This role is redundant since `.pf-v5-c-chip-group__list` is a `<ul>` but is required for screen readers to announce the list properly. **Required** |
 | `aria-label="[button label text]"` | `.pf-v5-c-chip-group__close > button` |  Provides an accessible name for a chip group close when an icon is used instead of text. Required when an icon is used with no supporting text. **Required** |
 | `aria-labelledby="[id value of .pf-v5-c-chip-group__close > button] [id value of .pf-v5-c-chip-group__label]"` | `.pf-v5-c-chip-group__close > button` | Provides an accessible name for the button. **Required** |
 

--- a/src/patternfly/components/DragDrop/examples/DragDrop.css
+++ b/src/patternfly/components/DragDrop/examples/DragDrop.css
@@ -6,8 +6,8 @@
   --pf-v5-c-draggable--m-dragging--BackgroundColor: var(--pf-v5-global--BackgroundColor--100);
 
   position: absolute;
- inset-block-start: 23%;
- inset-inline-start: .5em;
+  inset-block-start: 23%;
+  inset-inline-start: .5em;
   z-index: 9999;
   width: 100%;
 }

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -171,11 +171,7 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
       position: absolute;
       inset-block-start: 0;
       inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--Left);
-      transform: translateX(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX));
-
-      @include pf-v5-rtl {
-        transform: translateX(calc(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX) * -1));
-      }
+      transform: translateX(calc(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX) * var(--#{$pf-global}--rtl--transform--flip)));
     }
   }
 
@@ -298,8 +294,7 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
   padding-inline-end: var(--#{$dual-list-selector}__controls--PaddingRight);
 }
 
-.#{$dual-list-selector}__controls-item,
-.#{$dual-list-selector}__item-toggle-icon {
+:is(.#{$dual-list-selector}__controls-item, .#{$dual-list-selector}__item-toggle-icon) {
   @include pf-v5-rtl("flip-inline");
 }
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -169,9 +169,13 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
 
     .#{$dual-list-selector}__item-toggle {
       position: absolute;
-     inset-block-start: 0;
-     inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--Left);
+      inset-block-start: 0;
+      inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--Left);
       transform: translateX(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX));
+
+      @include pf-v5-rtl {
+        transform: translateX(calc(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX) * -1));
+      }
     }
   }
 
@@ -292,6 +296,11 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
   align-self: center;
   padding-inline-start: var(--#{$dual-list-selector}__controls--PaddingLeft);
   padding-inline-end: var(--#{$dual-list-selector}__controls--PaddingRight);
+}
+
+.#{$dual-list-selector}__controls-item,
+.#{$dual-list-selector}__item-toggle-icon {
+  @include pf-v5-rtl("flip-inline");
 }
 
 .#{$dual-list-selector}__item-main {

--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -700,7 +700,7 @@ In addition to the JavaScript management of [editable labels](/components/label#
 ### Label group accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `role="list"` | `.pf-v5-c-label-group__list` | Indicates that the label group list is a list element. This role is redundant since `.pf-v5-c-label-group__list` is a `<ul>` but is required for screen readers to announce the list propertly. **Required** |
+| `role="list"` | `.pf-v5-c-label-group__list` | Indicates that the label group list is a list element. This role is redundant since `.pf-v5-c-label-group__list` is a `<ul>` but is required for screen readers to announce the list properly. **Required** |
 | `aria-label="[button label text]"` | `.pf-v5-c-label-group__close > button` |  Provides an accessible name for a label group close button when an icon is used instead of text. Required when an icon is used with no supporting text. **Required** |
 | `aria-labelledby="[id value of .pf-v5-c-label-group__close > button] [id value of .pf-v5-c-label-group__label]"` | `.pf-v5-c-label-group__close > button` | Provides an accessible name for the button. **Required** |
 | `aria-label="[label text]"` | `.pf-v5-c-label-group__textarea` | Provides an accessible name for the textarea. **Required** |

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -246,6 +246,8 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   .#{$pagination}.pf-m-compact & + & {
     margin-inline-start: var(--#{$pagination}--m-compact__nav-control--nav-control--MarginLeft);
   }
+
+  @include pf-v5-rtl("flip-inline");
 }
 
 // nav page element

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -237,6 +237,8 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
 // nav control
 .#{$pagination}__nav-control {
+  @include pf-v5-rtl("flip-inline");
+
   .#{$button} {
     padding-inline-start: var(--#{$pagination}__nav-control--c-button--PaddingLeft);
     padding-inline-end: var(--#{$pagination}__nav-control--c-button--PaddingRight);
@@ -246,8 +248,6 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   .#{$pagination}.pf-m-compact & + & {
     margin-inline-start: var(--#{$pagination}--m-compact__nav-control--nav-control--MarginLeft);
   }
-
-  @include pf-v5-rtl("flip-inline");
 }
 
 // nav page element

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -88,7 +88,7 @@
       background-color: var(--#{$switch}__input--checked__toggle--BackgroundColor);
 
       &::before {
-        transform: translateX(var(--#{$switch}__input--checked__toggle--before--TranslateX));
+        transform: translateX(calc(var(--#{$switch}__input--checked__toggle--before--TranslateX) * var(--#{$pf-global}--rtl--transform--flip)));
       }
     }
 

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -433,7 +433,7 @@ import './Wizard.css'
       {{#> wizard-main}}
         {{#> bullseye}}
           {{#> empty-state empty-state--modifier="pf-m-lg"}}
-            {{#> empty-state-icon empty-state-icon--type="cogs"}}{{/empty-state-icon}}
+            {{#> empty-state-icon empty-state-icon--type="cogs" empty-state-icon--modifier="pf-v5-m-rtl-flip-inline"}}{{/empty-state-icon}}
             {{#> empty-state-title empty-state-title--attribute=(concat 'id="' wizard--id '-empty-state-title"')}}
               {{#> empty-state-title-text}}
                 Validating credentials

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -433,7 +433,7 @@ import './Wizard.css'
       {{#> wizard-main}}
         {{#> bullseye}}
           {{#> empty-state empty-state--modifier="pf-m-lg"}}
-            {{#> empty-state-icon empty-state-icon--type="cogs" empty-state-icon--modifier="pf-v5-m-rtl-flip-inline"}}{{/empty-state-icon}}
+            {{#> empty-state-icon empty-state-icon--type="cogs"}}{{/empty-state-icon}}
             {{#> empty-state-title empty-state-title--attribute=(concat 'id="' wizard--id '-empty-state-title"')}}
               {{#> empty-state-title-text}}
                 Validating credentials

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -337,6 +337,8 @@
 .#{$wizard}__toggle-separator {
   margin-inline-start: var(--#{$wizard}__toggle-separator--MarginLeft);
   color: var(--#{$wizard}__toggle-separator--Color);
+
+  @include pf-v5-rtl("flip-inline");
 }
 
 .#{$wizard}__toggle-icon {
@@ -460,8 +462,8 @@
   @at-root .#{$wizard}__toggle-num,
   &::before {
     position: absolute;
-   inset-block-start: var(--#{$wizard}__nav-link--before--Top);
-   inset-inline-start: 0;
+    inset-block-start: var(--#{$wizard}__nav-link--before--Top);
+    inset-inline-start: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -473,6 +475,10 @@
     background-color: var(--#{$wizard}__nav-link--before--BackgroundColor);
     border-radius: var(--#{$wizard}__nav-link--before--BorderRadius);
     transform: translateX(var(--#{$wizard}__nav-link--before--TranslateX));
+
+    @include pf-v5-rtl {
+      transform: translateX(calc(var(--#{$wizard}__nav-link--before--TranslateX) * -1));
+    }
   }
 
   // Nav step number

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -335,10 +335,10 @@
 }
 
 .#{$wizard}__toggle-separator {
+  @include pf-v5-rtl("flip-inline");
+
   margin-inline-start: var(--#{$wizard}__toggle-separator--MarginLeft);
   color: var(--#{$wizard}__toggle-separator--Color);
-
-  @include pf-v5-rtl("flip-inline");
 }
 
 .#{$wizard}__toggle-icon {
@@ -474,11 +474,7 @@
     color: var(--#{$wizard}__nav-link--before--Color);
     background-color: var(--#{$wizard}__nav-link--before--BackgroundColor);
     border-radius: var(--#{$wizard}__nav-link--before--BorderRadius);
-    transform: translateX(var(--#{$wizard}__nav-link--before--TranslateX));
-
-    @include pf-v5-rtl {
-      transform: translateX(calc(var(--#{$wizard}__nav-link--before--TranslateX) * -1));
-    }
+    transform: translateX(calc(var(--#{$wizard}__nav-link--before--TranslateX) * var(--#{$pf-global}--rtl--transform--flip)));
   }
 
   // Nav step number
@@ -534,6 +530,8 @@
 }
 
 .#{$wizard}__nav-link-toggle-icon {
+  @include pf-v5-rtl("flip-inline");
+
   display: inline-block;
   transition: var(--#{$wizard}__nav-link-toggle-icon--Transition);
   transform: rotate(var(--#{$wizard}__nav-link-toggle-icon--Rotate));

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -311,7 +311,7 @@
 }
 
 @mixin pf-v5-rtl($transform: null) {
-  @at-root :where(.ws-dir-rtl, [dir="rtl"]) & {
+  @at-root :where(.ws-dir-rtl, .#{$pf-prefix}m-dir-rtl, [dir="rtl"]) & {
     @if $transform == 'flip-inline' {
       scale: -1 1;
     }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -310,11 +310,27 @@
   }
 }
 
+// Applies custom styles to support RTL
 @mixin pf-v5-rtl($transform: null) {
-  @at-root :where(.ws-dir-rtl, .#{$pf-prefix}m-dir-rtl, [dir="rtl"]) & {
-    @if $transform == 'flip-inline' {
-      scale: -1 1;
+  // resets property used to inverse transform values calc()s in RTL
+  @if $transform == "transform-flip-revert" {
+    --#{$pf-global}--rtl--transform--flip: 1;
+  } @else {
+    // establishes the selectors used to target RTL
+    // remove .ws-dir-rtl before releasing RTL
+    @at-root :where(.ws-dir-rtl, .#{$pf-prefix}m-dir-rtl, [dir="rtl"]) #{&} {
+      // sets property used in calcs to inverse transform values
+      @if $transform == "transform-flip" {
+        --#{$pf-global}--rtl--transform--flip: -1;
+      }
+
+      // flips something horizontally/inline. relies upon scale/scale() not already being used for the element
+      @if $transform == 'flip-inline' {
+        scale: -1 1;
+      }
+
+      // any custom CSS to apply within the selectors that target RTL
+      @content
     }
-    @content
   }
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -309,3 +309,12 @@
     }
   }
 }
+
+@mixin pf-v5-rtl($transform: null) {
+  @at-root :where(.ws-dir-rtl, [dir="rtl"]) & {
+    @if $transform == 'flip-inline' {
+      scale: -1 1;
+    }
+    @content
+  }
+}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5839
fixes https://github.com/patternfly/patternfly/issues/5840

----

## Global
* Adds a `pf-v5-rtl($transform)` mixin that manages 2 things so far:
  * Handles selector(s) we'll use to wrap RTL styles.
    * Currently works on `.ws-dir-rtl, .#{$pf-prefix}m-dir-rtl, [dir="rtl"]`.
  * Can return helpful, common blocks of CSS with a preferred way of doing some RTL transform by passing a `$transform`. 
    * Added a "flip-inline" transform that applies `scale: -1 1`
* Adds `.pf-v5-m-rtl-flip-inline` as a helper class to flip something horizontally (inline), and gets its code from ^ `pf-v5-rtl($transform: "flip-inline")`
* Adds `.pf-v5-m-dir-rtl` to apply `direction: rtl;` to something
* Adds `.pf-v5-m-dir-ltr` to apply `direction: ltr;` to something if you don't want it to flip in RTL. This is what keeps the dark theme and RTL switches in the bottom right of the full page examples from switching to RTL when the whole document changes to RTL.

## Wizard
* Added  `.pf-v5-m-rtl-flip-inline` to the wizard icon bem element to flip the icon in the "finished" example. **I'll take this out prior to merging, so it isn't confused as something that's required for use in the component.** It should probably go on the icon itself anyways, but it was easier to add it to the wizard icon bem element for this example.
* Added `pf-v5-rtl("flip-inline")` to the mobile nav breadcrumb arrows

## Pagination
* Added `pf-v5-rtl("flip-inline")` to the next/prev arrows

## Follow-ups
* I'd like to update the workspace RTL button to use either `dir="rtl"` (probably preferred, as I think this is our main use case) or `.pf-v5-m-dir-rtl` on full page examples. Also `.pf-v5-m-dir-ltr` on the dark theme/RTL switcher box. Then we can remove the current `.ws-dir-[rtl/ltr]` classes from the workspace code.
* Doesn't have to happen, but I'd also like to add a toggle in the masthead on the main workspace view (like the dark theme switcher) that can toggle `.pf-v5-m-dir-rtl` on the example blocks, which would let us quickly scan RTL examples in the example list page. That should be an easy add. It could eventually toggle the whole page, too, not the example blocks, if we wanted to test the workspace this way.
  * We could probably just add a plain action in the masthead that toggles between the FA [align-left](https://fontawesome.com/icons/align-left?f=classic&s=solid) and [align-right](https://fontawesome.com/icons/align-right?f=classic&s=solid) icons?

