### PR TITLE
fix(font): use variable font, add opt-in for legacy font

### DIFF
--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -18,10 +18,14 @@
 }
 
 // Variable font opt-in
-.#{$pf-prefix}m-vf-font {
-  --#{$pf-global}--FontFamily--text: var(--#{$pf-global}--FontFamily--text--vf);
-  --#{$pf-global}--FontFamily--heading: var(--#{$pf-global}--FontFamily--heading--vf);
-  --#{$pf-global}--FontFamily--monospace: var(--#{$pf-global}--FontFamily--monospace--vf);
+.#{$pf-prefix}m-legacy-font {
+  --pf-t--global--font--family--body: var(--pf-t--global--font--family--body--legacy);
+  --pf-t--global--font--family--heading: var(--pf-t--global--font--family--heading--legacy);
+  --pf-t--global--font--family--mono: var(--pf-t--global--font--family--mono--legacy);
+  --pf-t--global--font--weight--body: var(--pf-t--global--font--weight--body--legacy);
+  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--body--bold--legacy);
+  --pf-t--global--font--weight--heading: var(--pf-t--global--font--weight--heading--legacy);
+  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--heading--bold--legacy);
 }
 
 // RTL helpers

--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -5,9 +5,9 @@
 
 :root {
   // Base tokens for fonts
-  --pf-t--global--font--family--100: redhattext;
-  --pf-t--global--font--family--200: redhatdisplay;
-  --pf-t--global--font--family--300: redhatmono;
+  --pf-t--global--font--family--100: redhattextvf, redhattext, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--200: redhatdisplayvf, redhatdisplay, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--300: redhatmonovf, redhatmono, liberationmono, consolas, sfmono-regular, menlo, monaco, courier new, monospace;
   --pf-t--global--font--line-height--100: 1.3;
   --pf-t--global--font--line-height--200: 1.5;
   --pf-t--global--font--weight--body--100: 400;
@@ -44,6 +44,15 @@
   --pf-t--global--font--size--heading--lg: var(--pf-t--global--font--size--heading--400);
   --pf-t--global--font--size--heading--xl: var(--pf-t--global--font--size--heading--500);
   --pf-t--global--font--size--heading--2xl: var(--pf-t--global--font--size--heading--600);
+
+  // Legacy/non-variable font opt-in
+  --pf-t--global--font--family--body--legacy: redhattext, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--heading--legacy: redhatdisplay, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--mono--legacy: redhatmono, liberationmono, consolas, sfmono-regular, menlo, monaco, courier new, monospace;
+  --pf-t--global--font--weight--body--legacy: 400;
+  --pf-t--global--font--weight--body--bold--legacy: 700;
+  --pf-t--global--font--weight--heading--legacy: 400;
+  --pf-t--global--font--weight--heading--bold--legacy: 700;
 
   // Other missing ones
   // text-decoration


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6072

I didn't add any base vars for the legacy font families/weights. It's a global opt-in, design should never need to use it - it's just for products if they aren't ready to change their font-weights to use VF, and imagine we'll drop this support with the next major release so I don't think we need to make room for it outside of overriding the existing vars. LMK if that sounds alright!

This probably won't look right until https://github.com/patternfly/patternfly/pull/6070/ goes in, since #6070 updates the bold body text token to use `500`. @lboehling if https://github.com/patternfly/patternfly/pull/6070/ looks OK, we can merge that and rebase this PR so you can see the change.