### PR TITLE
feat(truncate): add tokens

### DIFF
--- a/src/patternfly/components/Truncate/examples/Truncate.css
+++ b/src/patternfly/components/Truncate/examples/Truncate.css
@@ -4,6 +4,6 @@
   overflow: auto;
   min-width: 161px;
   max-width: 100%;
-  padding: var(--pf-v5-global--spacer--md);
-  border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
+  padding: var(--pf-t--global--spacer--sm);
+  border: var(--pf-t--global--border--width--box--default) solid var(--pf-t--global--border--color--default);
 }

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,9 +1,12 @@
 // @debug $truncate; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
+:root,
 .#{$truncate} {
   --#{$truncate}--MinWidth: 12ch;
   --#{$truncate}__start--MinWidth: 6ch;
+}
 
+.#{$truncate} {
   display: inline-grid;
   grid-auto-flow: column;
   align-items: baseline;


### PR DESCRIPTION
Just adds the `:root` selector and puts a couple of tokens into the example css. 

Fixes #6143 