### PR TITLE
fix(box-shadow): typo in box shadow token names

### DIFF
--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -85,10 +85,10 @@
 
     // box shadow
     --pf-t--global--box-shadow--sm: 0px 1px 2px 0px rgb(0 0 0 / 50%);
-    --pf-t--global--box-shadow--sm-top: 0px -1px 2px 0px rgb(0 0 0 / 50%);
-    --pf-t--global--box-shadow--sm-right: 1px 0px 2px 0px rgb(0 0 0 / 50%);
-    --pf-t--global--box-shadow--sm-bottom: 0px 1px 2px 0px rgb(0 0 0 / 50%);
-    --pf-t--global--box-shadow--sm-left: -1px 0px 2px 0px rgb(0 0 0 / 50%);
+    --pf-t--global--box-shadow--sm--top: 0px -1px 2px 0px rgb(0 0 0 / 50%);
+    --pf-t--global--box-shadow--sm--right: 1px 0px 2px 0px rgb(0 0 0 / 50%);
+    --pf-t--global--box-shadow--sm--bottom: 0px 1px 2px 0px rgb(0 0 0 / 50%);
+    --pf-t--global--box-shadow--sm--left: -1px 0px 2px 0px rgb(0 0 0 / 50%);
     --pf-t--global--box-shadow--md: 0px 4px 8px 0px rgb(0 0 0 / 50%);
     --pf-t--global--box-shadow--lg: 0px 8px 24px 0px rgb(0 0 0 / 50%);
   }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -132,12 +132,12 @@ $pf-page-v5--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--section--m-sticky-top--ZIndex: var(--#{$pf-global}--ZIndex--md);
   --#{$page}--section--m-sticky-top--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
   --#{$page}--section--m-sticky-bottom--ZIndex: var(--#{$pf-global}--ZIndex--md);
-  --#{$page}--section--m-sticky-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm-top);
+  --#{$page}--section--m-sticky-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
 
   // Shadows
-  --#{$page}--section--m-shadow-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm-bottom);
+  --#{$page}--section--m-shadow-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
   --#{$page}--section--m-shadow-bottom--ZIndex: var(--#{$pf-global}--ZIndex--xs);
-  --#{$page}--section--m-shadow-top--BoxShadow: var(--pf-t--global--box-shadow--sm-top);
+  --#{$page}--section--m-shadow-top--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
   --#{$page}--section--m-shadow-top--ZIndex: var(--#{$pf-global}--ZIndex--xs);
 
   // Main section horizontal nav


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6034

the beans:

<img width="811" alt="Screenshot 2023-11-07 at 1 57 09 PM" src="https://github.com/patternfly/patternfly/assets/35148959/14655fa7-8f0e-4f3e-9ee5-339fc4fa0324">
