### PR TITLE
feat(card): added header wrap modifier

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -8,6 +8,8 @@
   --#{$card}--child--PaddingBottom: var(--#{$pf-global}--spacer--lg);
   --#{$card}--child--PaddingLeft: var(--#{$pf-global}--spacer--lg);
   --#{$card}--c-divider--child--PaddingTop: var(--#{$pf-global}--spacer--lg);
+  --#{$card}__header--m-wrap--RowGap: var(--#{$pf-global}--spacer--sm);
+  --#{$card}__header--m-wrap--ColumnGap: var(--#{$pf-global}--spacer--md);
   --#{$card}__title--not--last-child--PaddingBottom: var(--#{$pf-global}--spacer--md);
   --#{$card}__title-text--FontFamily: var(--#{$pf-global}--FontFamily--heading);
   --#{$card}__title-text--FontSize: var(--#{$pf-global}--FontSize--md);
@@ -27,7 +29,6 @@
   --#{$card}__header-toggle--MarginLeft: calc(var(--#{$pf-global}--spacer--md) * -1);
   --#{$card}__header-toggle-icon--Transition: var(--#{$pf-global}--Transition);
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
-
 
   // Selectable/Clickable
   --#{$card}--m-selectable--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
@@ -339,13 +340,6 @@
   flex-direction: row;
   align-items: center;
 
-  .#{$card}__title {
-    --#{$card}--first-child--PaddingTop: 0;
-    --#{$card}__title--not--last-child--PaddingBottom: 0;
-
-    padding: 0;
-  }
-
   &.pf-m-toggle-right {
     --#{$card}__header-toggle--MarginRight: var(--#{$card}__header--m-toggle-right--toggle--MarginRight);
     --#{$card}__header-toggle--MarginLeft: var(--#{$card}__header--m-toggle-right--toggle--MarginLeft);
@@ -353,6 +347,33 @@
     .#{$card}__header-toggle {
       order: 2;
     }
+  }
+
+  &.pf-m-wrap {
+    --pf-v5-c-card__actions--PaddingLeft: 0;
+    
+    gap: var(--#{$card}__header--m-wrap--RowGap) var(--#{$card}__header--m-wrap--ColumnGap);
+
+    &,
+    .#{$card}__actions {
+      flex-wrap: wrap;
+      row-gap: var(--#{$card}__header--m-wrap--RowGap);
+    }
+
+    .#{$card}__actions {
+      + * {
+        margin-inline-end: auto;
+      }
+
+      margin-inline-start: 0
+    }
+  }
+
+  .#{$card}__title {
+    --#{$card}--first-child--PaddingTop: 0;
+    --#{$card}__title--not--last-child--PaddingBottom: 0;
+
+    padding: 0;
   }
 }
 

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -709,6 +709,25 @@ import './Card.css'
 {{/card}}
 ```
 
+### Card with header that wraps
+```hbs isBeta
+{{#> card}}
+  {{#> card-header card-header--modifier="pf-m-wrap"}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> button button--modifier="pf-m-primary"}}Primary action{{/button}}
+      {{#> button button--modifier="pf-m-secondary"}}Secondary action{{/button}}
+      {{#> button button--modifier="pf-m-secondary"}}Secondary action{{/button}}
+      {{#> button button--modifier="pf-m-secondary"}}Secondary action{{/button}}
+      {{#> button button--modifier="pf-m-secondary"}}Secondary action{{/button}}
+    {{/card-actions}}
+    {{> card-title card-title-text--value="This is a longer card title that takes up more space"}}
+  {{/card-header}}
+  {{#> card-body}}
+    This is the card body
+  {{/card-body}}
+{{/card}}
+```
+
 ## Documentation
 ### Overview
 A card is a generic rectangular container that can be used to build other components. Use a default card for regular page content and the compact variation for dashboard or small cards.
@@ -731,6 +750,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-v5-c-card__sr-input` | `<input>` | Creates an input which, when focused, makes a following `.pf-v5-c-card` appear focused. |
 | `.pf-m-compact` | `.pf-v5-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. This variation is for use on dashboards and where a smaller card is preferred. |
 | `.pf-m-display-lg` | `.pf-v5-c-card` | Creates a large variation of the card component that involves larger font sizes and spacing. This variation is for marketing use cases. |
+| `.pf-m-wrap` | `.pf-v5-c-card__header` | Modifies the card header to wrap its children. |
 | `.pf-m-no-fill` | `.pf-v5-c-card__body` | Sets a `.pf-v5-c-card__body` not to fill the available space in `.pf-v5-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-selectable` | `.pf-v5-c-card` | Modifies a card to be selectable.  |
 | `.pf-m-clickable` | `.pf-v5-c-card` | Modifies a card to be clickable. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/3713

@garrett sorry for the delay on this issue. This is in response to the PR you opened a while back - https://github.com/patternfly/patternfly/pull/3714. When you get a sec, would you mind giving your thoughts and if this will work for your use cases? It's pretty much the same as your PR except I'm not setting any flex layout properties on the `__header-main` element since that isn't a flex layout in PF. If it's alright, I'd also like to close https://github.com/patternfly/patternfly/pull/3714. If you agree, feel free to go ahead and close it.