### PR TITLE
chore(Badge/MenuToggle): updated styling

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -26,12 +26,12 @@
 
   // breadcrumb dropdown
   --#{$breadcrumb}__menu-toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$breadcrumb}__menu-toggle--MarginInlineEnd: calc(var(--#{$breadcrumb}__item--MarginInlineEnd) * -1);
+  --#{$breadcrumb}__menu-toggle--MarginInlineEnd: var(--pf-t--global--spacer--xs);
   --#{$breadcrumb}__menu-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$breadcrumb}__menu-toggle--MarginInlineStart: calc(var(--#{$breadcrumb}__item-divider--MarginInlineEnd) * -1);
+  --#{$breadcrumb}__menu-toggle--MarginInlineStart: var(--pf-t--global--spacer--xs);
   --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart: 0;
   --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd: 0;
-  
+
   // breadcrumb toggle
   --#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight: var(--pf-t--global--font--line-height--body);
 }

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -29,8 +29,8 @@
   --#{$breadcrumb}__menu-toggle--MarginInlineEnd: var(--pf-t--global--spacer--xs);
   --#{$breadcrumb}__menu-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$breadcrumb}__menu-toggle--MarginInlineStart: var(--pf-t--global--spacer--xs);
-  --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart: 0;
-  --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd: 0;
+  --#{$breadcrumb}__menu-toggle--PaddingBlockStart: 0;
+  --#{$breadcrumb}__menu-toggle--PaddingBlockEnd: 0;
 
   // breadcrumb toggle
   --#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -118,8 +118,8 @@
   margin-inline-end: var(--#{$breadcrumb}__menu-toggle--MarginInlineEnd);
 
   .#{$menu-toggle} {
-    padding-block-start: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart);
-    padding-block-end: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd);
+    padding-block-start: var(--#{$breadcrumb}__menu-toggle--PaddingBlockStart);
+    padding-block-end: var(--#{$breadcrumb}__menu-toggle--PaddingBlockEnd);
     line-height: var(--#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight);
   }
 }

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -29,11 +29,6 @@
   --#{$breadcrumb}__menu-toggle--MarginInlineEnd: var(--pf-t--global--spacer--xs);
   --#{$breadcrumb}__menu-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$breadcrumb}__menu-toggle--MarginInlineStart: var(--pf-t--global--spacer--xs);
-  --#{$breadcrumb}__menu-toggle--PaddingBlockStart: 0;
-  --#{$breadcrumb}__menu-toggle--PaddingBlockEnd: 0;
-
-  // breadcrumb toggle
-  --#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight: var(--pf-t--global--font--line-height--body);
 }
 
 .#{$breadcrumb} {
@@ -116,12 +111,6 @@
   margin-block-end: var(--#{$breadcrumb}__menu-toggle--MarginBlockEnd);
   margin-inline-start: var(--#{$breadcrumb}__menu-toggle--MarginInlineStart);
   margin-inline-end: var(--#{$breadcrumb}__menu-toggle--MarginInlineEnd);
-
-  .#{$menu-toggle} {
-    padding-block-start: var(--#{$breadcrumb}__menu-toggle--PaddingBlockStart);
-    padding-block-end: var(--#{$breadcrumb}__menu-toggle--PaddingBlockEnd);
-    line-height: var(--#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight);
-  }
 }
 
 .#{$breadcrumb}__heading {

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -29,7 +29,9 @@
   --#{$breadcrumb}__menu-toggle--MarginInlineEnd: calc(var(--#{$breadcrumb}__item--MarginInlineEnd) * -1);
   --#{$breadcrumb}__menu-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$breadcrumb}__menu-toggle--MarginInlineStart: calc(var(--#{$breadcrumb}__item-divider--MarginInlineEnd) * -1);
-
+  --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart: 0;
+  --#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd: 0;
+  
   // breadcrumb toggle
   --#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight: var(--pf-t--global--font--line-height--body);
 }
@@ -117,6 +119,11 @@
 
   .#{$menu-toggle} {
     line-height: var(--#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight);
+  }
+
+  .#{$menu-toggle} {
+    padding-block-start: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart);
+    padding-block-end: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd);
   }
 }
 

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -118,12 +118,9 @@
   margin-inline-end: var(--#{$breadcrumb}__menu-toggle--MarginInlineEnd);
 
   .#{$menu-toggle} {
-    line-height: var(--#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight);
-  }
-
-  .#{$menu-toggle} {
     padding-block-start: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockStart);
     padding-block-end: var(--#{$breadcrumb}__dropdown--c-menu-toggle--PaddingBlockEnd);
+    line-height: var(--#{$breadcrumb}__menu-toggle--c-menu-toggle--LineHeight);
   }
 }
 

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -138,7 +138,7 @@ cssPrefix: pf-v6-c-breadcrumb
     {{#> breadcrumb-item}}
       {{> breadcrumb-item-divider}}
       {{#> breadcrumb-dropdown}}
-        {{#> menu-toggle menu-toggle--IsPlain=true}}
+        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
           {{#> menu-toggle-count}}
             {{#> badge badge--modifier="pf-m-unread"}}
               4

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -138,7 +138,7 @@ cssPrefix: pf-v6-c-breadcrumb
     {{#> breadcrumb-item}}
       {{> breadcrumb-item-divider}}
       {{#> breadcrumb-dropdown}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
+        {{#> menu-toggle menu-toggle--IsText=true menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
           {{#> menu-toggle-count}}
             {{#> badge badge--modifier="pf-m-unread"}}
               4

--- a/src/patternfly/components/Menu/templates/menu-breadcrumbs--dropdown.hbs
+++ b/src/patternfly/components/Menu/templates/menu-breadcrumbs--dropdown.hbs
@@ -1,7 +1,7 @@
 {{#> breadcrumb-item}}
   {{> breadcrumb-item-divider}}
   {{#> breadcrumb-dropdown}}
-    {{#> menu-toggle menu-toggle--IsPlain=true}}
+    {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
       {{#> menu-toggle-count}}
         {{#> badge badge--modifier="pf-m-read"}}
           {{menu-toggle--badge--text}}

--- a/src/patternfly/components/Menu/templates/menu-breadcrumbs--dropdown.hbs
+++ b/src/patternfly/components/Menu/templates/menu-breadcrumbs--dropdown.hbs
@@ -1,7 +1,7 @@
 {{#> breadcrumb-item}}
   {{> breadcrumb-item-divider}}
   {{#> breadcrumb-dropdown}}
-    {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
+    {{#> menu-toggle menu-toggle--IsText=true menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
       {{#> menu-toggle-count}}
         {{#> badge badge--modifier="pf-m-read"}}
           {{menu-toggle--badge--text}}

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -63,7 +63,7 @@ import './MenuToggle.css'
 
 &nbsp;
 
-{{#> menu-toggle menu-toggle--IsPlain=true}}
+{{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
   {{#> menu-toggle-count}}
     {{#> badge badge--modifier="pf-m-unread"}}
       4

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -63,7 +63,7 @@ import './MenuToggle.css'
 
 &nbsp;
 
-{{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
+{{#> menu-toggle menu-toggle--IsText=true menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
   {{#> menu-toggle-count}}
     {{#> badge badge--modifier="pf-m-unread"}}
       4

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -162,6 +162,9 @@
   // * Menu toggle small
   --#{$menu-toggle}--m-small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$menu-toggle}--m-small--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}--m-small--ColumnGap: calc(var(--pf-t--global--spacer--control--horizontal--compact) / 2);
+  --#{$menu-toggle}--m-small--FontSize: var(--pf-t--global--font--size--body--sm);
+  --#{$menu-toggle}--m-small__controls--MinWidth: calc(var(--#{$menu-toggle}--FontSize) + var(--pf-t--global--spacer--xs) + var(--pf-t--global--spacer--xs));
 
   // Status icon
   --#{$menu-toggle}__status-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
@@ -329,6 +332,9 @@
   &.pf-m-small {
     --#{$menu-toggle}--PaddingBlockStart: var(--#{$menu-toggle}--m-small--PaddingBlockStart);
     --#{$menu-toggle}--PaddingBlockEnd: var(--#{$menu-toggle}--m-small--PaddingBlockEnd);
+    --#{$menu-toggle}--FontSize: var(--#{$menu-toggle}--m-small--FontSize);
+    --#{$menu-toggle}--ColumnGap: var(--#{$menu-toggle}--m-small--ColumnGap);
+    --#{$menu-toggle}__controls--MinWidth: var(--#{$menu-toggle}--m-small__controls--MinWidth);
   }
 
   &:has(.#{$button}) {


### PR DESCRIPTION
Closes #6463 

Currently I'm applying some additional styling to a `pf-m-small` MenuToggle rather than only when it's inside a breadcrumb dropdown. I can update to only change that styling when the MenuToggle is inside the breadcrumb dropdown, but was curious if it would make sense to adjust other styling for a `pf-m-small` Menu Toggle rather than only the top/bottom padding.

Also note that the `pf-m-text` modifier on MenuToggle no longer actually does anything, but we've kept it on the React component.