### PR TITLE
feat(tokens): update tokens, add opacity, box-shadow tokens

### DIFF
--- a/src/patternfly/base/tokens/_tokens-charts.scss
+++ b/src/patternfly/base/tokens/_tokens-charts.scss
@@ -1,6 +1,6 @@
 // /**
 //  * Do not edit directly
-//  * Generated on Tue, 06 Feb 2024 18:33:23 GMT
+//  * Generated on Tue, 20 Feb 2024 01:08:05 GMT
 //  */
 
 :root {
@@ -95,31 +95,31 @@
   --pf-t--chart--theme--colorscales--Multi-colored-unordered--colorscale--300: var(--pf-t--chart--color--green--300);
   --pf-t--chart--theme--colorscales--Multi-colored-unordered--colorscale--200: var(--pf-t--chart--color--yellow--300);
   --pf-t--chart--theme--colorscales--Multi-colored-unordered--colorscale--100: var(--pf-t--chart--color--blue--300);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2500: var(--pf-t--chart--color--orange--200);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2400: var(--pf-t--chart--color--yellow--400);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2300: var(--pf-t--chart--color--teal--400);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2200: var(--pf-t--chart--color--green--200);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2100: var(--pf-t--chart--color--blue--400);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--2000: var(--pf-t--chart--color--orange--400);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1900: var(--pf-t--chart--color--yellow--200);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1800: var(--pf-t--chart--color--teal--200);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1700: var(--pf-t--chart--color--green--400);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1600: var(--pf-t--chart--color--blue--200);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1500: var(--pf-t--chart--color--orange--100);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1400: var(--pf-t--chart--color--yellow--500);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1300: var(--pf-t--chart--color--teal--500);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1200: var(--pf-t--chart--color--green--100);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1100: var(--pf-t--chart--color--blue--500);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--1000: var(--pf-t--chart--color--orange--500);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--900: var(--pf-t--chart--color--yellow--100);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--800: var(--pf-t--chart--color--teal--100);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--700: var(--pf-t--chart--color--green--500);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--600: var(--pf-t--chart--color--blue--100);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--500: var(--pf-t--chart--color--orange--300);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--400: var(--pf-t--chart--color--yellow--300);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--300: var(--pf-t--chart--color--teal--300);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--200: var(--pf-t--chart--color--green--300);
-  --pf-t--chart--theme--colorscales--Multi-colored-ordered--colorscale--100: var(--pf-t--chart--color--blue--300);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2500: var(--pf-t--chart--color--orange--200);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2400: var(--pf-t--chart--color--yellow--400);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2300: var(--pf-t--chart--color--teal--400);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2200: var(--pf-t--chart--color--green--200);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2100: var(--pf-t--chart--color--blue--400);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--2000: var(--pf-t--chart--color--orange--400);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1900: var(--pf-t--chart--color--yellow--200);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1800: var(--pf-t--chart--color--teal--200);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1700: var(--pf-t--chart--color--green--400);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1600: var(--pf-t--chart--color--blue--200);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1500: var(--pf-t--chart--color--orange--100);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1400: var(--pf-t--chart--color--yellow--500);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1300: var(--pf-t--chart--color--teal--500);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1200: var(--pf-t--chart--color--green--100);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1100: var(--pf-t--chart--color--blue--500);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--1000: var(--pf-t--chart--color--orange--500);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--900: var(--pf-t--chart--color--yellow--100);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--800: var(--pf-t--chart--color--teal--100);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--700: var(--pf-t--chart--color--green--500);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--600: var(--pf-t--chart--color--blue--100);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--500: var(--pf-t--chart--color--orange--300);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--400: var(--pf-t--chart--color--yellow--300);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--300: var(--pf-t--chart--color--teal--300);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--200: var(--pf-t--chart--color--green--300);
+  --pf-t--chart--theme--colorscales--multi-colored-ordered--colorscale--100: var(--pf-t--chart--color--blue--300);
   --pf-t--chart--theme--colorscales--orange--colorscale--500: var(--pf-t--chart--color--orange--400);
   --pf-t--chart--theme--colorscales--orange--colorscale--400: var(--pf-t--chart--color--orange--200);
   --pf-t--chart--theme--colorscales--orange--colorscale--300: var(--pf-t--chart--color--orange--500);

--- a/src/patternfly/base/tokens/_tokens-dark.scss
+++ b/src/patternfly/base/tokens/_tokens-dark.scss
@@ -1,12 +1,19 @@
 // /**
 //  * Do not edit directly
-//  * Generated on Tue, 06 Feb 2024 18:33:23 GMT
+//  * Generated on Tue, 20 Feb 2024 01:08:05 GMT
 //  */
 
- :root:where(.pf-v5-theme-dark) {
+:root:where(.pf-v5-theme-dark) {
   --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);
+  --pf-t--global--dark--box-shadow--color--100: rgba(0, 0, 0, 0.5000);
+  --pf-t--global--dark--background--color--600: rgba(199, 199, 199, 0.1500);
   --pf-t--global--dark--background--color--500: rgba(21, 21, 21, 0.8000);
+  --pf-t--global--box-shadow--color--lg: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--md: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm: var(--pf-t--global--dark--box-shadow--color--100);
   --pf-t--global--background--color--backdrop--default: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--dark--background--color--600);
   --pf-t--global--dark--icon--color--300: var(--pf-t--color--gray--90);
   --pf-t--global--dark--icon--color--200: var(--pf-t--color--gray--40);
   --pf-t--global--dark--icon--color--100: var(--pf-t--color--gray--10);
@@ -71,7 +78,7 @@
   --pf-t--global--dark--background--color--400: var(--pf-t--color--gray--10);
   --pf-t--global--dark--background--color--300: var(--pf-t--color--gray--70);
   --pf-t--global--dark--background--color--200: var(--pf-t--color--gray--80);
-  --pf-t--global--dark--background--color--100: var(--pf-t--color--black);
+  --pf-t--global--dark--background--color--100: var(--pf-t--color--gray--95);
   --pf-t--global--text--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--300);
   --pf-t--global--text--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--300);
   --pf-t--global--text--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--250);
@@ -180,8 +187,8 @@
   --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--300);
   --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--dark--background--color--200);
   --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--dark--background--color--200);
-  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--dark--background--color--200);
-  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--200);
   --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--300);
   --pf-t--global--background--color--secondary--clicked: var(--pf-t--global--dark--background--color--200);
   --pf-t--global--background--color--secondary--hover: var(--pf-t--global--dark--background--color--200);
@@ -344,12 +351,10 @@
   --pf-t--global--icon--color--on-brand--default: var(--pf-t--global--icon--color--inverse);
   --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
   --pf-t--global--color--status--read--on-secondary: var(--pf-t--global--background--color--control--default);
-  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
   --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
   --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
   --pf-t--global--color--status--unread--default--clicked: var(--pf-t--global--color--brand--clicked);
   --pf-t--global--color--status--unread--default--hover: var(--pf-t--global--color--brand--hover);
   --pf-t--global--color--status--unread--default--default: var(--pf-t--global--color--brand--default);
-  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--background--color--action--plain--hover);
-  --pf-t--global--background--color--floating--hover: var(--pf-t--global--background--color--action--plain--hover);
 }

--- a/src/patternfly/base/tokens/_tokens-dark.scss
+++ b/src/patternfly/base/tokens/_tokens-dark.scss
@@ -22,7 +22,7 @@
   --pf-t--global--dark--text--color--link--100: var(--pf-t--color--blue--20);
   --pf-t--global--dark--text--color--400: var(--pf-t--color--red-orange--30);
   --pf-t--global--dark--text--color--300: var(--pf-t--color--gray--90);
-  --pf-t--global--dark--text--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--text--color--200: var(--pf-t--color--gray--30);
   --pf-t--global--dark--text--color--100: var(--pf-t--color--gray--10);
   --pf-t--global--dark--border--color--200: var(--pf-t--color--gray--40);
   --pf-t--global--dark--border--color--100: var(--pf-t--color--gray--50);

--- a/src/patternfly/base/tokens/_tokens-default.scss
+++ b/src/patternfly/base/tokens/_tokens-default.scss
@@ -1,11 +1,32 @@
 // /**
 //  * Do not edit directly
-//  * Generated on Tue, 06 Feb 2024 18:33:23 GMT
+//  * Generated on Tue, 20 Feb 2024 01:08:05 GMT
 //  */
 
 :root {
   --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
+  --pf-t--global--background--color--600: rgba(199, 199, 199, 0.2500);
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);
+  --pf-t--global--box-shadow--color--200: rgba(0, 0, 0, 0.1200)px;
+  --pf-t--global--box-shadow--color--100: rgba(0, 0, 0, 0.1600)px;
+  --pf-t--global--box-shadow--spread--100: 0px;
+  --pf-t--global--box-shadow--blur--300: 24px;
+  --pf-t--global--box-shadow--blur--200: 8px;
+  --pf-t--global--box-shadow--blur--100: 2px;
+  --pf-t--global--box-shadow--Y--700: 8px;
+  --pf-t--global--box-shadow--Y--600: 4px;
+  --pf-t--global--box-shadow--Y--500: 1px;
+  --pf-t--global--box-shadow--Y--400: 0px;
+  --pf-t--global--box-shadow--Y--300: -1px;
+  --pf-t--global--box-shadow--Y--200: -4px;
+  --pf-t--global--box-shadow--Y--100: -8px;
+  --pf-t--global--box-shadow--X--700: 8px;
+  --pf-t--global--box-shadow--X--600: 4px;
+  --pf-t--global--box-shadow--X--500: 1px;
+  --pf-t--global--box-shadow--X--400: 0px;
+  --pf-t--global--box-shadow--X--300: -1px;
+  --pf-t--global--box-shadow--X--200: -4px;
+  --pf-t--global--box-shadow--X--100: -8px;
   --pf-t--global--Zindex--600: 600;
   --pf-t--global--Zindex--500: 500;
   --pf-t--global--Zindex--400: 400;
@@ -98,12 +119,53 @@
   --pf-t--global--color--brand--200: var(--pf-t--color--blue--50);
   --pf-t--global--color--brand--100: var(--pf-t--color--blue--40);
   --pf-t--global--background--color--backdrop--default: var(--pf-t--global--background--color--500);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--background--color--600);
   --pf-t--global--background--color--highlight--200: var(--pf-t--color--yellow--40);
   --pf-t--global--background--color--highlight--100: var(--pf-t--color--yellow--30);
   --pf-t--global--background--color--400: var(--pf-t--color--gray--80);
   --pf-t--global--background--color--300: var(--pf-t--color--gray--20);
   --pf-t--global--background--color--200: var(--pf-t--color--gray--10);
   --pf-t--global--background--color--100: var(--pf-t--color--white);
+  --pf-t--global--box-shadow--color--lg: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--md: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--sm: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--spread--lg: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--md: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--sm: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--blur--lg: var(--pf-t--global--box-shadow--blur--300);
+  --pf-t--global--box-shadow--blur--md: var(--pf-t--global--box-shadow--blur--200);
+  --pf-t--global--box-shadow--blur--sm: var(--pf-t--global--box-shadow--blur--100);
+  --pf-t--global--box-shadow--Y--lg--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--bottom: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--lg--top: var(--pf-t--global--box-shadow--Y--100);
+  --pf-t--global--box-shadow--Y--lg--default: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--md--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--bottom: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--md--top: var(--pf-t--global--box-shadow--Y--200);
+  --pf-t--global--box-shadow--Y--md--default: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--sm--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--bottom: var(--pf-t--global--box-shadow--Y--500);
+  --pf-t--global--box-shadow--Y--sm--top: var(--pf-t--global--box-shadow--Y--300);
+  --pf-t--global--box-shadow--Y--sm--default: var(--pf-t--global--box-shadow--Y--500);
+  --pf-t--global--box-shadow--X--lg--right: var(--pf-t--global--box-shadow--X--700);
+  --pf-t--global--box-shadow--X--lg--left: var(--pf-t--global--box-shadow--X--100);
+  --pf-t--global--box-shadow--X--lg--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--right: var(--pf-t--global--box-shadow--X--600);
+  --pf-t--global--box-shadow--X--md--left: var(--pf-t--global--box-shadow--X--200);
+  --pf-t--global--box-shadow--X--md--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--right: var(--pf-t--global--box-shadow--X--500);
+  --pf-t--global--box-shadow--X--sm--left: var(--pf-t--global--box-shadow--X--300);
+  --pf-t--global--box-shadow--X--sm--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--default: var(--pf-t--global--box-shadow--X--400);
   --pf-t--global--Zindex--2xl: 600;
   --pf-t--global--Zindex--xl: 500;
   --pf-t--global--Zindex--lg: 400;
@@ -139,10 +201,10 @@
   --pf-t--global--border--width--box--default: var(--pf-t--global--border--width--100);
   --pf-t--global--border--width--extra-strong: var(--pf-t--global--border--width--300);
   --pf-t--global--border--width--strong: var(--pf-t--global--border--width--200);
-  --pf-t--global--border--width--regular: var(--pf-t--global--border--width--100);
   --pf-t--global--border--width--divider--clicked: var(--pf-t--global--border--width--100);
   --pf-t--global--border--width--divider--hover: var(--pf-t--global--border--width--100);
   --pf-t--global--border--width--divider--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--regular: var(--pf-t--global--border--width--100);
   --pf-t--global--icon--color--300: var(--pf-t--color--white);
   --pf-t--global--icon--color--200: var(--pf-t--color--gray--50);
   --pf-t--global--icon--color--100: var(--pf-t--color--gray--90);
@@ -233,8 +295,6 @@
   --pf-t--global--background--color--inverse--default: var(--pf-t--global--background--color--400);
   --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--100);
   --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--100);
-  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--background--color--200);
-  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--background--color--200);
   --pf-t--global--background--color--floating--clicked: var(--pf-t--global--background--color--200);
   --pf-t--global--background--color--floating--hover: var(--pf-t--global--background--color--200);
   --pf-t--global--background--color--floating--default: var(--pf-t--global--background--color--100);
@@ -369,8 +429,8 @@
   --pf-t--global--text--color--on-brand--hover: var(--pf-t--global--text--color--inverse);
   --pf-t--global--text--color--on-brand--default: var(--pf-t--global--text--color--inverse);
   --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
-  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
   --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
   --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
   --pf-t--global--color--status--unread--default--clicked: var(--pf-t--global--color--brand--clicked);
   --pf-t--global--color--status--unread--default--hover: var(--pf-t--global--color--brand--hover);

--- a/src/patternfly/base/tokens/_tokens-default.scss
+++ b/src/patternfly/base/tokens/_tokens-default.scss
@@ -7,8 +7,8 @@
   --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
   --pf-t--global--background--color--600: rgba(199, 199, 199, 0.2500);
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);
-  --pf-t--global--box-shadow--color--200: rgba(0, 0, 0, 0.1200)px;
-  --pf-t--global--box-shadow--color--100: rgba(0, 0, 0, 0.1600)px;
+  --pf-t--global--box-shadow--color--200: rgba(0, 0, 0, 0.1200);
+  --pf-t--global--box-shadow--color--100: rgba(0, 0, 0, 0.1600);
   --pf-t--global--box-shadow--spread--100: 0px;
   --pf-t--global--box-shadow--blur--300: 24px;
   --pf-t--global--box-shadow--blur--200: 8px;

--- a/src/patternfly/base/tokens/_tokens-default.scss
+++ b/src/patternfly/base/tokens/_tokens-default.scss
@@ -69,7 +69,7 @@
   --pf-t--global--text--color--link--100: var(--pf-t--color--blue--50);
   --pf-t--global--text--color--400: var(--pf-t--color--red-orange--40);
   --pf-t--global--text--color--300: var(--pf-t--color--white);
-  --pf-t--global--text--color--200: var(--pf-t--color--gray--50);
+  --pf-t--global--text--color--200: var(--pf-t--color--gray--60);
   --pf-t--global--text--color--100: var(--pf-t--color--gray--90);
   --pf-t--global--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
   --pf-t--global--color--nonstatus--gray--200: var(--pf-t--color--gray--30);

--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -50,32 +50,103 @@
   --pf-t--global--link--text-decoration: var(--pf-t--global--text-decoration--100);
   --pf-t--global--link--text-decoration--hover: var(--pf-t--global--text-decoration--200);
 
-  // blend modes 
-  --pf-t--global--mix-blend-mode--100: multiply;
-  --pf-t--global--mix-blend-mode--200: screen;
-  --pf-t--global--background--color--action--plain--hover--blend: var(--pf-t--global--mix-blend-mode--100);
+  // sm box-shadow
+  --pf-t--global--box-shadow--sm: 
+    var(--pf-t--global--box-shadow--X--sm--default) 
+    var(--pf-t--global--box-shadow--Y--sm--default) 
+    var(--pf-t--global--box-shadow--blur--sm) 
+    var(--pf-t--global--box-shadow--spread--sm)
+    var(--pf-t--global--box-shadow--color--sm);
+  --pf-t--global--box-shadow--sm--top: 
+    var(--pf-t--global--box-shadow--X--sm--top) 
+    var(--pf-t--global--box-shadow--Y--sm--top) 
+    var(--pf-t--global--box-shadow--blur--sm) 
+    var(--pf-t--global--box-shadow--spread--sm)
+    var(--pf-t--global--box-shadow--color--sm);
+  --pf-t--global--box-shadow--sm--bottom: 
+    var(--pf-t--global--box-shadow--X--sm--bottom) 
+    var(--pf-t--global--box-shadow--Y--sm--bottom) 
+    var(--pf-t--global--box-shadow--blur--sm) 
+    var(--pf-t--global--box-shadow--spread--sm)
+    var(--pf-t--global--box-shadow--color--sm);
+  --pf-t--global--box-shadow--sm--left: 
+    var(--pf-t--global--box-shadow--X--sm--left) 
+    var(--pf-t--global--box-shadow--Y--sm--left) 
+    var(--pf-t--global--box-shadow--blur--sm) 
+    var(--pf-t--global--box-shadow--spread--sm)
+    var(--pf-t--global--box-shadow--color--sm);
+  --pf-t--global--box-shadow--sm--right: 
+    var(--pf-t--global--box-shadow--X--sm--right) 
+    var(--pf-t--global--box-shadow--Y--sm--right) 
+    var(--pf-t--global--box-shadow--blur--sm) 
+    var(--pf-t--global--box-shadow--spread--sm)
+    var(--pf-t--global--box-shadow--color--sm);
 
-  // box-shadow
-  --pf-t--global--box-shadow--sm: 0px 1px 2px 0px rgb(0 0 0 / 16%);
-  --pf-t--global--box-shadow--sm--top: 0px -1px 2px 0px rgb(0 0 0 / 16%);
-  --pf-t--global--box-shadow--sm--bottom: 0px 1px 2px 0px rgb(0 0 0 / 16%);
-  --pf-t--global--box-shadow--sm--left: -1px 0px 2px 0px rgb(0 0 0 / 16%);
-  --pf-t--global--box-shadow--sm--right: 1px 0px 2px 0px rgb(0 0 0 / 16%);
-  --pf-t--global--box-shadow--md: 0px 4px 8px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--md--top: 0px -4px 8px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--md--bottom: 0px 4px 8px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--md--left: -4px 0px 8px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--md--right: 4px 0px 8px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--lg: 0px 8px 24px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--lg--top: 0px -8px 24px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--lg--bottom: 0px 8px 24px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--lg--left: -8px 0px 24px 0px rgb(0 0 0 / 12%);
-  --pf-t--global--box-shadow--lg--right: 8px 0px 24px 0px rgb(0 0 0 / 12%);
+  // md box-shadow
+  --pf-t--global--box-shadow--md: 
+    var(--pf-t--global--box-shadow--X--md--default) 
+    var(--pf-t--global--box-shadow--Y--md--default) 
+    var(--pf-t--global--box-shadow--blur--md) 
+    var(--pf-t--global--box-shadow--spread--md)
+    var(--pf-t--global--box-shadow--color--md);
+  --pf-t--global--box-shadow--md--top: 
+    var(--pf-t--global--box-shadow--X--md--top) 
+    var(--pf-t--global--box-shadow--Y--md--top) 
+    var(--pf-t--global--box-shadow--blur--md) 
+    var(--pf-t--global--box-shadow--spread--md)
+    var(--pf-t--global--box-shadow--color--md);
+  --pf-t--global--box-shadow--md--bottom: 
+    var(--pf-t--global--box-shadow--X--md--bottom) 
+    var(--pf-t--global--box-shadow--Y--md--bottom) 
+    var(--pf-t--global--box-shadow--blur--md) 
+    var(--pf-t--global--box-shadow--spread--md)
+    var(--pf-t--global--box-shadow--color--md);
+  --pf-t--global--box-shadow--md--left: 
+    var(--pf-t--global--box-shadow--X--md--left) 
+    var(--pf-t--global--box-shadow--Y--md--left) 
+    var(--pf-t--global--box-shadow--blur--md) 
+    var(--pf-t--global--box-shadow--spread--md)
+    var(--pf-t--global--box-shadow--color--md);
+  --pf-t--global--box-shadow--md--right: 
+    var(--pf-t--global--box-shadow--X--md--right) 
+    var(--pf-t--global--box-shadow--Y--md--right) 
+    var(--pf-t--global--box-shadow--blur--md) 
+    var(--pf-t--global--box-shadow--spread--md)
+    var(--pf-t--global--box-shadow--color--md);
+
+  // lg box-shadow
+  --pf-t--global--box-shadow--lg: 
+    var(--pf-t--global--box-shadow--X--lg--default) 
+    var(--pf-t--global--box-shadow--Y--lg--default) 
+    var(--pf-t--global--box-shadow--blur--lg) 
+    var(--pf-t--global--box-shadow--spread--lg)
+    var(--pf-t--global--box-shadow--color--lg);
+  --pf-t--global--box-shadow--lg--top: 
+    var(--pf-t--global--box-shadow--X--lg--top) 
+    var(--pf-t--global--box-shadow--Y--lg--top) 
+    var(--pf-t--global--box-shadow--blur--lg) 
+    var(--pf-t--global--box-shadow--spread--lg)
+    var(--pf-t--global--box-shadow--color--lg);
+  --pf-t--global--box-shadow--lg--bottom: 
+    var(--pf-t--global--box-shadow--X--lg--bottom) 
+    var(--pf-t--global--box-shadow--Y--lg--bottom) 
+    var(--pf-t--global--box-shadow--blur--lg) 
+    var(--pf-t--global--box-shadow--spread--lg)
+    var(--pf-t--global--box-shadow--color--lg);
+  --pf-t--global--box-shadow--lg--left: 
+    var(--pf-t--global--box-shadow--X--lg--left) 
+    var(--pf-t--global--box-shadow--Y--lg--left) 
+    var(--pf-t--global--box-shadow--blur--lg) 
+    var(--pf-t--global--box-shadow--spread--lg)
+    var(--pf-t--global--box-shadow--color--lg);
+  --pf-t--global--box-shadow--lg--right: 
+    var(--pf-t--global--box-shadow--X--lg--right) 
+    var(--pf-t--global--box-shadow--Y--lg--right) 
+    var(--pf-t--global--box-shadow--blur--lg) 
+    var(--pf-t--global--box-shadow--spread--lg)
+    var(--pf-t--global--box-shadow--color--lg);
 
   &:where(.pf-v5-theme-dark) {
-    // blend mode
-    --pf-t--global--background--color--action--plain--hover--blend: var(--pf-t--global--mix-blend-mode--200);
-
     // box shadow
     --pf-t--global--box-shadow--sm: 0px 1px 2px 0px rgb(0 0 0 / 50%);
     --pf-t--global--box-shadow--sm--top: 0px -1px 2px 0px rgb(0 0 0 / 50%);

--- a/src/patternfly/base/tokens/_tokens-palette.scss
+++ b/src/patternfly/base/tokens/_tokens-palette.scss
@@ -1,6 +1,6 @@
 // /**
 //  * Do not edit directly
-//  * Generated on Tue, 06 Feb 2024 18:33:23 GMT
+//  * Generated on Tue, 20 Feb 2024 01:08:05 GMT
 //  */
 
 :root {

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -7,7 +7,7 @@
 
   // accordion item
   --#{$accordion}__item--BorderRadius: var(--pf-t--global--border--radius--200);
-  --#{$accordion}__item--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--selected);
+  --#{$accordion}__item--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
 
   // accordion toggle
   --#{$accordion}__toggle--ColumnGap: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -14,7 +14,6 @@
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--button--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$button}--TextDecoration: none;
-  --#{$button}--MixBlendMode: normal;
 
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
@@ -75,8 +74,6 @@
   --#{$button}--m-link--PaddingLeft: var(--pf-t--global--spacer--md);
   --#{$button}--m-link--Color: var(--pf-t--global--text--color--brand--default);
   --#{$button}--m-link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$button}--m-link--hover--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
-  --#{$button}--m-link--m-clicked--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$button}--m-link__icon--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$button}--m-link--hover--Color: var(--pf-t--global--text--color--brand--hover);
   --#{$button}--m-link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
@@ -105,8 +102,6 @@
   --#{$button}--m-link--m-inline--PaddingBottom: 0;
   --#{$button}--m-link--m-inline--PaddingLeft: 0;
   --#{$button}--m-link--m-inline--hover--TextDecoration: var(--pf-t--global--link--text-decoration--hover);
-  --#{$button}--m-link--m-inline--hover--MixBlendMode: normal;
-  --#{$button}--m-link--m-inline--m-clicked--MixBlendMode: normal;
   --#{$button}--m-link--m-inline__progress--Left: var(--pf-t--global--spacer--xs);
   --#{$button}--m-link--m-inline--m-in-progress--PaddingLeft: calc(var(--#{$button}--m-link--m-inline__progress--Left) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -120,8 +115,6 @@
   --#{$button}--m-plain--PaddingLeft: var(--pf-t--global--spacer--sm);
   --#{$button}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$button}--m-plain--hover--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
-  --#{$button}--m-plain--m-clicked--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$button}--m-plain--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--m-plain--PaddingTop) + var(--#{$button}--m-plain--PaddingBottom));
   --#{$button}--m-plain--hover--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
@@ -135,8 +128,6 @@
   --#{$button}--m-plain--m-small--PaddingLeft: var(--pf-t--global--spacer--xs);
 
   // Plain no padding
-  --#{$button}--m-plain--m-no-padding--hover--MixBlendMode: normal;
-  --#{$button}--m-plain--m-no-padding--m-clicked--MixBlendMode: normal;
   --#{$button}--m-plain--m-no-padding--MinWidth: auto;
   --#{$button}--m-plain--m-no-padding--PaddingTop: 0;
   --#{$button}--m-plain--m-no-padding--PaddingRight: 0;
@@ -240,7 +231,6 @@
 
   // Disabled
   --#{$button}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$button}--disabled--MixBlendMode: normal;
   --#{$button}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$button}--disabled--BorderColor: transparent;
   --#{$button}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
@@ -303,7 +293,6 @@
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
   border-end-start-radius: var(--#{$button}--BorderEndStartRadius, var(--#{$button}--BorderRadius));
   border-end-end-radius: var(--#{$button}--BorderEndEndRadius, var(--#{$button}--BorderRadius));
-  mix-blend-mode: var(--#{$button}--MixBlendMode);
 
   &::after {
     position: absolute;
@@ -381,13 +370,11 @@
     --#{$button}--BorderRadius: var(--#{$button}--m-link--BorderRadius);
     --#{$button}--BackgroundColor: var(--#{$button}--m-link--BackgroundColor);
     --#{$button}__icon--Color: var(--#{$button}--m-link__icon--Color);
-    --#{$button}--hover--MixBlendMode: var(--#{$button}--m-link--hover--MixBlendMode);
     --#{$button}--hover--Color: var(--#{$button}--m-link--hover--Color);
     --#{$button}--hover--BackgroundColor: var(--#{$button}--m-link--hover--BackgroundColor);
     --#{$button}--hover__icon--Color: var(--#{$button}--m-link--hover__icon--Color);
     --#{$button}--m-clicked--Color: var(--#{$button}--m-link--m-clicked--Color);
     --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-link--m-clicked--BackgroundColor);
-    --#{$button}--m-clicked--MixBlendMode: var(--#{$button}--m-link--m-clicked--MixBlendMode);
     --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-link--m-clicked__icon--Color);
 
     &.pf-m-inline {
@@ -402,9 +389,7 @@
       --#{$button}__progress--Left: var(--#{$button}--m-link--m-inline__progress--Left);
       --#{$button}--hover--TextDecoration: var(--#{$button}--m-link--m-inline--hover--TextDecoration);
       --#{$button}--hover--BackgroundColor: transparent;
-      --#{$button}--hover--MixBlendMode: var(--#{$button}--m-link--m-inline--hover--MixBlendMode);
       --#{$button}--m-clicked--BackgroundColor: transparent;
-      --#{$button}--m-clicked--MixBlendMode: var(--#{$button}--m-link--m-inline--m-clicked--MixBlendMode);
       --#{$button}--disabled--BackgroundColor: transparent;
       --#{$button}--disabled--Color: var(--#{$button}--m-link--m-inline--disabled--Color);
       --#{$button}--disabled__icon--Color: var(--#{$button}--m-link--m-inline--disabled__icon--Color);
@@ -535,10 +520,8 @@
     --#{$button}__progress--Color: var(--#{$button}--m-in-progress--m-plain--Color);
     --#{$button}--hover--Color: var(--#{$button}--m-plain--hover--Color);
     --#{$button}--hover--BackgroundColor: var(--#{$button}--m-plain--hover--BackgroundColor);
-    --#{$button}--hover--MixBlendMode: var(--#{$button}--m-plain--hover--MixBlendMode);
     --#{$button}--m-clicked--Color: var(--#{$button}--m-plain--m-clicked--Color);
     --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
-    --#{$button}--m-clicked--MixBlendMode: var(--#{$button}--m-plain--m-clicked--MixBlendMode);
     --#{$button}--disabled--Color: var(--#{$button}--m-plain--disabled--Color);
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
     --#{$button}--m-small--PaddingTop: var(--#{$button}--m-plain--m-small--PaddingTop);
@@ -554,8 +537,6 @@
       --#{$button}--m-plain--PaddingRight: var(--#{$button}--m-plain--m-no-padding--PaddingRight);
       --#{$button}--m-plain--PaddingBottom: var(--#{$button}--m-plain--m-no-padding--PaddingBottom);
       --#{$button}--m-plain--PaddingLeft: var(--#{$button}--m-plain--m-no-padding--PaddingLeft);
-      --#{$button}--m-plain--hover--MixBlendMode: var(--#{$button}--m-plain--m-no-padding--hover--MixBlendMode);
-      --#{$button}--m-plain--m-clicked--MixBlendMode: var(--#{$button}--m-plain--m-no-padding--m-clicked--MixBlendMode);
 
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
     }
@@ -590,7 +571,6 @@
     --#{$button}--BorderColor: var(--#{$button}--hover--BorderColor);
     --#{$button}--BorderWidth: var(--#{$button}--hover--BorderWidth);
     --#{$button}--TextDecoration: var(--#{$button}--hover--TextDecoration);
-    --#{$button}--MixBlendMode: var(--#{$button}--hover--MixBlendMode);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
   }
 
@@ -599,7 +579,6 @@
     --#{$button}--BackgroundColor: var(--#{$button}--m-clicked--BackgroundColor);
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
-    --#{$button}--MixBlendMode: var(--#{$button}--m-clicked--MixBlendMode);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
   }
 
@@ -616,7 +595,6 @@
     --#{$badge}--m-unread--Color: var(--#{$button}--disabled__c-badge--Color);
     --#{$badge}--m-unread--BackgroundColor: var(--#{$button}--disabled__c-badge--BackgroundColor);
     --#{$button}--m-primary__c-badge--BorderWidth: 0;
-    --#{$button}--MixBlendMode: var(--#{$button}--disabled--MixBlendMode);
 
     color: var(--#{$button}--disabled--Color);
     background-color: var(--#{$button}--disabled--BackgroundColor);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -186,7 +186,6 @@
   --#{$label}--m-overflow--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$label}--m-overflow--hover--Color: var(--pf-t--global--text--color--brand--hover);
   --#{$label}--m-overflow--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$label}--m-overflow--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
 
   // Add
   --#{$label}--m-add--Color: var(--pf-t--global--text--color--brand--default);
@@ -358,7 +357,7 @@
     --#{$label}--m-outline__icon--Color: var(--#{$label}--m-success--m-outline__icon--Color);
     --#{$label}--m-outline--BorderColor: var(--#{$label}--m-success--m-outline--BorderColor);
     --#{$label}--m-outline--m-clickable--hover--BorderColor: var(--#{$label}--m-success--m-outline--m-clickable--hover--BorderColor);
-    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-success--m-outline--m-clickable--hover__icon--Color)
+    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-success--m-outline--m-clickable--hover__icon--Color);
   }
 
   &.pf-m-warning {
@@ -371,7 +370,7 @@
     --#{$label}--m-outline__icon--Color: var(--#{$label}--m-warning--m-outline__icon--Color);
     --#{$label}--m-outline--BorderColor: var(--#{$label}--m-warning--m-outline--BorderColor);
     --#{$label}--m-outline--m-clickable--hover--BorderColor: var(--#{$label}--m-warning--m-outline--m-clickable--hover--BorderColor);
-    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-warning--m-outline--m-clickable--hover__icon--Color)
+    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-warning--m-outline--m-clickable--hover__icon--Color);
   }
 
   &.pf-m-danger {
@@ -384,7 +383,7 @@
     --#{$label}--m-outline__icon--Color: var(--#{$label}--m-danger--m-outline__icon--Color);
     --#{$label}--m-outline--BorderColor: var(--#{$label}--m-danger--m-outline--BorderColor);
     --#{$label}--m-outline--m-clickable--hover--BorderColor: var(--#{$label}--m-danger--m-outline--m-clickable--hover--BorderColor);
-    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-danger--m-outline--m-clickable--hover__icon--Color)
+    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-danger--m-outline--m-clickable--hover__icon--Color);
   }
 
   &.pf-m-info {
@@ -397,7 +396,7 @@
     --#{$label}--m-outline__icon--Color: var(--#{$label}--m-info--m-outline__icon--Color);
     --#{$label}--m-outline--BorderColor: var(--#{$label}--m-info--m-outline--BorderColor);
     --#{$label}--m-outline--m-clickable--hover--BorderColor: var(--#{$label}--m-info--m-outline--m-clickable--hover--BorderColor);
-    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-info--m-outline--m-clickable--hover__icon--Color)
+    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-info--m-outline--m-clickable--hover__icon--Color);
   }
 
   &.pf-m-custom {
@@ -410,7 +409,7 @@
     --#{$label}--m-outline__icon--Color: var(--#{$label}--m-custom--m-outline__icon--Color);
     --#{$label}--m-outline--BorderColor: var(--#{$label}--m-custom--m-outline--BorderColor);
     --#{$label}--m-outline--m-clickable--hover--BorderColor: var(--#{$label}--m-custom--m-outline--m-clickable--hover--BorderColor);
-    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-success--m-outline--m-clickable--hover__icon--Color)
+    --#{$label}--m-outline--m-clickable--hover__icon--Color: var(--#{$label}--m-success--m-outline--m-clickable--hover__icon--Color);
   }
 
   &.pf-m-compact {
@@ -464,8 +463,6 @@
   &.pf-m-overflow {
     --#{$label}--Color: var(--#{$label}--m-overflow--Color);
     --#{$label}--BackgroundColor: var(--#{$label}--m-overflow--BackgroundColor);
-
-    mix-blend-mode: var(--#{$label}--m-overflow--MixBlendMode);
 
     &:is(:hover, :focus) {
       --#{$label}--m-overflow--Color: var(--#{$label}--m-overflow--hover--Color);

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -38,8 +38,6 @@
   --#{$menu}__list-item--Color: var(--pf-t--global--text--color--regular);
   --#{$menu}__list-item--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$menu}__list-item--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$menu}__list-item--MixBlendMode: normal;
-  --#{$menu}__list-item--MixBlendMode--hover: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$menu}__list-item--m-danger--Color: var(--pf-t--global--text--color--status--danger--default);
   --#{$menu}__list-item--m-load__item--Color: var(--pf-t--global--text--color--link--default);
   --#{$menu}__list-item--has--menu-action--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -440,7 +438,6 @@
     inset: 0;
     content: "";
     background-color: var(--#{$menu}__list-item--BackgroundColor);
-    mix-blend-mode: var(--#{$menu}__list-item--MixBlendMode);
   }
 
   // - Menu item load
@@ -474,7 +471,6 @@
 
   &:has(> :hover) {
     --#{$menu}__list-item--BackgroundColor: var(--#{$menu}__list-item--hover--BackgroundColor);
-    --#{$menu}__list-item--MixBlendMode: var(--#{$menu}__list-item--MixBlendMode--hover);
 
     .#{$menu}__item-select-icon,
     .#{$menu}__item-external-icon {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -149,7 +149,6 @@
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$menu-toggle}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$menu-toggle}--m-plain--BorderColor: transparent;
-  --#{$menu-toggle}--m-plain--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$menu-toggle}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$menu-toggle}--m-plain--active--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$menu-toggle}--m-plain--expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
@@ -259,8 +258,6 @@
     --#{$menu-toggle}--active--BackgroundColor: var(--#{$menu-toggle}--m-plain--active--BackgroundColor);
     --#{$menu-toggle}--expanded--BackgroundColor: var(--#{$menu-toggle}--m-plain--expanded--BackgroundColor);
     --#{$menu-toggle}--disabled--Color: var(--#{$menu-toggle}--m-plain--disabled--Color);
-
-    mix-blend-mode: var(--#{$menu-toggle}--m-plain--MixBlendMode);
 
     &::before {
       border: none;

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -13,7 +13,6 @@
   --#{$simple-list}__item-link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$simple-list}__item-link--hover--Color: var(--pf-t--global--text--color--subtle);
   --#{$simple-list}__item-link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$simple-list}__item-link--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$simple-list}__item-link--BorderRadius: var(--pf-t--global--border--radius--tiny);
 
   // Simple list item link
@@ -61,14 +60,11 @@
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--hover--Color);
 
     text-decoration: none;
-    mix-blend-mode: var(--#{$simple-list}__item-link--MixBlendMode);
   }
 
   &.pf-m-current {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--m-current--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-current--Color);
-
-    mix-blend-mode: var(--#{$simple-list}__item-link--MixBlendMode);
   }
 }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -639,9 +639,7 @@ $pf-v5-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   &:where(:hover, :focus) {
     --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__link--hover--BackgroundColor);
-    
-    mix-blend-mode: var(--pf-t--global--background--color--action--plain--hover--blend);
-  }
+      }
 
   &:disabled,
   &.pf-m-disabled {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -43,13 +43,10 @@
   --#{$wizard}__nav-link--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$wizard}__nav-link--hover--Color: var(--pf-t--global--text--color--subtle);
   --#{$wizard}__nav-link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-  --#{$wizard}__nav-link--hover--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$wizard}__nav-link--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$wizard}__nav-link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
-  --#{$wizard}__nav-link--m-current--MixBlendMode: var(--pf-t--global--background--color--action--plain--hover--blend);
   --#{$wizard}__nav-link--m-disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$wizard}__nav-link--m-disabled--BackgroundColor: transparent;
-  --#{$wizard}__nav-link--m-disabled--hover--MixBlendMode: normal;
 
   // Nav link toggle icon
   --#{$wizard}__nav-link-toggle--PaddingRight: var(--pf-t--global--spacer--sm);
@@ -450,8 +447,6 @@
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--m-current--Color);
     --#{$wizard}__nav-link--BackgroundColor: var(--#{$wizard}__nav-link--m-current--BackgroundColor);
 
-    mix-blend-mode: var(--#{$wizard}__nav-link--m-current--MixBlendMode);
-
     @at-root .#{$wizard}__toggle-num,
     &::before {
       --#{$wizard}__nav-link--before--BackgroundColor: var(--#{$wizard}__nav-link--m-current--before--BackgroundColor);
@@ -462,16 +457,13 @@
   &:where(:hover, :focus) {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);
     --#{$wizard}__nav-link--BackgroundColor: var(--#{$wizard}__nav-link--hover--BackgroundColor);
-    
-    mix-blend-mode: var(--#{$wizard}__nav-link--hover--MixBlendMode);
-  }
+      }
 
   // override the button background/color for disabled nav links
   &:disabled,
   &.pf-m-disabled {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--m-disabled--Color);
     --#{$wizard}__nav-link--BackgroundColor: var(--#{$wizard}__nav-link--m-disabled--BackgroundColor);
-    --#{$wizard}__nav-link--hover--MixBlendMode: var(--#{$wizard}__nav-link--m-disabled--hover--MixBlendMode);
 
     pointer-events: none;
 


### PR DESCRIPTION
Tokens updated
- Box shadow tokens from figma added
- Box shadows built from constituent tokens
- Clicked changed to use opacity rather than blend mode
- Some additional color changes

Components:
- Mix blend mode removed
- Accordion `--selected` token changed to `--clicked`
- Fixed some missing semicolons in button