### PR TITLE
chore(ModalBox): center modal for workspace in RTL

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.css
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.css
@@ -1,10 +1,6 @@
 .ws-core-c-modal .ws-preview-html {
   position: relative;
-}
-
-.ws-core-c-modal .pf-v5-c-modal-box {
-  position: absolute;
- inset-block-start: 50%;
- inset-inline-start: 50%;
-  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
Fixes #5814 
No changes to modal needed, but the workspace was using translate to center the modal. I changed it to center in a flex container instead.
Demos are using a bullseye layout, so no problem there.