### PR TITLE
fix(Toolbar): increase workspace container height

### DIFF
--- a/src/patternfly/demos/Toolbar/examples/Toolbar.css
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.css
@@ -5,6 +5,10 @@
   min-height: 420px;
 }
 
+#ws-html-demos-c-toolbar-toolbar-attribute-value-single-select-filter-on-desktop {
+  min-height: 320px;
+}
+
 #ws-html-demos-c-toolbar-toolbar-attribute-value-search-filter-on-mobile {
   min-height: 175px;
 }


### PR DESCRIPTION
Fixes #5772 
Went ahead and did it since stalebot was on it's tail!
Adds min height for the 4th toolbar demo.