### PR TITLE
chore(tokens): updating usage of new font tokens

### DIFF
--- a/src/patternfly/base/_globals.scss
+++ b/src/patternfly/base/_globals.scss
@@ -47,7 +47,7 @@
 
   :where(body) {
     font-family: var(--pf-t--global--font--family--body);
-    font-size: var(--pf-t--global--font--size--body);
+    font-size: var(--pf-t--global--font--size--body--default);
     font-weight: var(--pf-t--global--font--weight--body);
     line-height: var(--pf-t--global--font--line-height--body);
     color: var(--pf-t--global--text--color--regular);

--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -15,19 +15,6 @@
   --pf-t--global--font--weight--heading--100: 700;
   --pf-t--global--font--weight--heading--200: 700;
 
-  // TODO these are sm/def/lg? CAN BE REMOVED?
-  --pf-t--global--font--size--body--100: 12px;
-  --pf-t--global--font--size--body--200: 14px;
-  --pf-t--global--font--size--body--300: 16px;
-
-  // TODO these are h1-h6 NOT USED
-  --pf-t--global--font--size--heading--100: 16px;
-  --pf-t--global--font--size--heading--200: 18px;
-  --pf-t--global--font--size--heading--300: 20px;
-  --pf-t--global--font--size--heading--400: 22px;
-  --pf-t--global--font--size--heading--500: 28px;
-  --pf-t--global--font--size--heading--600: 36px;
-
   // Semantic tokens for fonts
   --pf-t--global--font--family--body: var(--pf-t--global--font--family--100);
   --pf-t--global--font--family--heading: var(--pf-t--global--font--family--200);
@@ -39,19 +26,13 @@
   --pf-t--global--font--weight--heading: var(--pf-t--global--font--weight--heading--100);
   --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--heading--200);
 
-  // TODO USED IN COMPONENTS
-  --pf-t--global--font--size--body--sm: var(--pf-t--global--font--size--body--100); // now SMALL
-  --pf-t--global--font--size--body--md: var(--pf-t--global--font--size--body--200); // REMOVED
-  --pf-t--global--font--size--body--lg: var(--pf-t--global--font--size--body--300); // now LARGE
-  --pf-t--global--font--size--body: var(--pf-t--global--font--size--body--md); // REMOVED
-
-  // TODO USED IN COMPONENTS these are now h1-h6
-  --pf-t--global--font--size--heading--xs: var(--pf-t--global--font--size--heading--100);
-  --pf-t--global--font--size--heading--sm: var(--pf-t--global--font--size--heading--200);
-  --pf-t--global--font--size--heading--md: var(--pf-t--global--font--size--heading--300);
-  --pf-t--global--font--size--heading--lg: var(--pf-t--global--font--size--heading--400);
-  --pf-t--global--font--size--heading--xl: var(--pf-t--global--font--size--heading--500);
-  --pf-t--global--font--size--heading--2xl: var(--pf-t--global--font--size--heading--600);
+  // TODO Maintaining these in addition to the h1-h6 sizes
+  --pf-t--global--font--size--heading--xs: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--sm: var(--pf-t--global--font--size--lg);
+  --pf-t--global--font--size--heading--md: var(--pf-t--global--font--size--xl);
+  --pf-t--global--font--size--heading--lg: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--font--size--heading--xl: var(--pf-t--global--font--size--3xl);
+  --pf-t--global--font--size--heading--2xl: var(--pf-t--global--font--size--4xl);
 
   // Legacy/non-variable font opt-in
   --pf-t--global--font--family--body--legacy: redhattext, helvetica, arial, sans-serif;

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -39,7 +39,7 @@
   --#{$accordion}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
-  --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$accordion}__expandable-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
 
   // accordion expandable content body

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -18,7 +18,7 @@
   --#{$alert}--PaddingRight: var(--pf-t--global--spacer--md);
   --#{$alert}--PaddingBottom: var(--pf-t--global--spacer--md);
   --#{$alert}--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$alert}--FontSize: var(--pf-t--global--font--size--body);
+  --#{$alert}--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Toggle
   --#{$alert}__toggle--MarginTop: calc(-1 * var(--#{$pf-global}--spacer--form-element) - #{pf-size-prem(1px)});

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -7,7 +7,7 @@
   --#{$banner}--PaddingBottom: var(--pf-t--global--spacer--xs);
   --#{$banner}--PaddingLeft: var(--pf-t--global--spacer--md);
   --#{$banner}--md--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$banner}--FontSize: var(--pf-t--global--font--size--body);
+  --#{$banner}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$banner}--Color: var(--pf-t--global--text--color--nonstatus--on-gray--default);
   --#{$banner}--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -8,7 +8,7 @@
   --#{$button}--PaddingLeft: var(--pf-t--global--spacer--lg);
   --#{$button}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body);
-  --#{$button}--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$button}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$button}--BackgroundColor: transparent;
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$button}--after--BorderColor: transparent;

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -4,7 +4,7 @@
   // Body
   --#{$content}--MarginBottom: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);
-  --#{$content}--FontSize: var(--pf-t--global--font--size--body);
+  --#{$content}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$content}--FontWeight: var(--pf-t--global--font--weight--body);
 
   // this ensures color is not overridden
@@ -17,42 +17,42 @@
   --#{$content}--h1--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h1--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h1--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h1--FontSize: var(--pf-t--global--font--size--heading--lg);
+  --#{$content}--h1--FontSize: var(--pf-t--global--font--size--heading--h1);
   --#{$content}--h1--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h2
   --#{$content}--h2--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h2--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h2--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h2--FontSize: var(--pf-t--global--font--size--heading--md);
+  --#{$content}--h2--FontSize: var(--pf-t--global--font--size--heading--h2);
   --#{$content}--h2--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h3
   --#{$content}--h3--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h3--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h3--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h3--FontSize: var(--pf-t--global--font--size--heading--sm);
+  --#{$content}--h3--FontSize: var(--pf-t--global--font--size--heading--h3);
   --#{$content}--h3--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h4
   --#{$content}--h4--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h4--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h4--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h4--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$content}--h4--FontSize: var(--pf-t--global--font--size--heading--h4);
   --#{$content}--h4--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h5
   --#{$content}--h5--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h5--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h5--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h5--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$content}--h5--FontSize: var(--pf-t--global--font--size--heading--h5);
   --#{$content}--h5--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h6
   --#{$content}--h6--MarginTop: var(--pf-t--global--spacer--lg);
   --#{$content}--h6--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$content}--h6--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$content}--h6--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$content}--h6--FontSize: var(--pf-t--global--font--size--heading--h6);
   --#{$content}--h6--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // Small text

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -19,7 +19,7 @@
   --#{$hint}__title--LineHeight: var(--pf-t--global--font--line-height--heading);
 
   // Hint Body
-  --#{$hint}__body--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$hint}__body--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Hint Footer
   --#{$hint}__footer--MarginTop: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -58,7 +58,7 @@
   // main header desc
   --#{$login}__main-header-desc--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$login}__main-header-desc--md--MarginBottom: 0;
-  --#{$login}__main-header-desc--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$login}__main-header-desc--FontSize: var(--pf-t--global--font--size--body--default);
 
 
   @media (min-width: $pf-v5-global--breakpoint--md) {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -6,7 +6,7 @@
   --#{$menu-toggle}--PaddingRight: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--PaddingBottom: var(--pf-t--global--spacer--sm); // TODO semantic spacer?
   --#{$menu-toggle}--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--FontSize: var(--pf-t--global--font--size--body--md);
+  --#{$menu-toggle}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$menu-toggle}--Color: var(--pf-t--global--text--color--regular);
   --#{$menu-toggle}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$menu-toggle}--BackgroundColor: var(--pf-t--global--background--color--control--default);

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -51,7 +51,7 @@
   --#{$modal-box}__description--Color: var(--pf-t--global--text--color--subtle);
   
   // Body
-  --#{$modal-box}__body--MinHeight: calc(var(--pf-t--global--font--size--body) * var(--pf-t--global--font--line-height--body)); // Allow for at least 1 line of content in the body
+  --#{$modal-box}__body--MinHeight: calc(var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)); // Allow for at least 1 line of content in the body
   --#{$modal-box}__body--PaddingTop: var(--pf-t--global--spacer--lg);
   --#{$modal-box}__body--PaddingRight: var(--pf-t--global--spacer--lg);
   --#{$modal-box}__body--PaddingLeft: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -45,7 +45,7 @@
   --#{$nav}__item--before--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
 
   // Link
-  --#{$nav}__link--FontSize: var(--pf-t--global--font--size--body);
+  --#{$nav}__link--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$nav}__link--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$nav}__link--PaddingTop: var(--pf-t--global--spacer--md);
   --#{$nav}__link--PaddingRight: var(--pf-t--global--spacer--md);
@@ -232,7 +232,7 @@
   --#{$nav}__section-title--MarginBottom: var(--pf-t--global--spacer--sm);
   --#{$nav}__section-title--xl--PaddingRight: var(--pf-t--global--spacer--xl);
   --#{$nav}__section-title--xl--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$nav}__section-title--FontSize: var(--pf-t--global--font--size--body);
+  --#{$nav}__section-title--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
   --#{$nav}__section-title--BorderBottomColor: transparent;
   --#{$nav}__section-title--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--sm);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -16,7 +16,7 @@
   --#{$table}--border-width--base: var(--pf-t--global--border--width--divider--default);
 
   // Caption
-  --#{$table}__caption--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}__caption--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__caption--Color: var(--pf-t--global--text--color--subtle);
   --#{$table}__caption--PaddingTop: var(--#{$pf-global}--spacer--md);
   --#{$table}__caption--PaddingRight: var(--#{$pf-global}--spacer--lg);
@@ -31,7 +31,7 @@
   }
 
   // Thead
-  --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // Tbody cell
@@ -43,7 +43,7 @@
 
   // Th / td shared variables
   --#{$table}--cell--Padding--base: var(--#{$pf-global}--spacer--md);
-  --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
   --#{$table}--cell--PaddingTop: var(--#{$table}--cell--Padding--base);
@@ -108,12 +108,12 @@
   // Check
   --#{$table}__check--input--MarginTop: #{pf-size-prem(3px)};
   --#{$table}__thead__check--input--TranslateY: var(--#{$table}__check--input--MarginTop);
-  --#{$table}__check--input--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}__check--input--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Favorite
   --#{$table}--cell--m-favorite--Color: var(--pf-t--global--text--color--subtle);
   --#{$table}__favorite--c-button--Color: var(--pf-t--global--text--color--subtle);
-  --#{$table}__favorite--c-button--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}__favorite--c-button--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__favorite--c-button--MarginTop: calc(var(--#{$pf-global}--spacer--form-element) * -1);
   --#{$table}__favorite--c-button--MarginRight: calc(var(--#{$pf-global}--spacer--md) * -1);
   --#{$table}__favorite--c-button--MarginBottom: calc(var(--#{$pf-global}--spacer--form-element) * -1);
@@ -236,7 +236,7 @@
   --#{$table}--m-compact--cell--first-last-child--PaddingRight: var(--#{$pf-global}--spacer--md);
   --#{$table}--m-compact--cell--first-last-child--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
   --#{$table}--m-compact--cell--first-last-child--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$table}--m-compact--FontSize: var(--pf-t--global--font--size--body);
+  --#{$table}--m-compact--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--m-compact__expandable-row-content--PaddingTop: var(--#{$pf-global}--spacer--lg);
   --#{$table}--m-compact__expandable-row-content--PaddingRight: var(--#{$pf-global}--spacer--lg);
   --#{$table}--m-compact__expandable-row-content--PaddingBottom: var(--#{$pf-global}--spacer--lg);

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -37,32 +37,32 @@
   // HEADING modifiers 
   // h1
   --#{$title}--m-h1--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h1--FontSize: var(--pf-t--global--font--size--heading--lg);
+  --#{$title}--m-h1--FontSize: var(--pf-t--global--font--size--heading--h1);
   --#{$title}--m-h1--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h2
   --#{$title}--m-h2--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h2--FontSize: var(--pf-t--global--font--size--heading--md);
+  --#{$title}--m-h2--FontSize: var(--pf-t--global--font--size--heading--h2);
   --#{$title}--m-h2--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h3
   --#{$title}--m-h3--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h3--FontSize: var(--pf-t--global--font--size--heading--sm);
+  --#{$title}--m-h3--FontSize: var(--pf-t--global--font--size--heading--h3);
   --#{$title}--m-h3--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h4
   --#{$title}--m-h4--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h4--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$title}--m-h4--FontSize: var(--pf-t--global--font--size--heading--h4);
   --#{$title}--m-h4--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h5
   --#{$title}--m-h5--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h5--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$title}--m-h5--FontSize: var(--pf-t--global--font--size--heading--h5);
   --#{$title}--m-h5--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h6
   --#{$title}--m-h6--LineHeight: var(--pf-t--global--font--line-height--heading);
-  --#{$title}--m-h6--FontSize: var(--pf-t--global--font--size--heading--xs);
+  --#{$title}--m-h6--FontSize: var(--pf-t--global--font--size--heading--h6);
   --#{$title}--m-h6--FontWeight: var(--pf-t--global--font--weight--heading);
 }
 


### PR DESCRIPTION
This builds on the update of the font tokens coming from Figma. It removes font size tokens from the non-generated font token file, except for heading sizes xs-2xl, which haven't been added to figma. These are still used in a few components when it's not clearly a particular heading level (h tag).