### PR TITLE
feat(misc): convert chip to label in examples

### DIFF
--- a/src/patternfly/components/Select/select-chip-group-collapsed.hbs
+++ b/src/patternfly/components/Select/select-chip-group-collapsed.hbs
@@ -1,57 +1,57 @@
-{{#> chip-group}}
-  {{#> chip-group-main}}
-    {{#> chip-group-list chip-group-list--attribute='aria-label="Chip group list"'}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_one"')}}
+{{#> label-group}}
+  {{#> label-group-main}}
+    {{#> label-group-list label-group-list--attribute='aria-label="Label group list"'}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_one"')}}
               Arkansas
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_one ' select--id '-chip_one" aria-label="Remove" id="remove_' select--id '_chip_one"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_one ' select--id '-label_one" aria-label="Remove" id="remove_' select--id '_label_one"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_two"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_two"')}}
               Massachusetts
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_two ' select--id '-chip_two" aria-label="Remove" id="remove_' select--id '_chip_two"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_two ' select--id '-label_two" aria-label="Remove" id="remove_' select--id '_label_two"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_three"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_three"')}}
               New Mexico
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_three ' select--id '-chip_three" aria-label="Remove" id="remove_' select--id '_chip_three"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_three ' select--id '-label_three" aria-label="Remove" id="remove_' select--id '_label_three"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip chip--type="button" chip--modifier="pf-m-overflow"}}
-          {{#> chip-content}}
-            {{#> chip-text}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--type="button" label--modifier="pf-m-overflow"}}
+          {{#> label-content}}
+            {{#> label-text}}
               2 more
-            {{/chip-text}}
-          {{/chip-content}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-    {{/chip-group-list}}
-  {{/chip-group-main}}
-{{/chip-group}}
+            {{/label-text}}
+          {{/label-content}}
+        {{/label}}
+      {{/label-group-list-item}}
+    {{/label-group-list}}
+  {{/label-group-main}}
+{{/label-group}}

--- a/src/patternfly/components/Select/select-chip-group-expanded.hbs
+++ b/src/patternfly/components/Select/select-chip-group-expanded.hbs
@@ -1,76 +1,76 @@
-{{#> chip-group}}
-  {{#> chip-group-main}}
-    {{#> chip-group-list chip-group-list--attribute='aria-label="Chip group list"'}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_one"')}}
+{{#> label-group}}
+  {{#> label-group-main}}
+    {{#> label-group-list label-group-list--attribute='aria-label="Label group list"'}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_one"')}}
               Arkansas
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_one ' select--id '-chip_two" aria-label="Remove" id="remove_' select--id '_chip_one"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_one ' select--id '-label_two" aria-label="Remove" id="remove_' select--id '_label_one"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_two"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_two"')}}
               Massachusetts
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_two ' select--id '-chip_two" aria-label="Remove" id="remove_' select--id '_chip_two"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_two ' select--id '-label_two" aria-label="Remove" id="remove_' select--id '_label_two"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_three"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_three"')}}
               New Mexico
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_three ' select--id '-chip_three" aria-label="Remove" id="remove_' select--id '_chip_three"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_three ' select--id '-label_three" aria-label="Remove" id="remove_' select--id '_label_three"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_four"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_four"')}}
               Ohio
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_four ' select--id '-chip_four" aria-label="Remove" id="remove_' select--id '_chip_four"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_four ' select--id '-label_four" aria-label="Remove" id="remove_' select--id '_label_four"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' select--id '-chip_five"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' select--id '-label_five"')}}
               Washington
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="remove_' select--id '_chip_five ' select--id '-chip_five" aria-label="Remove" id="remove_' select--id '_chip_five"')}}
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="remove_' select--id '_label_five ' select--id '-label_five" aria-label="Remove" id="remove_' select--id '_label_five"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-    {{/chip-group-list}}
-  {{/chip-group-main}}
-{{/chip-group}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+    {{/label-group-list}}
+  {{/label-group-main}}
+{{/label-group}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -65,7 +65,7 @@ import './TextInputGroup.css'
 
 ### Filters expanded
 ```hbs
-{{#> text-input-group text-input-group--id="text-input-group-filters-expanded" text-input-group--chip-group--IsLong="true"}}
+{{#> text-input-group text-input-group--id="text-input-group-filters-expanded" text-input-group--label-group--IsLong="true"}}
   {{#> text-input-group-main}}
     {{> text-input-group--chip-group}}
     {{#> text-input-group-text}}

--- a/src/patternfly/components/TextInputGroup/text-input-group--chip-group.hbs
+++ b/src/patternfly/components/TextInputGroup/text-input-group--chip-group.hbs
@@ -1,214 +1,214 @@
-{{#> chip-group chip-group--id=(concat text-input-group--id '-chip-group')}}
-  {{#> chip-group-main}}
-    {{#> chip-group-list chip-group-list--attribute='aria-label="Chip group list"'}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_one_select_collapsed"')}}
-              Chip one
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_one_select_collapsed ' chip-group--id '-chip_one_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_one_select_collapsed"')}}
+{{#> label-group label-group--id=(concat text-input-group--id '-label-group')}}
+  {{#> label-group-main}}
+    {{#> label-group-list label-group-list--attribute='aria-label="Label group list"'}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_one_select_collapsed"')}}
+              Label one
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_one_select_collapsed ' label-group--id '-label_one_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_one_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_two_select_collapsed"')}}
-              Chip two
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_two_select_collapsed ' chip-group--id '-chip_two_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_two_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_two_select_collapsed"')}}
+              Label two
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_two_select_collapsed ' label-group--id '-label_two_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_two_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_three_select_collapsed"')}}
-              Chip three
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_three_select_collapsed ' chip-group--id '-chip_three_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_three_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_three_select_collapsed"')}}
+              Label three
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_three_select_collapsed ' label-group--id '-label_three_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_three_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_four_select_collapsed"')}}
-              Chip four
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_four_select_collapsed ' chip-group--id '-chip_four_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_four_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_four_select_collapsed"')}}
+              Label four
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_four_select_collapsed ' label-group--id '-label_four_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_four_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_five_select_collapsed"')}}
-              Chip five
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_five_select_collapsed ' chip-group--id '-chip_five_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_five_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_five_select_collapsed"')}}
+              Label five
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_five_select_collapsed ' label-group--id '-label_five_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_five_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_six_select_collapsed"')}}
-              Chip six
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_six_select_collapsed ' chip-group--id '-chip_six_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_six_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_six_select_collapsed"')}}
+              Label six
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_six_select_collapsed ' label-group--id '-label_six_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_six_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#if text-input-group--chip-group--IsLong}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_seven_select_collapsed"')}}
-              Chip seven
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_seven_select_collapsed ' chip-group--id '-chip_seven_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_seven_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#if text-input-group--label-group--IsLong}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_seven_select_collapsed"')}}
+              Label seven
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_seven_select_collapsed ' label-group--id '-label_seven_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_seven_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_eight_select_collapsed"')}}
-              Chip eight
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_eight_select_collapsed ' chip-group--id '-chip_eight_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_eight_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_eight_select_collapsed"')}}
+              Label eight
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_eight_select_collapsed ' label-group--id '-label_eight_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_eight_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_nine_select_collapsed"')}}
-              Chip nine
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_nine_select_collapsed ' chip-group--id '-chip_nine_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_nine_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_nine_select_collapsed"')}}
+              Label nine
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_nine_select_collapsed ' label-group--id '-label_nine_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_nine_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_ten_select_collapsed"')}}
-              Chip ten
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_ten_select_collapsed ' chip-group--id '-chip_ten_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_ten_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_ten_select_collapsed"')}}
+              Label ten
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_ten_select_collapsed ' label-group--id '-label_ten_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_ten_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_eleven_select_collapsed"')}}
-              Chip eleven
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_eleven_select_collapsed ' chip-group--id '-chip_eleven_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_eleven_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_eleven_select_collapsed"')}}
+              Label eleven
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_eleven_select_collapsed ' label-group--id '-label_eleven_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_eleven_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_twelve_select_collapsed"')}}
-              Chip twelve
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_twelve_select_collapsed ' chip-group--id '-chip_twelve_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_twelve_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_twelve_select_collapsed"')}}
+              Label twelve
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_twelve_select_collapsed ' label-group--id '-label_twelve_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_twelve_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_thirteen_select_collapsed"')}}
-              Chip thirteen
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_thirteen_select_collapsed ' chip-group--id '-chip_thirteen_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_thirteen_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_thirteen_select_collapsed"')}}
+              Label thirteen
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_thirteen_select_collapsed ' label-group--id '-label_thirteen_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_thirteen_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
-      {{#> chip-group-list-item}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip_fourteen_select_collapsed"')}}
-              Chip fourteen
-            {{/chip-text}}
-          {{/chip-content}}
-          {{#> chip-actions}}
-            {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id '-remove_chip_fourteen_select_collapsed ' chip-group--id '-chip_fourteen_select_collapsed" aria-label="Remove" id="' chip-group--id '-remove_chip_fourteen_select_collapsed"')}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
+      {{#> label-group-list-item}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label_fourteen_select_collapsed"')}}
+              Label fourteen
+            {{/label-text}}
+          {{/label-content}}
+          {{#> label-actions}}
+            {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id '-remove_label_fourteen_select_collapsed ' label-group--id '-label_fourteen_select_collapsed" aria-label="Remove" id="' label-group--id '-remove_label_fourteen_select_collapsed"')}}
               <i class="fas fa-times" aria-hidden="true"></i>
             {{/button}}
-          {{/chip-actions}}
-        {{/chip}}
-      {{/chip-group-list-item}}
+          {{/label-actions}}
+        {{/label}}
+      {{/label-group-list-item}}
       {{else}}
-        {{#> chip-group-list-item}}
-          {{#> chip chip--type="button" chip--modifier="pf-m-overflow"}}
-            {{#> chip-content}}
-              {{#> chip-text}}
+        {{#> label-group-list-item}}
+          {{#> label label--type="button" label--modifier="pf-m-overflow"}}
+            {{#> label-content}}
+              {{#> label-text}}
                 8 more
-              {{/chip-text}}
-          {{/chip-content}}
-          {{/chip}}
-        {{/chip-group-list-item}}
+              {{/label-text}}
+          {{/label-content}}
+          {{/label}}
+        {{/label-group-list-item}}
       {{/if}}
-    {{/chip-group-list}}
-  {{/chip-group-main}}
-{{/chip-group}}
+    {{/label-group-list}}
+  {{/label-group-main}}
+{{/label-group}}

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -368,8 +368,8 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
     {{#> toolbar-expandable-content}}
       {{#> toolbar-group toolbar-group--modifier='pf-m-chip-container'}}
         {{#> toolbar-group toolbar-group--modifier='pf-m-grow'}}
-          {{> toolbar--item-chip-group chip-group--label="Status" chip-group--id=(concat toolbar--id '-chip-group-status')}}
-          {{> toolbar--item-chip-group chip-group--label="Risk" chip-group--id=(concat toolbar--id '-chip-group-risk')}}
+          {{> toolbar--item-chip-group label-group--label="Status" label-group--id=(concat toolbar--id '-label-group-status')}}
+          {{> toolbar--item-chip-group label-group--label="Risk" label-group--id=(concat toolbar--id '-label-group-risk')}}
         {{/toolbar-group}}
         {{> toolbar-item-clear}}
       {{/toolbar-group}}
@@ -415,8 +415,8 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
       {{/toolbar-group}}
       {{#> toolbar-group toolbar-group--modifier='pf-m-chip-container'}}
         {{#> toolbar-group toolbar-group--modifier='pf-m-grow'}}
-          {{> toolbar--item-chip-group chip-group--label="Status" chip-group--id=(concat toolbar--id '-chip-group-status')}}
-          {{> toolbar--item-chip-group chip-group--label="Risk" chip-group--id=(concat toolbar--id '-chip-group-risk')}}
+          {{> toolbar--item-chip-group label-group--label="Status" label-group--id=(concat toolbar--id '-label-group-status')}}
+          {{> toolbar--item-chip-group label-group--label="Risk" label-group--id=(concat toolbar--id '-label-group-risk')}}
         {{/toolbar-group}}
         {{> toolbar-item-clear}}
       {{/toolbar-group}}
@@ -455,8 +455,8 @@ The `.pf-m-toggle-group` controls when, and at which breakpoint, filters will be
   {{#> toolbar-content toolbar-content--modifier="pf-m-chip-container"}}
     {{#> toolbar-group}}
       {{#> toolbar-group}}
-        {{> toolbar--item-chip-group chip-group--label="Status" chip-group--id=(concat toolbar--id '-chip-group-status')}}
-        {{> toolbar--item-chip-group chip-group--label="Risk" chip-group--id=(concat toolbar--id '-chip-group-risk')}}
+        {{> toolbar--item-chip-group label-group--label="Status" label-group--id=(concat toolbar--id '-label-group-status')}}
+        {{> toolbar--item-chip-group label-group--label="Risk" label-group--id=(concat toolbar--id '-label-group-risk')}}
       {{/toolbar-group}}
       {{> toolbar-item-clear}}
     {{/toolbar-group}}

--- a/src/patternfly/components/Toolbar/templates/toolbar--chip-group.hbs
+++ b/src/patternfly/components/Toolbar/templates/toolbar--chip-group.hbs
@@ -1,7 +1,7 @@
 {{#> toolbar-group toolbar-group--IsChipGroupContainer=true}}
   {{#> toolbar-group (reset toolbar-group--IsChipGroup) toolbar-group--IsChipGroup=true}}
-    {{> toolbar--item-chip-group chip-group--label="Status" chip-group--id=(concat toolbar--id '-chip-group-status')}}
-    {{> toolbar--item-chip-group chip-group--label="Risk" chip-group--id=(concat toolbar--id '-chip-group-risk')}}
+    {{> toolbar--item-chip-group label-group--label="Status" label-group--id=(concat toolbar--id '-label-group-status')}}
+    {{> toolbar--item-chip-group label-group--label="Risk" label-group--id=(concat toolbar--id '-label-group-risk')}}
   {{/toolbar-group}}
   {{> toolbar-item-clear}}
 {{/toolbar-group}}

--- a/src/patternfly/components/Toolbar/templates/toolbar--item-chip-group.hbs
+++ b/src/patternfly/components/Toolbar/templates/toolbar--item-chip-group.hbs
@@ -1,53 +1,53 @@
 {{#> toolbar-item}}
-  {{#> chip-group}}
-    {{#> chip-group-main}}
-      {{#> chip-group-label chip-group-label--attribute=(concat 'id="' chip-group--id '-chip-group-label"')}}
-        {{chip-group--label}}
-      {{/chip-group-label}}
-      {{#> chip-group-list chip-group-list--attribute=(concat 'aria-labelledby="' chip-group--id '-chip-group-label"')}}
-        {{#> chip-group-list-item}}
-          {{#> chip}}
-            {{#> chip-content}}
-              {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-one"')}}
-                Chip one
-              {{/chip-text}}
-            {{/chip-content}}
-            {{#> chip-actions}}
-              {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-one ' chip-group--id 'chip-one" aria-label="Remove" id="' chip-group--id 'remove-chip-one"')}}
+  {{#> label-group label-group--modifier="pf-m-category"}}
+    {{#> label-group-main}}
+      {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label-group-label"')}}
+        {{label-group--label}}
+      {{/label-group-label}}
+      {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby="' label-group--id '-label-group-label"')}}
+        {{#> label-group-list-item}}
+          {{#> label label--IsOutlined=true}}
+            {{#> label-content}}
+              {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-one"')}}
+                Label one
+              {{/label-text}}
+            {{/label-content}}
+            {{#> label-actions}}
+              {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-one ' label-group--id 'label-one" aria-label="Remove" id="' label-group--id 'remove-label-one"')}}
                 <i class="fas fa-times" aria-hidden="true"></i>
               {{/button}}
-          {{/chip-actions}}
-          {{/chip}}
-        {{/chip-group-list-item}}
-        {{#> chip-group-list-item}}
-          {{#> chip}}
-            {{#> chip-content}}
-              {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-two"')}}
-                Chip two
-              {{/chip-text}}
-            {{/chip-content}}
-            {{#> chip-actions}}
-              {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-two ' chip-group--id 'chip-two" aria-label="Remove" id="' chip-group--id 'remove-chip-two"')}}
+          {{/label-actions}}
+          {{/label}}
+        {{/label-group-list-item}}
+        {{#> label-group-list-item}}
+          {{#> label label--IsOutlined=true}}
+            {{#> label-content}}
+              {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-two"')}}
+                Label two
+              {{/label-text}}
+            {{/label-content}}
+            {{#> label-actions}}
+              {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-two ' label-group--id 'label-two" aria-label="Remove" id="' label-group--id 'remove-label-two"')}}
                 <i class="fas fa-times" aria-hidden="true"></i>
               {{/button}}
-          {{/chip-actions}}
-          {{/chip}}
-        {{/chip-group-list-item}}
-        {{#> chip-group-list-item}}
-          {{#> chip}}
-            {{#> chip-content}}
-              {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-three"')}}
-                Chip three
-              {{/chip-text}}
-            {{/chip-content}}
-            {{#> chip-actions}}
-              {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-three ' chip-group--id 'chip-three" aria-label="Remove" id="' chip-group--id 'remove-chip-three"')}}
+          {{/label-actions}}
+          {{/label}}
+        {{/label-group-list-item}}
+        {{#> label-group-list-item}}
+          {{#> label label--IsOutlined=true}}
+            {{#> label-content}}
+              {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-three"')}}
+                Label three
+              {{/label-text}}
+            {{/label-content}}
+            {{#> label-actions}}
+              {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-three ' label-group--id 'label-three" aria-label="Remove" id="' label-group--id 'remove-label-three"')}}
                 <i class="fas fa-times" aria-hidden="true"></i>
               {{/button}}
-          {{/chip-actions}}
-          {{/chip}}
-        {{/chip-group-list-item}}
-      {{/chip-group-list}}
-    {{/chip-group-main}}
-  {{/chip-group}}
+          {{/label-actions}}
+          {{/label}}
+        {{/label-group-list-item}}
+      {{/label-group-list}}
+    {{/label-group-main}}
+  {{/label-group}}
 {{/toolbar-item}}

--- a/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
+++ b/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
@@ -5,7 +5,9 @@ cssPrefix: pf-d-description-list
 ---
 
 ## Examples
+
 ### Basic
+
 ```hbs isFullscreen
 {{> page-template page-template--id="description-list-basic-example"}}
 
@@ -27,6 +29,7 @@ cssPrefix: pf-d-description-list
 ```
 
 ### In drawer
+
 ```hbs isFullscreen
 {{> page-template page-template--id="description-list-in-drawer-example" page-template--IsDrawer="true" page-template--drawer-panel--IsOpen="true"}}
 
@@ -70,13 +73,13 @@ cssPrefix: pf-d-description-list
         {{/description-list-text}}
       {{/description-list-term}}
       {{#> description-list-description}}
-        {{#> chip}}
-          {{#> chip-content}}
-            {{#> chip-text}}
+        {{#> label label--IsOutlined=true}}
+          {{#> label-content}}
+            {{#> label-text}}
               app=mary-test
-            {{/chip-text}}
-          {{/chip-content}}
-        {{/chip}}
+            {{/label-text}}
+          {{/label-content}}
+        {{/label}}
       {{/description-list-description}}
     {{/description-list-group}}
     {{#> description-list-group}}
@@ -264,6 +267,7 @@ cssPrefix: pf-d-description-list
 ```
 
 ### Complex content
+
 ```hbs isFullscreen
 {{> page-template page-template--id="description-list-complex-content-example"}}
 

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.css
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.css
@@ -17,7 +17,7 @@
 .pf-v6-c-menu-toggle + .pf-v6-c-panel {
   position: absolute;
   top: calc(100% + 2px);
-  z-index: var(--pf-v6-global--ZIndex--sm);
+  z-index: var(--pf-t--global--z-index--sm);
 }
 
 .ws-html-demos-c-toolbar .pf-v6-c-toolbar__item {

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -304,57 +304,57 @@ import './Toolbar.css'
   {{/toolbar-content}}
   {{#> toolbar-content toolbar-content--modifier="pf-m-chip-container"}}
     {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-chip-group ' toolbar-item-chip-group--modifier)}}
-      {{#> chip-group chip-group--modifier="pf-m-category" chip-group--id=(concat toolbar--id "-chip-group")}}
-        {{#> chip-group-main}}
-          {{#> chip-group-label chip-group-label--attribute=(concat 'id="' chip-group--id '-chip-group-label"')}}
+      {{#> label-group label-group--modifier="pf-m-category" label-group--id=(concat toolbar--id "-label-group")}}
+        {{#> label-group-main}}
+          {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label-group-label"')}}
             Status
-          {{/chip-group-label}}
-          {{#> chip-group-list chip-group-list--attribute=(concat 'aria-labelledby="' chip-group--id '-chip-group-label"')}}
-            {{#> chip-group-list-item}}
-              {{#> chip}}
-                {{#> chip-content}}
-                  {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id '-chip-one"')}}
+          {{/label-group-label}}
+          {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby="' label-group--id '-label-group-label"')}}
+            {{#> label-group-list-item}}
+              {{#> label label--IsOutlined=true}}
+                {{#> label-content}}
+                  {{#> label-text label-text--attribute=(concat 'id="' label-group--id '-label-one"')}}
                     Canceled
-                  {{/chip-text}}
-                {{/chip-content}}
-                {{#> chip-actions}}
-                  {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-one ' chip-group--id 'chip-one" aria-label="Remove" id="' chip-group--id 'remove-chip-one"')}}
+                  {{/label-text}}
+                {{/label-content}}
+                {{#> label-actions}}
+                  {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-one ' label-group--id 'label-one" aria-label="Remove" id="' label-group--id 'remove-label-one"')}}
                     <i class="fas fa-times" aria-hidden=true></i>
                   {{/button}}
-                {{/chip-actions}}
-              {{/chip}}
-            {{/chip-group-list-item}}
-            {{#> chip-group-list-item}}
-              {{#> chip}}
-                {{#> chip-content}}
-                  {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-two"')}}
+                {{/label-actions}}
+              {{/label}}
+            {{/label-group-list-item}}
+            {{#> label-group-list-item}}
+              {{#> label label--IsOutlined=true}}
+                {{#> label-content}}
+                  {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-two"')}}
                     Paused
-                  {{/chip-text}}
-                {{/chip-content}}
-                {{#> chip-actions}}
-                  {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-two ' chip-group--id 'chip-two" aria-label="Remove" id="' chip-group--id 'remove-chip-two"')}}
+                  {{/label-text}}
+                {{/label-content}}
+                {{#> label-actions}}
+                  {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-two ' label-group--id 'label-two" aria-label="Remove" id="' label-group--id 'remove-label-two"')}}
                     <i class="fas fa-times" aria-hidden=true></i>
                   {{/button}}
-                {{/chip-actions}}
-              {{/chip}}
-            {{/chip-group-list-item}}
-            {{#> chip-group-list-item}}
-              {{#> chip}}
-                {{#> chip-content}}
-                  {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-three"')}}
+                {{/label-actions}}
+              {{/label}}
+            {{/label-group-list-item}}
+            {{#> label-group-list-item}}
+              {{#> label label--IsOutlined=true}}
+                {{#> label-content}}
+                  {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-three"')}}
                     Restarted
-                  {{/chip-text}}
-                {{/chip-content}}
-                {{#> chip-actions}}
-                  {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-three ' chip-group--id 'chip-three" aria-label="Remove" id="' chip-group--id 'remove-chip-three"')}}
+                  {{/label-text}}
+                {{/label-content}}
+                {{#> label-actions}}
+                  {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-three ' label-group--id 'label-three" aria-label="Remove" id="' label-group--id 'remove-label-three"')}}
                     <i class="fas fa-times" aria-hidden=true></i>
                   {{/button}}
-                {{/chip-actions}}
-              {{/chip}}
-            {{/chip-group-list-item}}
-          {{/chip-group-list}}
-        {{/chip-group-main}}
-      {{/chip-group}}
+                {{/label-actions}}
+              {{/label}}
+            {{/label-group-list-item}}
+          {{/label-group-list}}
+        {{/label-group-main}}
+      {{/label-group}}
     {{/toolbar-item}}
     {{> toolbar-item-clear}}
   {{/toolbar-content}}
@@ -419,57 +419,57 @@ import './Toolbar.css'
           {{/panel}}
         {{/toolbar-item}}
         {{#> toolbar-item toolbar-item--modifier=(concat 'pf-m-chip-group ' toolbar-item-chip-group--modifier)}}
-           {{#> chip-group chip-group--modifier="pf-m-category" chip-group--id=(concat toolbar--id "-chip-group")}}
-            {{#> chip-group-main}}
-              {{#> chip-group-label chip-group-label--attribute=(concat 'id="' chip-group--id '-chip-group-label"')}}
+           {{#> label-group label-group--modifier="pf-m-category" label-group--id=(concat toolbar--id "-label-group")}}
+            {{#> label-group-main}}
+              {{#> label-group-label label-group-label--attribute=(concat 'id="' label-group--id '-label-group-label"')}}
                 Status
-              {{/chip-group-label}}
-              {{#> chip-group-list chip-group-list--attribute=(concat 'aria-labelledby=" 'chip-group--id '-chip-group-label"')}}
-                {{#> chip-group-list-item}}
-                  {{#> chip}}
-                    {{#> chip-content}}
-                      {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-one"')}}
+              {{/label-group-label}}
+              {{#> label-group-list label-group-list--attribute=(concat 'aria-labelledby=" 'label-group--id '-label-group-label"')}}
+                {{#> label-group-list-item}}
+                  {{#> label label--IsOutlined=true}}
+                    {{#> label-content}}
+                      {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-one"')}}
                         Canceled
-                      {{/chip-text}}
-                    {{/chip-content}}
-                    {{#> chip-actions}}
-                      {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-one ' chip-group--id 'chip-one" aria-label="Remove" id="' chip-group--id 'remove-chip-one"')}}
+                      {{/label-text}}
+                    {{/label-content}}
+                    {{#> label-actions}}
+                      {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-one ' label-group--id 'label-one" aria-label="Remove" id="' label-group--id 'remove-label-one"')}}
                         <i class="fas fa-times" aria-hidden=true></i>
                       {{/button}}
-                    {{/chip-actions}}
-                  {{/chip}}
-                {{/chip-group-list-item}}
-                {{#> chip-group-list-item}}
-                  {{#> chip}}
-                    {{#> chip-content}}
-                      {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-two"')}}
+                    {{/label-actions}}
+                  {{/label}}
+                {{/label-group-list-item}}
+                {{#> label-group-list-item}}
+                  {{#> label label--IsOutlined=true}}
+                    {{#> label-content}}
+                      {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-two"')}}
                         Paused
-                      {{/chip-text}}
-                    {{/chip-content}}
-                    {{#> chip-actions}}
-                      {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-two ' chip-group--id 'chip-two" aria-label="Remove" id="' chip-group--id 'remove-chip-two"')}}
+                      {{/label-text}}
+                    {{/label-content}}
+                    {{#> label-actions}}
+                      {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-two ' label-group--id 'label-two" aria-label="Remove" id="' label-group--id 'remove-label-two"')}}
                         <i class="fas fa-times" aria-hidden=true></i>
                       {{/button}}
-                    {{/chip-actions}}
-                  {{/chip}}
-                {{/chip-group-list-item}}
-                {{#> chip-group-list-item}}
-                  {{#> chip}}
-                    {{#> chip-content}}
-                      {{#> chip-text chip-text--attribute=(concat 'id="' chip-group--id 'chip-three"')}}
+                    {{/label-actions}}
+                  {{/label}}
+                {{/label-group-list-item}}
+                {{#> label-group-list-item}}
+                  {{#> label label--IsOutlined=true}}
+                    {{#> label-content}}
+                      {{#> label-text label-text--attribute=(concat 'id="' label-group--id 'label-three"')}}
                         Restarted
-                      {{/chip-text}}
-                    {{/chip-content}}
-                    {{#> chip-actions}}
-                      {{#> button button--modifier="pf-m-plain" button--attribute=(concat 'aria-labelledby="' chip-group--id 'remove-chip-three ' chip-group--id 'chip-three" aria-label="Remove" id="' chip-group--id 'remove-chip-three"')}}
+                      {{/label-text}}
+                    {{/label-content}}
+                    {{#> label-actions}}
+                      {{#> button button--modifier="pf-m-plain" button--HasNoPadding=true button--attribute=(concat 'aria-labelledby="' label-group--id 'remove-label-three ' label-group--id 'label-three" aria-label="Remove" id="' label-group--id 'remove-label-three"')}}
                         <i class="fas fa-times" aria-hidden=true></i>
                       {{/button}}
-                    {{/chip-actions}}
-                  {{/chip}}
-                {{/chip-group-list-item}}
-              {{/chip-group-list}}
-            {{/chip-group-main}}
-          {{/chip-group}}
+                    {{/label-actions}}
+                  {{/label}}
+                {{/label-group-list-item}}
+              {{/label-group-list}}
+            {{/label-group-main}}
+          {{/label-group}}
         {{/toolbar-item}}
       {{/toolbar-group}}
       {{> toolbar-item-clear}}


### PR DESCRIPTION
Closes #5345 & #5346

LMK if I should change all references to chips in the examples, for now I've just replaced the usages of the chip component itself (so did not convert things like `text-input-group--chip-group` to `text-input-group--label-group`).