### PR TITLE
chore(popover): center examples

### DIFF
--- a/src/patternfly/components/Popover/examples/Popover.css
+++ b/src/patternfly/components/Popover/examples/Popover.css
@@ -1,4 +1,5 @@
 .ws-core-c-popover .ws-preview-html {
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5901

the pagination examples are fine, the result of fixing the pagination markup in a toolbar demo from a previous PR.