### PR TITLE
chore(Dropdown): reverse icon for RTL

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -784,6 +784,8 @@ $pf-v5-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 }
 
 .#{$dropdown}__menu-item-icon {
+  @include pf-v5-mirror-inline-on-rtl;
+
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Fixes #5762 
Menu was fixed in a previous PR
Dropdown needed to reverse one caret
No other changes needed for menu toggle, select, or overflow menu