### PR TITLE
fix(nav): updated example css

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -1,4 +1,4 @@
-.ws-core-c-navigation:not([id*="tertiary"]):not([id*="light-mode"]) .ws-preview-html {
+.ws-core-c-navigation:not([id*="tertiary"]):not([id*="light-mode"]) .pf-v5-c-nav{
   background-color: var(--pf-v5-global--BackgroundColor--dark-300);
 }
 


### PR DESCRIPTION
Fixes #5899 

• Looks like the [third level expandable example](https://www.patternfly.org/components/navigation/html#expandable-third-level) had an [explicit background color set](https://github.com/patternfly/patternfly/commit/447630c3449372332ee1628268397f16f5ffa965#diff-c0c17bbec61392998ccf9e8532dc141d0f007e6bc152355119b66317925f671cR1). I'm not entirely sure how backstop is drawing and comparing examples, but it doesn't seem to be appearing in localhost. Added the example css declaration back to navigation.css.

• Tabs are fine. Backstop seems to be throwing an error bc of scroll position. 

**.org**
<img width="409" alt="Screenshot 2023-09-05 at 3 01 34 PM" src="https://github.com/patternfly/patternfly/assets/5385435/50b061e9-c852-4938-bfc3-bb0abbfd0f36">

**localhost**
<img width="406" alt="Screenshot 2023-09-05 at 3 01 41 PM" src="https://github.com/patternfly/patternfly/assets/5385435/f68f75e4-689e-4ae0-bed6-3a1605ed48bb">

