### PR TITLE
fix(masthead): fix plain button color in light variants

### DIFF
--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -174,17 +174,21 @@ $pf-v5-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   background-color: var(--#{$masthead}--BackgroundColor);
 
   &.pf-m-light {
-    @include pf-v5-t-light;
-
     --#{$masthead}--BackgroundColor: var(--#{$masthead}--m-light--BackgroundColor);
     --#{$masthead}__main--BorderBottomColor: var(--#{$masthead}--m-light__main--BorderBottomColor);
   }
 
   &.pf-m-light-200 {
-    @include pf-v5-t-light;
-
     --#{$masthead}--BackgroundColor: var(--#{$masthead}--m-light-200--BackgroundColor);
     --#{$masthead}__main--BorderBottomColor: var(--#{$masthead}--m-light-200__main--BorderBottomColor);
+  }
+
+  &:is(.pf-m-light, .pf-m-light-200) {
+    @include pf-v5-t-light;
+
+    .#{$button}.pf-m-plain {
+      @include pf-v5-t-light(--#{$button}--m-plain--Color); // for all plain buttons, especially inside other components (.pf-v5-c-input-group), for dark mode
+    }
   }
 
   .#{$toolbar} {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6390

While it's a simple fix, I'm hesitant to make this change since:
* The style has been in PF since 8/2022 so folks may have worked around it, and our fix may conflict with theirs https://github.com/patternfly/patternfly/pull/4827
* It could have unintended side effects. It will change any plain button inside of the masthead, which is a wide spread change since it includes nested components that may have their own backgrounds where this change isn't wanted. 
* The masthead is a very prominent part of the page, so any unwanted change has a high impact.

From this comment, it looks like the light variants weren't part of the original design or intended to be used? https://github.com/patternfly/patternfly/pull/3716#pullrequestreview-542902494 @lboehling @andrew-ronaldson do you know if we support and encourage use of this variant? Just wondering how widespread a change might be and what might be needed to test. We also have some analytics that might give us an idea of how commonly this variant is used.

