### PR TITLE
feat(DragDrop): use tokens

### DIFF
--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -1,14 +1,16 @@
 // @debug $draggable; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
-.#{$draggable} {
+:where(:root), :where(.#{$draggable}) {
   --#{$draggable}--Cursor: auto;
   --#{$draggable}--m-dragging--Cursor: grabbing;
-  --#{$draggable}--m-dragging--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$draggable}--m-dragging--after--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$draggable}--m-dragging--after--BorderColor: var(--#{$pf-global}--active-color--100);
+  --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
+  --#{$draggable}--m-dragging--after--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$draggable}--m-dragging--after--BorderColor: var(--pf-t--global--border--color--brand--default);
   --#{$draggable}--m-drag-outside--Cursor: not-allowed;
-  --#{$draggable}--m-drag-outside--after--BorderColor: var(--#{$pf-global}--danger-color--100);
+  --#{$draggable}--m-drag-outside--after--BorderColor: var(--pf-t--global--border--color--status--danger--default);
+}
 
+.#{$draggable} {
   cursor: var(--#{$draggable}--Cursor);
 
   &.pf-m-dragging {
@@ -35,17 +37,19 @@
   }
 }
 
-.#{$droppable} {
+:where(:root), :where(.#{$droppable}) {
   --#{$droppable}--before--BackgroundColor: transparent;
   --#{$droppable}--before--Opacity: 0;
   --#{$droppable}--after--BorderWidth: 0;
   --#{$droppable}--after--BorderColor: transparent;
-  --#{$droppable}--m-dragging--before--BackgroundColor: var(--#{$pf-global}--palette--white);
+  --#{$droppable}--m-dragging--before--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$droppable}--m-dragging--before--Opacity: .6;
-  --#{$droppable}--m-dragging--after--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$droppable}--m-dragging--after--BorderColor: var(--#{$pf-global}--active-color--100);
-  --#{$droppable}--m-drag-outside--after--BorderColor: var(--#{$pf-global}--danger-color--100);
+  --#{$droppable}--m-dragging--after--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$droppable}--m-dragging--after--BorderColor: var(--pf-t--global--border--color--brand--default);
+  --#{$droppable}--m-drag-outside--after--BorderColor: var(--pf-t--global--border--color--status--danger--default);
+}
 
+.#{$droppable} {
   &::before,
   &::after {
     position: absolute;
@@ -78,11 +82,4 @@
   &.pf-m-drag-outside {
     --#{$droppable}--m-dragging--after--BorderColor: var(--#{$droppable}--m-drag-outside--after--BorderColor);
   }
-}
-
-// stylelint-disable no-invalid-position-at-import-rule
-@import "themes/dark/drag-drop";
-
-@include pf-v5-theme-dark {
-  @include pf-v5-theme-dark-drag-drop;
 }

--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -6,6 +6,7 @@
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$draggable}--m-dragging--after--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$draggable}--m-dragging--after--BorderColor: var(--pf-t--global--border--color--brand--default);
+  --#{$draggable}--m-dragging--after--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$draggable}--m-drag-outside--Cursor: not-allowed;
   --#{$draggable}--m-drag-outside--after--BorderColor: var(--pf-t--global--border--color--status--danger--default);
 }
@@ -28,6 +29,7 @@
       inset-inline-end: 0;
       content: "";
       border: var(--#{$draggable}--m-dragging--after--BorderWidth) solid var(--#{$draggable}--m-dragging--after--BorderColor);
+      border-radius: var(--#{$draggable}--m-dragging--after--BorderRadius);
     }
   }
 
@@ -46,6 +48,7 @@
   --#{$droppable}--m-dragging--before--Opacity: .6;
   --#{$droppable}--m-dragging--after--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$droppable}--m-dragging--after--BorderColor: var(--pf-t--global--border--color--brand--default);
+  --#{$droppable}--m-dragging--after--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$droppable}--m-drag-outside--after--BorderColor: var(--pf-t--global--border--color--status--danger--default);
 }
 
@@ -68,6 +71,7 @@
 
   &::after {
     border: var(--#{$droppable}--after--BorderWidth, 0) solid var(--#{$droppable}--after--BorderColor, transparent);
+    border-radius: var(--#{$droppable}--m-dragging--after--BorderRadius);
   }
 
   &.pf-m-dragging {

--- a/src/patternfly/components/DragDrop/examples/DragDrop.css
+++ b/src/patternfly/components/DragDrop/examples/DragDrop.css
@@ -3,7 +3,7 @@
 }
 
 .pf-v5-c-draggable.pf-m-dragging {
-  --pf-v5-c-draggable--m-dragging--BackgroundColor: var(--pf-v5-global--BackgroundColor--100);
+  --pf-v5-c-draggable--m-dragging--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   position: absolute;
   inset-block-start: 23%;

--- a/src/patternfly/components/DragDrop/themes/dark/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/themes/dark/drag-drop.scss
@@ -1,7 +1,0 @@
-@import "../../../../sass-utilities/themes/dark/all";
-
-@mixin pf-v5-theme-dark-drag-drop() {
-  .#{$droppable} {
-    --#{$droppable}--m-dragging--before--Opacity: .2;
-  }
-}


### PR DESCRIPTION
Closes #5740

As design for penta drag and drop is still in flight (for both the current and new implementations) this PR updates the current styling to use the new tokens. A follow up may be required later if the design changes.