### PR TITLE
fix(FormControl): updated select styling in light and dark themes

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -93,7 +93,7 @@
   --#{$form-control}--textarea--Width: var(--#{$form-control}--Width);
   --#{$form-control}--textarea--Height: auto;
 
-  // Form control icon 
+  // Form control icon
   --#{$form-control}__icon--PaddingTop: var(--#{$pf-global}--spacer--form-element);
   --#{$form-control}__icon--Color: var(--#{$pf-global}--icon--Color--light);
   --#{$form-control}__icon--m-status--Color: var(--#{$pf-global}--icon--Color--light);
@@ -174,7 +174,7 @@
   > ::placeholder {
     color: var(--#{$form-control}--m-placeholder--Color); // TODO update to set --#{$form-control}--Color in breaking change - also look for any other place to do that in this component
   }
-  
+
   > :is(input, select) {
     text-overflow: ellipsis;
   }
@@ -273,13 +273,18 @@
       --#{$form-control}--PaddingRight: calc(var(--#{$form-control}__select--PaddingRight) - 1px);
       --#{$form-control}--PaddingLeft: calc(var(--#{$form-control}__select--PaddingLeft) - 4px);
     }
+
+    // We need this property for certain Linux distros/non-Mac OS where dark theme styles aren'y applied properly.
+    background-color: var(--#{$form-control}--BackgroundColor);
   }
 
   &.pf-m-placeholder > select {
     --#{$form-control}--Color: var(--#{$form-control}--m-placeholder--Color);
 
     * {
-      --#{$form-control}--Color: var(--#{$form-control}--m-placeholder--child--Color);
+      // We need to use the color property instead of redefining a var
+      // for certain Linux distros/non-Mac OS
+      color: var(--#{$form-control}--m-placeholder--child--Color);
 
       // stylelint-disable max-nesting-depth
       &:disabled {
@@ -313,7 +318,6 @@
 
     overflow: auto;
   }
-
 }
 
 .#{$form-control}__icon {

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -274,7 +274,7 @@
       --#{$form-control}--PaddingLeft: calc(var(--#{$form-control}__select--PaddingLeft) - 4px);
     }
 
-    // We need this property for certain Linux distros/non-Mac OS where dark theme styles aren'y applied properly.
+    // We need this property for certain Linux distros/non-Mac OS where dark theme styles aren't applied properly.
     background-color: var(--#{$form-control}--BackgroundColor);
   }
 


### PR DESCRIPTION
Towards https://github.com/patternfly/patternfly/issues/5695 and #5751 

Need to test this update in other OS/browser combos to ensure nothing visually breaks.

Would most likely need a v6 update as well if we go forward with this.