### PR TITLE
feat(Panel): consumed Penta tokens

### DIFF
--- a/src/patternfly/components/Panel/examples/Panel.md
+++ b/src/patternfly/components/Panel/examples/Panel.md
@@ -16,6 +16,17 @@ cssPrefix: pf-v5-c-panel
 {{/panel}}
 ```
 
+### Secondary
+```hbs
+{{#> panel panel--modifier="pf-m-secondary"}}
+  {{#> panel-main}}
+    {{#> panel-main-body}}
+      Main content with secondary styling
+    {{/panel-main-body}}
+  {{/panel-main}}
+{{/panel}}
+```
+
 ### Header
 ```hbs
 {{#> panel}}
@@ -148,3 +159,4 @@ cssPrefix: pf-v5-c-panel
 | `.pf-m-bordered` | `.pf-v5-c-panel` | Modifies the panel for bordered styles. |
 | `.pf-m-raised` | `.pf-v5-c-panel` | Modifies the panel for raised styles. |
 | `.pf-m-scrollable` | `.pf-v5-c-panel` | Modifies the panel for scrollable styles. |
+| `.pf-m-secondary` | `.pf-v5-c-panel` | Modifies the panel for secondary styles. |

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -1,53 +1,59 @@
 // @debug $panel; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
+:root,
 .#{$panel} {
   --#{$panel}--Width: auto;
   --#{$panel}--MinWidth: auto;
   --#{$panel}--MaxWidth: none;
   --#{$panel}--ZIndex: auto;
-  --#{$panel}--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$panel}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$panel}--BoxShadow: none;
 
   // border
   --#{$panel}--before--BorderWidth: 0;
-  --#{$panel}--before--BorderColor: var(--#{$pf-global}--BorderColor--100);
+  --#{$panel}--before--BorderColor: var(--pf-t--global--border--color--default);
+
+  // secondary modifier
+  --#{$panel}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // bordered
-  --#{$panel}--m-bordered--before--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$panel}--m-bordered--before--BorderWidth: var(--pf-t--global--border--width--regular);
 
   // raised
-  --#{$panel}--m-raised--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$panel}--m-raised--ZIndex: var(--#{$pf-global}--ZIndex--sm);
-  --#{$panel}--m-raised--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$panel}--m-raised--BoxShadow: var(--pf-t--global--box-shadow--md);
+  --#{$panel}--m-raised--ZIndex: var(--pf-t--global--Zindex--sm);
+  --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // header
-  --#{$panel}__header--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__header--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__header--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__header--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$panel}__header--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingLeft: var(--pf-t--global--spacer--md);
 
   // main
   --#{$panel}__main--MaxHeight: none;
   --#{$panel}__main--Overflow: visible;
 
   // body
-  --#{$panel}__main-body--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__main-body--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__main-body--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__main-body--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$panel}__main-body--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingLeft: var(--pf-t--global--spacer--md);
 
   // footer
-  --#{$panel}__footer--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__footer--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__footer--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$panel}__footer--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$panel}__footer--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingLeft: var(--pf-t--global--spacer--md);
   --#{$panel}__footer--BoxShadow: none;
 
   // scrollable
   --#{$panel}--m-scrollable__main--MaxHeight: #{pf-size-prem(300px)};
   --#{$panel}--m-scrollable__main--Overflow: auto;
   --#{$panel}--m-scrollable__footer--BoxShadow: 0 #{pf-size-prem(-5px)} #{pf-size-prem(4px)} #{pf-size-prem(-4px)} #{rgba($pf-v5-color-black-1000, .16)}; // insets the shadow so it doesn't show on left/right sides
+}
 
+.#{$panel} {
   position: relative;
   z-index: var(--#{$panel}--ZIndex);
   width: var(--#{$panel}--Width);
@@ -66,6 +72,10 @@
 
   &.pf-m-bordered {
     --#{$panel}--before--BorderWidth: var(--#{$panel}--m-bordered--before--BorderWidth);
+  }
+
+  &.pf-m-secondary {
+    --#{$panel}--BackgroundColor: var(--#{$panel}--m-secondary--BackgroundColor);
   }
 
   &.pf-m-raised {
@@ -106,11 +116,4 @@
   padding-inline-start: var(--#{$panel}__footer--PaddingLeft);
   padding-inline-end: var(--#{$panel}__footer--PaddingRight);
   box-shadow: var(--#{$panel}__footer--BoxShadow);
-}
-
-// stylelint-disable no-invalid-position-at-import-rule
-@import "themes/dark/panel";
-
-@include pf-v5-theme-dark {
-  @include pf-v5-theme-dark-panel;
 }

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -22,7 +22,7 @@
   // raised
   --#{$panel}--m-raised--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$panel}--m-raised--ZIndex: var(--pf-t--global--Zindex--sm);
-  --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // header
   --#{$panel}__header--PaddingTop: var(--pf-t--global--spacer--md);
@@ -50,7 +50,7 @@
   // scrollable
   --#{$panel}--m-scrollable__main--MaxHeight: #{pf-size-prem(300px)};
   --#{$panel}--m-scrollable__main--Overflow: auto;
-  --#{$panel}--m-scrollable__footer--BoxShadow: 0 #{pf-size-prem(-5px)} #{pf-size-prem(4px)} #{pf-size-prem(-4px)} #{rgba($pf-v5-color-black-1000, .16)}; // insets the shadow so it doesn't show on left/right sides
+  --#{$panel}--m-scrollable__footer--BoxShadow: 0 #{pf-size-prem(-5px)} #{pf-size-prem(4px)} #{pf-size-prem(-4px)} rgba(0 0 0 / 16%); // insets the shadow so it doesn't show on left/right sides
 }
 
 .#{$panel} {

--- a/src/patternfly/components/Panel/themes/dark/panel.scss
+++ b/src/patternfly/components/Panel/themes/dark/panel.scss
@@ -1,7 +1,0 @@
-@import "../../../../sass-utilities/themes/dark/all";
-
-@mixin pf-v5-theme-dark-panel() {
-  .#{$panel} {
-    --#{$panel}--m-raised--BackgroundColor: var(--#{$pf-global}--BackgroundColor--300);
-  }
-}


### PR DESCRIPTION
Work towards #5711 

Right now this just updates vars to use tokens since the Drawer designs in Figma aren't totally 1:1 for what a Panel is.

Should we remove the bordered and raised styling for a panel, and follow more closely the inline, full page Drawer designs? That looks to have no border and always has a box shadow around it, but I'm not sure if we would always want the panel to have a box shadow.