### PR TITLE
fix(tokens): adjust font-weight base for headings

### DIFF
--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -11,8 +11,8 @@
   --pf-t--global--font--line-height--100: 1.3;
   --pf-t--global--font--line-height--200: 1.5;
   --pf-t--global--font--weight--body--100: 400;
-  --pf-t--global--font--weight--body--200: 600;
-  --pf-t--global--font--weight--heading--100: 700; // what should this be?
+  --pf-t--global--font--weight--body--200: 500;
+  --pf-t--global--font--weight--heading--100: 700;
   --pf-t--global--font--weight--heading--200: 700;
   --pf-t--global--font--size--body--100: 12px;
   --pf-t--global--font--size--body--200: 14px;

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -37,7 +37,7 @@
 
   // Title
   --#{$alert}__title--FontSize: var(--pf-t--global--font--size--heading--xs);
-  --#{$alert}__title--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+  --#{$alert}__title--FontWeight: var(--pf-t--global--font--weight--heading);
   --#{$alert}__title--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$alert}__title--Color: var(--pf-t--global--text--color--regular);
   --#{$alert}__title--max-lines: 1;

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -88,7 +88,7 @@ $pf-page-v5--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__sidebar-title--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$page}__sidebar-title--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$page}__sidebar-title--FontFamily: var(--pf-t--global--font--family--heading);
-  --#{$page}__sidebar-title--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+  --#{$page}__sidebar-title--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // Sidebar body
   --#{$page}__sidebar-body--PaddingRight: 0;


### PR DESCRIPTION
Result of a discussion with @lboehling
Bold body font weight should be 500.
Heading font weight - for now keep both base tokens at 700. They might adjust in the future.
Remove any uses of the semantic bold heading token to date in favor of the (regular) heading font weight token.