### PR TITLE
fix(popover/tooltip): revert arrow logical prop positioning

### DIFF
--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -452,10 +452,10 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-v5-c-popover__title-text` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>`,`<span>` | Creates the popover title text. |
 | `.pf-v5-c-popover__body` | `<div>` |  The popover's body text. **Required** |
 | `.pf-v5-c-popover__footer` | `<footer>` | Initiates a popover footer. |
-| `.pf-m-left{-top/bottom}`, `.pf-m-inline-start{-block-start/block-end}` | `.pf-v5-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |
-| `.pf-m-right{-top/bottom}`, `.pf-m-inline-end{-block-start/block-end}` | `.pf-v5-c-popover` | Positions the popover to the right (or right top/right bottom) of the element. |
-| `.pf-m-top{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-popover` | Positions the popover to the top (or top left/top right) of the element. |
-| `.pf-m-bottom{-left/right}`, `.pf-m-block-end{-inline-start/inline-end}` | `.pf-v5-c-popover` | Positions the popover to the bottom (or bottom left/bottom right) of the element. |
+| `.pf-m-left{-top/bottom}` | `.pf-v5-c-popover` | Positions the popover to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}` | `.pf-v5-c-popover` | Positions the popover to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}` | `.pf-v5-c-popover` | Positions the popover to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}` | `.pf-v5-c-popover` | Positions the popover to the bottom (or bottom left/bottom right) of the element. |
 | `.pf-m-no-padding` | `.pf-v5-c-popover` | Removes the outer padding from the popover content. |
 | `.pf-m-width-auto` | `.pf-v5-c-popover` | Allows popover width to be defined by the popover content. |
 | `.pf-m-custom` | `.pf-v5-c-popover` | Modifies for the custom alert state. |

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -91,127 +91,81 @@
   &:is(
     .pf-m-top,
     .pf-m-top-left,
-    .pf-m-top-right,
-    .pf-m-block-start,
-    .pf-m-block-start-inline-start,
-    .pf-m-block-start-inline-end
+    .pf-m-top-right
   ) {
-    .#{$popover}__arrow {
-      inset-block-end: 0;
-      inset-inline-start: 50%;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$popover}__arrow--m-top--TranslateX)) translateY(var(--#{$popover}__arrow--m-top--TranslateY)) rotate(var(--#{$popover}__arrow--m-top--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-top--TranslateX))}) translateY(var(--#{$popover}__arrow--m-top--TranslateY)) rotate(var(--#{$popover}__arrow--m-top--Rotate))
-      );
-    }
+    --#{$popover}__arrow--Bottom: var(--#{$popover}--m-top--Bottom, 0);
+    --#{$popover}__arrow--Left: var(--#{$popover}--m-top--Left, 50%);
+    --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-top--TranslateX);
+    --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
+    --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-top--Rotate);
   }
 
   &:is(
     .pf-m-bottom,
     .pf-m-bottom-left,
-    .pf-m-bottom-right,
-    .pf-m-block-end,
-    .pf-m-block-end-inline-start,
-    .pf-m-block-end-inline-end
-  ) {
-    .#{$popover}__arrow {
-      inset-block-start: 0;
-      inset-inline-start: 50%;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$popover}__arrow--m-bottom--TranslateX)) translateY(var(--#{$popover}__arrow--m-bottom--TranslateY)) rotate(var(--#{$popover}__arrow--m-bottom--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-bottom--TranslateX))}) translateY(var(--#{$popover}__arrow--m-bottom--TranslateY)) rotate(var(--#{$popover}__arrow--m-bottom--Rotate))
-      );
-    }
+    .pf-m-bottom-right
+   ) {
+    --#{$popover}__arrow--Top: var(--#{$popover}--m-bottom--Top, 0);
+    --#{$popover}__arrow--Left: var(--#{$popover}--m-bottom--Left, 50%);
+    --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-bottom--TranslateX);
+    --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-bottom--TranslateY);
+    --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-bottom--Rotate);
   }
 
   &:is(
     .pf-m-left,
     .pf-m-left-top,
-    .pf-m-left-bottom,
-    .pf-m-inline-start,
-    .pf-m-inline-start-block-start,
-    .pf-m-inline-start-block-end
+    .pf-m-left-bottom
   ) {
-    .#{$popover}__arrow {
-      inset-block-start: 50%;
-      inset-inline-end: 0;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$popover}__arrow--m-left--TranslateX)) translateY(var(--#{$popover}__arrow--m-left--TranslateY)) rotate(var(--#{$popover}__arrow--m-left--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-left--TranslateX))}) translateY(var(--#{$popover}__arrow--m-left--TranslateY)) rotate(var(--#{$popover}__arrow--m-left--Rotate))
-      );
-    }
+    --#{$popover}__arrow--Top: var(--#{$popover}--m-left--Top, 50%);
+    --#{$popover}__arrow--Right: var(--#{$popover}--m-left--Right, 0);
+    --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
+    --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-left--TranslateY);
+    --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-left--Rotate);
   }
 
   &:is(
     .pf-m-right,
     .pf-m-right-top,
-    .pf-m-right-bottom,
-    .pf-m-inline-end,
-    .pf-m-inline-end-block-start,
-    .pf-m-inline-end-block-end
+    .pf-m-right-bottom
   ) {
-    .#{$popover}__arrow {
-      inset-block-start: 50%;
-      inset-inline-start: 0;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$popover}__arrow--m-right--TranslateX)) translateY(var(--#{$popover}__arrow--m-right--TranslateY)) rotate(var(--#{$popover}__arrow--m-right--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$popover}__arrow--m-right--TranslateX))}) translateY(var(--#{$popover}__arrow--m-right--TranslateY)) rotate(var(--#{$popover}__arrow--m-right--Rotate))
-      );
-    }
+    --#{$popover}__arrow--Top: var(--#{$popover}--m-right--Top, 50%);
+    --#{$popover}__arrow--Left: var(--#{$popover}--m-right--Left, 0);
+    --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-right--TranslateX);
+    --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-right--TranslateY);
+    --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-right--Rotate);
   }
 
   &:is(
     .pf-m-left-top,
-    .pf-m-right-top,
-    .pf-m-inline-start-block-start,
-    .pf-m-inline-end-block-start
+    .pf-m-right-top
   ) {
-    .#{$popover}__arrow {
-      inset-block-start: var(--#{$popover}__arrow--Height);
-    }
+    --#{$popover}__arrow--Top: 0;
+    --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
   }
 
   &:is(
     .pf-m-left-bottom,
-    .pf-m-right-bottom,
-    .pf-m-inline-start-block-end,
-    .pf-m-inline-end-block-end
+    .pf-m-right-bottom
   ) {
-    .#{$popover}__arrow {
-      inset-block-start: auto;
-      inset-block-end: 0;
-    }
+    --#{$popover}__arrow--Top: auto;
+    --#{$popover}__arrow--Bottom: 0;
   }
 
   &:is(
     .pf-m-top-left,
-    .pf-m-bottom-left,
-    .pf-m-block-start-inline-start,
-    .pf-m-block-end-inline-start
+    .pf-m-bottom-left
   ) {
-    .#{$popover}__arrow {
-      inset-inline-start: var(--#{$popover}__arrow--Width);
-    }
+    --#{$popover}__arrow--Left: 0;
+    --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
   }
 
   &:is(
     .pf-m-top-right,
-    .pf-m-bottom-right,
-    .pf-m-block-start-inline-end,
-    .pf-m-block-end-inline-end
+    .pf-m-bottom-right
   ) {
-    .#{$popover}__arrow {
-      inset-inline-start: auto;
-      inset-inline-end: 0;
-    }
+    --#{$popover}__arrow--Right: 0;
+    --#{$popover}__arrow--Left: auto;
   }
 
   &.pf-m-danger {
@@ -244,7 +198,7 @@
   position: relative;
   padding-block-start: var(--#{$popover}__content--PaddingTop);
   padding-block-end: var(--#{$popover}__content--PaddingBottom);
-  padding-inline-start: var(--#{$popover}__content--PaddingLeft); 
+  padding-inline-start: var(--#{$popover}__content--PaddingLeft);
   padding-inline-end: var(--#{$popover}__content--PaddingRight);
   background-color: var(--#{$popover}__content--BackgroundColor);
 }
@@ -263,11 +217,18 @@
 
 .#{$popover}__arrow {
   position: absolute;
+  /* stylelint-disable liberty/use-logical-spec */
+  top: var(--#{$popover}__arrow--Top, auto);
+  right: var(--#{$popover}__arrow--Right, auto);
+  bottom: var(--#{$popover}__arrow--Bottom, auto);
+  left: var(--#{$popover}__arrow--Left, auto);
+  /* stylelint-enable */
   width: var(--#{$popover}__arrow--Width);
   height: var(--#{$popover}__arrow--Height);
   pointer-events: none;
   background-color: var(--#{$popover}__arrow--BackgroundColor);
   box-shadow: var(--#{$popover}__arrow--BoxShadow);
+  transform: translateX(var(--#{$popover}__arrow--TranslateX, 0)) translateY(var(--#{$popover}__arrow--TranslateY, 0)) rotate(var(--#{$popover}__arrow--Rotate, 0));
 }
 
 .#{$popover}__header {

--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -4,6 +4,8 @@ section: components
 cssPrefix: pf-v5-c-tooltip
 ---
 
+import "./Tooltip.css"
+
 ## Examples
 ### Top
 ```hbs

--- a/src/patternfly/components/Tooltip/examples/Tooltip.md
+++ b/src/patternfly/components/Tooltip/examples/Tooltip.md
@@ -4,8 +4,6 @@ section: components
 cssPrefix: pf-v5-c-tooltip
 ---
 
-import "./Tooltip.css"
-
 ## Examples
 ### Top
 ```hbs
@@ -92,8 +90,8 @@ A tooltip is used to provide contextual information for another component on hov
 | `.pf-v5-c-tooltip` | `<div>` |  Creates a tooltip. Always use with a modifier class that positions the tooltip relative to the element it describes. **Required**|
 | `.pf-v5-c-tooltip__arrow` | `<div>` |  Creates an arrow pointing towards the element the tooltip describes. **Required** |
 | `.pf-v5-c-tooltip__content` | `<div>` |  Creates the body of the tooltip. **Required** |
-| `.pf-m-left{-top/bottom}`, `.pf-m-inline-start{-block-start/block-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the left (or left top/left bottom) of the element. |
-| `.pf-m-right{-top/bottom}`, `.pf-m-inline-end{-block-start/block-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the right (or right top/right bottom) of the element. |
-| `.pf-m-top{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the top (or top left/top right) of the element. |
-| `.pf-m-bottom{-left/right}`, `.pf-m-block-start{-inline-start/inline-end}` | `.pf-v5-c-tooltip` | Positions the tooltip to the bottom (or bottom left/bottom right) of the element. |
-| `.pf-m-text-align-left`, `.pf-m-text-align-start` | `.pf-v5-c-tooltip__content` | Modifies tooltip content to text align left. |
+| `.pf-m-left{-top/bottom}` | `.pf-v5-c-tooltip` | Positions the tooltip to the left (or left top/left bottom) of the element. |
+| `.pf-m-right{-top/bottom}` | `.pf-v5-c-tooltip` | Positions the tooltip to the right (or right top/right bottom) of the element. |
+| `.pf-m-top{-left/right}` | `.pf-v5-c-tooltip` | Positions the tooltip to the top (or top left/top right) of the element. |
+| `.pf-m-bottom{-left/right}` | `.pf-v5-c-tooltip` | Positions the tooltip to the bottom (or bottom left/bottom right) of the element. |
+| `.pf-m-text-align-left` | `.pf-v5-c-tooltip__content` | Modifies tooltip content to text align left. |

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -39,127 +39,81 @@
   &:is(
     .pf-m-top,
     .pf-m-top-left,
-    .pf-m-top-right,
-    .pf-m-block-start,
-    .pf-m-block-start-inline-start,
-    .pf-m-block-start-inline-end
+    .pf-m-top-right
   ) {
-    .#{$tooltip}__arrow {
-      inset-block-end: 0;
-      inset-inline-start: 50%;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-top--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-top--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-top--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-top--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-top--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-top--Rotate))
-      );
-    }
+    --#{$tooltip}__arrow--Bottom: var(--#{$tooltip}--m-top--Bottom, 0);
+    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-top--Left, 50%);
+    --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-top--TranslateX);
+    --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
+    --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-top--Rotate);
   }
 
   &:is(
     .pf-m-bottom,
     .pf-m-bottom-left,
-    .pf-m-bottom-right,
-    .pf-m-block-end,
-    .pf-m-block-end-inline-start,
-    .pf-m-block-end-inline-end
-  ) {
-    .#{$tooltip}__arrow {
-      inset-block-start: 0;
-      inset-inline-start: 50%;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-bottom--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-bottom--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-bottom--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-bottom--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-bottom--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-bottom--Rotate))
-      );
-    }
+    .pf-m-bottom-right
+   ) {
+    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-bottom--Top, 0);
+    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-bottom--Left, 50%);
+    --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-bottom--TranslateX);
+    --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-bottom--TranslateY);
+    --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-bottom--Rotate);
   }
 
   &:is(
     .pf-m-left,
     .pf-m-left-top,
-    .pf-m-left-bottom,
-    .pf-m-inline-start,
-    .pf-m-inline-start-block-start,
-    .pf-m-inline-start-block-end
+    .pf-m-left-bottom
   ) {
-    .#{$tooltip}__arrow {
-      inset-block-start: 50%;
-      inset-inline-end: 0;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-left--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-left--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-left--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-left--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-left--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-left--Rotate))
-      );
-    }
+    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-left--Top, 50%);
+    --#{$tooltip}__arrow--Right: var(--#{$tooltip}--m-left--Right, 0);
+    --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
+    --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-left--TranslateY);
+    --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-left--Rotate);
   }
 
   &:is(
     .pf-m-right,
     .pf-m-right-top,
-    .pf-m-right-bottom,
-    .pf-m-inline-end,
-    .pf-m-inline-end-block-start,
-    .pf-m-inline-end-block-end
+    .pf-m-right-bottom
   ) {
-    .#{$tooltip}__arrow {
-      inset-block-start: 50%;
-      inset-inline-start: 0;
-
-      @include pf-v5-bidirectional-style(
-        $prop: transform,
-        $ltr-val: translateX(var(--#{$tooltip}__arrow--m-right--TranslateX)) translateY(var(--#{$tooltip}__arrow--m-right--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-right--Rotate)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tooltip}__arrow--m-right--TranslateX))}) translateY(var(--#{$tooltip}__arrow--m-right--TranslateY)) rotate(var(--#{$tooltip}__arrow--m-right--Rotate))
-      );
-    }
+    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-right--Top, 50%);
+    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-right--Left, 0);
+    --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-right--TranslateX);
+    --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-right--TranslateY);
+    --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-right--Rotate);
   }
 
   &:is(
     .pf-m-left-top,
-    .pf-m-right-top,
-    .pf-m-inline-start-block-start,
-    .pf-m-inline-end-block-start
+    .pf-m-right-top
   ) {
-    .#{$tooltip}__arrow {
-      inset-block-start: var(--#{$tooltip}__arrow--Height);
-    }
+    --#{$tooltip}__arrow--Top: 0;
+    --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
   }
 
   &:is(
     .pf-m-left-bottom,
-    .pf-m-right-bottom,
-    .pf-m-inline-start-block-end,
-    .pf-m-inline-end-block-end
+    .pf-m-right-bottom
   ) {
-    .#{$tooltip}__arrow {
-      inset-block-start: auto;
-      inset-block-end: 0;
-    }
+    --#{$tooltip}__arrow--Top: auto;
+    --#{$tooltip}__arrow--Bottom: 0;
   }
 
   &:is(
     .pf-m-top-left,
-    .pf-m-bottom-left,
-    .pf-m-block-start-block-start,
-    .pf-m-block-end-block-start
+    .pf-m-bottom-left
   ) {
-    .#{$tooltip}__arrow {
-      inset-inline-start: var(--#{$tooltip}__arrow--Width);
-    }
+    --#{$tooltip}__arrow--Left: 0;
+    --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
   }
 
   &:is(
     .pf-m-top-right,
-    .pf-m-bottom-right,
-    .pf-m-block-start-block-end,
-    .pf-m-block-end-block-end
+    .pf-m-bottom-right
   ) {
-    .#{$tooltip}__arrow {
-      inset-inline-start: auto;
-      inset-inline-end: 0;
-    }
+    --#{$tooltip}__arrow--Right: 0;
+    --#{$tooltip}__arrow--Left: auto;
   }
 }
 
@@ -175,18 +129,25 @@
   word-break: break-word;
   background-color: var(--#{$tooltip}__content--BackgroundColor);
 
-  &:is(.pf-m-text-align-left, .pf-m-text-align-start) {
+  &.pf-m-text-align-left {
     text-align: start;
   }
 }
 
 .#{$tooltip}__arrow {
   position: absolute;
+  /* stylelint-disable liberty/use-logical-spec */
+  top: var(--#{$tooltip}__arrow--Top, auto);
+  right: var(--#{$tooltip}__arrow--Right, auto);
+  bottom: var(--#{$tooltip}__arrow--Bottom, auto);
+  left: var(--#{$tooltip}__arrow--Left, auto);
+  /* stylelint-enable */
   width: var(--#{$tooltip}__arrow--Width);
   height: var(--#{$tooltip}__arrow--Height);
   pointer-events: none;
   background-color: var(--#{$tooltip}__arrow--BackgroundColor);
   box-shadow: var(--#{$tooltip}__arrow--BoxShadow);
+  transform: translateX(var(--#{$tooltip}__arrow--TranslateX, 0)) translateY(var(--#{$tooltip}__arrow--TranslateY, 0)) rotate(var(--#{$tooltip}__arrow--Rotate, 0));
 }
 
 // stylelint-disable no-invalid-position-at-import-rule


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5951

This also simplifies the CSS a bit, makes everything a variable, and makes everything's `top`, `right`, `bottom`, and `left` position provide the actual position for where the arrow should be. Previously a couple of variations were using the arrow's width as the values for some of those position properties. What that will allow is better control of the arrow position via setting CSS vars for a feature it looks like we want to introduce in popper - [overflow prevention](https://codesandbox.io/s/github/floating-ui/popper.js.org/tree/master/examples/overflow-prevention). That allows the popper element to act as if it's sticky to an overflow edge as overflow is scrolling, and the arrow's position updates dynamically as you scroll based on your scroll position.