### PR TITLE
chore(table): updated truncate width, nested button

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -68,6 +68,9 @@
   --#{$table}--m-truncate--cell--MaxWidth: 1px;
   --#{$table}--m-truncate--cell--MinWidth: calc(5ch + var(--#{$table}--cell--PaddingRight) + var(--#{$table}--cell--PaddingLeft));
 
+  // * Table truncate
+  --#{$table}--m-truncate__text--MinWidth: 5ch;
+
   // * Table cell hidden visible
   --#{$table}--cell--hidden-visible--Display: table-cell;
 
@@ -254,6 +257,10 @@
   --#{$table}__subhead--PaddingRight: var(--pf-t--global--spacer--sm);
   --#{$table}__subhead--Color: var(--pf-t--global--text--color--subtle);
 
+  // * Table subhead button
+  --#{$table}__nested-column-header__button--PaddingLeft: calc(var(--#{$table}__button--PaddingLeft) - var(--pf-t--global--spacer--sm));
+  --#{$table}__nested-column-header__button--PaddingRight: calc(var(--#{$table}__button--PaddingRight) - var(--pf-t--global--spacer--xs));
+
   // * Table striped
   --#{$table}--m-striped__tr--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
@@ -415,6 +422,7 @@
 
     &.pf-m-border-right::before {
       border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderRightWidth) solid var(--#{$table}--cell--m-border-right--before--BorderRightColor);
+
     }
 
     &.pf-m-border-left::before {
@@ -457,15 +465,9 @@
 
     // - Table subhead
     .#{$table}__subhead {
-      --#{$table}--cell--PaddingLeft: var(--#{$table}__subhead--PaddingLeft);
-      --#{$table}--cell--PaddingRight: var(--#{$table}__subhead--PaddingRight);
       --#{$table}__sort__button__text--Color: var(--#{$table}__subhead--Color);
 
       color: var(--#{$table}__subhead--Color);
-
-      .#{$table}__button {
-        margin-inline-start: calc(var(--#{$table}--cell--PaddingLeft) * -1);
-      }
     }
   }
 
@@ -652,6 +654,7 @@
   // Only apply these settings if specifically modified
   &.pf-m-truncate {
     --#{$table}--cell--MinWidth: 100%;
+    --#{$table}--text--MinWidth: var(--#{$table}--m-truncate__text--MinWidth);
 
     > :where(th, td) {
       overflow: var(--#{$table}--cell--Overflow);
@@ -1067,6 +1070,17 @@
   --#{$table}__toggle--PaddingBottom: var(--#{$table}__thead__toggle--PaddingBottom);
 
   vertical-align: bottom;
+
+  // - Table nested column header button
+  &.pf-m-nested-column-header {
+    .#{$table}__button {
+      --#{$table}__button--PaddingLeft: var(--#{$table}__nested-column-header__button--PaddingLeft);
+      --#{$table}__button--PaddingRight: var(--#{$table}__nested-column-header__button--PaddingRight);
+
+      // margin to align with thead padding
+      margin-inline-end: calc(var(--#{$table}__button--PaddingLeft) * -1);
+    }
+  }
 }
 
 // - Table tbody
@@ -1078,6 +1092,7 @@
     background-color: var(--#{$table}--compound-expansion--m-expanded--BackgroundColor);
   }
 }
+
 
 // Table table tbody expandable
 .#{$table}.pf-m-expandable {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -422,7 +422,6 @@
 
     &.pf-m-border-right::before {
       border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderRightWidth) solid var(--#{$table}--cell--m-border-right--before--BorderRightColor);
-
     }
 
     &.pf-m-border-left::before {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1093,7 +1093,6 @@
   }
 }
 
-
 // Table table tbody expandable
 .#{$table}.pf-m-expandable {
   .#{$table}__tr.pf-m-expanded {


### PR DESCRIPTION
references #6293 

This PR 

- Adjusts table text truncate `min-width`
- Adjusts nested table header sort buttons

## Text truncate

Before:

![Screenshot 2024-03-14 at 1 09 44 PM](https://github.com/patternfly/patternfly/assets/5385435/bb048f78-e0c9-4fc4-b93c-0a28b011f34d)
 
After:

![Screenshot 2024-03-14 at 1 09 05 PM](https://github.com/patternfly/patternfly/assets/5385435/37a3b3b0-a80c-4cc7-a2b6-6d24159177fb)

## Nested table header sort button 

Before: 

![Screenshot 2024-03-14 at 1 16 47 PM](https://github.com/patternfly/patternfly/assets/5385435/cf161cc5-54e4-4d23-958b-8585a0c3428f)

After:

![Screenshot 2024-03-14 at 1 16 39 PM](https://github.com/patternfly/patternfly/assets/5385435/0e61907f-85f1-4b79-b8b0-24d12b8e21eb)
