### PR TITLE
feat(SimpleFileUpload): consumed Penta tokens

### DIFF
--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -36,6 +36,39 @@ cssPrefix: pf-v5-c-file-upload
 {{/file-upload}}
 ```
 
+### With helper text
+
+```hbs
+{{#> file-upload file-upload--id="file-upload-helper-text"}}
+  {{#> file-upload-file-select}}
+    {{#> input-group}}
+      {{#> input-group-item input-group-item--IsFill=true}}
+        {{> file-upload-text-input
+          form-control--IsReadonly="true"
+          file-upload-text-input--aria-label="Drag and drop a file or upload one"
+          file-upload-text-input--attribute=(concat 'placeholder="Drag and drop a file or upload one" aria-describedby="' file-upload--id '-browse"')
+          }}
+      {{/input-group-item}}
+      {{#> input-group-item}}
+        {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse" aria-describedby="helper-text-example"')}}
+          Upload
+        {{/button}}
+      {{/input-group-item}}
+      {{#> input-group-item}}
+        {{#> button button--modifier="pf-m-control" button--attribute="disabled"}}
+          Clear
+        {{/button}}
+      {{/input-group-item}}
+    {{/input-group}}
+  {{/file-upload-file-select}}
+  {{#> file-upload-file-details file-upload-file-details--aria-label="Uploaded file content"}}
+  {{/file-upload-file-details}}
+  {{#> file-upload-helper-text}}
+    {{> helper-text helper-text--value="Upload a CSV file" helper-text-item--id='helper-text-example'}}
+  {{/file-upload-helper-text}}
+{{/file-upload}}
+```
+
 ### Upload complete non editable
 ```hbs
 {{#> file-upload file-upload--id="browsed-file-upload-complete"}}
@@ -138,7 +171,7 @@ cssPrefix: pf-v5-c-file-upload
                 }}
             {{/input-group-item}}
             {{#> input-group-item}}
-              {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
+              {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse" aria-describedby="with-error-example-helper-text"')}}
                 Upload
               {{/button}}
             {{/input-group-item}}
@@ -151,12 +184,12 @@ cssPrefix: pf-v5-c-file-upload
         {{/file-upload-file-select}}
         {{#> file-upload-file-details 
           form-control--IsError='true'
-          file-upload-file-details--attribute='aria-describedby="textAreaHelperText1" aria-invalid="true"' 
+          file-upload-file-details--attribute='aria-describedby="with-error-example-helper-text" aria-invalid="true"' 
           file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
+        {{#> file-upload-helper-text}}
+          {{> helper-text helper-text-item--HasIcon=true helper-text--value="Must be a CSV file no larger than 1 KB" helper-text-item--id='with-error-example-helper-text' helper-text-item--IsError=true}}
+        {{/file-upload-helper-text}}
       {{/file-upload}}
-      {{#> form-helper-text}}
-        {{> helper-text helper-text-item--HasIcon=true helper-text--value="Must be a CSV file no larger than 1 KB" helper-text-item--id='textAreaHelperText1' helper-text-item--IsError=true}}
-      {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -203,5 +236,6 @@ cssPrefix: pf-v5-c-file-upload
 | `.pf-v5-c-file-upload__file-select` | `<div>` | Initiates the file select element. **Required** |
 | `.pf-v5-c-file-upload__file-details` | `<div>` | Initiates the file details element. **Required** |
 | `.pf-v5-c-file-upload__file-details-spinner` | `<div>` | Initiates the file details element. **Required** |
+| `.pf-v5-c-file-upload__helper-text` | `<div>` | Initiates a container for [helper text](/components/helper-text) |
 | `.pf-m-drag-hover` | `.pf-v5-c-file-upload` | Modifies file upload for when an element is dragged or dropped inside of its container. |
 | `.pf-m-loading` | `.pf-v5-c-file-upload` | Modifies file upload for the loading state. |

--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -126,36 +126,38 @@ cssPrefix: pf-v5-c-file-upload
 ```hbs
 {{#> form}}
   {{#> form-group}}
-    {{#> file-upload file-upload--id="file-upload-error"}}
-      {{#> file-upload-file-select}}
-        {{#> input-group}}
-          {{#> input-group-item input-group-item--IsFill=true}}
-            {{> file-upload-text-input
-              form-control--IsRequired='true'
-              file-upload-text-input--aria-label="File upload error"
-              file-upload-text-input--attribute=(concat 'value="Sample.png"  aria-describedby="' file-upload--id '-browse"')
-              }}
-          {{/input-group-item}}
-          {{#> input-group-item}}
-            {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
-              Upload
-            {{/button}}
-          {{/input-group-item}}
-          {{#> input-group-item}}
-            {{#> button button--modifier="pf-m-control"}}
-              Clear
-            {{/button}}
-          {{/input-group-item}}
-        {{/input-group}}
-      {{/file-upload-file-select}}
-      {{#> file-upload-file-details 
-        form-control--IsError='true'
-        file-upload-file-details--attribute='aria-describedby="textAreaHelperText1" aria-invalid="true"' 
-        file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
-    {{/file-upload}}
-    {{#> form-helper-text}}
-      {{> helper-text helper-text--value="We don't support this file type. Try again with a different file type." helper-text-item--id='textAreaHelperText1' helper-text-item--IsError=true}}
-    {{/form-helper-text}}
+    {{#> form-group-control}}
+      {{#> file-upload file-upload--id="file-upload-error"}}
+        {{#> file-upload-file-select}}
+          {{#> input-group}}
+            {{#> input-group-item input-group-item--IsFill=true}}
+              {{> file-upload-text-input
+                form-control--IsReadonly='true'
+                file-upload-text-input--aria-label="File upload error"
+                file-upload-text-input--attribute=(concat 'value="Sample.png"  aria-describedby="' file-upload--id '-browse"')
+                }}
+            {{/input-group-item}}
+            {{#> input-group-item}}
+              {{#> button button--modifier="pf-m-control" button--attribute=(concat 'id="' file-upload--id '-browse"')}}
+                Upload
+              {{/button}}
+            {{/input-group-item}}
+            {{#> input-group-item}}
+              {{#> button button--modifier="pf-m-control"}}
+                Clear
+              {{/button}}
+            {{/input-group-item}}
+          {{/input-group}}
+        {{/file-upload-file-select}}
+        {{#> file-upload-file-details 
+          form-control--IsError='true'
+          file-upload-file-details--attribute='aria-describedby="textAreaHelperText1" aria-invalid="true"' 
+          file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
+      {{/file-upload}}
+      {{#> form-helper-text}}
+        {{> helper-text helper-text-item--HasIcon=true helper-text--value="Must be a CSV file no larger than 1 KB" helper-text-item--id='textAreaHelperText1' helper-text-item--IsError=true}}
+      {{/form-helper-text}}
+    {{/form-group-control}}
   {{/form-group}}
 {{/form}}
 ```

--- a/src/patternfly/components/FileUpload/file-upload-helper-text.hbs
+++ b/src/patternfly/components/FileUpload/file-upload-helper-text.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}file-upload__helper-text{{#if file-upload-helper-text--modifier}} {{file-upload-helper-text--modifier}}{{/if}}"
+  {{#if file-upload-helper-text--attribute}}
+    {{{file-upload-helper-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -16,9 +16,6 @@
   --#{$file-upload}--m-drag-hover--BorderColor: var(--pf-t--global--icon--color--brand--default);
   --#{$file-upload}--m-drag-hover--BorderStyle: dashed;
 
-  // File select > Input group
-  --#{$file-upload}__file-select__c-input-group--ColumnGap: var(--pf-t--global--spacer--xs);
-
   // File select > Button
   --#{$file-upload}__file-select__c-button--m-control--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
@@ -51,10 +48,6 @@
 }
 
 .#{$file-upload}__file-select {
-  .#{$input-group} {
-    column-gap: var(--#{$file-upload}__file-select__c-input-group--ColumnGap);
-  }
-
   .#{$button}.pf-m-control {
     outline-offset: var(--#{$file-upload}__file-select__c-button--m-control--OutlineOffset);
   }

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -1,65 +1,72 @@
 // @debug $file-upload; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
-.#{$file-upload} {
-  // pf-m-loading
-  --#{$file-upload}--m-loading__file-details--before--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
-  --#{$file-upload}--m-loading__file-details--before--Left: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$file-upload}--m-loading__file-details--before--Right: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$file-upload}--m-loading__file-details--before--Bottom: var(--#{$pf-global}--BorderWidth--sm);
+:where(:root),
+:where(.#{$file-upload}) {
+  --#{$file-upload}--RowGap: var(--pf-t--global--spacer--sm);
+  --#{$file-upload}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$file-upload}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$file-upload}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$file-upload}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$file-upload}--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$file-upload}--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$file-upload}--BorderColor: transparent;
+  --#{$file-upload}--BorderStyle: solid;
 
   // pf-m-drag-hover
-  --#{$file-upload}--m-drag-hover--before--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$file-upload}--m-drag-hover--before--BorderColor: var(--#{$pf-global}--primary-color--100);
-  --#{$file-upload}--m-drag-hover--before--ZIndex: var(--#{$pf-global}--ZIndex--xs);
-  --#{$file-upload}--m-drag-hover--after--BackgroundColor: var(--#{$pf-global}--primary-color--100);
-  --#{$file-upload}--m-drag-hover--after--Opacity: .1;
+  --#{$file-upload}--m-drag-hover--BorderColor: var(--pf-t--global--icon--color--brand--default);
+  --#{$file-upload}--m-drag-hover--BorderStyle: dashed;
 
-  // Text area
-  --#{$file-upload}__file-details__c-form-control--MinHeight: calc(var(--#{$pf-global}--spacer--3xl) * 2);
+  // File select > Input group
+  --#{$file-upload}__file-select__c-input-group--ColumnGap: var(--pf-t--global--spacer--xs);
 
-  // Button overrides
-  --#{$file-upload}__file-select__c-button--m-control--OutlineOffset: calc(-1 * var(--#{$pf-global}--spacer--xs));
+  // File select > Button
+  --#{$file-upload}__file-select__c-button--m-control--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
+  // File details > Text area
+  --#{$file-upload}__file-details__c-form-control--MinHeight: calc(var(--pf-t--global--spacer--3xl) * 2);
+
+  // Form helper text overrides
+  --#{$file-upload}__c-form-helper-text--MarginBlockStart: 0;
+  --#{$file-upload}__c-form-helper-text--PaddingInlineStart: var(--#{$file-upload}--PaddingInlineStart);
+  --#{$file-upload}__c-form-helper-text--PaddingInlineEnd: var(--#{$file-upload}--PaddingInlineEnd);
+}
+
+.#{$file-upload} {
   position: relative;
   display: flex;
   flex-direction: column;
+  row-gap: var(--#{$file-upload}--RowGap);
+  padding-block-start: var(--#{$file-upload}--PaddingBlockStart);
+  padding-block-end: var(--#{$file-upload}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$file-upload}--PaddingInlineStart);
+  padding-inline-end: var(--#{$file-upload}--PaddingInlineEnd);
+  border: var(--#{$file-upload}--BorderWidth) var(--#{$file-upload}--BorderStyle) var(--#{$file-upload}--BorderColor);
+  border-radius: var(--#{$file-upload}--BorderRadius);
 
   &.pf-m-drag-hover {
-    &::before {
-      position: absolute;
-      inset: 0;
-      z-index: var(--#{$file-upload}--m-drag-hover--before--ZIndex);
-      content: "";
-      border: var(--#{$file-upload}--m-drag-hover--before--BorderWidth) solid var(--#{$file-upload}--m-drag-hover--before--BorderColor);
-    }
-
-    &::after {
-      position: absolute;
-      inset: 0;
-      content: "";
-      background-color: var(--#{$file-upload}--m-drag-hover--after--BackgroundColor);
-      opacity: var(--#{$file-upload}--m-drag-hover--after--Opacity);
-    }
+    --#{$file-upload}--BorderColor: var(--#{$file-upload}--m-drag-hover--BorderColor);
+    --#{$file-upload}--BorderStyle: var(--#{$file-upload}--m-drag-hover--BorderStyle);
   }
 
   &.pf-m-loading {
     .#{$file-upload}__file-details {
       position: relative;
-
-      &::before {
-        position: absolute;
-        inset-block-start: 0;
-        inset-block-end: var(--#{$file-upload}--m-loading__file-details--before--Left);
-        inset-inline-start: var(--#{$file-upload}--m-loading__file-details--before--Left);
-        inset-inline-end: var(--#{$file-upload}--m-loading__file-details--before--Left);
-        content: "";
-        background-color: var(--#{$file-upload}--m-loading__file-details--before--BackgroundColor);
-      }
     }
+  }
+
+  & + .#{$form}__helper-text {
+    --#{$form}__helper-text__MarginTop:var(--#{$file-upload}__c-form-helper-text--MarginBlockStart);
+
+    padding-inline-start: var(--#{$file-upload}__c-form-helper-text--PaddingInlineStart);
+    padding-inline-end: var(--#{$file-upload}__c-form-helper-text--PaddingInlineEnd);
   }
 }
 
 .#{$file-upload}__file-select {
+  .#{$input-group} {
+    column-gap: var(--#{$file-upload}__file-select__c-input-group--ColumnGap);
+  }
+
   .#{$button}.pf-m-control {
     outline-offset: var(--#{$file-upload}__file-select__c-button--m-control--OutlineOffset);
   }
@@ -78,7 +85,7 @@
 
 .#{$file-upload}__file-details-spinner {
   position: absolute;
- inset-block-start: 50%;
- inset-inline-start: 50%;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
   transform: translate(-50%, -50%);
 }

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -24,11 +24,6 @@
 
   // File details > Text area
   --#{$file-upload}__file-details__c-form-control--MinHeight: calc(var(--pf-t--global--spacer--3xl) * 2);
-
-  // Form helper text overrides
-  --#{$file-upload}__c-form-helper-text--MarginBlockStart: 0;
-  --#{$file-upload}__c-form-helper-text--PaddingInlineStart: var(--#{$file-upload}--PaddingInlineStart);
-  --#{$file-upload}__c-form-helper-text--PaddingInlineEnd: var(--#{$file-upload}--PaddingInlineEnd);
 }
 
 .#{$file-upload} {
@@ -52,13 +47,6 @@
     .#{$file-upload}__file-details {
       position: relative;
     }
-  }
-
-  & + .#{$form}__helper-text {
-    --#{$form}__helper-text__MarginTop:var(--#{$file-upload}__c-form-helper-text--MarginBlockStart);
-
-    padding-inline-start: var(--#{$file-upload}__c-form-helper-text--PaddingInlineStart);
-    padding-inline-end: var(--#{$file-upload}__c-form-helper-text--PaddingInlineEnd);
   }
 }
 


### PR DESCRIPTION
Closes #6209 

- Removed usage of the form helper text since it seems like from the design the helper text should be tied to File Upload, not Form
- Added a helper text example that makes the text area aria label "Uploaded file content" and tied the helper text to the Upload button. Also made these updates to the "with error" example. As a follow up we should consider making similar changes to other examples, as well as:
  - possibly updating the text input aria label to "File name"; right now it just duplicates the placeholder or value attribute
  - remove the aria-describedby from the text input, as currently it being described by the upload button doesn't provide adequate description

For the "with error" example, is the intent that if a file upload has a type/size restriction, it must be placed in a Form component? Or is this example more like a demo of showing how one could place a file upload inside a form? Right now React only uses Form components for a similar "restrictive" example, but it would seem like a non-restrictive file upload could/should also be placed inside a Form for some sort of submission as well.