### PR TITLE
chore(Alert,NotificationDrawer): added additional rtl styling

### DIFF
--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -199,7 +199,7 @@
 }
 
 .#{$alert}__toggle-icon {
-  @include pf-v5-rtl('flip-inline');
+  @include pf-v5-mirror-inline-on-rtl;
   
   display: inline-block;
   transition: var(--#{$alert}__toggle-icon--Transition);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -199,6 +199,8 @@
 }
 
 .#{$alert}__toggle-icon {
+  @include pf-v5-rtl('flip-inline');
+  
   display: inline-block;
   transition: var(--#{$alert}__toggle-icon--Transition);
   transform: rotate(var(--#{$alert}__toggle-icon--Rotate));

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -307,6 +307,8 @@
 }
 
 .#{$notification-drawer}__group-toggle-icon {
+  @include pf-v5-rtl('flip-inline');
+
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginRight);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);
   transition: var(--#{$notification-drawer}__group-toggle-icon--Transition);

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -307,7 +307,7 @@
 }
 
 .#{$notification-drawer}__group-toggle-icon {
-  @include pf-v5-rtl('flip-inline');
+  @include pf-v5-mirror-inline-on-rtl;
 
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginRight);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);


### PR DESCRIPTION
Closes #5817 
closes #5818 

For both Alert and Notification drawer, the truncation is slightly different between Chromium and Firefox when viewing an example in a new window (viewing the examples normally on the component page things like fine). In Chromium a line clamp of 1 seems to cause the first word to be cut off, while a line clamp greater than 1 seems to truncate okay (same screenshot from the alert/hint issue linked above):

![Alert title truncation with RTL direction in Chrome](https://github.com/patternfly/patternfly/assets/70952936/941e40d3-a209-4f8a-8a51-466c6e6121b1)

In Firefox, it seems to be the reverse; line clamp of 1 truncates okay, while line clamp greater than 1 causes the first word of the last line to be cut off:

![Alert title truncation with RTL direction in Firefox](https://github.com/patternfly/patternfly/assets/70952936/76be7e09-c118-4745-827e-89ec66002273)

Since it seems to more have this affect if the Alert is wide enough it may not be a huge issue. This could also just be an issue with the Core examples, as applying `dir="rtl"` to the `html` tag in the React example the truncation looks fine (though that was also without any of the other RTL styling updates from Core).