### PR TITLE
feat(Sidebar): applied Penta tokens

### DIFF
--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -23,7 +23,7 @@ import './Sidebar.css'
 {{/sidebar}}
 ```
 
-### Secondary
+### With secondary background
 
 ```hbs
 {{#> sidebar}}

--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -23,6 +23,23 @@ import './Sidebar.css'
 {{/sidebar}}
 ```
 
+### Secondary
+
+```hbs
+{{#> sidebar}}
+  {{#> sidebar-panel sidebar-panel--modifier="pf-m-secondary"}}
+    Sidebar panel
+  {{/sidebar-panel}}
+  {{#> sidebar-content sidebar-content--modifier="pf-m-secondary"}}
+    {{#> content}}
+      <p>Default layout.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse dapibus nulla id augue dictum commodo. Donec mollis arcu massa, sollicitudin venenatis est rutrum vitae. Integer pulvinar ligula at augue mollis, ac pulvinar arcu semper. Maecenas nisi lorem, malesuada ac lectus nec, porta pretium neque. Ut convallis libero sit amet metus mattis, vel facilisis lorem malesuada. Duis consectetur ante sit amet magna efficitur, a interdum leo vulputate.</p>
+      <p>Praesent at odio nec sapien ultrices tincidunt in non mauris. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis consectetur nisl quis facilisis faucibus. Sed eu bibendum risus. Suspendisse porta euismod tortor, at elementum odio suscipit sed. Cras eget ultrices urna, ac feugiat lectus. Integer a pharetra velit, in imperdiet mi. Phasellus vel hendrerit velit. Vestibulum ut augue vitae erat vulputate bibendum a ut magna.</p>
+    {{/content}}
+  {{/sidebar-content}}
+{{/sidebar}}
+```
+
 ### Gutter
 ```hbs
 {{#> sidebar sidebar--modifier="pf-m-gutter"}}
@@ -218,3 +235,4 @@ import './Sidebar.css'
 | `.pf-m-static` | `.pf-v5-c-sidebar__panel` | Modifies the panel to be positioned statically. |
 | `.pf-m-width-{default, 25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-v5-c-sidebar__panel` | Modifies the panel width at optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). **Note:** does not apply when the panel is stacked on top of the content. |
 | `.pf-m-no-background` | `.pf-v5-c-sidebar`, `.pf-v5-c-sidebar__panel, .pf-v5-c-sidebar__content` | Modifies the element to have a transparent background. |
+| `.pf-m-secondary` | `.pf-v5-c-sidebar__panel, .pf-v5-c-sidebar__content` | Modifies the element to have secondary styling. |

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -2,12 +2,12 @@
 $pf-v5-c-sidebar--breakpoint-map--width: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
-.#{$sidebar} {
-  --#{$sidebar}--inset: var(--#{$pf-global}--spacer--md);
-  --#{$sidebar}--xl--inset: var(--#{$pf-global}--spacer--lg);
-  --#{$sidebar}--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
-  --#{$sidebar}--BorderWidth--base: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$sidebar}--BorderColor--base: var(--#{$pf-global}--BorderColor--100);
+:root,
+:where(.#{$sidebar}) {
+  --#{$sidebar}--inset: var(--pf-t--global--spacer--md);
+  --#{$sidebar}--xl--inset: var(--pf-t--global--spacer--lg);
+  --#{$sidebar}--BorderWidth--base: var(--pf-t--global--border--width--regular);
+  --#{$sidebar}--BorderColor--base: var(--pf-t--global--border--color--default);
 
   // Panel
   --#{$sidebar}__panel--PaddingTop: 0;
@@ -85,15 +85,21 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__panel--md--FlexBasis: #{pf-size-prem(250px)};
   --#{$sidebar}__panel--m-split--FlexBasis: #{pf-size-prem(250px)};
   --#{$sidebar}__panel--m-stack--FlexBasis: auto;
-  --#{$sidebar}__panel--ZIndex: var(--#{$pf-global}--ZIndex--xs);
-  --#{$sidebar}__panel--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$sidebar}__panel--ZIndex: var(--pf-t--global--Zindex--xs);
+  --#{$sidebar}__panel--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$sidebar}__panel--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // Content
-  --#{$sidebar}__content--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$sidebar}__content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$sidebar}__content--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // Sticky
   --#{$sidebar}__panel--m-sticky--Top: 0;
   --#{$sidebar}__panel--m-sticky--Position: sticky;
+}
+
+.#{$sidebar} {
+  height: 100%;
 
   @media (min-width: $pf-v5-global--breakpoint--md) {
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}__main--md--FlexDirection);
@@ -144,8 +150,6 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}--m-split__main--m-border--before--Display);
     --#{$sidebar}--m-panel-right__panel--Order: var(--#{$sidebar}--m-split--m-panel-right__panel--Order);
   }
-
-  height: 100%;
 }
 
 .#{$sidebar}__main {
@@ -192,6 +196,10 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__panel--Position: static;
     --#{$sidebar}__panel--Top: auto;
   }
+
+  &.pf-m-secondary {
+    --#{$sidebar}__panel--BackgroundColor: var(--#{$sidebar}__panel--m-secondary--BackgroundColor);
+  }
 }
 
 .#{$sidebar}__content {
@@ -212,6 +220,10 @@ $pf-v5-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   &.pf-m-no-background {
     --#{$sidebar}__content--BackgroundColor: transparent;
+  }
+
+  &.pf-m-secondary {
+    --#{$sidebar}__content--BackgroundColor: var(--#{$sidebar}__content--m-secondary--BackgroundColor);
   }
 
   & + .#{$sidebar}__panel {


### PR DESCRIPTION
Work towards https://github.com/patternfly/patternfly/issues/5711

I removed a background color var on sidebar itself that wasn't being used at all. I can add it back and apply the background color property to pf-v5-c-sidebar if we want.

