### PR TITLE
fix(popover, tooltip): added rtl styles

### DIFF
--- a/src/patternfly/components/Popover/examples/Popover.css
+++ b/src/patternfly/components/Popover/examples/Popover.css
@@ -1,10 +1,4 @@
 .ws-core-c-popover .ws-preview-html {
-  position: relative;
- }
-
- .ws-core-c-popover .pf-v5-c-popover {
-   position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 50%;
-   transform: translate(-50%, -50%);
- }
+  display: grid;
+  place-items: center;
+}

--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -452,10 +452,10 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-v5-c-popover__title-text` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`,`<span>` | Creates the popover title text. |
 | `.pf-v5-c-popover__body` | `<div>` |  The popover's body text. **Required** |
 | `.pf-v5-c-popover__footer` | `<footer>` | Initiates a popover footer. |
-| `.pf-m-left{-top/bottom}` | `.pf-v5-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |
-| `.pf-m-right{-top/bottom}` | `.pf-v5-c-popover` | Positions the popover to the right (or right top/right bottom) of the element. |
-| `.pf-m-top{-left/right}` | `.pf-v5-c-popover` | Positions the popover to the top (or top left/top right) of the element. |
-| `.pf-m-bottom{-left/right}` | `.pf-v5-c-popover` | Positions the popover to the bottom (or bottom left/bottom right) of the element. |
+| `.pf-m-left{-top/bottom}`, `.pf-m-inline-start{-block-start/block-end}` | `.pf-v5-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}`, `.pf-m-inline-end{-block-start/block-end}` | `.pf-v5-c-popover` | Positions the popover to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-popover` | Positions the popover to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}`, `.pf-m-block-end{-inline-start/inline-end}` | `.pf-v5-c-popover` | Positions the popover to the bottom (or bottom left/bottom right) of the element. |
 | `.pf-m-no-padding` | `.pf-v5-c-popover` | Removes the outer padding from the popover content. |
 | `.pf-m-width-auto` | `.pf-v5-c-popover` | Allows popover width to be defined by the popover content. |
 | `.pf-m-custom` | `.pf-v5-c-popover` | Modifies for the custom alert state. |

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -88,73 +88,129 @@
     --#{$popover}--MaxWidth: none;
   }
 
-  &.pf-m-top,
-  &.pf-m-top-left,
-  &.pf-m-top-right {
+  &:is(
+    .pf-m-top,
+    .pf-m-top-left,
+    .pf-m-top-right,
+    .pf-m-block-start,
+    .pf-m-block-start-inline-start,
+    .pf-m-block-start-inline-end
+  ) {
     .#{$popover}__arrow {
-     inset-block-end: 0;
-     inset-inline-start: 50%;
-      transform: translateX(var(--#{$popover}__arrow--m-top--TranslateX)) translateY(var(--#{$popover}__arrow--m-top--TranslateY)) rotate(var(--#{$popover}__arrow--m-top--Rotate));
+      inset-block-end: 0;
+      inset-inline-start: 50%;
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$popover}__arrow--m-top--TranslateX)) translateY(var(--#{$popover}__arrow--m-top--TranslateY)) rotate(var(--#{$popover}__arrow--m-top--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-top--TranslateX))}) translateY(var(--#{$popover}__arrow--m-top--TranslateY)) rotate(var(--#{$popover}__arrow--m-top--Rotate))
+      );
     }
   }
 
-  &.pf-m-bottom,
-  &.pf-m-bottom-left,
-  &.pf-m-bottom-right {
+  &:is(
+    .pf-m-bottom,
+    .pf-m-bottom-left,
+    .pf-m-bottom-right,
+    .pf-m-block-end,
+    .pf-m-block-end-inline-start,
+    .pf-m-block-end-inline-end
+  ) {
     .#{$popover}__arrow {
-     inset-block-start: 0;
-     inset-inline-start: 50%;
-      transform: translateX(var(--#{$popover}__arrow--m-bottom--TranslateX)) translateY(var(--#{$popover}__arrow--m-bottom--TranslateY)) rotate(var(--#{$popover}__arrow--m-bottom--Rotate));
+      inset-block-start: 0;
+      inset-inline-start: 50%;
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$popover}__arrow--m-bottom--TranslateX)) translateY(var(--#{$popover}__arrow--m-bottom--TranslateY)) rotate(var(--#{$popover}__arrow--m-bottom--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-bottom--TranslateX))}) translateY(var(--#{$popover}__arrow--m-bottom--TranslateY)) rotate(var(--#{$popover}__arrow--m-bottom--Rotate))
+      );
     }
   }
 
-  &.pf-m-left,
-  &.pf-m-left-top,
-  &.pf-m-left-bottom {
+  &:is(
+    .pf-m-left,
+    .pf-m-left-top,
+    .pf-m-left-bottom,
+    .pf-m-inline-start,
+    .pf-m-inline-start-block-start,
+    .pf-m-inline-start-block-end
+  ) {
     .#{$popover}__arrow {
-     inset-block-start: 50%;
-     inset-inline-end: 0;
-      transform: translateX(var(--#{$popover}__arrow--m-left--TranslateX)) translateY(var(--#{$popover}__arrow--m-left--TranslateY)) rotate(var(--#{$popover}__arrow--m-left--Rotate));
+      inset-block-start: 50%;
+      inset-inline-end: 0;
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$popover}__arrow--m-left--TranslateX)) translateY(var(--#{$popover}__arrow--m-left--TranslateY)) rotate(var(--#{$popover}__arrow--m-left--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-left--TranslateX))}) translateY(var(--#{$popover}__arrow--m-left--TranslateY)) rotate(var(--#{$popover}__arrow--m-left--Rotate))
+      );
     }
   }
 
-  &.pf-m-right,
-  &.pf-m-right-top,
-  &.pf-m-right-bottom {
+  &:is(
+    .pf-m-right,
+    .pf-m-right-top,
+    .pf-m-right-bottom,
+    .pf-m-inline-end,
+    .pf-m-inline-end-block-start,
+    .pf-m-inline-end-block-end
+  ) {
     .#{$popover}__arrow {
-     inset-block-start: 50%;
-     inset-inline-start: 0;
-      transform: translateX(var(--#{$popover}__arrow--m-right--TranslateX)) translateY(var(--#{$popover}__arrow--m-right--TranslateY)) rotate(var(--#{$popover}__arrow--m-right--Rotate));
+      inset-block-start: 50%;
+      inset-inline-start: 0;
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$popover}__arrow--m-right--TranslateX)) translateY(var(--#{$popover}__arrow--m-right--TranslateY)) rotate(var(--#{$popover}__arrow--m-right--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-right--TranslateX))}) translateY(var(--#{$popover}__arrow--m-right--TranslateY)) rotate(var(--#{$popover}__arrow--m-right--Rotate))
+      );
     }
   }
 
-  &.pf-m-left-top,
-  &.pf-m-right-top {
+  &:is(
+    .pf-m-left-top,
+    .pf-m-right-top,
+    .pf-m-inline-start-block-start,
+    .pf-m-inline-end-block-start
+  ) {
     .#{$popover}__arrow {
-     inset-block-start: var(--#{$popover}__arrow--Height);
+      inset-block-start: var(--#{$popover}__arrow--Height);
     }
   }
 
-  &.pf-m-left-bottom,
-  &.pf-m-right-bottom {
+  &:is(
+    .pf-m-left-bottom,
+    .pf-m-right-bottom,
+    .pf-m-inline-start-block-end,
+    .pf-m-inline-end-block-end
+  ) {
     .#{$popover}__arrow {
-     inset-block-start: auto;
-     inset-block-end: 0;
+      inset-block-start: auto;
+      inset-block-end: 0;
     }
   }
 
-  &.pf-m-top-left,
-  &.pf-m-bottom-left {
+  &:is(
+    .pf-m-top-left,
+    .pf-m-bottom-left,
+    .pf-m-block-start-inline-start,
+    .pf-m-block-end-inline-start
+  ) {
     .#{$popover}__arrow {
-     inset-inline-start: var(--#{$popover}__arrow--Width);
+      inset-inline-start: var(--#{$popover}__arrow--Width);
     }
   }
 
-  &.pf-m-top-right,
-  &.pf-m-bottom-right {
+  &:is(
+    .pf-m-top-right,
+    .pf-m-bottom-right,
+    .pf-m-block-start-inline-end,
+    .pf-m-block-end-inline-end
+  ) {
     .#{$popover}__arrow {
-     inset-inline-start: auto;
-     inset-inline-end: 0;
+      inset-inline-start: auto;
+      inset-inline-end: 0;
     }
   }
 
@@ -196,8 +252,8 @@
 // Close button
 .#{$popover}__close {
   position: absolute;
- inset-block-start: var(--#{$popover}__close--Top);
- inset-inline-end: var(--#{$popover}__close--Right);
+  inset-block-start: var(--#{$popover}__close--Top);
+  inset-inline-end: var(--#{$popover}__close--Right);
 
   // Create room for the close button
   + * {

--- a/src/patternfly/components/Tooltip/examples/Tooltip.css
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.css
@@ -1,0 +1,4 @@
+/* adds padding to full page examples so arrows are visible */
+.ws-core-c-tooltip:not(.ws-preview) {
+  padding: var(--pf-v5-global--spacer--md);
+}

--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -4,6 +4,8 @@ section: components
 cssPrefix: pf-v5-c-tooltip
 ---
 
+import "./Tooltip.css"
+
 ## Examples
 ### Top
 ```hbs
@@ -90,8 +92,8 @@ A tooltip is used to provide contextual information for another component on hov
 | `.pf-v5-c-tooltip` | `<div>` |  Creates a tooltip. Always use with a modifier class that positions the tooltip relative to the element it describes. **Required**|
 | `.pf-v5-c-tooltip__arrow` | `<div>` |  Creates an arrow pointing towards the element the tooltip describes. **Required** |
 | `.pf-v5-c-tooltip__content` | `<div>` |  Creates the body of the tooltip. **Required** |
-| `.pf-m-left{-top/bottom}` | `.pf-v5-c-tooltip` | Positions the tooltip to the left (or left top/left bottom) of the element. |
-| `.pf-m-right{-top/bottom}` | `.pf-v5-c-tooltip` | Positions the tooltip to the right (or right top/right bottom) of the element. |
-| `.pf-m-top{-left/right}` | `.pf-v5-c-tooltip` | Positions the tooltip to the top (or top left/top right) of the element. |
-| `.pf-m-bottom{-left/right}` | `.pf-v5-c-tooltip` | Positions the tooltip to the bottom (or bottom left/bottom right) of the element. |
-| `.pf-m-text-align-left` | `.pf-v5-c-tooltip__content` | Modifies tooltip content to text align left. |
+| `.pf-m-left{-top/bottom}`, `.pf-m-inline-start{-block-start/block-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}`, `.pf-m-inline-end{-block-start/block-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the bottom (or bottom left/bottom right) of the element. |
+| `.pf-m-text-align-left`, `.pf-m-text-align-start` | `.pf-v5-c-tooltip__content` | Modifies tooltip content to text align left. |

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -36,70 +36,126 @@
   max-width: var(--#{$tooltip}--MaxWidth);
   box-shadow: var(--#{$tooltip}--BoxShadow);
 
-  &.pf-m-top,
-  &.pf-m-top-left,
-  &.pf-m-top-right {
+  &:is(
+    .pf-m-top,
+    .pf-m-top-left,
+    .pf-m-top-right,
+    .pf-m-block-start,
+    .pf-m-block-start-inline-start,
+    .pf-m-block-start-inline-end
+  ) {
     .#{$tooltip}__arrow {
       inset-block-end: 0;
       inset-inline-start: 50%;
-      transform: translateX(var(--#{$tooltip}__arrow--m-top--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-top--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-top--Rotate));
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-top--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-top--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-top--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-top--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-top--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-top--Rotate))
+      );
     }
   }
 
-  &.pf-m-bottom,
-  &.pf-m-bottom-left,
-  &.pf-m-bottom-right {
+  &:is(
+    .pf-m-bottom,
+    .pf-m-bottom-left,
+    .pf-m-bottom-right,
+    .pf-m-block-end,
+    .pf-m-block-end-inline-start,
+    .pf-m-block-end-inline-end
+  ) {
     .#{$tooltip}__arrow {
       inset-block-start: 0;
       inset-inline-start: 50%;
-      transform: translateX(var(--#{$tooltip}__arrow--m-bottom--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-bottom--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-bottom--Rotate));
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-bottom--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-bottom--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-bottom--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-bottom--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-bottom--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-bottom--Rotate))
+      );
     }
   }
 
-  &.pf-m-left,
-  &.pf-m-left-top,
-  &.pf-m-left-bottom {
+  &:is(
+    .pf-m-left,
+    .pf-m-left-top,
+    .pf-m-left-bottom,
+    .pf-m-inline-start,
+    .pf-m-inline-start-block-start,
+    .pf-m-inline-start-block-end
+  ) {
     .#{$tooltip}__arrow {
       inset-block-start: 50%;
       inset-inline-end: 0;
-      transform: translateX(var(--#{$tooltip}__arrow--m-left--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-left--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-left--Rotate));
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-left--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-left--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-left--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-left--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-left--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-left--Rotate))
+      );
     }
   }
 
-  &.pf-m-right,
-  &.pf-m-right-top,
-  &.pf-m-right-bottom {
+  &:is(
+    .pf-m-right,
+    .pf-m-right-top,
+    .pf-m-right-bottom,
+    .pf-m-inline-end,
+    .pf-m-inline-end-block-start,
+    .pf-m-inline-end-block-end
+  ) {
     .#{$tooltip}__arrow {
       inset-block-start: 50%;
       inset-inline-start: 0;
-      transform: translateX(var(--#{$tooltip}__arrow--m-right--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-right--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-right--Rotate));
+
+      @include pf-v5-bidirectional-style(
+        $prop: transform,
+        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-right--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-right--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-right--Rotate)),
+        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-right--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-right--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-right--Rotate))
+      );
     }
   }
 
-  &.pf-m-left-top,
-  &.pf-m-right-top {
+  &:is(
+    .pf-m-left-top,
+    .pf-m-right-top,
+    .pf-m-inline-start-block-start,
+    .pf-m-inline-end-block-start
+  ) {
     .#{$tooltip}__arrow {
       inset-block-start: var(--#{$tooltip}__arrow--Height);
     }
   }
 
-  &.pf-m-left-bottom,
-  &.pf-m-right-bottom {
+  &:is(
+    .pf-m-left-bottom,
+    .pf-m-right-bottom,
+    .pf-m-inline-start-block-end,
+    .pf-m-inline-end-block-end
+  ) {
     .#{$tooltip}__arrow {
       inset-block-start: auto;
       inset-block-end: 0;
     }
   }
 
-  &.pf-m-top-left,
-  &.pf-m-bottom-left {
+  &:is(
+    .pf-m-top-left,
+    .pf-m-bottom-left,
+    .pf-m-block-start-block-start,
+    .pf-m-block-end-block-start
+  ) {
     .#{$tooltip}__arrow {
       inset-inline-start: var(--#{$tooltip}__arrow--Width);
     }
   }
 
-  &.pf-m-top-right,
-  &.pf-m-bottom-right {
+  &:is(
+    .pf-m-top-right,
+    .pf-m-bottom-right,
+    .pf-m-block-start-block-end,
+    .pf-m-block-end-block-end
+  ) {
     .#{$tooltip}__arrow {
       inset-inline-start: auto;
       inset-inline-end: 0;
@@ -119,7 +175,7 @@
   word-break: break-word;
   background-color: var(--#{$tooltip}__content--BackgroundColor);
 
-  &.pf-m-text-align-left {
+  &:is(.pf-m-text-align-left, .pf-m-text-align-start) {
     text-align: start;
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5829

Adds support for the top/left/right/bottom/etc modifiers as logical equivalents since those are a little more clear. Uses `:is()` so it should actually decrease the size of those stylesheets with the additional modifiers. Also adds support for `.pf-m-text-align-start` on tooltip content.

I think we'll want these modifiers eventually, though we don't have to add them, or add prop vals for them in react as part of this release, but we could. And if we keep them, we could also update our examples to use them by default, as the preferred way to set the popover/tooltip direction. Thoughts?