### PR TITLE
fix(label): added support for disabled labels

### DIFF
--- a/src/patternfly/components/Label/examples/Label.md
+++ b/src/patternfly/components/Label/examples/Label.md
@@ -695,6 +695,7 @@ In addition to the JavaScript management of [editable labels](/components/label#
 | `.pf-m-gold` | `.pf-v5-c-label` | Modifies the label to have gold colored styling. |
 | `.pf-m-editable` | `.pf-v5-c-label` | Modifies label for editable styles. |
 | `.pf-m-editable-active` | `.pf-v5-c-label.pf-m-editable` | Modifies editable label for active styles. |
+| `.pf-m-disabled` | `.pf-v5-c-label` | Modifies label for disabled styles. |
 | `--pf-v5-c-label__text--MaxWidth` | `.pf-v5-c-label` | Modifiex the max width of the text before text will truncate. |
 
 ### Label group accessibility

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -6,7 +6,7 @@
     href="#"
     {{#if label--IsDisabled}}
       tabindex="-1"
-      aria-hidden="true"
+      aria-disabled="true"
     {{/if}}
   {{/if}}
   {{#if label-content--IsAction}}

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -4,6 +4,10 @@
 <{{#if label-content--IsLink}}a{{else if label-content--IsAction}}button{{else}}span{{/if}} class="{{pfv}}label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
   {{#if label-content--IsLink}}
     href="#"
+    {{#if label--IsDisabled}}
+      tabindex="-1"
+      aria-hidden="true"
+    {{/if}}
   {{/if}}
   {{#if label-content--IsAction}}
     type="button"

--- a/src/patternfly/components/Label/label-content.hbs
+++ b/src/patternfly/components/Label/label-content.hbs
@@ -1,13 +1,19 @@
 {{#if label--IsEditable}}
   {{#> label-editable-content}}{{> @partial-block}}{{/label-editable-content}}
 {{else}}
-<{{#if label-content--IsLink}}a{{else}}span{{/if}} class="{{pfv}}label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
+<{{#if label-content--IsLink}}a{{else if label-content--IsAction}}button{{else}}span{{/if}} class="{{pfv}}label__content{{#if label-content--modifier}} {{label-content--modifier}}{{/if}}"
   {{#if label-content--IsLink}}
     href="#"
+  {{/if}}
+  {{#if label-content--IsAction}}
+    type="button"
+    {{#if label--IsDisabled}}
+      disabled
+    {{/if}}
   {{/if}}
   {{#if label-content--attribute}}
     {{{label-content--attribute}}}
   {{/if}}>
   {{~> @partial-block}}
-</{{#if label-content--IsLink}}a{{else}}span{{/if}}>
+</{{#if label-content--IsLink}}a{{else if label-content--IsAction}}button{{else}}span{{/if}}>
 {{/if}}

--- a/src/patternfly/components/Label/label-template-variants.hbs
+++ b/src/patternfly/components/Label/label-template-variants.hbs
@@ -29,6 +29,19 @@
     label-text--value=(concat label-template-variants--title ' link removable')
     label-content--IsLink=true}}
 
+
+{{> label
+    label--id=(concat label-template-variants--id '-clickable')
+    label-text--value=(concat label-template-variants--title ' clickable')
+    label-content--IsAction=true}}
+
+{{> label
+    label--isRemovable=true
+    label--id=(concat label-template-variants--id '-clickable-removable')
+    label-text--value=(concat label-template-variants--title ' clickable removable')
+    label-content--IsAction=true}}
+    
+
 {{> label
     label--id=(concat label-template-variants--id '-truncated')
     label-text--value=(concat label-template-variants--title ' label, max-width truncation customization')
@@ -40,6 +53,22 @@
     label--id=(concat label-template-variants--id '-truncated-with-icon')
     label-text--value=(concat label-template-variants--title ' label with icon and set max-width truncation customization')
     label-text--attribute='style="--pf-v5-c-label__text--MaxWidth: 38ch"'
+    label-icon--value="info-circle"}}
+
+{{> label
+    label--isRemovable=true
+    label--id=(concat label-template-variants--id '-link-removable')
+    label--IsDisabled=true
+    label-text--value=(concat label-template-variants--title ' link removable (disabled)')
+    label-content--IsLink=true
+    label-icon--value="info-circle"}}
+
+{{> label
+    label--isRemovable=true
+    label--id=(concat label-template-variants--id '-clickable-removable')
+    label--IsDisabled=true
+    label-text--value=(concat label-template-variants--title ' clickable removable (disabled)')
+    label-content--IsAction=true
     label-icon--value="info-circle"}}
 
 {{#if @partial-block}}

--- a/src/patternfly/components/Label/label-template-variants.hbs
+++ b/src/patternfly/components/Label/label-template-variants.hbs
@@ -57,7 +57,7 @@
 
 {{> label
     label--isRemovable=true
-    label--id=(concat label-template-variants--id '-link-removable')
+    label--id=(concat label-template-variants--id '-link-disabled')
     label--IsDisabled=true
     label-text--value=(concat label-template-variants--title ' link removable (disabled)')
     label-content--IsLink=true
@@ -65,7 +65,7 @@
 
 {{> label
     label--isRemovable=true
-    label--id=(concat label-template-variants--id '-clickable-removable')
+    label--id=(concat label-template-variants--id '-clickable-disabled')
     label--IsDisabled=true
     label-text--value=(concat label-template-variants--title ' clickable removable (disabled)')
     label-content--IsAction=true

--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -5,6 +5,7 @@
   {{#if label--IsAdd}} pf-m-add{{/if}}
   {{#if label--IsEditable}} pf-m-editable{{/if}}
   {{#if label--IsEditableActive}} pf-m-editable-active{{/if}}
+  {{#if label--IsDisabled}} pf-m-disabled{{/if}}
   {{#if label--color}}
     pf-m-{{label--color}}
   {{/if}}
@@ -28,8 +29,7 @@
   {{/label-content}}
   {{#if label--isRemovable}}
     {{#> label-actions}}
-      {{#> button button--IsPlain=true button--attribute=(concat 'id="' label--id '-button"
-    aria-label="Remove" aria-labelledby="' label--id '-button ' label--id '-text"')}}
+      {{#> button button--IsPlain=true button--IsDisabled=label--IsDisabled button--attribute=(concat 'id="' label--id '-button" aria-label="Remove" aria-labelledby="' label--id '-button ' label--id '-text"')}}
         <i class="fas fa-times fa-fw" aria-hidden="true"></i>
       {{/button}}
     {{/label-actions}}

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -185,6 +185,12 @@
   --#{$label}--m-editable--m-editable-active__content--before--BorderWidth: 0;
   --#{$label}--m-editable--m-editable-active__content--before--BorderColor: transparent;
 
+  // Disabled
+  --#{$label}--m-disabled--BackgroundColor: var(--#{$pf-global}--disabled-color--200);
+  --#{$label}--m-disabled__content--Color: var(--#{$pf-global}--disabled-color--100);
+  --#{$label}--m-disabled__icon--Color: var(--#{$pf-global}--disabled-color--100);
+  --#{$label}--c-button--m-disabled--Color: var(--#{$pf-global}--disabled-color--100);
+
   position: relative;
   max-width: var(--#{$label}--MaxWidth);
   padding-block-start: var(--#{$label}--PaddingTop);
@@ -394,6 +400,19 @@
     --#{$label}__content--link--hover--before--BorderColor: var(--#{$label}--m-overflow__content--link--hover--before--BorderColor);
     --#{$label}__content--link--focus--before--BorderWidth: var(--#{$label}--m-overflow__content--link--focus--before--BorderWidth);
     --#{$label}__content--link--focus--before--BorderColor: var(--#{$label}--m-overflow__content--link--focus--before--BorderColor);
+  }
+
+  &.pf-m-disabled {
+    --#{$label}--BackgroundColor: var(--#{$label}--m-disabled--BackgroundColor);
+    --#{$label}__content--Color: var(--#{$label}--m-disabled__content--Color);
+    --#{$label}__icon--Color: var(--#{$label}--m-disabled__icon--Color);
+    --#{$label}__content--before--BorderWidth: 0;
+
+    pointer-events: none;
+
+    .#{$button} {
+      --#{$button}--m-plain--disabled--Color: var(--#{$label}--c-button--m-disabled--Color);
+    }
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6055

* Moves the template hbs file to the root label component dir since the workspace doesn't auto-compile-n-reload on files nested in subdirs.
* Sets the close button color in a disabled label to the same color as the disabled text, since by default a disabled close button color is the same color as the disabled label background.
* Just setup to work on regular (filled/outline) labels - not the overflow or add. It's easy enough to add support for those, or we could add that support if/when it comes up. wdyt @lboehling @andrew-ronaldson?