### PR TITLE
chore(divider): added tokens, fixed breaking change comments

### DIFF
--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -1,98 +1,83 @@
 // @debug $divider; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
-$pf-v5-c-divider--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
+$pf-v5-c-divider--breakpoint-map: build-breakpoint-map("sm", "md", "lg", "xl", "2xl");
 $pf-v5-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "xl", "2xl", "3xl");
 
+// * Divider horizontal
 @mixin pf-v5-c-divider--m-horizontal {
-  --#{$divider}--Display: var(--#{$divider}--m-horizontal--Display);
-  --#{$divider}--FlexDirection: var(--#{$divider}--m-horizontal--FlexDirection);
-  --#{$divider}--after--Width: var(--#{$divider}--m-horizontal--after--Width);
-  --#{$divider}--after--Height: var(--#{$divider}--m-horizontal--after--Height);
-
-  width: 100%; // update to var breaking change
-  height: auto; // update to var breaking change
-
-  &::after {
-    flex-basis:
-      calc(
-        var(--#{$divider}--after--FlexBasis) - calc(var(--#{$divider}--after--Inset) * 2)
-      ); // update at breaking change
-  }
+  flex-direction: row;
+  width: 100%;
+  height: var(--#{$divider}--Size);  // apply size to width in horizontal orientation
 }
 
+// * Divider vertical
 @mixin pf-v5-c-divider--m-vertical {
-  --#{$divider}--Display: var(--#{$divider}--m-vertical--Display);
-  --#{$divider}--FlexDirection: var(--#{$divider}--m-vertical--FlexDirection);
-  --#{$divider}--after--Width: var(--#{$divider}--m-vertical--after--Width);
-  --#{$divider}--after--Height: var(--#{$divider}--m-vertical--after--Height);
+  flex-direction: column;
+  width: var(--#{$divider}--Size); // apply size to width in vertical orientation
+  height: 100%;
+}
 
-  width: auto; // update to var breaking change
-  height: inherit; // update to var at breaking change
+:root {
+  // * Divider
+  --#{$divider}--Display: flex;
+  --#{$divider}--Color: var(--pf-t--global--border--color--default);
+  --#{$divider}--Size: var(--pf-t--global--border--width--divider--default);
 
-  &::after {
-    flex-basis:
-      calc(
-        var(--#{$divider}--m-vertical--after--FlexBasis) - var(--#{$divider}--after--Inset)
-      ); // update at breaking change
+  // * Divider before
+  --#{$divider}--before--FlexBasis: 100%;
+}
+
+// - Divider
+.#{$divider} {
+  @include pf-v5-c-divider--m-horizontal; // default, set to orientation to horizontal
+  @include pf-v5-hidden-visible(var(--#{$divider}--Display));
+
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+
+  &:is(hr) {
+    border: 0; // removes the default border styling on an hr
+  }
+
+  // - Divider before
+  &::before {
+    flex-basis: var(--#{$divider}--before--FlexBasis);
+    content: "";
+    background-color: var(--#{$divider}--Color);
+  }
+
+  // - Divider horizontal
+  &.pf-m-horizontal {
+    @include pf-v5-c-divider--m-horizontal;
+  }
+
+  // - Divider vertical
+  &.pf-m-vertical {
+    @include pf-v5-c-divider--m-vertical;
+  }
+
+  // - Divider spacer insets
+  @each $spacer, $spacer-value in $pf-v5-c-divider--spacer-map {
+    @if $spacer == none {
+      $spacer-value: 0%;
+    }
+
+    &.pf-m-inset-#{$spacer} {
+      --#{$divider}--before--FlexBasis: calc(100% - #{$spacer-value} * 2);
+    }
   }
 }
 
+// TODO: move this loop to separate file for resize observer implementation
+// TODO: make responsive values opt in/out
+// stylelint-disable
 .#{$divider} {
-  // Base
-  --#{$divider}--BorderWidth--base: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$divider}--BorderColor--base: var(--#{$divider}--BackgroundColor); // update at breaking change
-  --#{$divider}--Height: var(--#{$divider}--BorderWidth--base); // remove at breaking change
-  --#{$divider}--BackgroundColor: var(--#{$pf-global}--BorderColor--100); // remove at breaking change
-  --#{$divider}--after--BackgroundColor: var(--#{$divider}--BorderColor--base); // remove at breaking change
-
-  // Borders
-  --#{$divider}--after--FlexBasis: 100%;
-  --#{$divider}--after--Inset: 0%;
-
-  // Vertical
-  --#{$divider}--m-vertical--after--FlexBasis: 100%; // remove at breaking change
-
-  // Horizontal mixin
-  --#{$divider}--m-horizontal--Display: flex;
-  --#{$divider}--m-horizontal--FlexDirection: row;
-  --#{$divider}--m-horizontal--after--Height: var(--#{$divider}--Height); // update at breaking change
-  --#{$divider}--m-horizontal--after--Width: auto;
-
-  // Vertical mixin
-  --#{$divider}--m-vertical--Display: inline-flex;
-  --#{$divider}--m-vertical--FlexDirection: column;
-  --#{$divider}--m-vertical--after--Height: auto;
-  --#{$divider}--m-vertical--after--Width: var(--#{$divider}--BorderWidth--base); // remove at breaking change
-
-  // Vertical
-  @include pf-v5-hidden-visible(var(--#{$divider}--Display));
-  @include pf-v5-c-divider--m-horizontal; // set to default to horizontal
-
-  flex-direction: var(--#{$divider}--FlexDirection);
-  flex-shrink: 0;
-  align-items: center;
-  align-self: stretch;
-  justify-content: center;
-  border: 0; // removes the default border styling on an hr
-
-  &::after {
-    align-self: stretch;
-    justify-self: center;
-    width: var(--#{$divider}--after--Width);
-    height: var(--#{$divider}--after--Height);
-    content: "";
-    background-color: var(--#{$divider}--after--BackgroundColor);
-  }
-
-  // stylelint-disable max-nesting-depth
-
   @each $breakpoint, $breakpoint-value in $pf-v5-c-divider--breakpoint-map {
-    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+    $breakpoint-name: '-on-' + #{$breakpoint};
 
-    @if $breakpoint != "base" {
-      @include pf-v5-apply-breakpoint($breakpoint) {
-        &.pf-m-horizontal#{$breakpoint-name} {
-          @include pf-v5-c-divider--m-horizontal;
-        }
+    @include pf-v5-apply-breakpoint($breakpoint) {
+      &.pf-m-horizontal#{$breakpoint-name} {
+        @include pf-v5-c-divider--m-horizontal;
       }
     }
 
@@ -104,16 +89,15 @@ $pf-v5-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
 
     @include pf-v5-apply-breakpoint($breakpoint) {
       @each $spacer, $spacer-value in $pf-v5-c-divider--spacer-map {
-        @if $spacer == none {
-          $spacer-value: 0%;
-        }
-
         &.pf-m-inset-#{$spacer}#{$breakpoint-name} {
-          --#{$divider}--after--Inset: #{$spacer-value};
+          @if $spacer == none {
+            --#{$divider}--before--FlexBasis: 100%;
+          } @else {
+            --#{$divider}--before--FlexBasis: calc(100% - #{$spacer-value} * 2);
+          }
         }
       }
     }
   }
-
-  // stylelint-enable
 }
+// stylelint-enable

--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -6,7 +6,7 @@ $pf-v5-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
 @mixin pf-v5-c-divider--m-horizontal {
   flex-direction: row;
   width: 100%;
-  height: var(--#{$divider}--Size);  // apply size to width in horizontal orientation
+  height: var(--#{$divider}--Size);  // apply size to height in horizontal orientation
 }
 
 // * Divider vertical
@@ -16,7 +16,8 @@ $pf-v5-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
   height: 100%;
 }
 
-:root {
+:root,
+:where(.#{$divider}) {
   // * Divider
   --#{$divider}--Display: flex;
   --#{$divider}--Color: var(--pf-t--global--border--color--default);
@@ -31,13 +32,9 @@ $pf-v5-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
   @include pf-v5-c-divider--m-horizontal; // default, set to orientation to horizontal
   @include pf-v5-hidden-visible(var(--#{$divider}--Display));
 
-  display: flex;
   align-items: stretch;
   justify-content: center;
-
-  &:is(hr) {
-    border: 0; // removes the default border styling on an hr
-  }
+  border: 0; // removes the default border styling on an hr
 
   // - Divider before
   &::before {

--- a/src/patternfly/components/Divider/examples/Divider.css
+++ b/src/patternfly/components/Divider/examples/Divider.css
@@ -3,11 +3,13 @@
   align-items: center;
 }
 
+[id*="divider-vertical"],
 [id*="ws-core-c-divider-vertical"],
 #ws-core-c-divider-horizontal-on-lg {
-  height: 4rem;
+  height: 6rem;
 }
 
 [id*="ws-core-c-divider"] .ws-preview-html {
   height: 100%;
 }
+

--- a/src/patternfly/components/Divider/examples/Divider.md
+++ b/src/patternfly/components/Divider/examples/Divider.md
@@ -25,7 +25,6 @@ import './Divider.css'
 ```
 
 ### div
-
 ```hbs
 {{> divider divider--type="div"}}
 ```
@@ -33,19 +32,19 @@ import './Divider.css'
 ### Inset medium
 
 ```hbs
-{{> divider divider--type="div" divider--modifier="pf-m-inset-md"}}
+{{> divider divider--modifier="pf-m-inset-md"}}
 ```
 
 ### Md inset, no inset on md, 3xl inset on lg, lg inset on xl
 
 ```hbs
-{{> divider divider--type="div" divider--modifier="pf-m-inset-md pf-m-inset-none-on-md pf-m-inset-3xl-on-lg pf-m-inset-lg-on-xl"}}
+{{> divider divider--modifier="pf-m-inset-md pf-m-inset-none-on-md pf-m-inset-3xl-on-lg pf-m-inset-lg-on-xl"}}
 ```
 
 ### Vertical
 
 ```hbs
-{{> divider divider--type="div" divider--modifier="pf-m-vertical pf-m-inset-md"}}
+{{> divider divider--type="div" divider--modifier="pf-m-vertical"}}
 ```
 
 ### Vertical, inset medium


### PR DESCRIPTION
closes #6136 

Couple of things to note
• Added `// * {Component}` to `:root` variable comments to make them searchable by `{Component}` or `* {Component}`
• Added `// - {Component}` to component/elements comments to make them searchable by `{Component}` or `- {Component}`
• Removed unnecessary `::after` styling and breaking change comments
• Simplified implementation