### PR TITLE
fix(card/menu-toggle/check): alignment bugs

### DIFF
--- a/src/patternfly/components/Card/card--check.hbs
+++ b/src/patternfly/components/Card/card--check.hbs
@@ -1,6 +1,6 @@
-{{#> check check--modifier="pf-m-standalone"}}
-  {{#> check-input check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id ' "')}}{{/check-input}}
-  {{#if card--IsSelectable}}
-    {{#> check-label check-label--attribute=(concat 'id="' card--id '-check-label" name="' card--id '-check" for="' card--id '-check" name="' card--id '-check"')}}{{/check-label}}
-  {{/if}}
-{{/check}}
+{{> check
+    check--IsStandalone=(inverse card--IsSelectable)
+    check-label--text=(ternary card--IsSelectable " " false)
+    check-label--attribute=(concat 'id="' card--id '-check-label" name="' card--id '-check" for="' card--id '-check" name="' card--id '-check"')
+    check-input--attribute=(concat 'id="' card--id '-check" name="' card--id '-check" aria-labelledby="' card--id ' "')
+  }}

--- a/src/patternfly/components/Card/card--radio.hbs
+++ b/src/patternfly/components/Card/card--radio.hbs
@@ -1,6 +1,7 @@
-{{#> radio radio--modifier="pf-m-standalone"}}
-  {{#> radio-input radio-input--attribute=(concat 'id="' card--id '-radio" name="' card--id '-radio" aria-labelledby="' card--id '" ' card--radio--IsDisabled ' ' card--radio--IsChecked)}}{{/radio-input}}
-  {{#if card--IsSelectable}}
-    {{#> radio-label radio-label--modifier=(ternary card--radio--IsDisabled ' pf-m-disabled' '') radio-label--attribute=(concat 'id="' card--id '-radio-label" name="' card--id '-radio" for="' card--id '-radio" name="' card--id '-radio"')}}{{/radio-label}}
-  {{/if}}
-{{/radio}}
+{{> radio
+    radio--IsStandalone=(inverse card--IsSelectable)
+    radio-input--attribute=(concat 'id="' card--id '-radio" name="' card--id '-radio" aria-labelledby="' card--id '" ' card--radio--IsDisabled ' ' card--radio--IsChecked)
+    radio-label--text=(ternary card--IsSelectable " " false)
+    radio-label--modifier=(ternary card--radio--IsDisabled ' pf-m-disabled' '')
+    radio-label--attribute=(concat 'id="' card--id '-radio-label" name="' card--id '-radio" for="' card--id '-radio" name="' card--id '-radio"')
+  }}

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -149,6 +149,14 @@
   box-shadow: var(--#{$card}--BoxShadow);
 
   // SELECTABLE CARDS, CLICKABLE CARDS
+  &.pf-m-selectable {
+    // disables the gap since these have an empty label
+    // TODO - update/refactor selectable check/radio to use the standalone varioation with a <label> on the outer parent component class element
+    .#{$card}__selectable-actions :is(.#{$check}, .#{$radio}) {
+      gap: 0;
+    }
+  }
+
   &.pf-m-selectable,
   &.pf-m-clickable {
     isolation: isolate;

--- a/src/patternfly/components/Check/examples/Check.md
+++ b/src/patternfly/components/Check/examples/Check.md
@@ -18,7 +18,7 @@ cssPrefix: pf-v5-c-check
 
 ### Checked
 ```hbs
-{{> check check--id="check-checked-example" check-label--text="Check checked"}}
+{{> check check--id="check-checked-example" check-label--text="Check checked" check-input--IsChecked=true}}
 ```
 
 ### Label wrapping input

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -388,6 +388,8 @@
       align-self: stretch;
 
       .#{$check}__input {
+        --#{$check}__input--TranslateY: 0;
+
         align-self: center;
       }
     }

--- a/src/patternfly/components/Radio/examples/Radio.md
+++ b/src/patternfly/components/Radio/examples/Radio.md
@@ -29,7 +29,7 @@ cssPrefix: pf-v5-c-radio
 ### Disabled
 ```hbs
 {{> radio radio--id="radio-disabled-example" radio-label--text="Radio disabled" radio--IsDisabled=true}}
-{{> radio radio--id="radio-disabled-checked-example" radio-label--text="Radio disabled" radio--IsDisabled=true radio--IsChecked=true}}
+{{> radio radio--id="radio-disabled-checked-example" radio-label--text="Radio disabled checked" radio--IsDisabled=true radio--IsChecked=true}}
 ```
 
 ### With description


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6007

Fixes everything except https://core-staging.patternfly.org/components/card/#clickable-and-selectable

Looking at that, here are some issues aside from the misalignment:
* The presence of the checkbox is changing the layout/spacing compared with a card without it (delete the checkbox and watch the layout change)
* The checkbox is using the standalone variation, but the label element is present - the standalone variant should only have the checkbox input as a child.

In those examples, probably the simplest way to fix that is to remove `.pf-m-standalone`? That isn't ideal, but it addresses the issues mentioned above. 

Longer term, I wonder if those checkboxes (in all of the selectable/clickable card variants) can be updated to the standalone variant with the `<label>` wrapping the input, which you can see in the [standalone example in core](https://core-staging.patternfly.org/components/forms/checkbox#standalone-input).

wdyt @srambach? You're probably most familiar with the clickable/selectable cards.