### PR TITLE
fix(Switch): updated focus style to focus-visible

### DIFF
--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -74,7 +74,7 @@
   cursor: pointer;
   opacity: 0;
 
-  &:focus ~ .#{$switch}__toggle {
+  &:focus-visible ~ .#{$switch}__toggle {
     outline: var(--#{$switch}__input--focus__toggle--OutlineWidth) solid var(--#{$switch}__input--focus__toggle--OutlineColor);
     outline-offset: var(--#{$switch}__input--focus__toggle--OutlineOffset);
   }


### PR DESCRIPTION
Closes #5481 

Question for @andrew-ronaldson and/or @lboehling: I did a quick check of some of our other components, and curious whether you think a similar update should/could be made to our Slider and Toggle Group styles. For the Slider, when you click the thumb the focus style remains:
![Slider with focus styles after click](https://github.com/patternfly/patternfly/assets/70952936/5d4ff9cf-b0f5-409c-b6e2-2b24037af34d)

For Toggle Group, a clicked item that isn't selected and a selected item are fairly similar in look. In the following screen shot, Option 2 was clicked to select it, then Option 1 was clicked to deselect it (but it still retains focus after clicking). The styling is more similar in light theme (to me), and would be even more most likely to a user with some form of color blindness:
![Toggle group with focus style on the first option after clicking](https://github.com/patternfly/patternfly/assets/70952936/0fde99ae-0bc1-47d7-aa78-961ec11c6504)

Unrelated to the above, but I did some basic testing using [Talon](https://talonvoice.com/) to see how an interaction works with a voice-input based navigation method, as I was curious if removing focus styles on click would somehow affect that sort of assistive tech. From what I can tell using focus-visible doesn't cause any issues in terms of focus styling; speaking to tab through elements on the page triggers the focus styles I'd expect on the Switch, and moving the mouse via voice commands worked as I'd expect. Couple of videos for anyone interested in some niftyness are below

Using keyboard commands with Talon:


https://github.com/patternfly/patternfly/assets/70952936/6f5fb3f5-f395-4ad4-b614-672167c71ccb



Using mouse interactions with Talon:



https://github.com/patternfly/patternfly/assets/70952936/87483fa4-c2bc-4015-837f-22747a5022ea



