### PR TITLE
chore(markdown): update version prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
 
 #### Examples
 
-To create a "Test component" component (`.pf-v5-c-test-component`), run:
+To create a "Test component" component (`.pf-v6-c-test-component`), run:
 
 `node generate TestComponent`
 

--- a/patternfly-docs/site/pages/contribution.md
+++ b/patternfly-docs/site/pages/contribution.md
@@ -33,7 +33,7 @@ For example:
 
 ```html noLive
 <!-- Component definition -->
-<div class="pf-v5-c-grid{{#if grid--modifier}} {{grid--modifier}}{{/if}}"
+<div class="pf-v6-c-grid{{#if grid--modifier}} {{grid--modifier}}{{/if}}"
   {{#if grid--attribute}}
     {{{grid--attribute}}}
   {{/if}}>

--- a/patternfly-docs/site/pages/guidelines.md
+++ b/patternfly-docs/site/pages/guidelines.md
@@ -21,7 +21,7 @@ Layouts are the containers that allow for organizing and grouping its immediate 
 
 - A layout never imposes padding or element styles on its children.
 
-The classes are prefixed with `-l` (after the PatternFly prefix `pf-`), for example: `.pf-v5-l-split` or `.pf-v5-l-stack`.
+The classes are prefixed with `-l` (after the PatternFly prefix `pf-`), for example: `.pf-v6-l-split` or `.pf-v6-l-stack`.
 
 ### Components
 
@@ -32,7 +32,7 @@ Components are modular and independent structures concerned with how a thing loo
 - The first element in a component should never use top margins and should touch the top of its component.
 - Components should include semantic markup and necessary ARIA tags to implement the [accessibility guidelines](/accessibility-guide).
 
-The parent container of a component is prefixed with `-c` (after the PatternFly prefix `pf-` and version `v5-`), for example: `.pf-v5-c-alert` or `.pf-v5-c-button`.
+The parent container of a component is prefixed with `-c` (after the PatternFly prefix `pf-` and version `v6-`), for example: `.pf-v6-c-alert` or `.pf-v6-c-button`.
 
 ### When to create a new component
 
@@ -48,7 +48,7 @@ PatternFly is made up of isolated components that don't allow dependencies. Ther
 
 However, from time to time it is recognized that an exception to the PatternFly styling may be needed for a special case. For those instances, utility classes are supplied to assist in allowing minor styling changes without creating the need for adding custom CSS.
 
-A utility class is prefixed with `-u` (after the PatternFly prefix `pf-`), for example: `.pf-v5-u-align-content-center`.
+A utility class is prefixed with `-u` (after the PatternFly prefix `pf-`), for example: `.pf-v6-u-align-content-center`.
 
 ### Demos
 
@@ -99,8 +99,8 @@ For example a global variable setup would look like:
 
 The second layer is scoped to themeable component custom properties. This setup allows for consistency across components, generates a common language between designers and developers, and gives granular control to authors. The rules are as follows:
 
-- They follow this general formula `--pf-v5-c-block[__element][--modifier][--state][--breakpoint][--pseudo-element][[--child]|[--tag]|[--c-component]]--PropertyCamelCase`.
-  - `--pf-v5-c-block` refers to the block, usually the component or layout name (i.e., `--pf-v5-c-alert`).
+- They follow this general formula `--pf-v6-c-block[__element][--modifier][--state][--breakpoint][--pseudo-element][[--child]|[--tag]|[--c-component]]--PropertyCamelCase`.
+  - `--pf-v6-c-block` refers to the block, usually the component or layout name (i.e., `--pf-v6-c-alert`).
   - `__element` refers to the element inside of the block (i.e., `__title`).
   - `--modifier` refers to a modifier class such as `.pf-m-danger`, and is prefixed with `m-` in the component variable (i.e., `--m-danger`).
   - `--state` is something like `hover` or `active`.
@@ -115,35 +115,35 @@ For example:
 
 ```scss
 // Component scoped variables are always defined by global variables
---pf-v5-c-alert--Padding: var(--pf-global--spacer--xl);
---pf-v5-c-alert--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
---pf-v5-c-alert__title--FontSize: var(--pf-global--FontSize--2xl);
+--pf-v6-c-alert--Padding: var(--pf-global--spacer--xl);
+--pf-v6-c-alert--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
+--pf-v6-c-alert__title--FontSize: var(--pf-global--FontSize--2xl);
 
 // --block--PropertyCamelCase
-.pf-v5-c-alert {
-  padding: var(--pf-v5-c-alert--Padding);
+.pf-v6-c-alert {
+  padding: var(--pf-v6-c-alert--Padding);
 }
 
 // --block--state--PropertyCamelCase
-.pf-v5-c-alert {
+.pf-v6-c-alert {
   &:hover {
-    background-color: var(--pf-v5-c-alert--hover--BackgroundColor);
+    background-color: var(--pf-v6-c-alert--hover--BackgroundColor);
   }
 }
 
 // --block__element--PropertyCamelCase
-.pf-v5-c-alert__title {
-  font-size: var(--pf-v5-c-alert__title--FontSize);
+.pf-v6-c-alert__title {
+  font-size: var(--pf-v6-c-alert__title--FontSize);
 }
 
 // A more complex example
-.pf-v5-c-switch {
+.pf-v6-c-switch {
   @media (max-width: $pf-global--breakpoint--sm) {
-    .pf-v5-c-switch__input {
+    .pf-v6-c-switch__input {
       &:disabled {
-        ~ .pf-v5-c-switch__toggle {
+        ~ .pf-v6-c-switch__toggle {
           &::before {
-            background-color: var(--pf-v5-c-switch--sm__input--disabled__toggle--before--BackgroundColor);
+            background-color: var(--pf-v6-c-switch--sm__input--disabled__toggle--before--BackgroundColor);
           }
         }
       }
@@ -330,11 +330,11 @@ To make sure you are writing mobile first, always do `min-width`:
 States of a component should be included as a nested element. This includes hover, focus, and active states:
 
 ```scss
-.pf-v5-c-button {
-  background: var(--pf-v5-c-button--Background);
+.pf-v6-c-button {
+  background: var(--pf-v6-c-button--Background);
 
   &:hover {
-    background: var(--pf-v5-c-button--hover--Background);
+    background: var(--pf-v6-c-button--hover--Background);
   }
 }
 ```

--- a/src/patternfly/components/Label/label--variants.hbs
+++ b/src/patternfly/components/Label/label--variants.hbs
@@ -33,13 +33,13 @@
   {{> label
       label--id=(concat label--variants--id '-status-truncated')
       label-text--value=(concat label--variants--title ', max-width truncation customization')
-      label-text--attribute='style="--pf-v5-c-label__text--MaxWidth: 28ch"'}}
+      label-text--attribute='style="--pf-v6-c-label__text--MaxWidth: 28ch"'}}
 
   {{> label
       label--IsRemovable=true
       label--id=(concat label--variants--id '-status-truncated-removable')
       label-text--value=(concat label--variants--title ' removable, max-width truncation customization')
-      label-text--attribute='style="--pf-v5-c-label__text--MaxWidth: 28ch"'}}
+      label-text--attribute='style="--pf-v6-c-label__text--MaxWidth: 28ch"'}}
 
   {{> label
       label--IsRemovable=true
@@ -100,14 +100,14 @@
   {{> label
       label--id=(concat label--variants--id '-truncated')
       label-text--value=(concat label--variants--title ' label, max-width truncation customization')
-      label-text--attribute='style="--pf-v5-c-label__text--MaxWidth: 28ch"'
+      label-text--attribute='style="--pf-v6-c-label__text--MaxWidth: 28ch"'
       label-icon--value="cube"}}
 
   {{> label
       label--IsRemovable=true
       label--id=(concat label--variants--id '-truncated-with-icon')
       label-text--value=(concat label--variants--title ' label with icon and set max-width truncation customization')
-      label-text--attribute='style="--pf-v5-c-label__text--MaxWidth: 38ch"'
+      label-text--attribute='style="--pf-v6-c-label__text--MaxWidth: 38ch"'
       label-icon--value="cube"}}
 
   {{> label

--- a/src/patternfly/components/LogViewer/templates/__log-viewer-dropdown-menu.hbs
+++ b/src/patternfly/components/LogViewer/templates/__log-viewer-dropdown-menu.hbs
@@ -1,6 +1,6 @@
 {{#> dropdown dropdown--id=(concat log-viewer--id '-dropdown')}}
   {{> dropdown-toggle dropdown-toggle--IsPlain="true"}}
-  {{#> menu menu--modifier="pf-m-drilldown pf-m-align-right" menu--attribute='style="--pf-v5-c-menu--Width: 200px;"'}}
+  {{#> menu menu--modifier="pf-m-drilldown pf-m-align-right" menu--attribute='style="--pf-v6-c-menu--Width: 200px;"'}}
     {{#> menu-content menu-content--attribute=menu--Drilldown--menu__content--attribute menu--attribute=''}}
       {{#> menu-list menu-content--attribute=''}}
         {{> menu-list-item menu-list-item--text="Clear log"}}

--- a/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
+++ b/src/patternfly/components/LogViewer/templates/__log-viewer-dynamic-data.hbs
@@ -1,5 +1,5 @@
 <!--prettyhtml-ignore-start-->
-<div class="{{pfv}}log-viewer__list" style="--pf-v5-c-log-viewer__list--Height: 301080px;">
+<div class="{{pfv}}log-viewer__list" style="--pf-v6-c-log-viewer__list--Height: 301080px;">
   <div class="{{pfv}}log-viewer__list-item" style="top: 0px;">
     <span class="{{pfv}}log-viewer__index">1</span>
     <span class="{{pfv}}log-viewer__text">Copying system trust bundle</span>

--- a/src/patternfly/components/LogViewer/templates/__log-viewer-toolbar-search-filter.hbs
+++ b/src/patternfly/components/LogViewer/templates/__log-viewer-toolbar-search-filter.hbs
@@ -1,4 +1,4 @@
-{{#> toolbar-item toolbar-item--modifier="pf-m-search-filter" toolbar-item--attribute=(concat 'style="--pf-v5-c-toolbar__item--Width: ' __log-viewer-toolbar-search-filter--Width '"')}}
+{{#> toolbar-item toolbar-item--modifier="pf-m-search-filter" toolbar-item--attribute=(concat 'style="--pf-v6-c-toolbar__item--Width: ' __log-viewer-toolbar-search-filter--Width '"')}}
   {{#if __log-viewer-toolbar--IsMatch}}
     {{> text-input-group--search-input text-input-group-text-input--placeholder="Find" text-input-group--value="openshift" text-input-group--search-input--count="1 / 10" text-input-group--search-input--IsNavigable="true" text-input-group--search-input--IsFirstMatch="true"}}
   {{else}}

--- a/src/patternfly/components/Login/__login-header.hbs
+++ b/src/patternfly/components/Login/__login-header.hbs
@@ -1,3 +1,3 @@
 {{#> login-header}}
-  {{#> brand brand--attribute='src="/assets/images/pf_logo_color.svg" alt="PatternFly Logo" style="--pf-v5-c-brand--Height:48px;"'}}{{/brand}}
+  {{#> brand brand--attribute='src="/assets/images/pf_logo_color.svg" alt="PatternFly Logo" style="--pf-v6-c-brand--Height:48px;"'}}{{/brand}}
 {{/login-header}}

--- a/src/patternfly/components/ModalBox/modal-box-header-help.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header-help.hbs
@@ -3,6 +3,6 @@
     {{{modal-box-header-help--attribute}}}
   {{/if}}>
   {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Help"'}}
-      <i class="pf-v5-pficon pf-v5-pficon-help" aria-hidden="true"></i>
+      <i class="pf-v6-pficon pf-v6-pficon-help" aria-hidden="true"></i>
   {{/button}}
 </div>

--- a/src/patternfly/components/MultipleFileUpload/__multiple-file-upload-default.hbs
+++ b/src/patternfly/components/MultipleFileUpload/__multiple-file-upload-default.hbs
@@ -36,7 +36,7 @@
               {{#> multiple-file-upload-status-item-main}}
                 {{#> progress
                   progress__value="35"
-                  progress__description='<span class="pf-v5-c-multiple-file-upload__status-item-progress"><span class="pf-v5-c-multiple-file-upload__status-item-progress-text">filename.png</span> <span class="pf-v5-c-multiple-file-upload__status-item-progress-size">40 mb</span></span>'
+                  progress__description='<span class="pf-v6-c-multiple-file-upload__status-item-progress"><span class="pf-v6-c-multiple-file-upload__status-item-progress-text">filename.png</span> <span class="pf-v6-c-multiple-file-upload__status-item-progress-size">40 mb</span></span>'
                   progress__id=(concat multiple-file-upload--id "-progress-png")
                   }}
                 {{/progress}}
@@ -48,7 +48,7 @@
               {{#> multiple-file-upload-status-item-main}}
                 {{#> progress
                   progress__value="70"
-                  progress__description='<span class="pf-v5-c-multiple-file-upload__status-item-progress"><span class="pf-v5-c-multiple-file-upload__status-item-progress-text">filename.doc</span> <span class="pf-v5-c-multiple-file-upload__status-item-progress-size">30 mb</span></span>'
+                  progress__description='<span class="pf-v6-c-multiple-file-upload__status-item-progress"><span class="pf-v6-c-multiple-file-upload__status-item-progress-text">filename.doc</span> <span class="pf-v6-c-multiple-file-upload__status-item-progress-size">30 mb</span></span>'
                   progress__id=(concat multiple-file-upload--id "-progress-doc")
                   }}
                 {{/progress}}
@@ -60,7 +60,7 @@
               {{#> multiple-file-upload-status-item-main}}
                 {{#> progress
                   progress__value="50"
-                  progress__description='<span class="pf-v5-c-multiple-file-upload__status-item-progress"><span class="pf-v5-c-multiple-file-upload__status-item-progress-text">filename.pdf</span> <span class="pf-v5-c-multiple-file-upload__status-item-progress-size">25 mb</span></span>'
+                  progress__description='<span class="pf-v6-c-multiple-file-upload__status-item-progress"><span class="pf-v6-c-multiple-file-upload__status-item-progress-text">filename.pdf</span> <span class="pf-v6-c-multiple-file-upload__status-item-progress-size">25 mb</span></span>'
                   progress__id=(concat multiple-file-upload--id "-progress-pdf")
                   }}
                 {{/progress}}

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload-status-progress-icon.hbs
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload-status-progress-icon.hbs
@@ -2,5 +2,5 @@
   {{#if multiple-file-upload-status-progress-icon--attribute}}
     {{{multiple-file-upload-status-progress-icon--attribute}}}
   {{/if}}>
-  <i class="pf-v5-pficon pf-v5-pficon-in-progress"></i>
+  <i class="pf-v6-pficon pf-v6-pficon-in-progress"></i>
 </div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -141,7 +141,7 @@
   {{#> notification-drawer-list-item notification-drawer-list-item--modifier="pf-m-hoverable" notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
-      {{#> notification-drawer-list-item-header-title  notification-drawer-list-item-header-title--modifier="pf-m-truncate"  notification-drawer-list-item-header-title--attribute='style="--pf-v5-c-notification-drawer__list-item-header-title--max-lines: 2"'}}
+      {{#> notification-drawer-list-item-header-title  notification-drawer-list-item-header-title--modifier="pf-m-truncate"  notification-drawer-list-item-header-title--attribute='style="--pf-v6-c-notification-drawer__list-item-header-title--max-lines: 2"'}}
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quis odio risus. Ut dictum vitae sapien at posuere. Nullam suscipit massa quis lacus pellentesque scelerisque. Donec non maximus neque, quis ornare nunc. Vivamus in nibh sed libero feugiat feugiat. Nulla lacinia rutrum est, a commodo odio vestibulum suscipit. Nullam id quam et quam porttitor interdum quis nec tellus. Vestibulum arcu dui, pulvinar eu tellus in, semper mattis diam. Sed commodo tincidunt lacus non pulvinar. Curabitur tempor molestie vestibulum. Vivamus vel mi dignissim, efficitur neque eget, efficitur massa. Mauris vitae nunc augue. Donec augue lorem, malesuada et quam vitae, volutpat mattis nisi. Nullam nec venenatis ex, quis lobortis purus. Sed nisl dolor, mattis sit amet tincidunt quis, mollis sed massa.
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}
@@ -149,7 +149,7 @@
       {{> dropdown dropdown--id=(concat notification-drawer--id 'dropdown-kebab-7') dropdown--modifier="pf-m-top" dropdown-toggle--IsPlain="true" dropdown-menu--modifier="pf-m-align-right"}}
     {{/notification-drawer-list-item-action}}
     {{#> notification-drawer-list-item-description}}
-      This example uses ".pf-m-truncate" and sets "--pf-v5-c-notification-drawer__list-item-header-title--max-lines: 2" to limit title to two lines and truncate any overflow text with ellipses.
+      This example uses ".pf-m-truncate" and sets "--pf-v6-c-notification-drawer__list-item-header-title--max-lines: 2" to limit title to two lines and truncate any overflow text with ellipses.
     {{/notification-drawer-list-item-description}}
     {{#> notification-drawer-list-item-timestamp}}
       50 minutes ago

--- a/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
+++ b/src/patternfly/components/OverflowMenu/overflow-menu-control.hbs
@@ -8,7 +8,7 @@
       {{{dropdown--attribute}}}
     {{/if}}>
     {{#if overflow-menu-control--IsControl}}
-      {{#> button button--modifier="pf-v5-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+      {{#> button button--modifier="pf-v6-c-dropdown__toggle pf-m-plain pf-m-control" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
         {{#if dropdown--icon}}
           <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
         {{else}}
@@ -16,7 +16,7 @@
         {{/if}}
       {{/button}}
     {{else}}
-      {{#> button button--modifier="pf-v5-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
+      {{#> button button--modifier="pf-v6-c-dropdown__toggle pf-m-plain" button--attribute=(concat 'id="' overflow-menu--id '-dropdown-toggle" aria-label="' overflow-menu-button--aria-label '" aria-expanded="' overflow-menu-button--aria-expanded '"')}}
         {{#if dropdown-icon}}
           <i class="fas {{dropdown--icon}}" aria-hidden="true"></i>
         {{else}}

--- a/src/patternfly/components/Select/__select-checkbox-checked.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-checked.hbs
@@ -9,7 +9,7 @@
     {{/select-menu-search}}
     {{> divider}}
   {{/if}}
-  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"' check--modifier="pf-v5-c-select__menu-item" check--IsLabelWrapped=true}}
+  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"' check--modifier="pf-v6-c-select__menu-item" check--IsLabelWrapped=true}}
     {{> check check--id=(concat select--id '-check-active') check-label--text="Active" check-input--IsChecked=true}}
     {{> check check--id=(concat select--id '-check-canceled') check-label--text="Canceled" check-input--IsChecked=true}}
     {{> check check--id=(concat select--id '-check-paused') check-label--text="Paused"}}

--- a/src/patternfly/components/Select/__select-checkbox-counts.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-counts.hbs
@@ -3,7 +3,7 @@
   {{#if select-multi--attribute}}
     {{{select-multi-attribute}}}
   {{/if}}>
-  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"' check--modifier=(concat 'pf-v5-c-select__menu-item ' select-menu-item-check--modifier)}}
+  {{#> select-menu-fieldset select-menu-fieldset--attribute='aria-label="Select input"' check--modifier=(concat 'pf-v6-c-select__menu-item ' select-menu-item-check--modifier)}}
     {{#> select-menu-item-check check-input--IsChecked=true select-menu-item-check--name="active"}}
       {{#> select-menu-item-row}}
         {{#> select-menu-item-text}}

--- a/src/patternfly/components/Select/__select-checkbox-groups-checked.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-groups-checked.hbs
@@ -13,7 +13,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' select--id '-group-status"')}}
       Status
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-status"') check--modifier="pf-v5-c-select__menu-item" check--IsLabelWrapped=true}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-status"') check--modifier="pf-v6-c-select__menu-item" check--IsLabelWrapped=true}}
       {{> check check--id=(concat select--id '-check-running') check-label--text="Running"}}
       {{> check check--id=(concat select--id '-check-stopped') check-label--text="Stopped"}}
       {{> check check--id=(concat select--id '-check-down') check-label--text="Down"}}
@@ -25,7 +25,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' select--id '-group-vendor"')}}
       Vendor
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-vendor"') check--modifier="pf-v5-c-select__menu-item" check--IsLabelWrapped=true}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-vendor"') check--modifier="pf-v6-c-select__menu-item" check--IsLabelWrapped=true}}
       {{> check check--id=(concat select--id '-check-dell') check-label--text="Dell"}}
       {{> check check--id=(concat select--id '-check-Samsung') check-label--text="Samsung" check--IsDisabled=true}}
       {{> check check--id=(concat select--id '-check-Hp') check-label--text="Hewlett-Packard"}}

--- a/src/patternfly/components/Select/__select-checkbox-groups.hbs
+++ b/src/patternfly/components/Select/__select-checkbox-groups.hbs
@@ -7,7 +7,7 @@
     {{#> select-menu-group-title select-menu-group-title--attribute=(concat 'id="' select--id '-group-status"')}}
       Status
     {{/select-menu-group-title}}
-    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-status"') check--modifier="pf-v5-c-select__menu-item" check--IsLabelWrapped=true}}
+    {{#> select-menu-fieldset select-menu-fieldset--attribute=(concat 'aria-labelledby="' select--id '-group-status"') check--modifier="pf-v6-c-select__menu-item" check--IsLabelWrapped=true}}
       {{> check check--id=(concat select--id '-check-running') check-label--text="Running"}}
       {{> check check--id=(concat select--id '-check-stopped') check-label--text="Stopped"}}
       {{> check check--id=(concat select--id '-check-down') check-label--text="Down"}}

--- a/src/patternfly/components/Select/select-menu-item-check.hbs
+++ b/src/patternfly/components/Select/select-menu-item-check.hbs
@@ -1,6 +1,6 @@
 {{#> check
       check--id=(concat select--id '-' select-menu-item-check--name)
-      check--modifier=(concat 'pf-v5-c-select__menu-item ' select-menu-item-check--modifier)
+      check--modifier=(concat 'pf-v6-c-select__menu-item ' select-menu-item-check--modifier)
       check--IsLabelWrapped=true
       check-description--text=select-menu-item-check--description
       check-input--IsChecked=select-menu-item-check--IsChecked

--- a/src/patternfly/components/Select/select-toggle-button.hbs
+++ b/src/patternfly/components/Select/select-toggle-button.hbs
@@ -1,15 +1,15 @@
 {{#if select--IsExpanded}}
-  {{#> button button--modifier="pf-m-plain pf-v5-c-select__toggle-button" button--attribute=(concat 'id="' select--id '-toggle" aria-haspopup="true" aria-expanded="true" aria-labelledby="' select--id '-label ' select--id '-toggle" aria-label="Select"')}}
+  {{#> button button--modifier="pf-m-plain pf-v6-c-select__toggle-button" button--attribute=(concat 'id="' select--id '-toggle" aria-haspopup="true" aria-expanded="true" aria-labelledby="' select--id '-label ' select--id '-toggle" aria-label="Select"')}}
     <i class="fas fa-caret-down {{pfv}}select__toggle-arrow" aria-hidden="true"></i>
   {{/button}}
 {{else}}
   {{#if select--IsDisabled}}
-    {{#> button button--modifier="pf-m-plain pf-v5-c-select__toggle-button"
+    {{#> button button--modifier="pf-m-plain pf-v6-c-select__toggle-button"
       button--attribute=(concat 'id="' select--id '-toggle" aria-haspopup="true" aria-expanded="false" aria-labelledby="' select--id '-label ' select--id '-toggle" aria-label="Select" disabled')}}
         <i class="fas fa-caret-down {{pfv}}select__toggle-arrow" aria-hidden="true"></i>
     {{/button}}
   {{else}}
-    {{#> button button--modifier="pf-m-plain pf-v5-c-select__toggle-button" button--attribute=(concat 'id="' select--id '-toggle" aria-haspopup="true" aria-expanded="false" aria-labelledby="' select--id '-label ' select--id '-toggle" aria-label="Select"')}}
+    {{#> button button--modifier="pf-m-plain pf-v6-c-select__toggle-button" button--attribute=(concat 'id="' select--id '-toggle" aria-haspopup="true" aria-expanded="false" aria-labelledby="' select--id '-label ' select--id '-toggle" aria-label="Select"')}}
       <i class="fas fa-caret-down {{pfv}}select__toggle-arrow" aria-hidden="true"></i>
     {{/button}}
   {{/if}}

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -2,20 +2,20 @@
   {{#> form-control controlType="input"
     input="true"
     form-control--IsDisabled='true'
-    form-control--modifier="pf-v5-c-select__toggle-typeahead"
+    form-control--modifier="pf-v6-c-select__toggle-typeahead"
     form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
   {{/form-control}}
 {{else}}
   {{#if select--IsInvalid}}
     {{#> form-control controlType="input"
       input="true"
-      form-control--modifier="pf-v5-c-select__toggle-typeahead"
+      form-control--modifier="pf-v6-c-select__toggle-typeahead"
       form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-invalid="true" value="Invalid" aria-label="Type to filter" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
     {{/form-control}}
   {{else}}
     {{#> form-control controlType="input"
       input="true"
-      form-control--modifier="pf-v5-c-select__toggle-typeahead"
+      form-control--modifier="pf-v6-c-select__toggle-typeahead"
       form-control--attribute=(concat 'type="text" id="' select--id '-typeahead" aria-label="Type to filter" value="' select-typeahead--Value '" placeholder="' (ternary select-typeahead--TypeaheadText select-typeahead--TypeaheadText select-typeahead--Placeholder) '"')}}
     {{/form-control}}
   {{/if}}

--- a/src/patternfly/components/Select/select-toggle.hbs
+++ b/src/patternfly/components/Select/select-toggle.hbs
@@ -84,7 +84,7 @@
   {{!-- Clear button if it's typeahead and something has been typed --}}
   {{#if select--IsTypeahead}}
     {{#if select--ItemIsSelected}}
-      {{#> button button--modifier="pf-m-plain pf-v5-c-select__toggle-clear" button--attribute='aria-label="Clear all"'}}
+      {{#> button button--modifier="pf-m-plain pf-v6-c-select__toggle-clear" button--attribute='aria-label="Clear all"'}}
         <i class="fas fa-times-circle" aria-hidden="true"></i>
       {{/button}}
     {{/if}}

--- a/src/patternfly/components/Slider/slider-step.hbs
+++ b/src/patternfly/components/Slider/slider-step.hbs
@@ -1,5 +1,5 @@
 <div class="{{pfv}}slider__step{{#if slider-step--IsActive}} pf-m-active{{/if}}{{#if slider-step--modifier}} {{slider-step--modifier}}{{/if}}"
-  style="--pf-v5-c-slider__step--Left: {{slider-step--Left}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
+  style="--pf-v6-c-slider__step--Left: {{slider-step--Left}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
   {{#if slider-step--attribute}}
     {{{slider-step--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/Tree-table/table-tr--tree.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tr--tree.hbs
@@ -1,5 +1,5 @@
 {{#> table-tr table-tr--attribute='role="row"'}}
-  {{#> table-th table-th--modifier="pf-v5-c-table__tree-view-title-cell"}}
+  {{#> table-th table-th--modifier="pf-v6-c-table__tree-view-title-cell"}}
     {{#> table-tree-view-main}}
       {{!-- TODO: fix this after merge --}}
       {{#unless (concat table-tr--tree--IsLeaf table-tr--HasNoPosinset table--HasNoPosinset)}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3237,13 +3237,13 @@ For sticky columns to function correctly, the parent table's width must be contr
       {{/table-tr}}
 
       {{#> table-tr table-tr--modifier="pf-m-first-cell-offset-reset"}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v5-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v6-c-table__subhead"}}
           Design lead
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v5-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v6-c-table__subhead"}}
           Interaction design
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v5-c-table__subhead pf-m-border-right"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-v6-c-table__subhead pf-m-border-right"}}
           Visual designers
         {{/table-th}}
       {{/table-tr}}

--- a/src/patternfly/components/Tooltip/__wizard-drawer-toggle.hbs
+++ b/src/patternfly/components/Tooltip/__wizard-drawer-toggle.hbs
@@ -1,4 +1,4 @@
-{{#> button button--modifier=(concat __wizard-drawer-toggle--modifier ' pf-m-link pf-m-inline pf-v5-u-float-right pf-v5-u-ml-md') button--attribute=__wizard-drawer-toggle--attribute}}
+{{#> button button--modifier=(concat __wizard-drawer-toggle--modifier ' pf-m-link pf-m-inline pf-v6-u-float-right pf-v6-u-ml-md') button--attribute=__wizard-drawer-toggle--attribute}}
   {{#if wizard-drawer-toggle--text}}
     {{wizard-drawer-toggle--text}}
   {{else}}

--- a/src/patternfly/demos/Banner/banner-template.hbs
+++ b/src/patternfly/demos/Banner/banner-template.hbs
@@ -1,15 +1,15 @@
 {{#> banner banner--id=banner-template--id banner--modifier=banner-template--modifier}}
   {{#> l-flex l-flex--modifier="pf-m-justify-content-center pf-m-justify-content-space-between-on-lg pf-m-nowrap"}}
-    {{#> display display--type="none pf-v5-u-display-block-on-lg"}}
+    {{#> display display--type="none pf-v6-u-display-block-on-lg"}}
       Localhost
     {{/display}}
-    {{#> display display--type="none pf-v5-u-display-block-on-lg"}}
+    {{#> display display--type="none pf-v6-u-display-block-on-lg"}}
       This message is sticky to the top or bottom of the page.
     {{/display}}
     {{#> display display--type="none-on-lg"}}
       Drop some text on mobile, truncate if needed.
     {{/display}}
-    {{#> display display--type="none pf-v5-u-display-block-on-lg"}}
+    {{#> display display--type="none pf-v6-u-display-block-on-lg"}}
       Ned Username
     {{/display}}
   {{/l-flex}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -84,7 +84,7 @@ import './Card.css'
           {{#> button button--IsAnchor="true" button--modifier="pf-m-link pf-m-inline" button--url="#"}}
             View all set up cluster steps
             {{#> button-icon button-icon--modifier="pf-m-end"}}
-              {{#> icon icon--modifier="pf-v5-m-mirror-inline-rtl"}}
+              {{#> icon icon--modifier="pf-v6-m-mirror-inline-rtl"}}
                 {{#> icon-content}}
                   <i class="fas fa-arrow-right" aria-hidden="true"></i>
                 {{/icon-content}}
@@ -108,7 +108,7 @@ import './Card.css'
          {{#> button button--IsAnchor="true" button--modifier="pf-m-link pf-m-inline" button--url="#"}}
             View all guided tours
             {{#> button-icon button-icon--modifier="pf-m-end"}}
-              {{#> icon icon--modifier="pf-v5-m-mirror-inline-rtl"}}
+              {{#> icon icon--modifier="pf-v6-m-mirror-inline-rtl"}}
                 {{#> icon-content}}
                   <i class="fas fa-arrow-right" aria-hidden="true"></i>
                 {{/icon-content}}
@@ -135,7 +135,7 @@ import './Card.css'
           {{#> button button--IsAnchor="true" button--modifier="pf-m-link pf-m-inline" button--url="#"}}
             View all quick starts
             {{#> button-icon button-icon--modifier="pf-m-end"}}
-              {{#> icon icon--modifier="pf-v5-m-mirror-inline-rtl"}}
+              {{#> icon icon--modifier="pf-v6-m-mirror-inline-rtl"}}
                 {{#> icon-content}}
                   <i class="fas fa-arrow-right" aria-hidden="true"></i>
                 {{/icon-content}}
@@ -162,7 +162,7 @@ import './Card.css'
           {{#> button button--IsAnchor="true" button--modifier="pf-m-link pf-m-inline" button--url="#"}}
             View all learning resources
             {{#> button-icon button-icon--modifier="pf-m-end"}}
-              {{#> icon icon--modifier="pf-v5-m-mirror-inline-rtl"}}
+              {{#> icon icon--modifier="pf-v6-m-mirror-inline-rtl"}}
                 {{#> icon-content}}
                   <i class="fas fa-arrow-right" aria-hidden="true"></i>
                 {{/icon-content}}
@@ -197,7 +197,7 @@ import './Card.css'
 
 ### Details card
 ```hbs
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 260px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 260px;"'}}
   {{#> card}}
     {{#> card-title}}
       {{#> title titleType="h2" title--modifier="pf-m-xl"}}
@@ -316,35 +316,35 @@ import './Card.css'
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item}}
     {{#> gallery gallery--modifier="pf-m-gutter"}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="5 Clusters"}}
         {{#> card-body}}
-          <i class="fas fa-check-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+          <i class="fas fa-check-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
         {{/card-body}}
       {{/card}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="15 Clusters"}}
         {{#> card-body}}
-          <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+          <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
         {{/card-body}}
       {{/card}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="3 Clusters"}}
         {{#> card-body}}
-          <i class="fas fa-times-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+          <i class="fas fa-times-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
         {{/card-body}}
       {{/card}}
     {{/gallery}}
   {{/grid-item}}
   {{#> grid-item}}
     {{#> gallery gallery--modifier="pf-m-gutter"}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="10 Hosts"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-inline-flex pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">2</a>
@@ -353,7 +353,7 @@ import './Card.css'
             {{> divider divider--modifier="pf-m-vertical"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">1</a>
@@ -362,13 +362,13 @@ import './Card.css'
           {{/l-flex}}
         {{/card-body}}
       {{/card}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="50 Hosts"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-inline-flex pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-check-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+                <i class="fas fa-check-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">5</a>
@@ -377,7 +377,7 @@ import './Card.css'
             {{> divider divider--modifier="pf-m-vertical"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-times-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+                <i class="fas fa-times-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">12</a>
@@ -386,13 +386,13 @@ import './Card.css'
           {{/l-flex}}
         {{/card-body}}
       {{/card}}
-      {{#> card card--modifier="pf-v5-u-text-align-center"}}
+      {{#> card card--modifier="pf-v6-u-text-align-center"}}
         {{> card-title card-title-text--value="12 Hosts"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-inline-flex pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">2</a>
@@ -401,7 +401,7 @@ import './Card.css'
             {{> divider divider--modifier="pf-m-vertical"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-times-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+                <i class="fas fa-times-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 <a href="#">7</a>
@@ -413,14 +413,14 @@ import './Card.css'
     {{/gallery}}
   {{/grid-item}}
   {{#> grid-item}}
-    {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 260px;"'}}
+    {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 260px;"'}}
       {{#> card}}
-        {{> card-title card-title-text--value="13 Hosts" card-title-text--modifier="pf-v5-u-text-align-center"}}
+        {{> card-title card-title-text--value="13 Hosts" card-title-text--modifier="pf-v6-u-text-align-center"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-justify-content-center pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-times-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+                <i class="fas fa-times-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">2 errors</a>
@@ -429,7 +429,7 @@ import './Card.css'
             {{/l-flex}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">1 warnings</a>
@@ -440,12 +440,12 @@ import './Card.css'
         {{/card-body}}
       {{/card}}
       {{#> card}}
-        {{> card-title card-title-text--value="3 Hosts" card-title--modifier="pf-v5-u-text-align-center"}}
+        {{> card-title card-title-text--value="3 Hosts" card-title--modifier="pf-v6-u-text-align-center"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-justify-content-center pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-check-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+                <i class="fas fa-check-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">2 successes</a>
@@ -454,7 +454,7 @@ import './Card.css'
             {{/l-flex}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">3 warnings</a>
@@ -465,12 +465,12 @@ import './Card.css'
         {{/card-body}}
       {{/card}}
       {{#> card}}
-        {{> card-title card-title-text--value="50 Hosts" card-title--modifier="pf-v5-u-text-align-center"}}
+        {{> card-title card-title-text--value="50 Hosts" card-title--modifier="pf-v6-u-text-align-center"}}
         {{#> card-body}}
           {{#> l-flex l-flex--modifier="pf-m-justify-content-center pf-m-space-items-md"}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-triangle pf-v5-u-warning-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-triangle pf-v6-u-warning-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">7 warnings</a>
@@ -479,7 +479,7 @@ import './Card.css'
             {{/l-flex}}
             {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-times-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+                <i class="fas fa-times-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> stack}}
                 <a href="#">1 error</a>
@@ -641,7 +641,7 @@ import './Card.css'
 
 ### Utilization card 1
 ```hbs
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="utilization-card-1-example"}}
     {{#> card-title card-title--id=(concat card--id '-title1')}}
       {{#> title title--modifier="pf-m-lg" titleType="h2"}}
@@ -678,7 +678,7 @@ import './Card.css'
 
 ### Utilization card 2
 ```hbs
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="utilization-card-2-example"}}
     {{#> card-title card-title--id=(concat card--id '-title1')}}
       {{#> title title--modifier="pf-m-lg" titleType="h2"}}
@@ -715,9 +715,9 @@ import './Card.css'
 ```hbs
 <b>Note:</b> Custom CSS is used in this demo to align the card title and select toggle text to <code>baseline</code> alignment.
 <br><br>
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="utilization-card-3-example"}}
-    {{#> card-header card-header--modifier="pf-v5-u-align-items-flex-start"}}
+    {{#> card-header card-header--modifier="pf-v6-u-align-items-flex-start"}}
       {{#> card-header-main}}
         {{#> card-title card-title--id=(concat card--id '-title1') card-title--attribute=('style="padding-block-start: 3px;"')}}
           {{#> title title--modifier="pf-m-lg" titleType="h2"}}
@@ -735,7 +735,7 @@ import './Card.css'
       {{#> l-flex l-flex--modifier="pf-m-column"}}
         <span>System</span>
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
-          <i class="fas fa-exclamation-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+          <i class="fas fa-exclamation-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
           <a hfer="#">25 incidents detected</a>
         {{/l-flex}}
         {{> card-demo--chart card-demo--chart--IsStackChart="true"}}
@@ -750,7 +750,7 @@ import './Card.css'
 
 ### Utilization card 4
 ```hbs
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="utilization-card-4-example"}}
     {{#> card-title card-title--id=(concat card--id '-title1')}}
       {{#> title title--modifier="pf-m-lg" titleType="h2"}}
@@ -783,7 +783,7 @@ import './Card.css'
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 1" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 1" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
     {{#> card-expandable-content}}
@@ -796,7 +796,7 @@ import './Card.css'
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 2" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 2" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
   {{/card}}
@@ -804,7 +804,7 @@ import './Card.css'
     {{#> card-header card-header--modifier="pf-m-toggle-right"}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 3" card-title--id=(concat card--id '-title"') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 3" card-title--id=(concat card--id '-title"') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
   {{/card}}
@@ -827,7 +827,7 @@ import './Card.css'
     {{#> card-header}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 1" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 1" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
     {{#> card-expandable-content}}
@@ -840,7 +840,7 @@ import './Card.css'
     {{#> card-header}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 2" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 2" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
   {{/card}}
@@ -848,7 +848,7 @@ import './Card.css'
     {{#> card-header}}
       {{> card-header-toggle}}
       {{#> card-header-main}}
-        {{> card-title card-title-text--value="CPU 3" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v5-u-font-weight-light"}}
+        {{> card-title card-title-text--value="CPU 3" card-title--id=(concat card--id '-title') card-title-text--modifier="pf-v6-u-font-weight-light"}}
       {{/card-header-main}}
     {{/card-header}}
   {{/card}}
@@ -871,7 +871,7 @@ import './Card.css'
     {{#> accordion}}
       {{#> accordion-toggle accordion-toggle--IsExpanded="true" accordion-toggle--attribute='aria-expanded="true"'}}
         {{#> accordion-toggle-text}}
-          <span class="pf-v5-u-font-weight-light">
+          <span class="pf-v6-u-font-weight-light">
             CPU 1
           </span>
         {{/accordion-toggle-text}}
@@ -885,7 +885,7 @@ import './Card.css'
 
       {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
         {{#> accordion-toggle-text}}
-          <span class="pf-v5-u-font-weight-light">
+          <span class="pf-v6-u-font-weight-light">
             CPU 2
           </span>
         {{/accordion-toggle-text}}
@@ -897,7 +897,7 @@ import './Card.css'
 
       {{#> accordion-toggle accordion-toggle--attribute='aria-expanded="false"'}}
         {{#> accordion-toggle-text}}
-          <span class="pf-v5-u-font-weight-light">
+          <span class="pf-v6-u-font-weight-light">
             CPU 3
           </span>
         {{/accordion-toggle-text}}
@@ -915,7 +915,7 @@ import './Card.css'
 ```hbs
 <b>Note:</b> Custom CSS is used in this demo to align the card title and select toggle text to <code>baseline</code> alignment.
 <br><br>
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="trend-card-1-example"}}
     {{#> card-header}}
       {{#> card-header-main}}
@@ -924,7 +924,7 @@ import './Card.css'
             1,050,765 IOPS
           {{/title}}
         {{/card-title}}
-        <span class="pf-v5-u-color-200">
+        <span class="pf-v6-u-color-200">
           Workload
         </span>
       {{/card-header-main}}
@@ -943,7 +943,7 @@ import './Card.css'
 
 ### Trend card 2
 ```hbs
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="trend-card-2-example"}}
     {{#> card-header}}
       {{#> card-header-main}}
@@ -955,7 +955,7 @@ import './Card.css'
                   842 TB
                 {{/title}}
               {{/card-title}}
-              <span class="pf-v5-u-color-200">
+              <span class="pf-v6-u-color-200">
                 Storage capacity
               </span>
             {{/l-flex}}
@@ -980,9 +980,9 @@ import './Card.css'
 ```hbs
 <b>Note:</b> Custom CSS is used in this demo to align the card title and select toggle text to <code>baseline</code> alignment.
 <br><br>
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="card-log-view-example"}}
-    {{#> card-header card-header--modifier="pf-v5-u-align-items-flex-start"}}
+    {{#> card-header card-header--modifier="pf-v6-u-align-items-flex-start"}}
       {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
         {{#> select select--id=(concat card--id '-select-dropdown') select-menu--modifier="pf-m-align-right" select-toggle--modifier="pf-m-plain"}}
           Most recent
@@ -1006,7 +1006,7 @@ import './Card.css'
             Readiness probe failed: Get https://10.131.0.7:5000/healthz: dial tcp 10.131.0.7:5000: connect: connection refused
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 11:02 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 11:02 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
@@ -1017,7 +1017,7 @@ import './Card.css'
             Successfully assigned default/example to ip-10-0-130-149.ec2.internal
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 11:13 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 11:13 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
@@ -1028,7 +1028,7 @@ import './Card.css'
             Pulling image "openshift/hello-openshift"
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 10:59 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 10:59 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
@@ -1039,7 +1039,7 @@ import './Card.css'
             Created container hello-openshift
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 10:45 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 10:45 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
       {{/description-list}}
@@ -1056,9 +1056,9 @@ import './Card.css'
 ```hbs
 <b>Note:</b> Custom CSS is used in this demo to align the card title and select toggle text to <code>baseline</code> alignment.
 <br><br>
-{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 360px;"'}}
+{{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 360px;"'}}
   {{#> card card--id="card-events-view-example"}}
-    {{#> card-header card-header--modifier="pf-v5-u-align-items-flex-start"}}
+    {{#> card-header card-header--modifier="pf-v6-u-align-items-flex-start"}}
       {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
         {{#> select select--id=(concat card--id '-select-dropdown') select-menu--modifier="pf-m-align-right" select-toggle--modifier="pf-m-plain"}}
           Status
@@ -1078,7 +1078,7 @@ import './Card.css'
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-exclamation-circle pf-v5-u-danger-color-100" aria-hidden="true"></i>
+                <i class="fas fa-exclamation-circle pf-v6-u-danger-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Readiness probe failed
@@ -1089,14 +1089,14 @@ import './Card.css'
             Readiness probe failed: Get https://10.131.0.7:5000/healthz: dial tcp 10.131.0.7:5000: connect: connection refused
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 11:02 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 11:02 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-check-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+                <i class="fas fa-check-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Successful assignment
@@ -1107,7 +1107,7 @@ import './Card.css'
             Successfully assigned default/example to ip-10-0-130-149.ec2.internal
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 11:13 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 11:13 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
@@ -1125,14 +1125,14 @@ import './Card.css'
             Pulling image "openshift/hello-openshift"
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 10:59 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 10:59 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
         {{#> description-list-group}}
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap pf-m-space-items-sm"}}
               {{#> l-flex-item}}
-                <i class="fas fa-check-circle pf-v5-u-success-color-100" aria-hidden="true"></i>
+                <i class="fas fa-check-circle pf-v6-u-success-color-100" aria-hidden="true"></i>
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Created container
@@ -1143,7 +1143,7 @@ import './Card.css'
             Created container hello-openshift
           {{/description-list-description}}
           {{#> description-list-description}}
-            <time class="pf-v5-u-color-200 pf-v5-u-font-size-sm">Jun 17, 10:45 am</time>
+            <time class="pf-v6-u-color-200 pf-v6-u-font-size-sm">Jun 17, 10:45 am</time>
           {{/description-list-description}}
         {{/description-list-group}}
       {{/description-list}}

--- a/src/patternfly/demos/Card/templates/card-demo--notification-list.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--notification-list.hbs
@@ -2,7 +2,7 @@
   {{#> notification-drawer-list-item notification-drawer-list-item--IsDanger="true" notification-drawer-list-item--IsRead=notification-drawer-basic-list--AllRead}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
-      {{#> notification-drawer-list-item-header-title notification-drawer-list-item-header-title--modifier="pf-v5-u-danger-color-200"}}
+      {{#> notification-drawer-list-item-header-title notification-drawer-list-item-header-title--modifier="pf-v6-u-danger-color-200"}}
         Critical alert regarding control plane
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}
@@ -13,7 +13,7 @@
   {{#> notification-drawer-list-item notification-drawer-list-item--IsWarning="true" notification-drawer-list-item--IsRead=notification-drawer-basic-list--AllRead}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
-      {{#> notification-drawer-list-item-header-title notification-drawer-list-item-header-title--modifier="pf-v5-u-warning-color-200"}}
+      {{#> notification-drawer-list-item-header-title notification-drawer-list-item-header-title--modifier="pf-v6-u-warning-color-200"}}
         Warning alert
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}

--- a/src/patternfly/demos/Card/templates/card-demo--popover.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--popover.hbs
@@ -1,5 +1,5 @@
 {{#if card-demo--popover--IsOpen}}
-  {{#> popover popover--modifier="pf-m-right" popover--attribute=(concat 'aria-labelledby="' popover--id '-popover-right-header" aria-describedby="' popover--id '-popover-right-body" style="--pf-v5-c-popover--MinWidth: 400px;"')}}
+  {{#> popover popover--modifier="pf-m-right" popover--attribute=(concat 'aria-labelledby="' popover--id '-popover-right-header" aria-describedby="' popover--id '-popover-right-body" style="--pf-v6-c-popover--MinWidth: 400px;"')}}
     {{#> popover-content}}
       {{#> popover-close}}
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}

--- a/src/patternfly/demos/Card/templates/card-demo--stacked-sparklines.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--stacked-sparklines.hbs
@@ -1,11 +1,11 @@
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid grid--modifier="pf-m-gutter"}}
     {{#> grid-item grid-item--modifier="pf-m-4-col-on-md"}}
-      {{#> l-flex l-flex--modifier="pf-m-column-on-md pf-m-space-items-none-on-md pf-m-justify-content-center-on-md pf-v5-u-h-100-on-md"}}
+      {{#> l-flex l-flex--modifier="pf-m-column-on-md pf-m-space-items-none-on-md pf-m-justify-content-center-on-md pf-v6-u-h-100-on-md"}}
         {{#> l-flex-item}}
           <b>Temperature</b>
         {{/l-flex-item}}
-        {{> divider divider--modifier="pf-m-vertical pf-m-inset-sm pf-v5-u-hidden-on-md"}}
+        {{> divider divider--modifier="pf-m-vertical pf-m-inset-sm pf-v6-u-hidden-on-md"}}
         {{#> l-flex-item}}
           <span>64C</span>
         {{/l-flex-item}}
@@ -32,14 +32,14 @@
       {{/grid}}
     {{/grid-item}}
   {{/grid}}
-  {{> divider divider--modifier="pf-v5-u-hidden-on-md"}}
+  {{> divider divider--modifier="pf-v6-u-hidden-on-md"}}
   {{#> grid grid--modifier="pf-m-gutter"}}
     {{#> grid-item grid-item--modifier="pf-m-4-col-on-md"}}
-      {{#> l-flex l-flex--modifier="pf-m-column-on-md pf-m-space-items-none-on-md pf-m-justify-content-center-on-md pf-v5-u-h-100-on-md"}}
+      {{#> l-flex l-flex--modifier="pf-m-column-on-md pf-m-space-items-none-on-md pf-m-justify-content-center-on-md pf-v6-u-h-100-on-md"}}
         {{#> l-flex-item}}
           <b>Speed</b>
         {{/l-flex-item}}
-        {{> divider divider--modifier="pf-m-vertical pf-m-inset-sm pf-v5-u-hidden-on-md"}}
+        {{> divider divider--modifier="pf-m-vertical pf-m-inset-sm pf-v6-u-hidden-on-md"}}
         {{#> l-flex-item}}
           <span>2.3Ghz</span>
         {{/l-flex-item}}

--- a/src/patternfly/demos/Card/templates/card-template-data-list.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-data-list.hbs
@@ -1,6 +1,6 @@
 {{#> reset grid--attribute=reset grid-item--attribute=reset grid--modifier=reset grid-item--modifier=reset l-flex--attribute=reset l-flex-item--attribute=reset l-flex--modifier=reset l-flex-item--modifier=reset}}
   {{#> card card--id=card-template-data-list--id}}
-    {{#> card-header card-header--modifier="pf-v5-u-align-items-flex-start"}}
+    {{#> card-header card-header--modifier="pf-v6-u-align-items-flex-start"}}
       {{#> card-title card-title--id=(concat card--id '-title1')}}
         {{#> title title--modifier="pf-m-lg" titleType="h2"}}
           Inventory

--- a/src/patternfly/demos/Card/templates/card-template-events.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-events.hbs
@@ -1,6 +1,6 @@
 {{#> reset grid--attribute=reset grid-item--attribute=reset grid--modifier=reset grid-item--modifier=reset l-flex--attribute=reset l-flex-item--attribute=reset l-flex--modifier=reset l-flex-item--modifier=reset}}
   {{#> card card--id=card-template-events--id}}
-    {{#> card-header card-header00--modifier="pf-v5-u-align-items-flex-start"}}
+    {{#> card-header card-header00--modifier="pf-v6-u-align-items-flex-start"}}
       {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
         {{#> select select--id=(concat card--id '-select-dropdown') select-menu--modifier="pf-m-align-right" select-toggle--modifier="pf-m-plain"}}
           Status

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -43,7 +43,7 @@
             {{/if}}
           </p>
         {{/l-flex-item}}
-        {{#> l-flex l-flex--modifier="pf-m-grow pf-m-column pf-m-row-on-lg pf-m-justify-content-flex-end pf-m-justify-content-flex-start-on-lg pf-m-align-content-flex-end-on-lg" l-flex--attribute='style="row-gap: var(--pf-v5-global--spacer--md);"'}}
+        {{#> l-flex l-flex--modifier="pf-m-grow pf-m-column pf-m-row-on-lg pf-m-justify-content-flex-end pf-m-justify-content-flex-start-on-lg pf-m-align-content-flex-end-on-lg" l-flex--attribute='style="row-gap: var(--pf-6-global--spacer--md);"'}}
           {{#if card-template-expandable-status-card--HasIncident}}
             {{#> l-flex-item l-flex-item--attribute='style="margin-block-end: -.25em"'}}
               {{> label label--color="red" label-text--value="Incident"}}

--- a/src/patternfly/demos/Card/templates/card-template-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-status.hbs
@@ -6,7 +6,7 @@
       {{/title}}
     {{/card-header}}
     {{#> card-body}}
-      {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v5-l-gallery--GridTemplateColumns--min: 100%; --pf-v5-l-gallery--GridTemplateColumns--min-on-sm: 180px; --pf-v5-l-gallery--GridTemplateColumns--min-on-lg: 150px; --pf-v5-l-gallery--GridTemplateColumns--max-on-sm: 1fr;"'}}
+      {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 100%; --pf-v6-l-gallery--GridTemplateColumns--min-on-sm: 180px; --pf-v6-l-gallery--GridTemplateColumns--min-on-lg: 150px; --pf-v6-l-gallery--GridTemplateColumns--max-on-sm: 1fr;"'}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
             <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
@@ -19,7 +19,7 @@
           {{#> l-flex-item}}
             <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
           {{/l-flex-item}}
-          {{#> l-flex-item l-flex-item--modifier="pf-v5-u-text-nowrap"}}
+          {{#> l-flex-item l-flex-item--modifier="pf-v6-u-text-nowrap"}}
             <span class="popover-parent">
               <a href="#">Control Panel</a>
               {{> card-demo--popover popover--id=(concat card--id '-popover')}}
@@ -27,7 +27,7 @@
           {{/l-flex-item}}
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
-          {{#> l-flex-item l-flex-item--modifier="pf-v5-u-text-nowrap"}}
+          {{#> l-flex-item l-flex-item--modifier="pf-v6-u-text-nowrap"}}
             <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
@@ -35,7 +35,7 @@
               <a href="#">Operators</a>
             {{/l-flex-item}}
             {{#> l-flex-item}}
-              <span class="pf-v5-u-color-200">1 degraged</span>
+              <span class="pf-v6-u-color-200">1 degraged</span>
             {{/l-flex-item}}
           {{/l-flex}}
         {{/l-flex}}

--- a/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
+++ b/src/patternfly/demos/ContextSelector/examples/ContextSelector.md
@@ -48,7 +48,7 @@ deprecated: true
       {{#> toolbar-content}}
         {{#> toolbar-content-section}}
           {{#> toolbar-item}}
-            {{#> context-selector context-selector--id=(concat page-template--id '-context-selector') context-selector--label-text="Selected project" context-selector-toggle--IsPlain="true" context-selector-toggle--IsText="true" context-selector--modifier="pf-m-page-insets pf-m-width-auto" context-selector--attribute='style="--pf-v5-c-context-selector--Width: 270px;"'}}
+            {{#> context-selector context-selector--id=(concat page-template--id '-context-selector') context-selector--label-text="Selected project" context-selector-toggle--IsPlain="true" context-selector-toggle--IsText="true" context-selector--modifier="pf-m-page-insets pf-m-width-auto" context-selector--attribute='style="--pf-v6-c-context-selector--Width: 270px;"'}}
               {{#> context-selector-toggle context-selector-toggle--attribute=(concat 'id="' context-selector--id '-toggle"' 'aria-labelledby="' context-selector--id '-label ' context-selector--id '-toggle"')}}
                 {{#> context-selector-toggle-text}}
                   Project: openshift-apple1

--- a/src/patternfly/demos/Dashboard/examples/Dashboard.md
+++ b/src/patternfly/demos/Dashboard/examples/Dashboard.md
@@ -13,14 +13,14 @@ cssPrefix: pf-d-dashboard
   {{#> page-main-section page-main-section--IsLimitWidth=true}}
     {{#> grid grid--modifier="pf-m-gutter"}}
       {{> card-template-expandable-status card-template-expandable-status--id=(concat page-template--id '-expandable-status-card-1')}}
-      {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-6-col-on-2xl" grid-item--attribute='style="--pf-v5-l-grid--item--Order-on-lg:3"'}}
+      {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-6-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:3"'}}
         {{#> l-flex l-flex--modifier="pf-m-column"}}
           {{> card-template-status card-template-status--id=(concat page-template--id '-status-card-1')}} <!-- inventory -->
           {{> card-template-line-chart card-template-line-chart--id=(concat page-template--id '-line-chart-card-1')}}
           {{> card-template-metrics card-template-metrics--id=(concat page-template--id '-metrics-card-1')}}
         {{/l-flex}}
       {{/grid-item}}
-      {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v5-l-grid--item--Order-on-lg:2"'}}
+      {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:2"'}}
         {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-md pf-m-column-on-lg"}}
           {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
             {{> card-template-details card-template-details--id=(concat page-template--id '-details-card-1')}}
@@ -30,7 +30,7 @@ cssPrefix: pf-d-dashboard
           {{/l-flex-item}}
         {{/l-flex}}
       {{/grid-item}}
-      {{#> grid-item grid-item--modifier="pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v5-l-grid--item--Order-on-lg:4"'}}
+      {{#> grid-item grid-item--modifier="pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:4"'}}
         {{#> l-flex l-flex--modifier="pf-m-column"}}
           {{> card-template-events card-template-events--id=(concat page-template--id '-events-card-1')}}
         {{/l-flex}}

--- a/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
+++ b/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
@@ -85,7 +85,7 @@ cssPrefix: pf-d-description-list
           Node selector
         {{/description-list-text}}
       {{/description-list-term}}
-      {{#> description-list-description description-list-text--type="p" description-list-text--modifier="pf-v5-u-color-200"}}
+      {{#> description-list-description description-list-text--type="p" description-list-text--modifier="pf-v6-u-color-200"}}
         Nod selector is not available at this time
       {{/description-list-description}}
     {{/description-list-group}}
@@ -95,7 +95,7 @@ cssPrefix: pf-d-description-list
           Tolerations
         {{/description-list-text}}
       {{/description-list-term}}
-      {{#> description-list-description description-list-text--modifier="pf-v5-u-color-200"}}
+      {{#> description-list-description description-list-text--modifier="pf-v6-u-color-200"}}
         No tolerations
       {{/description-list-description}}
     {{/description-list-group}}
@@ -105,7 +105,7 @@ cssPrefix: pf-d-description-list
           Annotations
         {{/description-list-text}}
       {{/description-list-term}}
-      {{#> description-list-description description-list-text--modifier="pf-v5-u-color-200"}}
+      {{#> description-list-description description-list-text--modifier="pf-v6-u-color-200"}}
         No annotations
       {{/description-list-description}}
     {{/description-list-group}}
@@ -164,7 +164,7 @@ cssPrefix: pf-d-description-list
           Session affinity
         {{/description-list-text}}
       {{/description-list-term}}
-      {{#> description-list-description description-list-text--modifier="pf-v5-u-color-200"}}
+      {{#> description-list-description description-list-text--modifier="pf-v6-u-color-200"}}
         None
       {{/description-list-description}}
     {{/description-list-group}}
@@ -244,7 +244,7 @@ cssPrefix: pf-d-description-list
           Min ready seconds
         {{/description-list-text}}
       {{/description-list-term}}
-      {{#> description-list-description description-list-text--modifier="pf-v5-u-color-200"}}
+      {{#> description-list-description description-list-text--modifier="pf-v6-u-color-200"}}
         Not configured
       {{/description-list-description}}
     {{/description-list-group}}

--- a/src/patternfly/demos/Masthead/masthead-template-content-toolbar-content.hbs
+++ b/src/patternfly/demos/Masthead/masthead-template-content-toolbar-content.hbs
@@ -23,7 +23,7 @@
   {{/toolbar-item}}
 
   {{#if masthead-template--HasHorizontalNav}}
-    {{#> toolbar-item toolbar-item--modifier="pf-m-overflow-container" toolbar-item--attribute='style="--pf-v5-c-toolbar__item--MinWidth: 18ch;"'}}
+    {{#> toolbar-item toolbar-item--modifier="pf-m-overflow-container" toolbar-item--attribute='style="--pf-v6-c-toolbar__item--MinWidth: 18ch;"'}}
       {{#> nav nav--HasScroll=true nav--IsHorizontal=true nav--IsScrollable=true nav--HasScroll=true nav--attribute=(concat 'id="' masthead--id '-horizontal-nav" aria-label="Global"')}}
         {{#> nav-list}}
           {{#> nav-item}}

--- a/src/patternfly/demos/Modal/examples/Modal.md
+++ b/src/patternfly/demos/Modal/examples/Modal.md
@@ -83,7 +83,7 @@ section: components
       {{/modal-box-title}}
     {{/modal-box-header}}
     {{#> modal-box-body}}
-      <p id="modal-md-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v5-c-modal-box__body"</p>
+      <p id="modal-md-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v6-c-modal-box__body"</p>
       <p>Form here</p>
     {{/modal-box-body}}
     {{#> modal-box-footer}}
@@ -111,7 +111,7 @@ section: components
       {{/modal-box-title}}
     {{/modal-box-header}}
     {{#> modal-box-body}}
-      <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v5-c-modal-box__body"</p>
+      <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v6-c-modal-box__body"</p>
       <p>Form here</p>
     {{/modal-box-body}}
     {{#> modal-box-footer}}
@@ -139,7 +139,7 @@ section: components
       {{/modal-box-title}}
     {{/modal-box-header}}
     {{#> modal-box-body}}
-      <p id="modal-top-aligned-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v5-c-modal-box__body"</p>
+      <p id="modal-top-aligned-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-v6-c-modal-box__body"</p>
       <p>Form here</p>
     {{/modal-box-body}}
     {{#> modal-box-footer}}

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -127,10 +127,10 @@ wrapperTag: div
     {{> page-template-gallery-cards}}
   {{/page-main-section}}
   {{> divider}}
-  {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier="pf-m-align-center pf-v5-u-text-align-center"}}
+  {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier="pf-m-align-center pf-v6-u-text-align-center"}}
     {{#> card}}
       {{#> card-body}}
-        <p>The content in this section is also centered using the <code>.pf-v5-u-text-align-center</code> utility class.</p>
+        <p>The content in this section is also centered using the <code>.pf-v6-u-text-align-center</code> utility class.</p>
       {{/card-body}}
     {{/card}}
   {{/page-main-section}}

--- a/src/patternfly/demos/Page/examples/Penta.md
+++ b/src/patternfly/demos/Page/examples/Penta.md
@@ -15,8 +15,8 @@ wrapperTag: div
       {{> masthead-toggle}}
       {{#> masthead-main}}
         {{#> masthead-brand}}
-          {{> brand brand--modifier="pf-m-light" brand--attribute='src="/assets/images/PF-IconLogo-color.svg" style="--pf-v5-c-brand--Width: 37px;" alt="PatternFly logo"'}}
-          {{> brand brand--modifier="pf-m-dark" brand--attribute='src="/assets/images/PF-IconLogo-Reverse.svg" style="--pf-v5-c-brand--Width: 37px;" alt="PatternFly logo"'}}
+          {{> brand brand--modifier="pf-m-light" brand--attribute='src="/assets/images/PF-IconLogo-color.svg" style="--pf-v6-c-brand--Width: 37px;" alt="PatternFly logo"'}}
+          {{> brand brand--modifier="pf-m-dark" brand--attribute='src="/assets/images/PF-IconLogo-Reverse.svg" style="--pf-v6-c-brand--Width: 37px;" alt="PatternFly logo"'}}
         {{/masthead-brand}}
       {{/masthead-main}}
     {{/masthead-logo}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -245,7 +245,7 @@ import './Table.css'
 
 {{#*inline "page-template-section"}}
   {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl" page-main-section--IsLimitWidth=true}}
-    <div class="pf-v5-c-scroll-outer-wrapper">
+    <div class="pf-v6-c-scroll-outer-wrapper">
       {{> toolbar-template
           toolbar-template--id=(concat page--id '-toolbar')
           toolbar-template--HasBulkSelect=true
@@ -254,7 +254,7 @@ import './Table.css'
           toolbar-template--HasSortButton=true
           toolbar-template--HasOverflowMenu=true
         }}
-      <div class="pf-v5-c-scroll-inner-wrapper">
+      <div class="pf-v6-c-scroll-inner-wrapper">
         {{> table--scrollable
             table--scrollable--id="sticky-first-column-demo-table"
             table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"
@@ -272,7 +272,7 @@ import './Table.css'
 
 {{#*inline "page-template-section"}}
   {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl pf-m-overflow-scroll" page-main-section--IsLimitWidth=true}}
-    <div class="pf-v5-c-scroll-outer-wrapper">
+    <div class="pf-v6-c-scroll-outer-wrapper">
       {{> toolbar-template
           toolbar-template--id=(concat page--id '-toolbar')
           toolbar-template--HasBulkSelect=true
@@ -281,7 +281,7 @@ import './Table.css'
           toolbar-template--HasSortButton=true
           toolbar-template--HasOverflowMenu=true
         }}
-      <div class="pf-v5-c-scroll-inner-wrapper">
+      <div class="pf-v6-c-scroll-inner-wrapper">
         {{>
             table--scrollable
             table--scrollable--id="sticky-multiple-columns-demo-table"
@@ -301,7 +301,7 @@ import './Table.css'
 
 {{#*inline "page-template-section"}}
   {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl pf-m-overflow-scroll" page-main-section--IsLimitWidths=true}}
-    <div class="pf-v5-c-scroll-outer-wrapper">
+    <div class="pf-v6-c-scroll-outer-wrapper">
       {{> toolbar-template
           toolbar-template--id=(concat page--id '-toolbar')
           toolbar-template--HasBulkSelect=true
@@ -310,7 +310,7 @@ import './Table.css'
           toolbar-template--HasSortButton=true
           toolbar-template--HasOverflowMenu=true
         }}
-      <div class="pf-v5-c-scroll-inner-wrapper">
+      <div class="pf-v6-c-scroll-inner-wrapper">
         {{> table--scrollable
             table--scrollable--id="sticky-header-and-multiple-columns-demo-table"
             table--scrollable--modifier="pf-m-sticky-header"
@@ -330,7 +330,7 @@ import './Table.css'
 
 {{#*inline "page-template-section"}}
   {{#> page-main-section page-main-section--modifier="pf-m-no-padding pf-m-padding-on-xl pf-m-overflow-scroll" page-main-section--IsLimitWidths=true}}
-    <div class="pf-v5-c-scroll-outer-wrapper">
+    <div class="pf-v6-c-scroll-outer-wrapper">
       {{> toolbar-template
           toolbar-template--id=(concat page--id '-toolbar')
           toolbar-template--HasBulkSelect=true
@@ -339,7 +339,7 @@ import './Table.css'
           toolbar-template--HasSortButton=true
           toolbar-template--HasOverflowMenu=true
         }}
-      <div class="pf-v5-c-scroll-inner-wrapper">
+      <div class="pf-v6-c-scroll-inner-wrapper">
         {{> table--scrollable
             table--scrollable--id="sticky-right-column-example"
             table--scrollable--th--modifier--cell-9-modifier="pf-m-truncate pf-m-border-left"
@@ -385,7 +385,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
         {{#> table-tr}}
           {{#> table-td table-td--data-label="Repository name"}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
-              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v5-u-mt-sm"}}
+              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v6-u-mt-sm"}}
                 <div class="table-demo-icon">
                   {{> icon-red-hat}}
                 </div>
@@ -394,7 +394,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
                 {{#> title title--modifier="pf-m-xl"}}
                   Repository 1
                 {{/title}}
-                <span class="pf-v5-u-font-size-sm">
+                <span class="pf-v6-u-font-size-sm">
                   2.6.6 provided by Red Hat Inc
                 </span>
               {{/l-flex}}
@@ -417,7 +417,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
         {{#> table-tr}}
           {{#> table-td table-td--data-label="Repository name"}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
-              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v5-u-mt-sm"}}
+              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v6-u-mt-sm"}}
                 <div class="table-demo-icon">
                   {{> icon-github}}
                 </div>
@@ -426,7 +426,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
                 {{#> title title--modifier="pf-m-xl"}}
                   Repository 2
                 {{/title}}
-                <span class="pf-v5-u-font-size-sm">
+                <span class="pf-v6-u-font-size-sm">
                   2.6.6 provided by Github
                 </span>
               {{/l-flex}}
@@ -449,7 +449,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
         {{#> table-tr}}
           {{#> table-td table-td--data-label="Repository name"}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
-              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v5-u-mt-sm"}}
+              {{#> l-flex l-flex--modifier="pf-m-align-self-flex-start pf-v6-u-mt-sm"}}
                 <div class="table-demo-icon">
                   {{> icon-google}}
                 </div>
@@ -458,7 +458,7 @@ By default, table cell alignment is set to baseline. This retains vertical align
                 {{#> title title--modifier="pf-m-xl"}}
                   Repository 3
                 {{/title}}
-                <span class="pf-v5-u-font-size-sm">
+                <span class="pf-v6-u-font-size-sm">
                   1.2.3 provided by Google
                 </span>
               {{/l-flex}}

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -21,7 +21,7 @@ section: components
       {{#> tabs-template-pod-tab-content}}
         {{#> l-flex l-flex--modifier="pf-m-column"}}
           {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-lg"}}
-            {{> title titleType="h2" title--modifier="pf-m-lg pf-v5-u-mt-sm" title--text="Pod details" title--attribute=(concat 'id="' tabs-template-pod-tab-content--id '-details-title"')}}
+            {{> title titleType="h2" title--modifier="pf-m-lg pf-v6-u-mt-sm" title--text="Pod details" title--attribute=(concat 'id="' tabs-template-pod-tab-content--id '-details-title"')}}
           {{/l-flex-item}}
           {{#> l-flex-item}}
             {{#> description-list description-list--modifier="pf-m-2-col-on-lg" description-list--attribute=(concat 'aria-labelledby="' tabs-template-pod-tab-content--id '-details-title"')}}

--- a/src/patternfly/demos/Tabs/tabs--page-grid-view.hbs
+++ b/src/patternfly/demos/Tabs/tabs--page-grid-view.hbs
@@ -60,7 +60,7 @@
     {{/card}}
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col-on-md pf-m-4-col-on-xl"}}
-    {{#> l-flex l-flex--modifier="pf-m-column pf-v5-u-h-100"}}
+    {{#> l-flex l-flex--modifier="pf-m-column pf-v6-u-h-100"}}
       {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
         {{#> card card--modifier="pf-m-full-height"}}
           {{#> card-header}}

--- a/src/patternfly/demos/Toolbar/toolbar-template.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template.hbs
@@ -91,7 +91,7 @@ Options: [
       {{!-- overflow menu --}}
       {{#if toolbar-template--HasOverflowMenu}}
         {{#> overflow-menu overflow-menu--id=(concat toolbar--id '-overflow-menu')}}
-          {{#> overflow-menu-content overflow-menu-content--modifier="pf-v5-u-display-none pf-v5-u-display-flex-on-lg"}}
+          {{#> overflow-menu-content overflow-menu-content--modifier="pf-v6-u-display-none pf-v6-u-display-flex-on-lg"}}
             {{#> overflow-menu-group overflow-menu-group--modifier="pf-m-button-group"}}
               {{#> overflow-menu-item}}
                 {{#> button button--modifier="pf-m-primary"}}

--- a/src/patternfly/demos/Wizard/examples/Wizard.md
+++ b/src/patternfly/demos/Wizard/examples/Wizard.md
@@ -202,7 +202,7 @@ wrapperTag: div
               {{#> drawer-main}}
                 {{#> drawer-content drawer-content--NoBody="true"}}
                   {{#> wizard-main-body}}
-                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v5-u-hidden"}}
+                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v6-u-hidden"}}
                     {{> __wizard-form}}
                   {{/wizard-main-body}}
                 {{/drawer-content}}
@@ -283,7 +283,7 @@ wrapperTag: div
               {{#> drawer-main}}
                 {{#> drawer-content drawer-content--NoBody="true"}}
                   {{#> wizard-main-body}}
-                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v5-u-hidden"}}
+                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v6-u-hidden"}}
                     {{> __wizard-form}}
                   {{/wizard-main-body}}
                 {{/drawer-content}}
@@ -364,7 +364,7 @@ wrapperTag: div
               {{#> drawer-main}}
                 {{#> drawer-content drawer-content--NoBody="true"}}
                   {{#> wizard-main-body}}
-                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v5-u-hidden"}}
+                    {{> __wizard-drawer-toggle __wizard-drawer-toggle--modifier="pf-v6-u-hidden"}}
                     {{> __wizard-info}}
                   {{/wizard-main-body}}
                 {{/drawer-content}}


### PR DESCRIPTION
Updates the prefix on markdown and hbs files.
Note: does not update `pf-v5-pficon` yet.

Fixes #6481 