### PR TITLE
feat(all): update component selectors to use where main and component

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
-:root {
-  // Component variables
+:where(:root, .#{$about-modal-box}) {
+    // Component variables
   --#{$about-modal-box}--BackgroundImage: none;
   --#{$about-modal-box}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$about-modal-box}--BackgroundPosition: bottom right;

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$accordion}) {
   // accordion
   --#{$accordion}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}--RowGap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/ActionList/action-list.scss
+++ b/src/patternfly/components/ActionList/action-list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root) {
+:where(:root, .#{$action-list}) {
   --#{$action-list}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$action-list}--ColumnGap: var(--pf-t--global--spacer--2xl);
 

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$alert}) {
   // Alert variables
   --#{$alert}--BoxShadow: var(--pf-t--global--box-shadow--lg);
   --#{$alert}--BackgroundColor: var(--pf-t--global--background--color--floating--default);

--- a/src/patternfly/components/Avatar/avatar.scss
+++ b/src/patternfly/components/Avatar/avatar.scss
@@ -3,7 +3,7 @@
 $pf-v6-c-avatar--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-avatar--sizes: "sm", "md", "lg", "xl";
 
-:root, .#{$avatar} {
+:where(:root, .#{$avatar}) {
   --#{$avatar}--BorderColor: transparent;
   --#{$avatar}--BorderWidth: 0;
   --#{$avatar}--BorderRadius: var(--pf-t--global--border--radius--pill);

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$back-to-top}) {
   --#{$back-to-top}--Right: var(--pf-t--global--spacer--2xl);
   --#{$back-to-top}--Bottom: var(--pf-t--global--spacer--lg);
   --#{$back-to-top}--md--Bottom: var(--pf-t--global--spacer--2xl);

--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$backdrop} {
+:where(:root, .#{$backdrop}) {
   --#{$backdrop}--Position: fixed;
   --#{$backdrop}--ZIndex: var(--pf-t--global--z-index--lg);
   --#{$backdrop}--BackgroundColor: var(--pf-t--global--background--color--backdrop--default);

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$background-image} {
+:where(:root, .#{$background-image}) {
   --#{$background-image}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$background-image}--BackgroundImage: none;
   --#{$background-image}--BackgroundSize--min-width: 200px;

--- a/src/patternfly/components/Badge/badge.scss
+++ b/src/patternfly/components/Badge/badge.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$badge}) {
   // Component
   --#{$badge}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$badge}--FontSize: var(--pf-t--global--font--size--body--sm);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$banner}) {
   --#{$banner}--PaddingTop: var(--pf-t--global--spacer--xs);
   --#{$banner}--PaddingRight: var(--pf-t--global--spacer--md);
   --#{$banner}--md--PaddingRight: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$breadcrumb}) {
+:where(:root, .#{$breadcrumb}) {
   // Breadcrumb item
   --#{$breadcrumb}__item--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$breadcrumb}__item--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$button}) {
+:where(:root, .#{$button}) {
   --#{$button}--Display: inline-block;
   --#{$button}--PaddingTop: var(--pf-t--global--spacer--sm);
   --#{$button}--PaddingRight: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$calendar-month}) {
+:where(:root, .#{$calendar-month}) {
   --#{$calendar-month}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$calendar-month}--PaddingTop: var(--pf-t--global--spacer--lg);
   --#{$calendar-month}--PaddingRight: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$card}) {
+:where(:root, .#{$card}) {
   --#{$card}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$card}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$card}--BorderStyle: solid;

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$check} {
+:where(:root, .#{$check}) {
   --#{$check}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
   --#{$check}--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$clipboard-copy}) {
+:where(:root, .#{$clipboard-copy}) {
   // Toggle icon
   --#{$clipboard-copy}__toggle-icon--Transition: .2s ease-in 0s;
   --#{$clipboard-copy}--m-expanded__toggle-icon--Rotate: 90deg;

--- a/src/patternfly/components/CodeBlock/code-block.scss
+++ b/src/patternfly/components/CodeBlock/code-block.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root, :where(.#{$code-block}) {
+:where(:root, .#{$code-block}) {
   --#{$code-block}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$code-block}--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$code-block}__header--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root), :where(.#{$code-editor}) {
+:where(:root, .#{$code-editor}) {
   // controls
   --#{$code-editor}__controls--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$code-editor}__controls--Gap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$content}) {
+:where(:root, .#{$content}) {
   // Body
   --#{$content}--MarginBottom: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 @use './data-list-grid' as *;
 
-:root, .#{$data-list} {
+:where(:root, .#{$data-list}) {
   --#{$data-list}--FontSize: var( --pf-t--global--font--size--body);
   --#{$data-list}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$data-list}--BorderTopColor: var(--pf-t--global--border--color--default);

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$date-picker}) {
+:where(:root, .#{$date-picker}) {
   --#{$date-picker}--m-top__calendar--Top: 0;
   --#{$date-picker}--m-top__calendar--TranslateY: calc(-100% - var(--pf-t--global--spacer--xs));
   --#{$date-picker}__helper-text--MarginTop: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root), :where(.#{$description-list}) {
+:where(:root, .#{$description-list}) {
   --#{$description-list}--RowGap: var(--pf-t--global--spacer--lg);
   --#{$description-list}--ColumnGap: var(--pf-t--global--spacer--lg);
   --#{$description-list}--GridTemplateColumns--count: 1;

--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -17,8 +17,7 @@ $pf-v6-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
   height: inherit;
 }
 
-:root,
-:where(.#{$divider}) {
+:where(:root, .#{$divider}) {
   // * Divider
   --#{$divider}--Display: flex;
   --#{$divider}--Color: var(--pf-t--global--border--color--default);

--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root), :where(.#{$draggable}) {
+:where(:root, .#{$draggable}) {
   --#{$draggable}--Cursor: auto;
   --#{$draggable}--m-dragging--Cursor: grabbing;
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
@@ -40,7 +40,7 @@
   }
 }
 
-:where(:root), :where(.#{$droppable}) {
+:where(:root, .#{$droppable}) {
   --#{$droppable}--before--BackgroundColor: transparent;
   --#{$droppable}--before--Opacity: 0;
   --#{$droppable}--after--BorderWidth: 0;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -5,8 +5,7 @@ $pf-v6-c-drawer--breakpoint-map: build-breakpoint-map("base", "lg", "xl", "2xl")
 $pf-v6-c-drawer--breakpoint-map--width: build-breakpoint-map("base", "lg", "xl", "2xl");
 $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
-:where(:root),
-:where(.#{$drawer}) {
+:where(:root, .#{$drawer}) {
   // Section
   --#{$drawer}__section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$drawer}__section--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
-:where(:root), :where(.#{$dual-list-selector}) {
+:where(:root, .#{$dual-list-selector}) {
   // Grid
   --#{$dual-list-selector}__header--GridArea: pane-header;
   --#{$dual-list-selector}__tools--GridArea: pane-tools;

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$empty-state}) {
   --#{$empty-state}--PaddingTop: var(--pf-t--global--spacer--xl);
   --#{$empty-state}--PaddingRight: var(--pf-t--global--spacer--xl);
   --#{$empty-state}--PaddingBottom: var(--pf-t--global--spacer--xl);

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$expandable-section}) {
   // Toggle
   --#{$expandable-section}__toggle--PaddingTop: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}__toggle--PaddingRight: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$file-upload}) {
+:where(:root, .#{$file-upload}) {
   --#{$file-upload}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$file-upload}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$file-upload}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -25,8 +25,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   }
 }
 
-:root,
-.#{$form} {
+:where(:root, .#{$form}) {
   --#{$form}--GridGap: var(--pf-t--global--spacer--lg);
 
   // Group

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$form-control} {
+:where(:root, .#{$form-control}) {
   --#{$form-control}--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$form-control}--Color: var(--pf-t--global--text--color--regular);
   --#{$form-control}--FontSize: var(--pf-t--global--font--size--body--default);

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$helper-text}) {
   --#{$helper-text}--Gap: var(--pf-t--global--spacer--xs);
   --#{$helper-text}--FontSize: var(--pf-t--global--font--size--body--sm);
 

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$hint}) {
   --#{$hint}--GridRowGap: var(--pf-t--global--spacer--sm);
   --#{$hint}--PaddingTop: var(--pf-t--global--spacer--lg);
   --#{$hint}--PaddingRight: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Icon/icon.scss
+++ b/src/patternfly/components/Icon/icon.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-:where(.#{$icon}) {
+:where(:root, .#{$icon}) {
   // Sizes
   --#{$icon}--Width: 1em;
   --#{$icon}--Height: 1em;

--- a/src/patternfly/components/InlineEdit/inline-edit.scss
+++ b/src/patternfly/components/InlineEdit/inline-edit.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where( .#{$inline-edit}) {
+:where(:root,  .#{$inline-edit}) {
   // Group
   --#{$inline-edit}__group--item--MarginRight: var(--pf-t--global--spacer--sm);
 

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$input-group} {
+:where(:root, .#{$input-group}) {
   --#{$input-group}--Gap: var(--pf-t--global--spacer--xs);
 
   // Input group item

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -2,8 +2,7 @@
 
 $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root),
-:where(.#{$jump-links}) {
+:where(:root, .#{$jump-links}) {
   // list
   --#{$jump-links}__list--Display: flex;
   --#{$jump-links}__list--PaddingTop: 0;

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$label-group}) {
+:where(:root, .#{$label-group}) {
   // Label group - spaces main with the close button
   --#{$label-group}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$label-group}--ColumnGap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$label}) {
+:where(:root, .#{$label}) {
   --#{$label}--PaddingTop: var(--pf-t--global--spacer--xs);
   --#{$label}--PaddingRight: var(--pf-t--global--spacer--sm);
   --#{$label}--PaddingBottom: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$login}) {
   --#{$login}--PaddingTop: var(--pf-t--global--spacer--lg);
   --#{$login}--PaddingBottom: var(--pf-t--global--spacer--lg);
 

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -3,8 +3,7 @@
 $pf-v6-c-masthead--breakpoint-map: build-breakpoint-map();
 $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root),
-:where(.#{$masthead}) {
+:where(:root, .#{$masthead}) {
   // * Masthead
   --#{$masthead}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$masthead}--ColumnGap: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$menu}) {
+:where(:root, .#{$menu}) {
   // * Menu
   --#{$menu}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$menu}--Width: auto;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -8,8 +8,7 @@
 // TODO: update text-input-button to use gap
 // TODO: label all variables group - // * Menu toggle (vars) // - Menu toggle (selectors)
 
-:where(:root),
-:where(.#{$menu-toggle}) {
+:where(:root, .#{$menu-toggle}) {
   --#{$menu-toggle}--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--PaddingTop: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--PaddingRight: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$modal-box}) {
   --#{$modal-box}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$modal-box}--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$modal-box}--BoxShadow: var(--pf-t--global--box-shadow--lg);

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-:where(.#{$multiple-file-upload}) {
+:where(:root, .#{$multiple-file-upload}) {
   --#{$multiple-file-upload}--GridTemplateColumns: 1fr;
   --#{$multiple-file-upload}--Gap: var(--pf-t--global--spacer--md);
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$nav}) {
+:where(:root, .#{$nav}) {
   // * Nav shared values
   --#{$nav}__link--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$nav}__link--PaddingBlockEnd: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/NotificationBadge/notification-badge.scss
+++ b/src/patternfly/components/NotificationBadge/notification-badge.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$notification-badge}) {
   --#{$notification-badge}--BackgroundColor: transparent;
   --#{$notification-badge}--MinWidth: 40px;
   --#{$notification-badge}--Gap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$notification-drawer} {
+:where(:root, .#{$notification-drawer}) {
   --#{$notification-drawer}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // Header

--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$number-input} {
+:where(:root, .#{$number-input}) {
   // unit
   --#{$number-input}__unit--c-input-group--MarginLeft: var(--pf-t--global--spacer--sm);
 

--- a/src/patternfly/components/OverflowMenu/overflow-menu.scss
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$overflow-menu}) {
   --#{$overflow-menu}--ColumnGap: var(--pf-t--global--spacer--md);
 
   // * Overflow menu group

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -5,7 +5,7 @@ $pf-page-v6--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl"
 $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 // stylelint-enable
 
-:root {
+:where(:root, .#{$page}) {
   --#{$page}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$page}--inset: var(--pf-t--global--spacer--md);
   --#{$page}--xl--inset: var(--pf-t--global--spacer--xl);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -3,8 +3,7 @@
 $pf-v6-c-pagination--breakpoint-map: build-breakpoint-map();
 $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root),
-:where(.#{$pagination}) {
+:where(:root, .#{$pagination}) {
   --#{$pagination}--inset: 0;
   --#{$pagination}--ColumnGap: var(--pf-t--global--spacer--lg);
 

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$panel} {
+:where(:root, .#{$panel}) {
   --#{$panel}--Width: auto;
   --#{$panel}--MinWidth: auto;
   --#{$panel}--MaxWidth: none;

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$progress} {
+:where(:root, .#{$progress}) {
   // Component variables
   --#{$progress}--GridGap: var(--pf-t--global--spacer--md);
 

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -58,8 +58,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 }
 
 // Progress stepper is vertically oriented by default
-:where(:root),
-:where(.#{$progress-stepper}) {
+:where(:root, .#{$progress-stepper}) {
   // Vertical - these are the default settings
   --#{$progress-stepper}--m-vertical--GridAutoFlow: row;
   --#{$progress-stepper}--m-vertical--GridTemplateColumns: auto 1fr;

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$radio} {
+:where(:root, .#{$radio}) {
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
   --#{$radio}--Height: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -4,8 +4,7 @@
 $pf-v6-c-sidebar--breakpoint-map--width: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
-:root,
-:where(.#{$sidebar}) {
+:where(:root, .#{$sidebar}) {
   --#{$sidebar}--inset: var(--pf-t--global--spacer--md);
   --#{$sidebar}--xl--inset: var(--pf-t--global--spacer--lg);
   --#{$sidebar}--BorderWidth--base: var(--pf-t--global--border--width--regular);

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root, .#{$simple-list} {
+:where(:root, .#{$simple-list}) {
   // Simple list item link
   --#{$simple-list}__item-link--PaddingTop: var(--pf-t--global--spacer--xs);
   --#{$simple-list}__item-link--PaddingRight: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Skeleton/skeleton.scss
+++ b/src/patternfly/components/Skeleton/skeleton.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$skeleton} {
+:where(:root, .#{$skeleton}) {
   --#{$skeleton}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$skeleton}--Width: auto;
   --#{$skeleton}--Height: auto;

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$skip-to-content}) {
   --#{$skip-to-content}--Top: var(--pf-t--global--spacer--md);
   --#{$skip-to-content}--ZIndex: var(--pf-t--global--z-index--2xl);
   --#{$skip-to-content}--focus--Left: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$slider} {
+:where(:root, .#{$slider}) {
   --#{$slider}--value: 0; // should always be set inline
   --#{$slider}__step--Left: 0; // should always be set inline
 

--- a/src/patternfly/components/Spinner/spinner.scss
+++ b/src/patternfly/components/Spinner/spinner.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$spinner} {
+:where(:root, .#{$spinner}) {
   --#{$spinner}--diameter: var(--pf-t--global--icon--size--2xl);
   --#{$spinner}--Width: var(--#{$spinner}--diameter);
   --#{$spinner}--Height: var(--#{$spinner}--diameter);

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$switch} {
+:where(:root, .#{$switch}) {
   // Switch - the vars for this file don't follow our normal order so that the IE11 script can convert the vars correctly
   --#{$switch}--FontSize: var(--pf-t--global--font--size--sm);
   --#{$switch}--ColumnGap: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/TabContent/tab-content.scss
+++ b/src/patternfly/components/TabContent/tab-content.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$tab-content} {
+:where(:root, .#{$tab-content}) {
   --#{$tab-content}__body--PaddingTop: 0;
   --#{$tab-content}__body--PaddingRight: 0;
   --#{$tab-content}__body--PaddingBottom: 0;

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -1,8 +1,7 @@
 @use '../../sass-utilities' as *;
 
 // * Table scrollable
-:where(:root),
-:where(.#{$table}) {
+:where(:root, .#{$table}) {
   --#{$table}__sticky-cell--MinWidth--base: #{pf-size-prem(140px)};
   --#{$table}__sticky-cell--MinWidth: var(--#{$table}__sticky-cell--MinWidth--base);
   --#{$table}__sticky-cell--ZIndex: var(--pf-t--global--z-index--xs);

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -3,8 +3,7 @@
 $pf-v6-c-tree-view--MaxDepth: 10;
 
 // * Table tree view
-:where(:root),
-:where(.#{$table}) {
+:where(:root, .#{$table}) {
   --#{$table}__tree-view-main--indent--base: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$table}__tree-view-icon--MinWidth)); // based off of the expected width of the toggle button
   --#{$table}__tree-view-main--nested-indent--base: calc(var(--#{$table}__tree-view-main--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -3,8 +3,7 @@
 // TODO: clean up unused variables
 // TODO: update grouping comments to // * Table {element}
 
-:where(:root),
-:where(.#{$table}) {
+:where(:root, .#{$table}) {
   --#{$table}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$table}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$table}--border-width--base: var(--pf-t--global--border--width--divider--default);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -3,8 +3,7 @@
 $pf-v6-c-tabs--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root),
-:where(.#{$tabs}) {
+:where(:root, .#{$tabs}) {
   --#{$tabs}--inset: 0;
   --#{$tabs}--Width: auto;
   --#{$tabs}--before--BorderColor: var(--pf-t--global--border--color--default);

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$text-input-group}) {
+:where(:root, .#{$text-input-group}) {
   --#{$text-input-group}--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$text-input-group}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$text-input-group}--BorderWidth: var(--pf-t--global--border--width--control--default);

--- a/src/patternfly/components/Tile/tile.scss
+++ b/src/patternfly/components/Tile/tile.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$tile}) {
+:where(:root, .#{$tile}) {
   --#{$tile}--PaddingTop: var(--pf-t--global--spacer--lg);
   --#{$tile}--PaddingRight: var(--pf-t--global--spacer--lg);
   --#{$tile}--PaddingBottom: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root, .#{$timestamp} {
+:where(:root, .#{$timestamp}) {
   --#{$timestamp}--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$timestamp}--Color: var(--pf-t--global--text--color--subtle);
   --#{$timestamp}--OutlineOffset: #{pf-size-prem(3px)};

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$title}) {
   --#{$title}--FontFamily: var(--pf-t--global--font--family--heading);
 
   // SIZE modifiers (note that the modifier names match PF5 sizes but use tokens that don't match in name

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$toggle-group}) {
+:where(:root, .#{$toggle-group}) {
   // button
   --#{$toggle-group}__button--PaddingTop: var(--pf-t--global--spacer--sm);
   --#{$toggle-group}__button--PaddingRight: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -10,8 +10,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   $pf-v6-c-toolbar--breakpoint-map: build-breakpoint-map('base', 'sm', 'md', 'lg', 'xl', '2xl');
 }
 
-:where(:root),
-:where(.#{$toolbar}) {
+:where(:root, .#{$toolbar}) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$toolbar}--ColumnGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlock: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root {
+:where(:root, .#{$tooltip}) {
   // Component variables
   --#{$tooltip}--MaxWidth: #{pf-size-prem(300px)};
   --#{$tooltip}--BoxShadow: var(--pf-t--global--box-shadow--md);

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -2,8 +2,7 @@
 
 $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
-:where(:root),
-:where(.#{$tree-view}) {
+:where(:root, .#{$tree-view}) {
   // Node base
   --#{$tree-view}__node--indent--base: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$tree-view}__node-toggle-icon--MinWidth)); // based off of the expected width of the toggle button
   --#{$tree-view}__node--nested-indent--base: calc(var(--#{$tree-view}__node--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:root,
-.#{$truncate} {
+:where(:root, .#{$truncate}) {
   --#{$truncate}--MinWidth: 12ch;
   --#{$truncate}__start--MinWidth: 6ch;
 }

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$wizard}) {
+:where(:root, .#{$wizard}) {
   --#{$wizard}--Height: 100%;
   --#{$modal-box}--c-wizard--FlexBasis: #{pf-size-prem(762px)}; // this is a specific height from design for the wizard in a modal
 

--- a/src/patternfly/layouts/Bullseye/bullseye.scss
+++ b/src/patternfly/layouts/Bullseye/bullseye.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$bullseye}) {
+:where(:root, .#{$bullseye}) {
   --#{$bullseye}--Padding: 0;
 }
 

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -6,8 +6,7 @@ $pf-v6-l-flex--spacer-map: build-spacer-map();
 $pf-v6-l-flex--gap-map: build-spacer-map("base", "none", "xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl");
 $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $pf-v6-l-flex--spacer-map);
 
-:where(:root),
-:where(.#{$flex}) {
+:where(:root, .#{$flex}) {
   --#{$flex}--Display: flex;
   --#{$flex}--FlexWrap: wrap;
   --#{$flex}--AlignItems: baseline;

--- a/src/patternfly/layouts/Gallery/gallery.scss
+++ b/src/patternfly/layouts/Gallery/gallery.scss
@@ -2,8 +2,7 @@
 
 $pf-v6-l-gallery--breakpoint-map: build-breakpoint-map();
 
-:where(:root),
-:where(.#{$gallery}) {
+:where(:root, .#{$gallery}) {
   --#{$gallery}--m-gutter--GridGap: var(--pf-t--global--spacer--lg);
   --#{$gallery}--GridTemplateColumns--min: 250px;
   --#{$gallery}--GridTemplateColumns--minmax--min: var(--#{$gallery}--GridTemplateColumns--min);

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -41,8 +41,7 @@ $pf-v6-l-grid--breakpoint-map: build-breakpoint-map(); // currently only used fo
 }
 
 // Grid base
-:where(:root),
-:where(.#{$grid}) {
+:where(:root, .#{$grid}) {
   --#{$grid}--m-gutter--GridGap: var(--pf-t--global--spacer--lg);
   --#{$grid}__item--GridColumnStart: auto;
   --#{$grid}__item--GridColumnEnd: span 12;

--- a/src/patternfly/layouts/Level/level.scss
+++ b/src/patternfly/layouts/Level/level.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$level}) {
+:where(:root, .#{$level}) {
   --#{$level}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
 }
 

--- a/src/patternfly/layouts/Split/split.scss
+++ b/src/patternfly/layouts/Split/split.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$split}) {
+:where(:root, .#{$split}) {
   --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
 }
 

--- a/src/patternfly/layouts/Stack/stack.scss
+++ b/src/patternfly/layouts/Stack/stack.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root),
-:where(.#{$stack}) {
+:where(:root, .#{$stack}) {
   --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
 }
 


### PR DESCRIPTION
Fixes #6409 

Visual regression test against screen shots in PR #6544 show only a difference in disabled button with badge (but matches PF6 workspace) and a dropdown toggle in /patterns/primary-detail/html-demos/primary-detail-content-body-padding (also matches current PF6 workspace)