### PR TITLE
chore: mirror fa-sort icon

### DIFF
--- a/src/patternfly/components/DualListSelector/dual-list-selector--actions.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector--actions.hbs
@@ -1,0 +1,10 @@
+{{#> dual-list-selector-tools-actions}}
+  {{#> dual-list-selector-tools-actions-item}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
+      <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
+    {{/button}}
+  {{/dual-list-selector-tools-actions-item}}
+  {{#> dual-list-selector-tools-actions-item}}
+    {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
+  {{/dual-list-selector-tools-actions-item}}
+{{/dual-list-selector-tools-actions}}

--- a/src/patternfly/components/DualListSelector/examples/DualListSelector.md
+++ b/src/patternfly/components/DualListSelector/examples/DualListSelector.md
@@ -20,16 +20,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -90,16 +81,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -129,16 +111,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -199,16 +172,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -238,16 +202,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -308,16 +263,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -347,16 +293,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -417,16 +354,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -459,16 +387,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -529,16 +448,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -572,16 +482,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -668,16 +569,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -707,16 +599,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text}}
@@ -796,16 +679,7 @@ cssPrefix: pf-v5-c-dual-list-selector
       {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
       {{/dual-list-selector-tools-filter}}
-      {{#> dual-list-selector-tools-actions}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-          {{/button}}
-        {{/dual-list-selector-tools-actions-item}}
-        {{#> dual-list-selector-tools-actions-item}}
-          {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-        {{/dual-list-selector-tools-actions-item}}
-      {{/dual-list-selector-tools-actions}}
+      {{> dual-list-selector--actions}}
     {{/dual-list-selector-tools}}
     {{#> dual-list-selector-status}}
       {{#> dual-list-selector-status-text
@@ -848,16 +722,7 @@ cssPrefix: pf-v5-c-dual-list-selector
         {{#> dual-list-selector-tools-filter}}
         {{> text-input-group--search-input text-input-group-text-input--aria-label="Available search input"}}
         {{/dual-list-selector-tools-filter}}
-        {{#> dual-list-selector-tools-actions}}
-          {{#> dual-list-selector-tools-actions-item}}
-            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-              <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-            {{/button}}
-          {{/dual-list-selector-tools-actions-item}}
-          {{#> dual-list-selector-tools-actions-item}}
-            {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-          {{/dual-list-selector-tools-actions-item}}
-        {{/dual-list-selector-tools-actions}}
+        {{> dual-list-selector--actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
         {{#> dual-list-selector-status-text}}
@@ -912,16 +777,7 @@ cssPrefix: pf-v5-c-dual-list-selector
         {{#> dual-list-selector-tools-filter}}
           {{> text-input-group--search-input text-input-group-text-input--aria-label="Chosen search input"}}
         {{/dual-list-selector-tools-filter}}
-        {{#> dual-list-selector-tools-actions}}
-          {{#> dual-list-selector-tools-actions-item}}
-            {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-              <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-            {{/button}}
-          {{/dual-list-selector-tools-actions-item}}
-          {{#> dual-list-selector-tools-actions-item}}
-            {{> dropdown dropdown--id=(concat "dropdown-kebab-" dual-list-selector-pane--id) dropdown-toggle--IsPlain="true"}}
-          {{/dual-list-selector-tools-actions-item}}
-        {{/dual-list-selector-tools-actions}}
+        {{> dual-list-selector--actions}}
       {{/dual-list-selector-tools}}
       {{#> dual-list-selector-status}}
         {{#> dual-list-selector-status-text}}

--- a/src/patternfly/components/OptionsMenu/deprecated/options-menu.md
+++ b/src/patternfly/components/OptionsMenu/deprecated/options-menu.md
@@ -66,21 +66,21 @@ import './options-menu.css'
 ```hbs
 {{#> options-menu options-menu--id="options-menu-plain-disabled-example" options-menu-toggle--IsDisabled="true"}}
   {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
-    <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+    <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}
 
 {{#> options-menu options-menu--id="options-menu-plain-example"}}
   {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
-    <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+    <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}
 
 {{#> options-menu options-menu--IsExpanded="true" options-menu--id="options-menu-plain-expanded-example"}}
   {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
-    <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+    <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}

--- a/src/patternfly/demos/Toolbar/toolbar-template.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template.hbs
@@ -46,7 +46,7 @@ Options: [
       {{#if toolbar-template--HasSortButton}}
         {{#> toolbar-item}}
           {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Sort"'}}
-            <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+            <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
           {{/button}}
         {{/toolbar-item}}
       {{/if}}
@@ -56,7 +56,7 @@ Options: [
         {{#> toolbar-item toolbar-item--modifier="pf-m-hidden-on-xl"}}
           {{#> options-menu options-menu--IsExpanded="true" options-menu--id="{{toolbar--id}}-sort-mobile-menu"}}
             {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
-              <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
+              <i class="fas fa-sort-amount-down {{pfv "unset-prefix"}}m-mirror-inline-rtl" aria-hidden="true"></i>
             {{/options-menu-toggle}}
             {{#> options-menu-menu}}
               {{#> options-menu-menu-item options-menu-menu-item--IsSelected="true"}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5918

Updates icons you can see in these examples:

/components/dual-list-selector
/components/table/html-demos/basic - there are separate icons for mobile and desktop to verify
/components/menus/options-menu#plain