### PR TITLE
feat(brand): support for SVG

### DIFF
--- a/src/patternfly/components/Brand/brand.hbs
+++ b/src/patternfly/components/Brand/brand.hbs
@@ -15,6 +15,8 @@
       <img src="/assets/images/pf_logo.svg" alt="Fallback patternFly default logo">
     {{/if}}
   </picture>
+{{else if brand--IsSVG}}
+  {{> masthead-logo masthead-logo--modifier=(concat 'pf-v5-c-brand') masthead-logo--attribute=brand--attribute masthead-logo--title=brand--AltText}}
 {{else}}
   <img class="{{pfv}}brand{{#if brand--modifier}} {{brand--modifier}}{{/if}}"
     {{#if brand--attribute}}

--- a/src/patternfly/components/Brand/examples/Brand.md
+++ b/src/patternfly/components/Brand/examples/Brand.md
@@ -6,6 +6,15 @@ section: components
 import './Brand.css'
 
 ## Examples
+### Inline SVG
+```hbs
+{{> brand
+  brand--IsSVG=true
+  brand--attribute='style="--pf-v5-c-brand--Width: 150px; --pf-v5-c-brand--Width-on-md: 300px;"'
+  brand--AltText="PatternFly inline SVG logo"
+}}
+```
+
 ### Basic
 ```hbs
 <div class="show-light">
@@ -55,7 +64,7 @@ Simple brand component.
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v5-c-brand` | `<img>, <picture>` |  Initiates a brand image. **Required** |
+| `.pf-v5-c-brand` | `<img>, <picture>, <svg>` |  Initiates a brand image. **Required** |
 | `.pf-m-picture` | `.pf-v5-c-brand` |  Modifies a brand image to a picture. |
 | `--pf-v5-c-brand--Width{-on-[breakpoint]}: {width}` | `.pf-v5-c-brand` |  Modifies the width value of a picture on optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
 | `--pf-v5-c-brand--Height{-on-[breakpoint]}: {height}` | `.pf-v5-c-brand` |  Modifies the height value of a picture on optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |

--- a/src/patternfly/components/Masthead/masthead-logo.hbs
+++ b/src/patternfly/components/Masthead/masthead-logo.hbs
@@ -1,6 +1,6 @@
 
-<svg height="40px" viewBox="0 0 679 158">
-    <title>PF-HorizontalLogo-Color </title>
+<svg height="40px" viewBox="0 0 679 158"{{#if masthead-logo--modifier}} class="{{masthead-logo--modifier}}"{{/if}} {{#if masthead-logo--attribute}} {{{masthead-logo--attribute}}}{{/if}}>
+    <title>{{#if masthead-logo--title}}{{masthead-logo--title}}{{else}}PF-HorizontalLogo-Color{{/if}}</title>
     <defs>
         <linearGradient x1="68%" y1="2.25860997e-13%" x2="32%" y2="100%" id="linearGradient-{{masthead--id}}">
             <stop stop-color="#2B9AF3" offset="0%"></stop>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5801

This would be a basic way to support an inline SVG in the brand component, though in the react implementation, a user will just provide an SVG, and this PR would require the react component modify attributes on the `<svg>` element supplied by the user - which isn't ideal.

I wonder if we could support the brand component classes/heights/widths on a wrapper (eg, `<span class="{{brand}}">`), and pass the user supplied SVG as a child of the wrapper, and ensure the SVG responds to heights/widths supplied to the brand component that are applied to the wrapper?