### PR TITLE
feat(button): sample animation on button and alert group

### DIFF
--- a/src/patternfly/base/_variables.scss
+++ b/src/patternfly/base/_variables.scss
@@ -12,3 +12,35 @@
 @include pf-v6-rtl {
   @include pf-v6-set-inverse;
 }
+
+// stylelint-disable
+.pf-m-no-motion * {
+  // simplest way of turning off all animation
+  // disadvantage: takes the wildcard selector
+  // transition: none !important;
+  // animation: none !important;
+}
+// styleline-enable
+
+.pf-m-no-motion {
+  // instead we can set all (or just semantic?) motion tokens to 0
+  // disadvantage - need to catch any new tokens created
+  // note - relies on always using tokens
+  --pf-t--global--delay--400: 0s;
+  --pf-t--global--delay--300: 0s;
+  --pf-t--global--delay--200: 0s;
+  --pf-t--global--delay--100: 0s;
+  --pf-t--global--duration--300: 0s;
+  --pf-t--global--duration--200: 0s;
+  --pf-t--global--duration--100: 0s;
+  --pf-t--global--duration--000: 0s;
+  --pf-t--global--motion--delay--long: 0s;
+  --pf-t--global--motion--delay--default: 0s;
+  --pf-t--global--motion--delay--short: 0s;
+  --pf-t--global--motion--delay--none: 0s;
+  --pf-t--global--motion--duration--long: 0s;
+  --pf-t--global--motion--duration--default: 0s;
+  --pf-t--global--motion--duration--short: 0s;
+  // added just for testing purposes
+  --pf-t--global--motion--duration--test: 0s;
+}

--- a/src/patternfly/base/tokens/_tokens-default.scss
+++ b/src/patternfly/base/tokens/_tokens-default.scss
@@ -4,6 +4,25 @@
 //  */
 
 :root {
+  // motion tokens manually added for testing
+  --pf-t--global--delay--400: 7000ms;
+  --pf-t--global--delay--300: 100ms;
+  --pf-t--global--delay--200: 50ms;
+  --pf-t--global--delay--100: 0ms;
+  --pf-t--global--duration--300: 450ms;
+  --pf-t--global--duration--200: 250ms;
+  --pf-t--global--duration--100: 150ms;
+  --pf-t--global--duration--000: 0ms;
+  --pf-t--global--motion--delay--long: var(--pf-t--global--delay--400);
+  --pf-t--global--motion--delay--default: var(--pf-t--global--delay--300);
+  --pf-t--global--motion--delay--short: var(--pf-t--global--delay--200);
+  --pf-t--global--motion--delay--none: var(--pf-t--global--delay--100);
+  --pf-t--global--motion--duration--long: var(--pf-t--global--duration--300);
+  --pf-t--global--motion--duration--default: var(--pf-t--global--duration--200);
+  --pf-t--global--motion--duration--short: var(--pf-t--global--duration--100);
+  --pf-t--global--motion--duration--test: 1s;  // added just for testing purposes
+
+  // begin generated tokens
   --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
   --pf-t--global--background--color--600: rgba(199, 199, 199, 0.2500);
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);

--- a/src/patternfly/base/tokens/_tokens-font.scss
+++ b/src/patternfly/base/tokens/_tokens-font.scss
@@ -147,6 +147,7 @@
     var(--pf-t--global--box-shadow--color--lg);
 
   // Transitions
+  // These are the old way and will likely be removed
   --pf-t--global--transition: all 250ms cubic-bezier(.42, 0, .58, 1);
   --pf-t--global--transition--timing-function: cubic-bezier(.645, .045, .355, 1);
   --pf-t--global--transition--duration: 250ms;

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -1,9 +1,15 @@
 // @debug $alert-group; // check your variable names located in src/patternfly/sass-utilities/component-namespaces.scss
 
 // Tabs
+:root, 
 .#{$alert-group} {
   // Alert group variables
   --#{$alert-group}__item--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__item--Opacity: 1;
+  --#{$alert-group}__item--m-remove--Opacity: 0;
+  --#{$alert-group}__item--TranslateX: 0;
+  --#{$alert-group}__item--m-remove--TranslateX: 0;
+  --#{$alert-group}__item--m-remove--Duration: var(--pf-t--global--motion--duration--test);
 
   // Toast variables
   --#{$alert-group}--m-toast--Top: var(--pf-t--global--spacer--2xl);
@@ -28,7 +34,18 @@
   --#{$alert-group}__overflow-button--focus--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
   --#{$alert-group}__overflow-button--active--Color: var(--pf-t--global--text--color--link--hover);
   --#{$alert-group}__overflow-button--active--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
+}
 
+// Variables for full motion - i.e. no preference for reduced motion
+@media screen and (prefers-reduced-motion: no-preference) {
+  :root, 
+  .#{$alert-group} {
+      --#{$alert-group}__item--m-remove--TranslateX: 200%;
+      --#{$alert-group}__item--m-remove--Opacity: 1;
+    }
+}
+
+.#{$alert-group} {
   // Spacing between alerts
   > * + * {
     margin-block-start: var(--#{$alert-group}__item--MarginTop);
@@ -42,6 +59,15 @@
     z-index: var(--#{$alert-group}--m-toast--ZIndex);
     width: calc(100% - calc(var(--#{$alert-group}--m-toast--Right) * 2));
     max-width: var(--#{$alert-group}--m-toast--MaxWidth);
+  }
+}
+
+.#{$alert-group}__item {
+  transition: all var(--#{$alert-group}__item--m-remove--Duration);
+
+  &.pf-m-remove {
+    opacity: var(--#{$alert-group}__item--m-remove--Opacity);
+    transform: translateX(var(--#{$alert-group}__item--m-remove--TranslateX));
   }
 }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -15,6 +15,9 @@
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$button}--TextDecoration: none;
 
+  // This one is super simple, so just one transition duration needed here and no reduced option needed
+  --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--test);
+
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
   --#{$button}--hover--BorderColor: transparent;
@@ -293,6 +296,7 @@
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
   border-end-start-radius: var(--#{$button}--BorderEndStartRadius, var(--#{$button}--BorderRadius));
   border-end-end-radius: var(--#{$button}--BorderEndEndRadius, var(--#{$button}--BorderRadius));
+  transition: background-color var(--#{$button}--TransitionDuration);
 
   &::after {
     position: absolute;
@@ -302,6 +306,7 @@
     border: var(--#{$button}--BorderWidth) solid;
     border-color: var(--#{$button}--BorderColor);
     border-radius: inherit;
+    transition: border-color var(--#{$button}--TransitionDuration);
   }
 
   // Primary


### PR DESCRIPTION
As part of #6515 spike, this shows a few things:
- motion tokens added. These exist in Figma but were copied over manually for now
- also adds and uses a test duration of 1s so you can see what's going on
- Button has a transition so on hover you can see the color slowly change (1s). This transition has no reduced motion alternative.
- Alert group item has a new class `.pf-m-remove`. This class causes the  item to be removed by sliding off to the right (translateX), or for reduced-motion, it fades (opacity).
- All transitions are removed when the class `.pf-m-no-motion` is applied to a parent. (no matter what the reduced motion setting is) This is intended to be used for testing purposes.

To test:
- Access the prefers-reduced-motion option through Settings -> Accessibility -> Display -> Reduce motion
- Add and remove `.pf-m-remove` on the alert group item
- Add and remove `.pf-m-no-motion` on the body or other parent tag