### PR TITLE
fix(code-editor): make code box and header LTR

### DIFF
--- a/src/patternfly/components/CodeEditor/code-editor-code.hbs
+++ b/src/patternfly/components/CodeEditor/code-editor-code.hbs
@@ -1,4 +1,4 @@
-<code class="{{pfv}}code-editor__code{{#if code-editor-code--modifier}} {{code-editor-code--modifier}}{{/if}}"
+<code dir="ltr" class="{{pfv}}code-editor__code{{#if code-editor-code--modifier}} {{code-editor-code--modifier}}{{/if}}"
   {{#if code-editor-code--attribute}}
     {{{code-editor-code--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -135,6 +135,11 @@
   // stylelint-enable selector-class-pattern
 }
 
+.#{$code-editor}__code,
+.#{$code-editor}__header {
+  direction: ltr;
+}
+
 .#{$code-editor}__header + .#{$code-editor}__main {
   border-block-start-width: 0;
 }

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -135,11 +135,6 @@
   // stylelint-enable selector-class-pattern
 }
 
-.#{$code-editor}__code,
-.#{$code-editor}__header {
-  direction: ltr;
-}
-
 .#{$code-editor}__header + .#{$code-editor}__main {
   border-block-start-width: 0;
 }


### PR DESCRIPTION
This updates the `__code` element to use `dir="ltr"` so it will always be LTR. Everything else adapts to RTL as normal.

fixes https://github.com/patternfly/patternfly/issues/5927

