### PR TITLE
feat(ToggleGroup): add border between like toggles

### DIFF
--- a/src/patternfly/base/tokens/_tokens-default.scss
+++ b/src/patternfly/base/tokens/_tokens-default.scss
@@ -1,7 +1,6 @@
-/**
- * Do not edit directly
- * Generated on Tue, 05 Dec 2023 16:11:05 GMT
- */
+ // Do not edit directly
+ // Generated on Tue, 05 Dec 2023 16:11:05 GMT
+
 
 :root {
   --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
@@ -285,6 +284,7 @@
   --pf-t--global--border--color--clicked: var(--pf-t--global--color--brand--200);
   --pf-t--global--border--color--hover: var(--pf-t--global--color--brand--100);
   --pf-t--global--border--color--default: var(--pf-t--global--border--color--100);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--background--color--disabled--default);
   --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--300);
   --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--300);
   --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--200);

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -15,8 +15,6 @@
   --#{$toggle-group}__button--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
   --#{$toggle-group}__button--hover--ZIndex: var(--pf-t--global--Zindex--xs);
   --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$toggle-group}__button--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
-  --#{$toggle-group}__button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$toggle-group}__button--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--default);
 
@@ -34,7 +32,15 @@
   --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$toggle-group}__button--m-selected--Color: var(--pf-t--global--text--color--on-brand--default);
   --#{$toggle-group}__button--m-selected--before--BorderColor: var(--pf-t--global--border--color--clicked);
+  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
   --#{$toggle-group}__button--m-selected--ZIndex: var(--pf-t--global--Zindex--xs);
+
+  // disabled
+  --#{$toggle-group}__button--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$toggle-group}__button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
+  --#{$toggle-group}__button--disabled--before--BorderColor: var(--pf-t--global--border--color--disabled);
+  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--Zindex--xs);
 
   // Compact
   --#{$toggle-group}--m-compact__button--PaddingTop: 0;
@@ -98,13 +104,18 @@
 
   &::before {
     position: absolute;
-   inset-block-start: 0;
-   inset-block-end: 0;
-   inset-inline-start: 0;
-   inset-inline-end: 0;
+    inset-block-start: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     pointer-events: none;
     content: "";
-    border: var(--#{$toggle-group}__button--before--BorderWidth) solid var(--#{$toggle-group}__button--before--BorderColor);
+    border-style: solid;
+    border-width: var(--#{$toggle-group}__button--before--BorderWidth);
+    border-block-start-color: var(--#{$toggle-group}__button--before--BorderBlockStartColor, var(--#{$toggle-group}__button--before--BorderColor));
+    border-block-end-color: var(--#{$toggle-group}__button--before--BorderBlockEndColor, var(--#{$toggle-group}__button--before--BorderColor));
+    border-inline-start-color: var(--#{$toggle-group}__button--before--BorderInlineStartColor, var(--#{$toggle-group}__button--before--BorderColor));
+    border-inline-end-color: var(--#{$toggle-group}__button--before--BorderInlineEndColor, var(--#{$toggle-group}__button--before--BorderColor));
   }
 
   &:hover,
@@ -127,9 +138,22 @@
   &.pf-m-disabled {
     --#{$toggle-group}__button--BackgroundColor: var(--#{$toggle-group}__button--disabled--BackgroundColor);
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--disabled--Color);
+    --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--disabled--ZIndex);
+    --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--disabled--before--BorderColor);
 
     pointer-events: none;
   }
+}
+
+// For consecutive selected items, turn the left border back to what it was
+.pf-v5-c-toggle-group__item:has(.pf-m-selected) + .pf-v5-c-toggle-group__item:has(.pf-m-selected) {
+  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor);
+}
+    
+// For consecutive disabled items, turn the left border back to what it was
+// .pf-v5-c-toggle-group__item:has(.pf-m-disabled) + .pf-v5-c-toggle-group__item:has(.pf-m-disabled),
+.pf-v5-c-toggle-group__item:has(:disabled, .pf-m-disabled) + .pf-v5-c-toggle-group__item:has(:disabled, .pf-m-disabled) {
+  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor);
 }
 
 .#{$toggle-group}__icon + .#{$toggle-group}__text,

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -151,7 +151,6 @@
 }
     
 // For consecutive disabled items, turn the left border back to what it was
-// .pf-v5-c-toggle-group__item:has(.pf-m-disabled) + .pf-v5-c-toggle-group__item:has(.pf-m-disabled),
 .pf-v5-c-toggle-group__item:has(:disabled, .pf-m-disabled) + .pf-v5-c-toggle-group__item:has(:disabled, .pf-m-disabled) {
   --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor);
 }


### PR DESCRIPTION
This addresses the adjacent borders in #6202 (but not the mobile is too-wide and cut off problems)

This adds a token that has already been added in Figma, and fixes the block comment on that file that lint complains about.
It splits the border into parts so that the left side can be set to the right color to divide two blocks of the same color. Fallbacks are used so that if the individual border colors aren't set, it falls back to the overall border color.