### PR TITLE
fix(banner): fixed invalid dark theme color declaration

### DIFF
--- a/src/patternfly/sass-utilities/themes/dark/mixins.scss
+++ b/src/patternfly/sass-utilities/themes/dark/mixins.scss
@@ -1,5 +1,7 @@
 @mixin pf-v5-theme-dark--t-dark($color: "--#{$pf-global}--Color--100") {
-  color: var(#{$color});
+  @if $color {
+    color: var(#{$color});
+  }
 
   @extend %pf-v5-theme-dark--t-dark;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5932

Looks like this mixin was meant to mimic the light theme mixins that have a conditional for the arg that gets passed

https://github.com/patternfly/patternfly/blob/c2db12236403508c577fc7c3cc524e29961f9dca/src/patternfly/sass-utilities/mixins.scss#L170-L182