### PR TITLE
fix(ModalBox): fix centering on mobile

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.css
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.css
@@ -1,4 +1,5 @@
 .ws-core-c-modal .ws-preview-html {
-  display: grid;
-  place-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
Changes centering of the modal in the examples from grid to flex. Now matches how bullseye centers.

Fixes #5900 