### PR TITLE
feat(Accordion): added left-aligned toggle variant

### DIFF
--- a/src/patternfly/components/Accordion/accordion.hbs
+++ b/src/patternfly/components/Accordion/accordion.hbs
@@ -1,4 +1,4 @@
-<{{#if accordion--IsDefinitionList}}dl{{else}}div{{/if}} class="{{pfv}}accordion{{#if accordion--modifier}} {{accordion--modifier}}{{/if}}"
+<{{#if accordion--IsDefinitionList}}dl{{else}}div{{/if}} class="{{pfv}}accordion{{#if accordion--IsStartAligned}} pf-m-start{{/if}}{{#if accordion--modifier}} {{accordion--modifier}}{{/if}}"
  {{#if accordion--attribute}}
    {{{accordion--attribute}}}
  {{/if}}>

--- a/src/patternfly/components/Accordion/accordion.hbs
+++ b/src/patternfly/components/Accordion/accordion.hbs
@@ -1,4 +1,4 @@
-<{{#if accordion--IsDefinitionList}}dl{{else}}div{{/if}} class="{{pfv}}accordion{{#if accordion--IsStartAligned}} pf-m-start{{/if}}{{#if accordion--modifier}} {{accordion--modifier}}{{/if}}"
+<{{#if accordion--IsDefinitionList}}dl{{else}}div{{/if}} class="{{pfv}}accordion{{#if accordion--IsStartAligned}} pf-m-toggle-start{{/if}}{{#if accordion--modifier}} {{accordion--modifier}}{{/if}}"
  {{#if accordion--attribute}}
    {{{accordion--attribute}}}
  {{/if}}>

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -19,6 +19,8 @@
   --#{$accordion}__toggle--after--Width: var(--#{$pf-global}--BorderWidth--lg);
   --#{$accordion}__toggle--m-expanded--after--BackgroundColor: var(--#{$pf-global}--primary-color--100);
   --#{$accordion}__toggle--BackgroundColor: transparent;
+  --#{$accordion}__toggle--JustifyContent: space-between;
+  --#{$accordion}__toggle--ColumnGap: 0;
 
   // accordion toggle text
   --#{$accordion}__toggle-text--MaxWidth: calc(100% - var(--#{$pf-global}--spacer--lg));
@@ -84,6 +86,11 @@
   @include pf-v5-t-light;
 
   background-color: var(--#{$accordion}--BackgroundColor);
+
+  &.pf-m-start {
+    --#{$accordion}__toggle--JustifyContent: start;
+    --#{$accordion}__toggle--ColumnGap: var(--#{$pf-global}--spacer--md);
+  }
 
   &.pf-m-display-lg {
     --#{$accordion}__toggle--PaddingTop: var(--#{$accordion}--m-display-lg__toggle--PaddingTop);
@@ -161,8 +168,9 @@
 .#{$accordion}__toggle {
   position: relative;
   display: flex;
+  column-gap: var(--#{$accordion}__toggle--ColumnGap);
   align-items: center;
-  justify-content: space-between;
+  justify-content: var(--#{$accordion}__toggle--JustifyContent);
   width: 100%;
   padding-block-start: var(--#{$accordion}__toggle--PaddingTop);
   padding-block-end: var(--#{$accordion}__toggle--PaddingBottom);

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -22,6 +22,10 @@
   --#{$accordion}__toggle--JustifyContent: space-between;
   --#{$accordion}__toggle--ColumnGap: 0;
 
+  // Accordion toggle toggle-start modifier
+  --#{$accordion}--m-toggle-start__toggle--JustifyContent: start;
+  --#{$accordion}--m-toggle-start__toggle--ColumnGap: var(--#{$pf-global}--spacer--md);
+
   // accordion toggle text
   --#{$accordion}__toggle-text--MaxWidth: calc(100% - var(--#{$pf-global}--spacer--lg));
   --#{$accordion}__toggle--hover__toggle-text--Color: var(--#{$pf-global}--link--Color);
@@ -87,9 +91,9 @@
 
   background-color: var(--#{$accordion}--BackgroundColor);
 
-  &.pf-m-start {
-    --#{$accordion}__toggle--JustifyContent: start;
-    --#{$accordion}__toggle--ColumnGap: var(--#{$pf-global}--spacer--md);
+  &.pf-m-toggle-start {
+    --#{$accordion}__toggle--JustifyContent: var(--#{$accordion}--m-toggle-start__toggle--JustifyContent);
+    --#{$accordion}__toggle--ColumnGap: var(--#{$accordion}--m-toggle-start__toggle--ColumnGap);
   }
 
   &.pf-m-display-lg {

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -232,6 +232,7 @@ cssPrefix: pf-v5-c-accordion
 ```
 
 ### Large bordered
+
 ```hbs
 {{#> accordion accordion--modifier="pf-m-display-lg pf-m-bordered"}}
   {{#> accordion-toggle}}
@@ -294,6 +295,62 @@ cssPrefix: pf-v5-c-accordion
 {{/accordion}}
 ```
 
+### Toggle icon at start
+
+```hbs
+{{#> accordion accordion--IsStartAligned="true"}}
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+  {{/accordion-toggle}}
+  {{#> accordion-expandable-content}}
+    {{#> accordion-expandable-content-body}}
+      This text is hidden
+    {{/accordion-expandable-content-body}}
+  {{/accordion-expandable-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+  {{/accordion-toggle}}
+  {{#> accordion-expandable-content}}
+    {{#> accordion-expandable-content-body}}
+      This text is hidden
+    {{/accordion-expandable-content-body}}
+  {{/accordion-expandable-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+  {{/accordion-toggle}}
+  {{#> accordion-expandable-content}}
+    {{#> accordion-expandable-content-body}}
+      This text is hidden
+    {{/accordion-expandable-content-body}}
+  {{/accordion-expandable-content}}
+
+  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+  {{/accordion-toggle}}
+  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
+    {{#> accordion-expandable-content-body}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    {{/accordion-expandable-content-body}}
+  {{/accordion-expandable-content}}
+
+  {{#> accordion-toggle}}
+    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+  {{/accordion-toggle}}
+  {{#> accordion-expandable-content}}
+    {{#> accordion-expandable-content-body}}
+      This text is hidden
+    {{/accordion-expandable-content-body}}
+  {{/accordion-expandable-content}}
+{{/accordion}}
+```
+
 ## Documentation
 ### Overview
 There are two variations to build the accordion component:
@@ -314,5 +371,6 @@ In these examples `.pf-v5-c-accordion` uses `<dl>`, `.pf-v5-c-accordion__toggle`
 | `.pf-v5-c-accordion__expandable-content-body` | `<div>` | Initiates expandable content body. **Required** |
 | `.pf-m-bordered` | `.pf-v5-c-accordion` | Modifies the accordion to add borders between items. |
 | `.pf-m-display-lg` | `.pf-v5-c-accordion` | Modifies the accordion for large display styling. This variation is for marketing/web use cases. |
+| `.pf-m-start` | `.pf-v5-c-accordion` | Modifies accordion styling when accordion toggle icons are rendered at the start of the toggle, before the toggle text. |
 | `.pf-m-expanded` | `.pf-v5-c-accordion__toggle`, `.pf-v5-c-accordion__expandable-content` | Modifies the accordion button and expandable content for the expanded state. |
 | `.pf-m-fixed` | `.pf-v5-c-accordion__expandable-content` | Modifies the expandable content for the fixed state. |

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -297,8 +297,8 @@ cssPrefix: pf-v5-c-accordion
 
 ### Toggle icon at start
 
-```hbs
-{{#> accordion accordion--IsStartAligned="true"}}
+```hbs isBeta
+{{#> accordion accordion--IsStartAligned=true}}
   {{#> accordion-toggle}}
     {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
     {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
@@ -371,6 +371,6 @@ In these examples `.pf-v5-c-accordion` uses `<dl>`, `.pf-v5-c-accordion__toggle`
 | `.pf-v5-c-accordion__expandable-content-body` | `<div>` | Initiates expandable content body. **Required** |
 | `.pf-m-bordered` | `.pf-v5-c-accordion` | Modifies the accordion to add borders between items. |
 | `.pf-m-display-lg` | `.pf-v5-c-accordion` | Modifies the accordion for large display styling. This variation is for marketing/web use cases. |
-| `.pf-m-start` | `.pf-v5-c-accordion` | Modifies accordion styling when accordion toggle icons are rendered at the start of the toggle, before the toggle text. |
+| `.pf-m-toggle-start` | `.pf-v5-c-accordion` | Modifies accordion styling when accordion toggle icons are rendered at the start of the toggle, before the toggle text. |
 | `.pf-m-expanded` | `.pf-v5-c-accordion__toggle`, `.pf-v5-c-accordion__expandable-content` | Modifies the accordion button and expandable content for the expanded state. |
 | `.pf-m-fixed` | `.pf-v5-c-accordion__expandable-content` | Modifies the expandable content for the fixed state. |


### PR DESCRIPTION
Closes #5426 

For context, I went with a medium spacer since it looked closer to the spacing between the toggle icon and toggle text when the text is truncated:

![image](https://github.com/patternfly/patternfly/assets/70952936/db3b9f7e-7a59-440e-8e6d-b2358424b8f2)

Opted to place the modifier on the top level `pf-v5-c-accordion` element since having that modifier on the individual `pf-v5-c-accordion__toggle` elements, there's the possibility to mix and match left and right aligned accordion toggles within the same accordion which isn't ideal. Having it on the top level element would sort of prevent that as the styling wouldn't be correct for the default accordion toggle positioning (the toggle icon would no longer be positioned at the end of the toggle)