### PR TITLE
feat(Accordion): applied tokens

### DIFF
--- a/src/patternfly/components/Accordion/accordion-expandable-content.hbs
+++ b/src/patternfly/components/Accordion/accordion-expandable-content.hbs
@@ -1,5 +1,5 @@
-<{{#if accordion--IsDefinitionList}}dd{{else}}div{{/if}} class="{{pfv}}accordion__expandable-content{{#if accordion-expandable-content--IsExpanded}} pf-m-expanded{{/if}}{{#if accordion-expandable-content--IsFixed}} pf-m-fixed{{/if}}{{#if accordion-expandable-content--modifier}} {{accordion-expandable-content--modifier}}{{/if}}"
-  {{#unless accordion-expandable-content--IsExpanded}}hidden{{/unless}}
+<{{#if accordion--IsDefinitionList}}dd{{else}}div{{/if}} class="{{pfv}}accordion__expandable-content{{#if accordion-expandable-content--IsFixed}} pf-m-fixed{{/if}}{{#if accordion-expandable-content--modifier}} {{accordion-expandable-content--modifier}}{{/if}}"
+  {{#unless accordion-item--IsExpanded}}hidden{{/unless}}
   {{#if accordion-expandable-content--IsFixed}}
     {{#unless accordion-expandable-content--HasNoScrollbar}}
       {{#unless accordion--IsDefinitionList}}

--- a/src/patternfly/components/Accordion/accordion-item.hbs
+++ b/src/patternfly/components/Accordion/accordion-item.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}accordion__item{{#if accordion-item--modifier}} {{accordion-item--modifier}}{{/if}}"
+  {{#if accordion-item--attribute}}
+    {{{accordion-item--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Accordion/accordion-item.hbs
+++ b/src/patternfly/components/Accordion/accordion-item.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}accordion__item{{#if accordion-item--modifier}} {{accordion-item--modifier}}{{/if}}"
+<div class="{{pfv}}accordion__item{{#if accordion-item--IsExpanded}} pf-m-expanded{{/if}}{{#if accordion-item--modifier}} {{accordion-item--modifier}}{{/if}}"
   {{#if accordion-item--attribute}}
     {{{accordion-item--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Accordion/accordion-toggle.hbs
+++ b/src/patternfly/components/Accordion/accordion-toggle.hbs
@@ -1,6 +1,6 @@
-<{{#if accordion--IsDefinitionList}}dt>{{else}}h3>{{/if}}<button class="{{pfv}}accordion__toggle{{#if accordion-toggle--IsExpanded}} pf-m-expanded{{/if}}{{#if accordion-toggle--modifier}} {{accordion-toggle--modifier}}{{/if}}"
+<{{#if accordion--IsDefinitionList}}dt>{{else}}h3>{{/if}}<button class="{{pfv}}accordion__toggle{{#if accordion-toggle--modifier}} {{accordion-toggle--modifier}}{{/if}}"
   type="button"
-  {{#if accordion-toggle--IsExpanded}}
+  {{#if accordion-item--IsExpanded}}
    aria-expanded="true"
   {{else}}
    aria-expanded="false"

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -67,7 +67,7 @@
   
   // bordered
   --#{$accordion}--m-bordered--RowGap: 0;
-  --#{$accordion}__item--m-bordered--BorderBottomWidth: var(--pf-t--global--border--width--100);
+  --#{$accordion}__item--m-bordered--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
   --#{$accordion}__item--m-bordered--BorderBottomColor: var(--pf-t--global--border--color--default);
 }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -19,9 +19,8 @@
   --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--focus--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$accordion}__toggle--FontFamily: var(--pf-t--global--font--family--body);
-  --#{$accordion}__toggle--FontSize: var(--pf-t--global--font--size--body--md);
-  --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--200);
+  --#{$accordion}__toggle--active--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // Accordion toggle toggle-start modifier
   --#{$accordion}--m-toggle-start__toggle--JustifyContent: start;
@@ -41,7 +40,7 @@
   --#{$accordion}__expandable-content--MarginBottom: var(--pf-t--global--spacer--md);
   --#{$accordion}__expandable-content--MarginLeft: var(--pf-t--global--spacer--md);
   --#{$accordion}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--200);
+  --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
   --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--md);
   --#{$accordion}__expandable-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
@@ -59,7 +58,7 @@
   --#{$accordion}--m-display-lg__toggle--PaddingBottom: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBottom: var(--pf-t--global--spacer--sm);
   --#{$accordion}--m-display-lg__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--body);
+  --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$accordion}--m-display-lg__toggle--FontSize: var(--pf-t--global--font--size--heading--sm);
   --#{$accordion}--m-display-lg__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
   --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
@@ -132,8 +131,8 @@
   padding-block-end: var(--#{$accordion}__toggle--PaddingBottom);
   padding-inline-start: var(--#{$accordion}__toggle--PaddingLeft);
   padding-inline-end: var(--#{$accordion}__toggle--PaddingRight);
-  font-family: var(--#{$accordion}__toggle--FontFamily);
-  font-size: var(--#{$accordion}__toggle--FontSize);
+  font-family: var(--#{$accordion}__toggle--FontFamily, inherit);
+  font-size: var(--#{$accordion}__toggle--FontSize, inherit);
   text-align: start;
   background-color: var(--#{$accordion}__toggle--BackgroundColor);
   border: 0;
@@ -145,6 +144,10 @@
 
   &:focus {
     background-color: var(--#{$accordion}__toggle--focus--BackgroundColor);
+  }
+
+  &:active {
+    background-color: var(--#{$accordion}__toggle--active--BackgroundColor);
   }
 }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,94 +1,81 @@
 // @debug $accordion; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
-.#{$accordion} {
+:root {
   // accordion
-  --#{$accordion}--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$accordion}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$accordion}--RowGap: var(--pf-t--global--spacer--xs);
+
+  // accordion item
+  --#{$accordion}__item--BorderRadius: var(--pf-t--global--border--radius--200);
+  --#{$accordion}__item--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--selected);
 
   // accordion toggle
-  --#{$accordion}__toggle--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$accordion}__toggle--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$accordion}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}__toggle--before--Top: 0;
-  --#{$accordion}__toggle--after--Top: 0;
-  --#{$accordion}__toggle--after--BackgroundColor: transparent;
-  --#{$accordion}__toggle--hover--BackgroundColor: var(--#{$pf-global}--BackgroundColor--200);
-  --#{$accordion}__toggle--focus--BackgroundColor: var(--#{$pf-global}--BackgroundColor--200);
-  --#{$accordion}__toggle--active--BackgroundColor: var(--#{$pf-global}--BackgroundColor--200);
-  --#{$accordion}__toggle--before--Width: var(--#{$pf-global}--BorderWidth--lg);
-  --#{$accordion}__toggle--after--Width: var(--#{$pf-global}--BorderWidth--lg);
-  --#{$accordion}__toggle--m-expanded--after--BackgroundColor: var(--#{$pf-global}--primary-color--100);
-  --#{$accordion}__toggle--BackgroundColor: transparent;
-  --#{$accordion}__toggle--JustifyContent: space-between;
-  --#{$accordion}__toggle--ColumnGap: 0;
+  --#{$accordion}__toggle--ColumnGap: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$accordion}__toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--m-expanded--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --#{$accordion}__toggle--focus--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --#{$accordion}__toggle--FontFamily: var(--pf-t--global--font--family--body);
+  --#{$accordion}__toggle--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--200);
 
   // Accordion toggle toggle-start modifier
   --#{$accordion}--m-toggle-start__toggle--JustifyContent: start;
   --#{$accordion}--m-toggle-start__toggle--ColumnGap: var(--#{$pf-global}--spacer--md);
 
   // accordion toggle text
-  --#{$accordion}__toggle-text--MaxWidth: calc(100% - var(--#{$pf-global}--spacer--lg));
-  --#{$accordion}__toggle--hover__toggle-text--Color: var(--#{$pf-global}--link--Color);
-  --#{$accordion}__toggle--active__toggle-text--Color: var(--#{$pf-global}--link--Color);
-  --#{$accordion}__toggle--active__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--bold);
-  --#{$accordion}__toggle--focus__toggle-text--Color: var(--#{$pf-global}--link--Color);
-  --#{$accordion}__toggle--focus__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--bold);
-  --#{$accordion}__toggle--m-expanded__toggle-text--Color: var(--#{$pf-global}--link--Color);
-  --#{$accordion}__toggle--m-expanded__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--bold);
-
+  --#{$accordion}__toggle-text--Color: var(--pf-t--global--text--color--regular);
+  --#{$accordion}__toggle-text--FontWeight: var(--pf-t--global--font--weight--body);
+  --#{$accordion}__toggle--m-expanded__toggle-text--FontWeight: var(--pf-t--global--font--weight--body--bold);
+  
   // accordion toggle icon
   --#{$accordion}__toggle-icon--Transition: .2s ease-in 0s;
   --#{$accordion}__toggle--m-expanded__toggle-icon--Rotate: 90deg;
-
-  // accordion expanded content
-  --#{$accordion}__expandable-content--Color: var(--#{$pf-global}--Color--200);
-  --#{$accordion}__expandable-content--FontSize: var(--#{$pf-global}--FontSize--sm);
-  --#{$accordion}__expandable-content--m-expanded__expandable-content-body--after--BackgroundColor: var(--#{$pf-global}--primary-color--100);
+  
+  // accordion expandable content
+  --#{$accordion}__expandable-content--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--200);
+  --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
+  --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--md);
   --#{$accordion}__expandable-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
-  --#{$accordion}__expandable-content-body--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$accordion}__expandable-content-body--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}__expandable-content-body--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$accordion}__expandable-content-body--PaddingLeft: var(--#{$pf-global}--spacer--md);
+
+  // accordion expandable content body
+  --#{$accordion}__expandable-content-body--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingLeft: var(--pf-t--global--spacer--sm);
   --#{$accordion}__expandable-content-body--expandable-content-body--PaddingTop: 0;
-  --#{$accordion}__expandable-content-body--after--BackgroundColor: transparent;
-  --#{$accordion}__expandable-content-body--after--Width: var(--#{$pf-global}--BorderWidth--lg);
-  --#{$accordion}__expandable-content-body--before--Top: 0;
-
+  
   // large
-  --#{$accordion}--m-display-lg__toggle--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$accordion}--m-display-lg__toggle--FontFamily: var(--#{$pf-global}--FontFamily--heading);
-  --#{$accordion}--m-display-lg__toggle--FontSize: var(--#{$pf-global}--FontSize--xl);
-  --#{$accordion}--m-display-lg__toggle--hover__toggle-text--Color: var(--#{$pf-global}--Color--100);
-  --#{$accordion}--m-display-lg__toggle--active__toggle-text--Color: var(--#{$pf-global}--Color--100);
-  --#{$accordion}--m-display-lg__toggle--active__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--normal);
-  --#{$accordion}--m-display-lg__toggle--focus__toggle-text--Color: var(--#{$pf-global}--Color--100);
-  --#{$accordion}--m-display-lg__toggle--focus__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--normal);
-  --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--Color: var(--#{$pf-global}--Color--100);
-  --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--#{$pf-global}--FontWeight--normal);
-  --#{$accordion}--m-display-lg__expandable-content--FontSize: var(--#{$pf-global}--FontSize--md);
-  --#{$accordion}--m-display-lg__expandable-content--Color: var(--#{$pf-global}--Color--100);
-  --#{$accordion}--m-display-lg__expandable-content-body--PaddingTop: 0;
-  --#{$accordion}--m-display-lg__expandable-content-body--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}--m-display-lg__expandable-content-body--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$accordion}--m-display-lg__expandable-content-body--last-child--PaddingBottom: var(--#{$pf-global}--spacer--lg);
-  --#{$accordion}--m-display-lg__expandable-content-body--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-
+  --#{$accordion}--m-display-lg__toggle--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$accordion}--m-display-lg__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--body);
+  --#{$accordion}--m-display-lg__toggle--FontSize: var(--pf-t--global--font--size--heading--sm);
+  --#{$accordion}--m-display-lg__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+  --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+  --#{$accordion}--m-display-lg__expandable-content--FontSize: var(--pf-t--global--font--size--body--lg);
+  --#{$accordion}--m-display-lg__expandable-content--Color: var(--pf-t--global--text--color--regular);
+  
   // bordered
-  --#{$accordion}--m-bordered--BorderTopWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$accordion}--m-bordered--BorderTopColor: var(--#{$pf-global}--BorderColor--100);
-  --#{$accordion}--m-bordered__toggle--after--Top: calc(-1 * var(--#{$pf-global}--BorderWidth--sm));
-  --#{$accordion}--m-bordered__toggle--before--BorderColor: var(--#{$pf-global}--BorderColor--100);
-  --#{$accordion}--m-bordered__toggle--before--BorderTopWidth: 0;
-  --#{$accordion}--m-bordered__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$accordion}--m-bordered__expandable-content--m-expanded__expandable-content-body--last-child--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$accordion}--m-bordered__expandable-content--m-expanded__expandable-content-body--last-child--before--BorderBottomColor: var(--#{$pf-global}--BorderColor--100);
+  --#{$accordion}--m-bordered--RowGap: 0;
+  --#{$accordion}__item--m-bordered--BorderBottomWidth: var(--pf-t--global--border--width--100);
+  --#{$accordion}__item--m-bordered--BorderBottomColor: var(--pf-t--global--border--color--default);
+}
 
-  // This component always needs to be light
-  @include pf-v5-t-light;
-
+.#{$accordion} {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--#{$accordion}--RowGap);
   background-color: var(--#{$accordion}--BackgroundColor);
 
   &.pf-m-toggle-start {
@@ -100,145 +87,73 @@
     --#{$accordion}__toggle--PaddingTop: var(--#{$accordion}--m-display-lg__toggle--PaddingTop);
     --#{$accordion}__toggle--PaddingRight: var(--#{$accordion}--m-display-lg__toggle--PaddingRight);
     --#{$accordion}__toggle--PaddingBottom: var(--#{$accordion}--m-display-lg__toggle--PaddingBottom);
+    --#{$accordion}__toggle--m-expanded--PaddingBottom: var(--#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBottom);
     --#{$accordion}__toggle--PaddingLeft: var(--#{$accordion}--m-display-lg__toggle--PaddingLeft);
     --#{$accordion}__toggle--FontFamily: var(--#{$accordion}--m-display-lg__toggle--FontFamily);
     --#{$accordion}__toggle--FontSize: var(--#{$accordion}--m-display-lg__toggle--FontSize);
-    --#{$accordion}__toggle--hover__toggle-text--Color: var(--#{$accordion}--m-display-lg__toggle--hover__toggle-text--Color);
-    --#{$accordion}__toggle--active__toggle-text--Color: var(--#{$accordion}--m-display-lg__toggle--active__toggle-text--Color);
-    --#{$accordion}__toggle--active__toggle-text--FontWeight: var(--#{$accordion}--m-display-lg__toggle--active__toggle-text--FontWeight);
-    --#{$accordion}__toggle--focus__toggle-text--Color: var(--#{$accordion}--m-display-lg__toggle--focus__toggle-text--Color);
-    --#{$accordion}__toggle--focus__toggle-text--FontWeight: var(--#{$accordion}--m-display-lg__toggle--focus__toggle-text--FontWeight);
-    --#{$accordion}__toggle--m-expanded__toggle-text--Color: var(--#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--Color);
+    --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}--m-display-lg__toggle-text--FontWeight);
     --#{$accordion}__toggle--m-expanded__toggle-text--FontWeight: var(--#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight);
-    --#{$accordion}__expandable-content-body--PaddingTop: var(--#{$accordion}--m-display-lg__expandable-content-body--PaddingTop);
-    --#{$accordion}__expandable-content-body--PaddingRight: var(--#{$accordion}--m-display-lg__expandable-content-body--PaddingRight);
-    --#{$accordion}__expandable-content-body--PaddingBottom: var(--#{$accordion}--m-display-lg__expandable-content-body--PaddingBottom);
-    --#{$accordion}__expandable-content-body--PaddingLeft: var(--#{$accordion}--m-display-lg__expandable-content-body--PaddingLeft);
     --#{$accordion}__expandable-content--FontSize: var(--#{$accordion}--m-display-lg__expandable-content--FontSize);
     --#{$accordion}__expandable-content--Color: var(--#{$accordion}--m-display-lg__expandable-content--Color);
-
-    .#{$accordion}__expandable-content-body:last-child {
-      --#{$accordion}__expandable-content-body--PaddingBottom: var(--#{$accordion}--m-display-lg__expandable-content-body--last-child--PaddingBottom);
-    }
   }
 
   &.pf-m-bordered {
-    --#{$accordion}__toggle--after--Top: var(--#{$accordion}--m-bordered__toggle--after--Top);
+    --#{$accordion}--RowGap: var(--#{$accordion}--m-bordered--RowGap);
+    --#{$accordion}__item--BorderRadius: 0;
+    --#{$accordion}__toggle--BorderRadius: 0;
 
-    border-block-start: var(--#{$accordion}--m-bordered--BorderTopWidth) solid var(--#{$accordion}--m-bordered--BorderTopColor);
-
-    .#{$accordion}__toggle {
-      &::before {
-        position: absolute;
-        inset-block-start: 0;
-        inset-block-end: 0;
-        inset-inline-start: 0;
-        inset-inline-end: 0;
-        content: "";
-        border-color: var(--#{$accordion}--m-bordered__toggle--before--BorderColor);
-        border-style: solid;
-        border-block-start-width: var(--#{$accordion}--m-bordered__toggle--before--BorderTopWidth);
-        border-block-end-width: var(--#{$accordion}--m-bordered__toggle--before--BorderBottomWidth);
-        border-inline-start-width: 0;
-        border-inline-end-width: 0;
-      }
-
-      &.pf-m-expanded {
-        --#{$accordion}--m-bordered__toggle--before--BorderBottomWidth: 0;
-      }
+    .#{$accordion}__item {
+      border-block-end: var(--#{$accordion}__item--m-bordered--BorderBottomWidth) solid var(--#{$accordion}__item--m-bordered--BorderBottomColor);
     }
-
-    // stylelint-disable selector-max-class, max-nesting-depth
-    .#{$accordion}__expandable-content {
-      &.pf-m-expanded {
-        .#{$accordion}__expandable-content-body:last-child {
-          &::before {
-            position: absolute;
-            inset-block-start: 0;
-            inset-block-end: 0;
-            inset-inline-start: 0;
-            inset-inline-end: 0;
-            pointer-events: none;
-            content: "";
-            border-block-end: var(--#{$accordion}--m-bordered__expandable-content--m-expanded__expandable-content-body--last-child--before--BorderBottomWidth) solid var(--#{$accordion}--m-bordered__expandable-content--m-expanded__expandable-content-body--last-child--before--BorderBottomColor);
-          }
-        }
-      }
-    }
-    // stylelint-enable
   }
 }
 
-.#{$accordion}__toggle {
-  position: relative;
-  display: flex;
-  column-gap: var(--#{$accordion}__toggle--ColumnGap);
-  align-items: center;
-  justify-content: var(--#{$accordion}__toggle--JustifyContent);
-  width: 100%;
-  padding-block-start: var(--#{$accordion}__toggle--PaddingTop);
-  padding-block-end: var(--#{$accordion}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$accordion}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$accordion}__toggle--PaddingRight);
-  font-family: var(--#{$accordion}__toggle--FontFamily, inherit);
-  font-size: var(--#{$accordion}__toggle--FontSize, inherit);
-  background-color: var(--#{$accordion}__toggle--BackgroundColor);
-  border: 0;
-
-  &::after {
-    position: absolute;
-    inset-block-start: var(--#{$accordion}__toggle--after--Top);
-    inset-block-end: 0;
-    inset-inline-start: 0;
-    width: var(--#{$accordion}__toggle--after--Width);
-    content: "";
-    background-color: var(--#{$accordion}__toggle--after--BackgroundColor);
-  }
-
+.#{$accordion}__item {
+  border-radius: var(--#{$accordion}__item--BorderRadius);
+  
   &.pf-m-expanded {
-    --#{$accordion}__toggle--after--BackgroundColor: var(--#{$accordion}__toggle--m-expanded--after--BackgroundColor);
-
-    .#{$accordion}__toggle-text {
-      font-weight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
-      color: var(--#{$accordion}__toggle--m-expanded__toggle-text--Color);
-    }
+    --#{$accordion}__toggle--PaddingBottom: var(--#{$accordion}__toggle--m-expanded--PaddingBottom);
+    --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
+    
+    background-color: var(--#{$accordion}__item--m-expanded--BackgroundColor);
 
     .#{$accordion}__toggle-icon {
       transform: rotate(var(--#{$accordion}__toggle--m-expanded__toggle-icon--Rotate));
     }
   }
+}
+
+.#{$accordion}__toggle {
+  display: flex;
+  column-gap: var(--#{$accordion}__toggle--ColumnGap);
+  align-items: center;
+  width: 100%;
+  padding-block-start: var(--#{$accordion}__toggle--PaddingTop);
+  padding-block-end: var(--#{$accordion}__toggle--PaddingBottom);
+  padding-inline-start: var(--#{$accordion}__toggle--PaddingLeft);
+  padding-inline-end: var(--#{$accordion}__toggle--PaddingRight);
+  font-family: var(--#{$accordion}__toggle--FontFamily);
+  font-size: var(--#{$accordion}__toggle--FontSize);
+  text-align: start;
+  background-color: var(--#{$accordion}__toggle--BackgroundColor);
+  border: 0;
+  border-radius: var(--#{$accordion}__toggle--BorderRadius);
 
   &:hover {
     background-color: var(--#{$accordion}__toggle--hover--BackgroundColor);
-
-    .#{$accordion}__toggle-text {
-      color: var(--#{$accordion}__toggle--hover__toggle-text--Color);
-    }
   }
 
   &:focus {
     background-color: var(--#{$accordion}__toggle--focus--BackgroundColor);
-
-    .#{$accordion}__toggle-text {
-      font-weight: var(--#{$accordion}__toggle--focus__toggle-text--FontWeight);
-      color: var(--#{$accordion}__toggle--focus__toggle-text--Color);
-    }
-  }
-
-  &:active {
-    background-color: var(--#{$accordion}__toggle--active--BackgroundColor);
-
-    .#{$accordion}__toggle-text {
-      font-weight: var(--#{$accordion}__toggle--active__toggle-text--FontWeight);
-      color: var(--#{$accordion}__toggle--active__toggle-text--Color);
-    }
   }
 }
 
 .#{$accordion}__toggle-text {
   @include pf-v5-text-overflow;
 
-  max-width: var(--#{$accordion}__toggle-text--MaxWidth);
+  flex-grow: 1;
+  font-weight: var(--#{$accordion}__toggle-text--FontWeight);
+  color: var(--#{$accordion}__toggle-text--Color);
 }
 
 .#{$accordion}__toggle-icon {
@@ -248,44 +163,27 @@
 }
 
 .#{$accordion}__expandable-content {
+  margin-block-end: var(--#{$accordion}__expandable-content--MarginBottom);
+  margin-inline-start: var(--#{$accordion}__expandable-content--MarginLeft);
+  margin-inline-end: var(--#{$accordion}__expandable-content--MarginRight);
   font-size: var(--#{$accordion}__expandable-content--FontSize);
   color: var(--#{$accordion}__expandable-content--Color);
+  background-color: var(--#{$accordion}__expandable-content--BackgroundColor);
+  border-radius: var(--#{$accordion}__expandable-content--BorderRadius);
 
   &.pf-m-fixed {
     max-height: var(--#{$accordion}__expandable-content--m-fixed--MaxHeight);
     overflow-y: auto;
   }
-
-  &.pf-m-expanded {
-    --#{$accordion}__expandable-content-body--after--BackgroundColor: var(--#{$accordion}__expandable-content--m-expanded__expandable-content-body--after--BackgroundColor);
-  }
 }
 
 .#{$accordion}__expandable-content-body {
-  position: relative;
   padding-block-start: var(--#{$accordion}__expandable-content-body--PaddingTop);
   padding-block-end: var(--#{$accordion}__expandable-content-body--PaddingBottom);
   padding-inline-start: var(--#{$accordion}__expandable-content-body--PaddingLeft);
   padding-inline-end: var(--#{$accordion}__expandable-content-body--PaddingRight);
 
-  &::after {
-    position: absolute;
-    inset-block-start: 0;
-    inset-block-end: 0;
-    inset-inline-start: 0;
-    width: var(--#{$accordion}__expandable-content-body--after--Width);
-    content: "";
-    background-color: var(--#{$accordion}__expandable-content-body--after--BackgroundColor);
-  }
-
   & + & {
     --#{$accordion}__expandable-content-body--PaddingTop: var(--#{$accordion}__expandable-content-body--expandable-content-body--PaddingTop);
   }
-}
-
-// stylelint-disable no-invalid-position-at-import-rule
-@import "themes/dark/accordion";
-
-@include pf-v5-theme-dark {
-  @include pf-v5-theme-dark-accordion;
 }

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -23,8 +23,7 @@
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // Accordion toggle toggle-start modifier
-  --#{$accordion}--m-toggle-start__toggle--JustifyContent: start;
-  --#{$accordion}--m-toggle-start__toggle--ColumnGap: var(--#{$pf-global}--spacer--md);
+  --#{$accordion}--m-toggle-start__toggle--ColumnGap: var(--pf-t--global--spacer--md);
 
   // accordion toggle text
   --#{$accordion}__toggle-text--Color: var(--pf-t--global--text--color--regular);
@@ -78,7 +77,6 @@
   background-color: var(--#{$accordion}--BackgroundColor);
 
   &.pf-m-toggle-start {
-    --#{$accordion}__toggle--JustifyContent: var(--#{$accordion}--m-toggle-start__toggle--JustifyContent);
     --#{$accordion}__toggle--ColumnGap: var(--#{$accordion}--m-toggle-start__toggle--ColumnGap);
   }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -18,8 +18,6 @@
   --#{$accordion}__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
   --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$accordion}__toggle--focus--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$accordion}__toggle--active--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // Accordion toggle toggle-start modifier
@@ -136,16 +134,8 @@
   border: 0;
   border-radius: var(--#{$accordion}__toggle--BorderRadius);
 
-  &:hover {
+  &:is(:hover, :focus) {
     background-color: var(--#{$accordion}__toggle--hover--BackgroundColor);
-  }
-
-  &:focus {
-    background-color: var(--#{$accordion}__toggle--focus--BackgroundColor);
-  }
-
-  &:active {
-    background-color: var(--#{$accordion}__toggle--active--BackgroundColor);
   }
 }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -57,7 +57,7 @@
   --#{$accordion}--m-display-lg__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$accordion}--m-display-lg__toggle--FontSize: var(--pf-t--global--font--size--heading--sm);
-  --#{$accordion}--m-display-lg__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+  --#{$accordion}--m-display-lg__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading);
   --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--bold);
   --#{$accordion}--m-display-lg__expandable-content--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$accordion}--m-display-lg__expandable-content--Color: var(--pf-t--global--text--color--regular);
@@ -135,7 +135,7 @@
   border-radius: var(--#{$accordion}__toggle--BorderRadius);
 
   &:is(:hover, :focus) {
-    background-color: var(--#{$accordion}__toggle--hover--BackgroundColor);
+    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--hover--BackgroundColor);
   }
 }
 

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -341,55 +341,65 @@ cssPrefix: pf-v5-c-accordion
 
 ```hbs isBeta
 {{#> accordion accordion--IsStartAligned=true}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -44,12 +44,12 @@ cssPrefix: pf-v5-c-accordion
     {{/accordion-expandable-content}}
   {{/accordion-item}}
 
-  {{#> accordion-item}}
-    {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle}}
       {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
       {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
     {{/accordion-toggle}}
-    {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
+    {{#> accordion-expandable-content}}
       {{#> accordion-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       {{/accordion-expandable-content-body}}
@@ -73,171 +73,201 @@ cssPrefix: pf-v5-c-accordion
 ### Fixed
 ```hbs
 {{#> accordion}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsFixed="true" accordion-expandable-content--HasNoScrollbar="true"}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--HasNoScrollbar=true}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute="id='accordion-fixed-item-two-toggle'"}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true" accordion-expandable-content--IsFixed="true" accordion-expandable-content--attribute="aria-labelledby='accordion-fixed-item-two-toggle'"}}
-    {{#> accordion-expandable-content-body}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle accordion-toggle--attribute="id='accordion-fixed-item-two-toggle'"}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--IsFixed=true accordion-expandable-content--attribute="aria-labelledby='accordion-fixed-item-two-toggle'"}}
+      {{#> accordion-expandable-content-body}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+      {{/accordion-expandable-content-body}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsFixed="true" accordion-expandable-content--HasNoScrollbar="true"}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--HasNoScrollbar=true}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsFixed="true" accordion-expandable-content--HasNoScrollbar="true"}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--HasNoScrollbar=true}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsFixed="true" accordion-expandable-content--HasNoScrollbar="true"}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--HasNoScrollbar=true}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 
 ### Definition list
 ```hbs
 {{#> accordion accordion--IsDefinitionList="true"}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 
 ### Bordered
 ```hbs
 {{#> accordion accordion--modifier="pf-m-bordered"}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      <a href="#">Lorem ipsum</a> dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 
@@ -245,63 +275,65 @@ cssPrefix: pf-v5-c-accordion
 
 ```hbs
 {{#> accordion accordion--modifier="pf-m-display-lg pf-m-bordered"}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-    {{#> accordion-expandable-content-body}}
-    {{#> button button--modifier="pf-m-link pf-m-inline pf-m-display-lg"}}
-      Call to action
-      {{#> button-icon button-icon--modifier="pf-m-end"}}
-        <i class="fas fa-arrow-right" aria-hidden="true"></i>
-      {{/button-icon}}
-    {{/button}}
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item accordion-item--IsExpanded=true}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -395,17 +395,25 @@ cssPrefix: pf-v5-c-accordion
 
 ## Documentation
 ### Overview
-There are two variations to build the accordion component:
-One way uses `<div>` and `<h1 - h6>` tags to build the component.
-In these examples `.pf-v5-c-accordion` uses `<div>`, `.pf-v5-c-accordion__toggle` uses `<h3><button>`, and `.pf-v5-c-accordion__expandable-content` uses `<div>`. The heading level that you use should fit within the rest of the headings outlined on your page.
+There are two variations to build the accordion component. The first is to use `<div>` and `<h1 - h6>` tags:
+
+- `.pf-v5-c-accordion` is placed on a `<div>`,
+- `.pf-v5-c-accordion__toggle` is placed on a `<button>` that is inside a `<h1-h6>`, and 
+- `.pf-v5-c-accordion__expandable-content` is placed on a `<div>`. 
+
+The heading level that you use should fit within the rest of the headings outlined on your page.
 
 Another variation is using the definition list:
-In these examples `.pf-v5-c-accordion` uses `<dl>`, `.pf-v5-c-accordion__toggle` uses `<dt><button>`, and `.pf-v5-c-accordion__expandable-content` uses `<dd>`.
+
+- `.pf-v5-c-accordion` is placed on a `<dl>`, 
+- `.pf-v5-c-accordion__toggle` is placed on a `<button>` that is inside a `<dt>`, and 
+- `.pf-v5-c-accordion__expandable-content` is placed on a `<dd>`.
 
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-v5-c-accordion` | `<div>`, `<dl>` | Initiates an accordion component. **Required**|
+| `.pf-v5-c-accordion__item` | `<div>` | Initiates an accordion item component. **Required**|
 | `.pf-v5-c-accordion__toggle` | `<h1-h6><button>`, `<dt><button>` | Initiates a toggle in the accordion. **Required** |
 | `.pf-v5-c-accordion__toggle-text` | `<span>` | Initiates the text inside the toggle. **Required** |
 | `.pf-v5-c-accordion__toggle-icon` | `<span>` | Initiates the toggle icon wrapper. **Required** |
@@ -414,5 +422,5 @@ In these examples `.pf-v5-c-accordion` uses `<dl>`, `.pf-v5-c-accordion__toggle`
 | `.pf-m-bordered` | `.pf-v5-c-accordion` | Modifies the accordion to add borders between items. |
 | `.pf-m-display-lg` | `.pf-v5-c-accordion` | Modifies the accordion for large display styling. This variation is for marketing/web use cases. |
 | `.pf-m-toggle-start` | `.pf-v5-c-accordion` | Modifies accordion styling when accordion toggle icons are rendered at the start of the toggle, before the toggle text. |
-| `.pf-m-expanded` | `.pf-v5-c-accordion__toggle`, `.pf-v5-c-accordion__expandable-content` | Modifies the accordion button and expandable content for the expanded state. |
+| `.pf-m-expanded` | `.pf-v5-c-accordion__item` | Modifies the accordion item for the expanded state. |
 | `.pf-m-fixed` | `.pf-v5-c-accordion__expandable-content` | Modifies the expandable content for the fixed state. |

--- a/src/patternfly/components/Accordion/examples/Accordion.md
+++ b/src/patternfly/components/Accordion/examples/Accordion.md
@@ -8,55 +8,65 @@ cssPrefix: pf-v5-c-accordion
 ### Fluid
 ```hbs
 {{#> accordion}}
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item one{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item two{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item three{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
-    {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
-    {{#> accordion-expandable-content-body}}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle accordion-toggle--IsExpanded="true"}}
+      {{#> accordion-toggle-text}}Item four{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content accordion-expandable-content--IsExpanded="true"}}
+      {{#> accordion-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis molestie lorem lacinia dolor aliquet faucibus. Suspendisse gravida imperdiet accumsan. Aenean auctor lorem justo, vitae tincidunt enim blandit vel. Aenean quis tempus dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 
-  {{#> accordion-toggle}}
-    {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
-    {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
-  {{/accordion-toggle}}
-  {{#> accordion-expandable-content}}
-    {{#> accordion-expandable-content-body}}
-      This text is hidden
-    {{/accordion-expandable-content-body}}
-  {{/accordion-expandable-content}}
+  {{#> accordion-item}}
+    {{#> accordion-toggle}}
+      {{#> accordion-toggle-text}}Item five{{/accordion-toggle-text}}
+      {{#> accordion-toggle-icon}}{{/accordion-toggle-icon}}
+    {{/accordion-toggle}}
+    {{#> accordion-expandable-content}}
+      {{#> accordion-expandable-content-body}}
+        This text is hidden
+      {{/accordion-expandable-content-body}}
+    {{/accordion-expandable-content}}
+  {{/accordion-item}}
 {{/accordion}}
 ```
 

--- a/src/patternfly/components/Accordion/themes/dark/accordion.scss
+++ b/src/patternfly/components/Accordion/themes/dark/accordion.scss
@@ -1,9 +1,0 @@
-@import "../../../../sass-utilities/themes/dark/all";
-
-@mixin pf-v5-theme-dark-accordion() {
-  .#{$accordion} {
-    --#{$accordion}__toggle--hover--BackgroundColor: var(--#{$pf-global}--BackgroundColor--300);
-    --#{$accordion}__toggle--focus--BackgroundColor: var(--#{$pf-global}--BackgroundColor--300);
-    --#{$accordion}__toggle--active--BackgroundColor: var(--#{$pf-global}--BackgroundColor--300);
-  }
-}


### PR DESCRIPTION
Work towards #5729 

[Accordion preview](https://patternfly-pr-6058.surge.sh/components/accordion/)

Need to wait to be able to pull in the v6 rebase so that I can make updates to the "toggle on the left/at the start" variant.

This required some markup change as well as moving where the `pf-m-expanded` class gets applied (a wrapper element rather than the toggle `<button>`). This at least aligns with expandable section's markup a little more, since the expanded classes is applied to a wrapper there as well instead of the `<button>`.
