### PR TITLE
fix(check): update standalone styling

### DIFF
--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -24,6 +24,7 @@
   --#{$check}__input--TranslateY: calc((var(--#{$check}__label--LineHeight) * var(--#{$check}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height
 }
 
+// - Check
 .#{$check} {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -36,12 +37,15 @@
     height: var(--#{$check}--Height);
 
     .#{$check}__input {
+      align-self: center;
       transform: none;
     }
   }
 }
 
+// - Check input
 .#{$check}__input {
+  align-self: start;
   font-size: var(--#{$check}__label--FontSize);
   line-height: var(--#{$check}__label--LineHeight);
 

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -4,12 +4,14 @@
 .#{$check} {
   --#{$check}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
+  --#{$check}--Height: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
+
+  // TODO: update to `--#{$check}--FontSize` `--#{$check}--LineHeight`
   --#{$check}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$check}__label--Color: var(--pf-t--global--text--color--regular);
   --#{$check}__label--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$check}__label--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$check}__label--LineHeight: var(--pf-t--global--font--line-height--body);
-  --#{$check}__input--TranslateY: calc((var(--#{$check}__label--LineHeight) * var(--#{$check}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height  
   --#{$check}__description--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$check}__description--Color: var(--pf-t--global--text--color--subtle);
 
@@ -17,6 +19,9 @@
   --#{$check}__label-required--MarginLeft: var(--pf-t--global--spacer--xs);
   --#{$check}__label-required--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$check}__label-required--Color: var(--pf-t--global--color--status--danger--default);
+
+  // TODO: due to subpixel rendering and this value resolving to 21px, the checkbox vertical centering is off by 1px. Mozilla rounds subpixels up while chrome rounds down. This is a temporary fix until we can find a better solution.
+  --#{$check}__input--TranslateY: calc((var(--#{$check}__label--LineHeight) * var(--#{$check}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height
 }
 
 .#{$check} {
@@ -26,15 +31,19 @@
   accent-color: var(--#{$check}--AccentColor);
 
   &.pf-m-standalone {
-    --#{$check}--GridGap: 0;
-    --#{$check}__input--TranslateY: none;
-
     display: inline-grid;
+    grid-template-columns: auto;
+    height: var(--#{$check}--Height);
+
+    .#{$check}__input {
+      transform: none;
+    }
   }
 }
 
 .#{$check}__input {
-  align-self: start;
+  font-size: var(--#{$check}__label--FontSize);
+  line-height: var(--#{$check}__label--LineHeight);
 
   // find height of single label, divide by two, offset by 50% of own height
   transform: translateY(var(--#{$check}__input--TranslateY));

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -4,19 +4,27 @@
 .#{$radio} {
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
+  --#{$radio}--Height: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
+
+  // TODO: update to `--#{$radio}--FontSize` `--#{$radio}--LineHeight`
   --#{$radio}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$radio}__label--Color: var(--pf-t--global--text--color--regular);
   --#{$radio}__label--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$radio}__label--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$radio}__label--LineHeight: var(--pf-t--global--font--line-height--body);
-  --#{$radio}__input--TranslateY: calc((var(--#{$radio}__label--LineHeight) * var(--#{$radio}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height
-  --#{$radio}__input--first-child--MarginLeft: #{pf-size-prem(1px)};
-  --#{$radio}__input--last-child--MarginRight: #{pf-size-prem(1px)};
   --#{$radio}__description--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$radio}__description--Color: var(--pf-t--global--text--color--subtle);
+
+  // * Radio input
+  --#{$radio}__input--first-child--MarginLeft: #{pf-size-prem(1px)};
+  --#{$radio}__input--last-child--MarginRight: #{pf-size-prem(1px)};
   --#{$radio}__body--MarginTop: var(--pf-t--global--spacer--sm);
+
+  // TODO: due to subpixel rendering and this value resolving to 21px, the checkbox vertical centering is off by 1px. Mozilla rounds subpixels up while chrome rounds down. This is a temporary fix until we can find a better solution.
+  --#{$radio}__input--TranslateY: calc((var(--#{$radio}__label--LineHeight) * var(--#{$radio}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height
 }
 
+// - Radio
 .#{$radio} {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -25,15 +33,22 @@
   accent-color: var(--#{$radio}--AccentColor);
 
   &.pf-m-standalone {
-    --#{$radio}--GridGap: 0;
-    --#{$radio}__input--TranslateY: none;
-
     display: inline-grid;
+    grid-template-columns: auto;
+    height: var(--#{$check}--Height);
+
+    .#{$radio}__input {
+      align-self: center;
+      transform: none;
+    }
   }
 }
 
+// - Radio input
 .#{$radio}__input {
   align-self: start;
+  font-size: var(--#{$radio}__label--FontSize);
+  line-height: var(--#{$radio}__label--LineHeight);
 
   // find height of single label, divide by two, offset by 50% of own height
   transform: translateY(var(--#{$radio}__input--TranslateY));

--- a/src/patternfly/components/Table/Tree-table/table-tr--tree.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tr--tree.hbs
@@ -6,7 +6,7 @@
       {{/unless}}
       {{#unless table-tr--tree--HasNoCheckbox}}
         {{#if tree-view--HasCheckboxes}}
-          {{#> table-td table-td--type="span" table-td--check="true"}}
+          {{#> table-td table-td--type="span" table-td--IsCheck=true}}
             <label>
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="' table--id '-checkrow-' table-tr--tree--index '" aria-labelledby="' table--id '-node-' table-tr--tree--index '"')}}{{/check-input}}

--- a/src/patternfly/components/Table/table-check.hbs
+++ b/src/patternfly/components/Table/table-check.hbs
@@ -1,7 +1,4 @@
-<label>
-  {{#> check check--modifier="pf-m-standalone"}}
-    {{#> check-input 
-      check-input--attribute=(concat (ternary table-check--name (concat 'name="' table-check--name '"') '') (ternary table-check--aria-labelledby (concat ' aria-labelledby="' table-check--aria-labelledby '"') '') (ternary table-check--aria-label (concat ' aria-label="' table-check--aria-label '"') ''))
-    }}{{/check-input}}
-  {{/check}}
-</label>
+{{#> check check--modifier="pf-m-standalone" check--IsLabelWrapped=true}}
+  {{> check-input check-input--attribute=(concat (ternary table-check--name (concat 'name="' table-check--name '"') '') (ternary table-check--aria-labelledby (concat ' aria-labelledby="' table-check--aria-labelledby '"') '') (ternary table-check--aria-label (concat ' aria-label="' table-check--aria-label '"') ''))
+  }}
+{{/check}}

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -1,13 +1,15 @@
 <{{#if table-td--type}}{{table-td--type}}{{else}}td{{/if}} class="{{pfv}}table__td
-  {{~#if table-td--toggle}} {{pfv}}table__toggle{{/if}}
-  {{~#if table-td--check}} {{pfv}}table__check{{/if}}
-  {{~#if table-td--action}} {{pfv}}table__action{{/if}}
+  {{~#if table-td--IsToggle}} {{pfv}}table__toggle{{/if}}
+  {{~#if table-td--IsCheck}} {{pfv}}table__check{{/if}}
+  {{~#if table-td--IsAction}} {{pfv}}table__action{{/if}}
+  {{~#if table-td--HasOverflowMenu}} {{pfv}}table__action{{/if}}
   {{~#if table-td--icon}} {{pfv}}table__icon{{/if}}
   {{~#if table-td--compound-expansion-toggle}} {{pfv}}table__compound-expansion-toggle{{/if}}
   {{~#if table-td--IsStickyColumn}} {{pfv}}table__sticky-column{{/if}}
   {{~#if table-td--IsFavorite}} {{pfv}}table__favorite{{/if}}
-  {{~#if table-td--IsFavorited}} pf-m-favorited{{/if}}
   {{~#if table-td--IsDraggable}} {{pfv}}table__draggable{{/if}}
+  {{~#if table-td--IsFavorited}} pf-m-favorited{{/if}}
+  {{~#if table--IsCompact}} pf-m-compact{{/if}}
   {{~#if table-td--modifier}} {{table-td--modifier}}{{/if}}"
   {{#unless table-td--IsEmpty}}
     {{#unless table-td--type}}
@@ -25,10 +27,22 @@
     data-label="{{table-td--data-label}}"
   {{/if}}>
   {{#unless table-td--IsEmpty}}
-    {{#if table-td--toggle}}
-      <button class="{{pfv}}button pf-m-plain{{#if table-tr--expanded}} pf-m-expanded{{/if}}" {{#if table-td--button--attribute}}{{{table-td--button--attribute}}}{{/if}} {{#if table-tr--expanded}}aria-expanded="true"{{/if}}>
+    {{#if table-td--HasOverflowMenu}}
+      {{> table--overflow-menu}}
+    {{else if table-td--IsAction}}
+      {{> menu-toggle menu-toggle--IsPlain=true menu-toggle--HasKebab=(ternary menu-toggle--icon false true) menu-toggle--aria-label='Table actions'}}
+      {{!-- TODO: add small variant to menu toggle --}}
+    {{else if table-td--IsToggle}}
+      {{#> button
+          button--aria-label='Toggle row'
+          button--IsSmall=table--IsCompact
+          button--IsPlain=true
+          button--IsExpanded=table-tr--expanded
+          button--IsAriaExpanded=table-tr--expanded
+          button--id=(dasherize table--id 'toggle' table-tr--index)
+      }}
         {{> table-toggle-icon}}
-      </button>
+      {{/button}}
     {{else if table-td--compound-expansion-toggle}}
       {{#> table-button table-button--attribute=table-th--button--attribute}}
         {{#> table-text}}
@@ -39,7 +53,7 @@
       {{> table-favorite-button}}
     {{else if table-td--IsDraggable}}
       {{> table-draggable-button}}
-    {{else}}
+    {{else if @partial-block}}
       {{> @partial-block}}
     {{/if}}
   {{/unless}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -927,21 +927,34 @@
   --#{$table}--cell--PaddingLeft: var(--#{$table}__check--PaddingLeft);
   --#{$table}--cell--PaddingRight: var(--#{$table}__check--PaddingRight);
 
-  .#{$check}.pf-m-standalone {
-    display: inline-flex;
+  vertical-align: top;
 
+  .#{$check} {
+    --#{$check}__label--FontSize: var(--#{$table}--cell--FontSize);
+    --#{$check}__label--LineHeight: var(--#{$table}--cell--LineHeight);
+  }
+
+  .#{$radio} {
+    --#{$radio}__label--FontSize: var(--#{$table}--cell--FontSize);
+    --#{$radio}__label--LineHeight: var(--#{$table}--cell--LineHeight);
+  }
+
+  thead & {
+    vertical-align: bottom;
+  }
+
+  .#{$check}.pf-m-standalone,
+  .#{$radio}.pf-m-standalone {
     thead & {
-      vertical-align: bottom;
+      display: table-cell;
+      height: auto;
+      line-height: 1;
+      vertical-align: baseline;
     }
 
     tbody & {
-      vertical-align: top;
+      height: auto;
     }
-  }
-
-  // TODO: remove label wrapper at breaking change
-  label {
-    display: contents;
   }
 }
 

--- a/src/patternfly/components/Table/templates/table--check.hbs
+++ b/src/patternfly/components/Table/templates/table--check.hbs
@@ -1,4 +1,4 @@
-{{#> table-td table-td--check="true"}}
+{{#> table-td table-td--IsCheck=true}}
   {{#if table--check--IsThead}}
     {{> table-check table-check--name=(concat table--id '-checkrow' table-tr--index) table-check--aria-label="Select all rows"}}
   {{else}}

--- a/src/patternfly/components/Table/templates/table--radio.hbs
+++ b/src/patternfly/components/Table/templates/table--radio.hbs
@@ -1,7 +1,5 @@
 {{#> table-td table-td--check="true"}}
-  <label>
-    {{#> radio radio--modifier="pf-m-standalone"}}
-      {{#> radio-input radio-input--attribute=(concat 'name="' table--id '-radio" aria-labelledby="' table--id '-node' table-tr--index '"')}}{{/radio-input}}
-    {{/radio}}
-  </label>
+  {{#> radio radio--IsStandalone=true}}
+    {{#> radio-input radio-input--attribute=(concat 'name="' table--id '-radio" aria-labelledby="' table--id '-node' table-tr--index '"')}}{{/radio-input}}
+  {{/radio}}
 {{/table-td}}

--- a/src/patternfly/components/Table/templates/table--radio.hbs
+++ b/src/patternfly/components/Table/templates/table--radio.hbs
@@ -1,4 +1,4 @@
-{{#> table-td table-td--check="true"}}
+{{#> table-td table-td--IsCheck=true}}
   {{#> radio radio--IsStandalone=true}}
     {{#> radio-input radio-input--attribute=(concat 'name="' table--id '-radio" aria-labelledby="' table--id '-node' table-tr--index '"')}}{{/radio-input}}
   {{/radio}}

--- a/src/patternfly/demos/DataList/data-list-expandable-compact-table.hbs
+++ b/src/patternfly/demos/DataList/data-list-expandable-compact-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id="compact-table-demo-data-list" table--grid="true" table--modifier="pf-m-compact pf-m-grid-lg pf-m-no-border-rows" table--attribute='aria-label="This is a compact table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
         {{/check}}
@@ -30,7 +30,7 @@
   {{/table-thead}}
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-name1"')}}{{/check-input}}
         {{/check}}
@@ -61,7 +61,7 @@
       {{/table-td}}
     {{/table-tr}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-name2"')}}{{/check-input}}
         {{/check}}
@@ -92,7 +92,7 @@
       {{/table-td}}
     {{/table-tr}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-name3"')}}{{/check-input}}
         {{/check}}
@@ -123,7 +123,7 @@
       {{/table-td}}
     {{/table-tr}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-name4"')}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Page/examples/Penta.md
+++ b/src/patternfly/demos/Page/examples/Penta.md
@@ -211,7 +211,7 @@ wrapperTag: div
       {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
         {{#> table-thead}}
           {{#> table-tr}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-node1"')}}{{/check-input}}
               {{/check}}
@@ -238,7 +238,7 @@ wrapperTag: div
 
         {{#> table-tbody table-tr--IsClickable="true" table-tr--basic--title="Clickable"}}
           {{#> table-tr}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-node1"')}}{{/check-input}}
               {{/check}}
@@ -292,7 +292,7 @@ wrapperTag: div
           {{/table-tr}}
 
           {{#> table-tr table-tr--IsSelected="true"}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-node2" checked')}}{{/check-input}}
               {{/check}}
@@ -346,7 +346,7 @@ wrapperTag: div
           {{/table-tr}}
 
           {{#> table-tr}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-node3"')}}{{/check-input}}
               {{/check}}
@@ -400,7 +400,7 @@ wrapperTag: div
           {{/table-tr}}
 
           {{#> table-tr}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-node4"')}}{{/check-input}}
               {{/check}}
@@ -454,7 +454,7 @@ wrapperTag: div
           {{/table-tr}}
 
           {{#> table-tr}}
-            {{#> table-td table-td--check="true"}}
+            {{#> table-td table-td--IsCheck=true}}
               {{#> check check--modifier="pf-m-standalone"}}
                 {{#> check-input check-input--attribute=(concat 'name="checkrow5" aria-labelledby="' table--id '-node5"')}}{{/check-input}}
               {{/check}}

--- a/src/patternfly/demos/Skeleton/table-skeleton.hbs
+++ b/src/patternfly/demos/Skeleton/table-skeleton.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-compact-table.hbs
+++ b/src/patternfly/demos/Table/table-compact-table.hbs
@@ -27,7 +27,7 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-name1"')}}{{/check-input}}
         {{/check}}
@@ -59,7 +59,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-name2"')}}{{/check-input}}
         {{/check}}
@@ -91,7 +91,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-name3"')}}{{/check-input}}
         {{/check}}
@@ -123,7 +123,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-name4"')}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-empty-state-table.hbs
+++ b/src/patternfly/demos/Table/table-empty-state-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id="empty-state-table-demo" table--grid="true" table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a table showing an empty state"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-expandable-table.hbs
+++ b/src/patternfly/demos/Table/table-expandable-table.hbs
@@ -77,8 +77,13 @@
 
   {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr table-tr--expanded="true"}}
+<<<<<<< Updated upstream
       {{#> table-td table-td--toggle="true" table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node2 expandable-toggle2" id="expandable-toggle2" aria-label="Details" aria-controls="' table--id '-content2"')}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
+=======
+      {{> table-td table-td--IsToggle=true table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node2 expandable-toggle2" id="expandable-toggle2" aria-label="Details" aria-controls="' table--id '-content2"')}}
+      {{#> table-td table-td--IsCheck=true}}
+>>>>>>> Stashed changes
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-node2"')}}{{/check-input}}
         {{/check}}
@@ -131,8 +136,13 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
+<<<<<<< Updated upstream
       {{#> table-td table-td--toggle="true" table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node3 expandable-toggle3" id="expandable-toggle3" aria-label="Details" aria-controls="' table--id '-content3"')}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
+=======
+      {{> table-td table-td--IsToggle=true table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node3 expandable-toggle3" id="expandable-toggle3" aria-label="Details" aria-controls="' table--id '-content3"')}}
+      {{#> table-td table-td--IsCheck=true}}
+>>>>>>> Stashed changes
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-node3"')}}{{/check-input}}
         {{/check}}
@@ -179,8 +189,13 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
+<<<<<<< Updated upstream
       {{#> table-td table-td--toggle="true" table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node4 expandable-toggle4" id="expandable-toggle4" aria-label="Details" aria-controls="' table--id '-content4"')}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
+=======
+      {{> table-td table-td--IsToggle=true table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node4 expandable-toggle4" id="expandable-toggle4" aria-label="Details" aria-controls="' table--id '-content4"')}}
+      {{#> table-td table-td--IsCheck=true}}
+>>>>>>> Stashed changes
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-node4"')}}{{/check-input}}
         {{/check}}
@@ -227,8 +242,13 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
+<<<<<<< Updated upstream
       {{#> table-td table-td--toggle="true" table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node5 expandable-toggle5" id="expandable-toggle5" aria-label="Details" aria-controls="' table--id '-content5"')}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
+=======
+      {{> table-td table-td--IsToggle=true table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node5 expandable-toggle5" id="expandable-toggle5" aria-label="Details" aria-controls="' table--id '-content5"')}}
+      {{#> table-td table-td--IsCheck=true}}
+>>>>>>> Stashed changes
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow5" aria-labelledby="' table--id '-node5"')}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-loading-table.hbs
+++ b/src/patternfly/demos/Table/table-loading-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id="table-loading-table" table--grid="true" table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a table showing a loading state"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -24,7 +24,7 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-node1"')}}{{/check-input}}
         {{/check}}
@@ -56,7 +56,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-node2"')}}{{/check-input}}
         {{/check}}
@@ -88,7 +88,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-node3"')}}{{/check-input}}
         {{/check}}
@@ -120,7 +120,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-node4"')}}{{/check-input}}
         {{/check}}
@@ -152,7 +152,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow5" aria-labelledby="' table--id '-node5"')}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Table/table-sortable-table.hbs
+++ b/src/patternfly/demos/Table/table-sortable-table.hbs
@@ -24,7 +24,7 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-node1"')}}{{/check-input}}
         {{/check}}
@@ -56,7 +56,7 @@
     {{/table-tr}}
 
       {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-node2"')}}{{/check-input}}
         {{/check}}
@@ -88,7 +88,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-node3"')}}{{/check-input}}
         {{/check}}
@@ -120,7 +120,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-node4"')}}{{/check-input}}
         {{/check}}
@@ -152,7 +152,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow5" aria-labelledby="' table--id '-node5"')}}{{/check-input}}
         {{/check}}

--- a/src/patternfly/demos/Tabs/tabs--table.hbs
+++ b/src/patternfly/demos/Tabs/tabs--table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--grid="true" table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
         {{/check}}
@@ -27,7 +27,7 @@
 
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow1" aria-labelledby="' table--id '-node1"')}}{{/check-input}}
         {{/check}}
@@ -77,7 +77,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--modifier="pf-m-selected"}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow2" aria-labelledby="' table--id '-node2"')}}{{/check-input}}
         {{/check}}
@@ -127,7 +127,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow3" aria-labelledby="' table--id '-node3"')}}{{/check-input}}
         {{/check}}
@@ -177,7 +177,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow4" aria-labelledby="' table--id '-node4"')}}{{/check-input}}
         {{/check}}
@@ -227,7 +227,7 @@
     {{/table-tr}}
 
     {{#> table-tr}}
-      {{#> table-td table-td--check="true"}}
+      {{#> table-td table-td--IsCheck=true}}
         {{#> check check--modifier="pf-m-standalone"}}
           {{#> check-input check-input--attribute=(concat 'name="checkrow5" aria-labelledby="' table--id '-node5"')}}{{/check-input}}
         {{/check}}


### PR DESCRIPTION
Applies to #6294 

This PR fixes standalone padding vertical alignment. The standalone variant lacks consideration in context. This code takes a line height and font size to calculate a height, then uses default alignment of center to position vertically, but will respond to alternative alignments. 
