### PR TITLE
feat(global): remove invalid selector crashing inspector

### DIFF
--- a/src/patternfly/base/_globals.scss
+++ b/src/patternfly/base/_globals.scss
@@ -33,10 +33,8 @@
 // Normalize
 @if $pf-v5-global--enable-normalize {
   *,
-  :where(
-    *::before,
-    *::after
-  ) {
+  *::before,
+  *::after {
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
`:where()` with a pseudo element is not valid, and this was causing the inspector in Chrome 119 and Edge to crash. This changes the selector to remove `:where`. The only side effect is increasing the specificity of that particular rule. 