### PR TITLE
chore(mixins): change version on rtl mixins

### DIFF
--- a/src/patternfly/base/_common.scss
+++ b/src/patternfly/base/_common.scss
@@ -32,19 +32,19 @@
 
 // Sets a block to RTL
 .#{$pf-prefix}m-dir-rtl {
-  @include pf-v5-set-inverse;
+  @include pf-v6-set-inverse;
 
   direction: rtl;
 }
 
 // Sets a block to LTR
 .#{$pf-prefix}m-dir-ltr {
-  @include pf-v5-set-inverse(false);
+  @include pf-v6-set-inverse(false);
 
   direction: ltr;
 }
 
 // Mirrors/flips something horizontally/inline in RTL
 .#{$pf-prefix}m-mirror-inline-rtl {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 }

--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -284,11 +284,11 @@
   --#{$pf-global}--target-size--MinHeight: #{$pf-v5-global--target-size--MinHeight};
 
   // RTL
-  @include pf-v5-set-inverse(false);
+  @include pf-v6-set-inverse(false);
 }
 
-@include pf-v5-rtl {
-  @include pf-v5-set-inverse;
+@include pf-v6-rtl {
+  @include pf-v6-set-inverse;
 }
 
 // stylelint-disable no-invalid-position-at-import-rule

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -15,7 +15,7 @@
   --#{$about-modal-box}--sm--GridTemplateColumns: 5fr 1fr;
   --#{$about-modal-box}--lg--GridTemplateColumns: 1fr .6fr;
 
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: --#{$about-modal-box}--BackgroundPosition,
     $ltr-val: bottom right,
     $rtl-val: bottom left

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -148,7 +148,7 @@
 }
 
 .#{$accordion}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   transition: var(--#{$accordion}__toggle-icon--Transition);
 }

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -187,7 +187,7 @@
 }
 
 .#{$alert}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
   
   display: inline-block;
   transition: var(--#{$alert}__toggle-icon--Transition);

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -12,7 +12,7 @@
 }
 
 .#{$background-image} {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: --#{$background-image}--BackgroundPosition,
     $ltr-val: bottom right,
     $rtl-val: bottom left

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -65,7 +65,7 @@
 
 // Breadcrumb divider
 .#{$breadcrumb}__item-divider {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   margin-inline-end: var(--#{$breadcrumb}__item-divider--MarginRight);
   font-size: var(--#{$breadcrumb}__item-divider--FontSize);

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -88,7 +88,7 @@
 }
 
 .#{$calendar-month}__header-nav-control {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   margin-inline-start: var(--#{$calendar-month}__header-nav-control--MarginLeft);
   margin-inline-end: var(--#{$calendar-month}__header-nav-control--MarginRight);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -261,7 +261,7 @@
 }
 
 .#{$card}__header-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
   transition: var(--#{$card}__header-toggle-icon--Transition);

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -76,7 +76,7 @@
 }
 
 .#{$clipboard-copy}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   transition: var(--#{$clipboard-copy}__toggle-icon--Transition);
 }

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -348,7 +348,7 @@
 
 // toggle icon rotate
 .#{$data-list}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   height: var(--#{$data-list}__toggle-icon--Height);
   pointer-events: none;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -153,12 +153,12 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 }
 
 .#{$drawer} {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: --#{$drawer}--m-expanded__panel--BoxShadow,
     $ltr-val: var(--pf-t--global--box-shadow--lg--left),
     $rtl-val: var(--pf-t--global--box-shadow--lg--right)
   ); 
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: --#{$drawer}--m-expanded--m-panel-left__panel--BoxShadow,
     $ltr-val: var(--#{$pf-global}--BoxShadow--lg-right),
     $rtl-val: var(--#{$pf-global}--BoxShadow--lg-left)
@@ -181,10 +181,10 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       order: 0;
       margin-inline-end: calc(var(--#{$drawer}__panel--FlexBasis) * -1);
 
-      @include pf-v5-bidirectional-style(
+      @include pf-v6-bidirectional-style(
         $prop: transform,
         $ltr-val: translateX(-100%),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(-100%)}),
+        $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)}),
       ); 
     }
 
@@ -201,10 +201,10 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // stylelint-disable selector-max-class
   &.pf-m-expanded {
     > .#{$drawer}__main > .#{$drawer}__panel {
-      @include pf-v5-bidirectional-style(
+      @include pf-v6-bidirectional-style(
         $prop: transform,
         $ltr-val: translateX(-100%),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(-100%)}),
+        $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)}),
       ); 
     }
 
@@ -463,10 +463,10 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   inset-block-start: var(--#{$drawer}__splitter-handle--Top);
   inset-inline-start: var(--#{$drawer}__splitter-handle--Left);
 
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translate(-50%, -50%),
-    $rtl-val: translate(#{pf-v5-calc-inverse(-50%)}, -50%),
+    $rtl-val: translate(#{pf-v6-calc-inverse(-50%)}, -50%),
   ); 
 
 
@@ -675,10 +675,10 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       > .#{$drawer}__main > .#{$drawer}__panel {
         margin-inline-start: calc(var(--#{$drawer}__panel--FlexBasis) * -1);
 
-        @include pf-v5-bidirectional-style(
+        @include pf-v6-bidirectional-style(
           $prop: transform,
           $ltr-val: translateX(100%),
-          $rtl-val: translateX(#{pf-v5-calc-inverse(100%)}),
+          $rtl-val: translateX(#{pf-v6-calc-inverse(100%)}),
         ); 
       }
 
@@ -699,10 +699,10 @@ $pf-v5-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
           margin-inline-start: 0;
           margin-inline-end: calc(var(--#{$drawer}__panel--FlexBasis) * -1);
 
-          @include pf-v5-bidirectional-style(
+          @include pf-v6-bidirectional-style(
             $prop: transform,
             $ltr-val: translateX(-100%),
-            $rtl-val: translateX(#{pf-v5-calc-inverse(-100%)}),
+            $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)}),
           ); 
         }
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -170,10 +170,10 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
     --#{$dual-list-selector}__item-toggle--MarginBottom: 0;
 
     .#{$dual-list-selector}__item-toggle {
-      @include pf-v5-bidirectional-style(
+      @include pf-v6-bidirectional-style(
         $prop: transform,
         $ltr-val: translateX(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX)),
-        $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX))}),
+        $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$dual-list-selector}__list__list__item-toggle--TranslateX))}),
       ); 
 
       position: absolute;
@@ -308,7 +308,7 @@ $pf-v5-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 :is(.#{$dual-list-selector}__controls-item, .#{$dual-list-selector}__item-toggle-icon) {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 }
 
 .#{$dual-list-selector}__item-main {

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -144,7 +144,7 @@
 }
 
 .#{$expandable-section}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   min-width: var(--#{$expandable-section}__toggle-icon--MinWidth);
   color: var(--#{$expandable-section}__toggle-icon--Color);

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -409,7 +409,7 @@ $pf-v5-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   transition: var(--#{$form}__field-group-toggle-icon--Transition);
   transform: rotate(var(--#{$form}__field-group-toggle-icon--Rotate));
 
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 }
 
 .#{$form}__field-group-header {

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -229,7 +229,7 @@ $pf-v5-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 }
 
 .#{$jump-links}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
   color: var(--#{$jump-links}__toggle-icon--Color);

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -259,10 +259,10 @@
       // target first list in menu
       > .#{$menu}__content > .#{$menu}__list,
       > .#{$menu}__list {
-        @include pf-v5-bidirectional-style(
+        @include pf-v6-bidirectional-style(
           $prop: transform,
           $ltr-val: translateX(-100%),
-          $rtl-val: translateX(#{pf-v5-calc-inverse(-100%)})
+          $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)})
         );
       }
       // stylelint-enable
@@ -279,10 +279,10 @@
 
       // stylelint-disable selector-max-class
       &.pf-m-drilled-in {
-        @include pf-v5-bidirectional-style(
+        @include pf-v6-bidirectional-style(
           $prop: transform,
           $ltr-val: translateX(-100%),
-          $rtl-val: translateX(#{pf-v5-calc-inverse(-100%)})
+          $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)})
         );
       }
       // stylelint-enable
@@ -571,7 +571,7 @@
 
 // - Menu toggle icon
 .#{$menu}__item-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   color: var(--#{$menu}__item-toggle-icon--Color, inherit);
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -249,7 +249,7 @@
   display: inline-block;
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   .#{$nav}__item:where(.pf-m-flyout) & {
     --#{$nav}__item--m-expanded__toggle-icon--Rotate: 0;
@@ -297,7 +297,7 @@
     outline-offset: var(--#{$nav}--OutlineOffset);
 
     > * {
-      @include pf-v5-mirror-inline-on-rtl;
+      @include pf-v6-mirror-inline-on-rtl;
     }
   }
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -303,7 +303,7 @@
 }
 
 .#{$notification-drawer}__group-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginRight);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -330,10 +330,10 @@ $pf-page-v5--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   background-color: var(--#{$page}__sidebar--BackgroundColor);
   transition: var(--#{$page}__sidebar--Transition);
 
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translateX(var(--#{$page}__sidebar--TranslateX)) translateZ(var(--#{$page}__sidebar--TranslateZ)),
-    $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$page}__sidebar--TranslateX))}) translateZ(var(--#{$page}__sidebar--TranslateZ))
+    $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$page}__sidebar--TranslateX))}) translateZ(var(--#{$page}__sidebar--TranslateZ))
   );
 
   // Mobile

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -171,7 +171,7 @@ $pf-v5-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
 // nav control
 .#{$pagination}__nav-control {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 }
 
 // nav page element

--- a/src/patternfly/components/Skeleton/skeleton.scss
+++ b/src/patternfly/components/Skeleton/skeleton.scss
@@ -76,7 +76,7 @@
   }
 
   &::after {
-    @include pf-v5-mirror-inline-on-rtl;
+    @include pf-v6-mirror-inline-on-rtl;
 
     position: absolute;
     inset: 0;

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -79,7 +79,7 @@
 }
 
 .#{$slider} {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: --#{$slider}__rail-track--before--fill--direction, 
     $ltr-val: right,
     $rtl-val: left
@@ -160,10 +160,10 @@
 }
 
 .#{$slider}__step-tick {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translateX(var(--#{$slider}__step-tick--TranslateX)),
-    $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$slider}__step-tick--TranslateX))})
+    $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$slider}__step-tick--TranslateX))})
   );
 
   position: absolute;
@@ -176,10 +176,10 @@
 }
 
 .#{$slider}__step-label {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translateX(var(--#{$slider}__step-label--TranslateX)),
-    $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$slider}__step-label--TranslateX))})
+    $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$slider}__step-label--TranslateX))})
   );
 
   position: absolute;
@@ -188,10 +188,10 @@
 }
 
 .#{$slider}__thumb {
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translate(var(--#{$slider}__thumb--TranslateX), var(--#{$slider}__thumb--TranslateY)),
-    $rtl-val: translate(#{pf-v5-calc-inverse(var(--#{$slider}__thumb--TranslateX))}, var(--#{$slider}__thumb--TranslateY))
+    $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$slider}__thumb--TranslateX))}, var(--#{$slider}__thumb--TranslateY))
   );
 
   position: absolute;
@@ -205,10 +205,10 @@
   box-shadow: var(--#{$slider}__thumb--BoxShadow);
 
   &::before {
-    @include pf-v5-bidirectional-style(
+    @include pf-v6-bidirectional-style(
       $prop: transform,
       $ltr-val: translate(var(--#{$slider}__thumb--before--TranslateX), var(--#{$slider}__thumb--before--TranslateY)),
-      $rtl-val: translate(#{pf-v5-calc-inverse(var(--#{$slider}__thumb--before--TranslateX))}, var(--#{$slider}__thumb--before--TranslateY))
+      $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$slider}__thumb--before--TranslateX))}, var(--#{$slider}__thumb--before--TranslateY))
     );
 
     position: absolute;
@@ -239,10 +239,10 @@
   margin-inline-start: var(--#{$slider}__value--MarginLeft);
 
   &.pf-m-floating {
-    @include pf-v5-bidirectional-style(
+    @include pf-v6-bidirectional-style(
       $prop: transform,
       $ltr-val: translate(var(--#{$slider}__value--m-floating--TranslateX), var(--#{$slider}__value--m-floating--TranslateY)),
-      $rtl-val: translate(#{pf-v5-calc-inverse(var(--#{$slider}__value--m-floating--TranslateX))}, var(--#{$slider}__value--m-floating--TranslateY)),
+      $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$slider}__value--m-floating--TranslateX))}, var(--#{$slider}__value--m-floating--TranslateY)),
     );
 
     --#{$slider}__value--MarginLeft: 0;

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -91,10 +91,10 @@
       background-color: var(--#{$switch}__input--checked__toggle--BackgroundColor);
 
       &::before {
-        @include pf-v5-bidirectional-style(
+        @include pf-v6-bidirectional-style(
           $prop: transform,
           $ltr-val: translate(var(--#{$switch}__input--checked__toggle--before--TranslateX), -50%),
-          $rtl-val: translate(#{pf-v5-calc-inverse(var(--#{$switch}__input--checked__toggle--before--TranslateX))}, -50%)
+          $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$switch}__input--checked__toggle--before--TranslateX))}, -50%)
         );
 
         background-color: var(--#{$switch}__input--checked__toggle--before--BackgroundColor);

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -69,10 +69,10 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   cursor: pointer;
 
   > .#{$table}__toggle {
-    @include pf-v5-bidirectional-style (
+    @include pf-v6-bidirectional-style (
       $prop: 'transform',
       $ltr-val: translateX(var(--#{$table}--m-tree-view__toggle--TranslateX)),
-      $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$table}--m-tree-view__toggle--TranslateX))})
+      $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$table}--m-tree-view__toggle--TranslateX))})
     );
 
     position: var(--#{$table}--m-tree-view__toggle--Position);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -724,7 +724,7 @@
 
 
   .#{$table}__toggle-icon {
-    @include pf-v5-mirror-inline-on-rtl;
+    @include pf-v6-mirror-inline-on-rtl;
 
     transition: var(--#{$table}__toggle--c-button__toggle-icon--Transition);
     transform: rotate(var(--#{$table}__toggle--c-button__toggle-icon--Rotate));

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -490,7 +490,7 @@ $pf-v5-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 }
 
 .#{$tabs}__toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
   color: var(--#{$tabs}__toggle-icon--Color);
@@ -677,7 +677,7 @@ $pf-v5-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 }
 
 .#{$tabs}__link-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   align-self: end;
   font-size: var(--#{$tabs}__link-toggle-icon--FontSize);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -255,7 +255,7 @@ $pf-v5--include-toolbar-breakpoints: true !default;
   transition: var(--#{$toolbar}__expand-all-icon--Transition);
   transform: rotate(var(--#{$toolbar}__expand-all-icon--Rotate));
 
-  @include pf-v5-mirror-inline-on-rtl; // - TODO: mirror this icon in breaking change
+  @include pf-v6-mirror-inline-on-rtl; // - TODO: mirror this icon in breaking change
 }
 
 // - Toolbar group - Toolbar item

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -325,7 +325,7 @@ $pf-v5-c-tree-view--MaxNesting: 10 !default;
 }
 
 .#{$tree-view}__node-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
   min-width: var(--#{$tree-view}__node-toggle-icon--MinWidth);
@@ -415,10 +415,10 @@ $pf-v5-c-tree-view--MaxNesting: 10 !default;
   background-color: var(--#{$tree-view}__node-toggle--BackgroundColor);
   border: 0;
 
-  @include pf-v5-bidirectional-style(
+  @include pf-v6-bidirectional-style(
     $prop: transform,
     $ltr-val: translateX(var(--#{$tree-view}__list-item__list-item__node-toggle--TranslateX)),
-    $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$tree-view}__list-item__list-item__node-toggle--TranslateX))})
+    $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$tree-view}__list-item__list-item__node-toggle--TranslateX))})
   );
 }
 

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -26,7 +26,7 @@
 
 // End
 .#{$truncate}__end {
-  @include pf-v5-bidirectional-style (
+  @include pf-v6-bidirectional-style (
     $prop: direction,
     $ltr-val: rtl,
     $rtl-val: ltr
@@ -36,7 +36,7 @@
 .#{$truncate}__start + .#{$truncate}__end {
   overflow: visible;
 
-  @include pf-v5-bidirectional-style (
+  @include pf-v6-bidirectional-style (
     $prop: direction,
     $ltr-val: ltr,
     $rtl-val: rtl
@@ -46,7 +46,7 @@
 // safari not supported
 @supports (-webkit-hyphens: none) {
   .#{$truncate}__end {
-    @include pf-v5-bidirectional-style (
+    @include pf-v6-bidirectional-style (
       $prop: direction,
       $ltr-val: ltr,
       $rtl-val: rtl

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -280,7 +280,7 @@
 }
 
 .#{$wizard}__toggle-separator {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   margin-inline-start: var(--#{$wizard}__toggle-separator--MarginLeft);
   color: var(--#{$wizard}__toggle-separator--Color);
@@ -416,10 +416,10 @@
   // Common step number styles
   @at-root .#{$wizard}__toggle-num,
   &::before {
-    @include pf-v5-bidirectional-style(
+    @include pf-v6-bidirectional-style(
       $prop: transform,
       $ltr-val: translateX(var(--#{$wizard}__nav-link--before--TranslateX)) translateY(var(--#{$wizard}__nav-link--before--TranslateY)),
-      $rtl-val: translateX(#{pf-v5-calc-inverse(var(--#{$wizard}__nav-link--before--TranslateX))}) translateY(var(--#{$wizard}__nav-link--before--TranslateY))
+      $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$wizard}__nav-link--before--TranslateX))}) translateY(var(--#{$wizard}__nav-link--before--TranslateY))
     );
 
     position: absolute;
@@ -485,7 +485,7 @@
 }
 
 .#{$wizard}__nav-link-toggle-icon {
-  @include pf-v5-mirror-inline-on-rtl;
+  @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
   transition: var(--#{$wizard}__nav-link-toggle-icon--Transition);

--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -118,6 +118,6 @@
 
 // Returns a calc() with the inverse of a value used for RTL. Most commonly used as the inverse/negative of a value in a transform function (eg, translate(), rotate(), scale(), etc)
 // Shouldn't be used on an existing LTR style as adding a calc() in an existing style could be breaking. Should used within an RTL selector, which is basically an opt-in.
-@function pf-v5-calc-inverse($val, $multiplier: var(--#{$pf-global}--inverse--multiplier)) {
+@function pf-v6-calc-inverse($val, $multiplier: var(--#{$pf-global}--inverse--multiplier)) {
   @return calc(#{$val} * #{$multiplier});
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -332,7 +332,7 @@
 
 // Used to create the RTL selector for RTL specific styles
 
-// @include pf-v5-rtl {
+// @include pf-v6-rtl {
 //   background: red;
 // }
 
@@ -341,14 +341,14 @@
 // [dir="rtl"] {
 //   background: red;
 // }
-@mixin pf-v5-rtl {
+@mixin pf-v6-rtl {
   @at-root :where(.#{$pf-prefix}m-dir-rtl, [dir="rtl"]) #{&} {
     @content;
   }
 }
 
 // Used to create the LTR selector for LTR specific styles
-@mixin pf-v5-ltr {
+@mixin pf-v6-ltr {
   @at-root :where(.#{$pf-prefix}m-dir-ltr, [dir="ltr"]) #{&} {
     @content;
   }
@@ -356,7 +356,7 @@
 
 // Creates a default/LTR declaration, and an RTL declaration.
 
-// @include pf-v5-bidirectional-style(background, blue, red)
+// @include pf-v6-bidirectional-style(background, blue, red)
 
 // renders as
 
@@ -364,26 +364,26 @@
 // [dir="rtl"] {
 //   background: red;
 // }
-@mixin pf-v5-bidirectional-style($prop, $ltr-val, $rtl-val) {
+@mixin pf-v6-bidirectional-style($prop, $ltr-val, $rtl-val) {
   #{$prop}: #{$ltr-val};
 
-  @include pf-v5-rtl {
+  @include pf-v6-rtl {
     #{$prop}: #{$rtl-val};
   }
 }
 
 // Mirrors/flips something horizontally/inline. Relies upon scale/scale() not already being used for the element. Can be extended to take arguments to use different methods other than scale().
-@mixin pf-v5-mirror-inline {
+@mixin pf-v6-mirror-inline {
   scale: -1 1;
 }
 
-@mixin pf-v5-mirror-inline-on-rtl {
-  @include pf-v5-rtl {
-    @include pf-v5-mirror-inline;
+@mixin pf-v6-mirror-inline-on-rtl {
+  @include pf-v6-rtl {
+    @include pf-v6-mirror-inline;
   }
 }
 
 // Declares a global inverse multiplier var used for returning the inverse of a number. Defined within blocks that reference the global var in calc() functions to conditionally return the default or inverse value of a number.
-@mixin pf-v5-set-inverse($val: true) {
+@mixin pf-v6-set-inverse($val: true) {
   --#{$pf-global}--inverse--multiplier: #{if($val, -1, 1)};
 }


### PR DESCRIPTION
This updates the version prefix on the RTL mixins and the function for calculating the inverse.
Note: the workspace does not currently work once the prefix is changed, so add dir="rtl" to the HTML tag manually.

Part of #6366 with more to come.