### PR TITLE
feat(all): rename variables to use logical direction names

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -22,34 +22,34 @@
   );
 
   // Brand
-  --#{$about-modal-box}__brand--PaddingTop: var(--pf-t--global--spacer--2xl);
-  --#{$about-modal-box}__brand--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__brand--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__brand--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__brand--sm--PaddingRight: var(--pf-t--global--spacer--3xl);
-  --#{$about-modal-box}__brand--sm--PaddingLeft: var(--pf-t--global--spacer--3xl);
-  --#{$about-modal-box}__brand--sm--PaddingBottom: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__brand--PaddingBlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$about-modal-box}__brand--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__brand--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__brand--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__brand--sm--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__brand--sm--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__brand--sm--PaddingBlockEnd: var(--pf-t--global--spacer--3xl);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$about-modal-box}__brand--PaddingRight: var(--#{$about-modal-box}__brand--sm--PaddingRight);
-    --#{$about-modal-box}__brand--PaddingLeft: var(--#{$about-modal-box}__brand--sm--PaddingLeft);
-    --#{$about-modal-box}__brand--PaddingBottom: var(--#{$about-modal-box}__brand--sm--PaddingBottom);
+    --#{$about-modal-box}__brand--PaddingInlineEnd: var(--#{$about-modal-box}__brand--sm--PaddingInlineEnd);
+    --#{$about-modal-box}__brand--PaddingInlineStart: var(--#{$about-modal-box}__brand--sm--PaddingInlineStart);
+    --#{$about-modal-box}__brand--PaddingBlockEnd: var(--#{$about-modal-box}__brand--sm--PaddingBlockEnd);
   }
 
   // Close
   --#{$about-modal-box}__close--ZIndex: var(--pf-t--global--z-index--2xl);
-  --#{$about-modal-box}__close--PaddingTop: var(--pf-t--global--spacer--2xl);
-  --#{$about-modal-box}__close--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__close--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__close--sm--PaddingBottom: var(--pf-t--global--spacer--3xl);
-  --#{$about-modal-box}__close--lg--PaddingRight: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__close--PaddingBlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$about-modal-box}__close--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__close--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__close--sm--PaddingBlockEnd: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__close--lg--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$about-modal-box}__close--PaddingBottom: var(--#{$about-modal-box}__close--sm--PaddingBottom);
+    --#{$about-modal-box}__close--PaddingBlockEnd: var(--#{$about-modal-box}__close--sm--PaddingBlockEnd);
   }
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--lg) {
-    --#{$about-modal-box}__close--PaddingRight: var(--#{$about-modal-box}__close--lg--PaddingRight);
+    --#{$about-modal-box}__close--PaddingInlineEnd: var(--#{$about-modal-box}__close--lg--PaddingInlineEnd);
   }
 
   // Close Button
@@ -59,42 +59,42 @@
   --#{$about-modal-box}__brand-image--Height: #{pf-size-prem(40px)};
 
   // Header
-  --#{$about-modal-box}__header--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__header--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$about-modal-box}__header--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__header--sm--PaddingRight: var(--pf-t--global--spacer--3xl);
-  --#{$about-modal-box}__header--sm--PaddingLeft: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__header--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__header--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$about-modal-box}__header--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__header--sm--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__header--sm--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$about-modal-box}__header--PaddingRight: var(--#{$about-modal-box}__header--sm--PaddingRight);
-    --#{$about-modal-box}__header--PaddingLeft: var(--#{$about-modal-box}__header--sm--PaddingLeft);
+    --#{$about-modal-box}__header--PaddingInlineEnd: var(--#{$about-modal-box}__header--sm--PaddingInlineEnd);
+    --#{$about-modal-box}__header--PaddingInlineStart: var(--#{$about-modal-box}__header--sm--PaddingInlineStart);
   }
 
   // Strapline
-  --#{$about-modal-box}__strapline--PaddingTop: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__strapline--PaddingBlockStart: var(--pf-t--global--spacer--xl);
   --#{$about-modal-box}__strapline--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$about-modal-box}__strapline--Color: var(--pf-t--global--text--color--subtle);
-  --#{$about-modal-box}__strapline--sm--PaddingTop: var(--pf-t--global--spacer--2xl);
+  --#{$about-modal-box}__strapline--sm--PaddingBlockStart: var(--pf-t--global--spacer--2xl);
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$about-modal-box}__strapline--PaddingTop: var(--#{$about-modal-box}__strapline--sm--PaddingTop);
+    --#{$about-modal-box}__strapline--PaddingBlockStart: var(--#{$about-modal-box}__strapline--sm--PaddingBlockStart);
   }
 
   // Content
-  --#{$about-modal-box}__content--MarginTop: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__content--MarginRight: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__content--MarginBottom: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__content--MarginLeft: var(--pf-t--global--spacer--xl);
-  --#{$about-modal-box}__content--sm--MarginTop: var(--pf-t--global--spacer--2xl);
-  --#{$about-modal-box}__content--sm--MarginRight: var(--pf-t--global--spacer--3xl);
-  --#{$about-modal-box}__content--sm--MarginBottom: var(--pf-t--global--spacer--2xl);
-  --#{$about-modal-box}__content--sm--MarginLeft: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__content--MarginBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__content--MarginInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__content--MarginBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__content--MarginInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$about-modal-box}__content--sm--MarginBlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$about-modal-box}__content--sm--MarginInlineEnd: var(--pf-t--global--spacer--3xl);
+  --#{$about-modal-box}__content--sm--MarginBlockEnd: var(--pf-t--global--spacer--2xl);
+  --#{$about-modal-box}__content--sm--MarginInlineStart: var(--pf-t--global--spacer--3xl);
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$about-modal-box}__content--MarginTop: var(--#{$about-modal-box}__content--sm--MarginTop);
-    --#{$about-modal-box}__content--MarginRight: var(--#{$about-modal-box}__content--sm--MarginRight);
-    --#{$about-modal-box}__content--MarginBottom: var(--#{$about-modal-box}__content--sm--MarginBottom);
-    --#{$about-modal-box}__content--MarginLeft: var(--#{$about-modal-box}__content--sm--MarginLeft);
+    --#{$about-modal-box}__content--MarginBlockStart: var(--#{$about-modal-box}__content--sm--MarginBlockStart);
+    --#{$about-modal-box}__content--MarginInlineEnd: var(--#{$about-modal-box}__content--sm--MarginInlineEnd);
+    --#{$about-modal-box}__content--MarginBlockEnd: var(--#{$about-modal-box}__content--sm--MarginBlockEnd);
+    --#{$about-modal-box}__content--MarginInlineStart: var(--#{$about-modal-box}__content--sm--MarginInlineStart);
   }
 }
 
@@ -137,10 +137,10 @@
 .#{$about-modal-box}__brand {
   display: flex;
   grid-area: brand;
-  padding-block-start: var(--#{$about-modal-box}__brand--PaddingTop);
-  padding-block-end: var(--#{$about-modal-box}__brand--PaddingBottom);
-  padding-inline-start: var(--#{$about-modal-box}__brand--PaddingLeft);
-  padding-inline-end: var(--#{$about-modal-box}__brand--PaddingRight);
+  padding-block-start: var(--#{$about-modal-box}__brand--PaddingBlockStart);
+  padding-block-end: var(--#{$about-modal-box}__brand--PaddingBlockEnd);
+  padding-inline-start: var(--#{$about-modal-box}__brand--PaddingInlineStart);
+  padding-inline-end: var(--#{$about-modal-box}__brand--PaddingInlineEnd);
 }
 
 .#{$about-modal-box}__brand-image {
@@ -152,14 +152,14 @@
   display: flex;
   flex-direction: column;
   grid-area: header;
-  padding-block-end: var(--#{$about-modal-box}__header--PaddingBottom);
-  padding-inline-start: var(--#{$about-modal-box}__header--PaddingLeft);
-  padding-inline-end: var(--#{$about-modal-box}__header--PaddingRight);
+  padding-block-end: var(--#{$about-modal-box}__header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$about-modal-box}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$about-modal-box}__header--PaddingInlineEnd);
 }
 
 // Strapline
 .#{$about-modal-box}__strapline {
-  padding-block-start: var(--#{$about-modal-box}__strapline--PaddingTop);
+  padding-block-start: var(--#{$about-modal-box}__strapline--PaddingBlockStart);
   margin-block-start: auto;
   font-size: var(--#{$about-modal-box}__strapline--FontSize);
   color: var(--#{$about-modal-box}__strapline--Color);
@@ -170,10 +170,10 @@
   display: flex;
   flex-direction: column;
   grid-area: content;
-  margin-block-start: var(--#{$about-modal-box}__content--MarginTop);
-  margin-block-end: var(--#{$about-modal-box}__content--MarginBottom);
-  margin-inline-start: var(--#{$about-modal-box}__content--MarginLeft); // Using margin instead of padding to prevent scrollbar extending to top of content block
-  margin-inline-end: var(--#{$about-modal-box}__content--MarginRight);
+  margin-block-start: var(--#{$about-modal-box}__content--MarginBlockStart);
+  margin-block-end: var(--#{$about-modal-box}__content--MarginBlockEnd);
+  margin-inline-start: var(--#{$about-modal-box}__content--MarginInlineStart); // Using margin instead of padding to prevent scrollbar extending to top of content block
+  margin-inline-end: var(--#{$about-modal-box}__content--MarginInlineEnd);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -194,9 +194,9 @@
   grid-area: close;
   align-items: flex-start;
   justify-content: flex-end;
-  padding-block-start: var(--#{$about-modal-box}__close--PaddingTop);
-  padding-block-end: var(--#{$about-modal-box}__close--PaddingBottom);
-  padding-inline-end: var(--#{$about-modal-box}__close--PaddingRight);
+  padding-block-start: var(--#{$about-modal-box}__close--PaddingBlockStart);
+  padding-block-end: var(--#{$about-modal-box}__close--PaddingBlockEnd);
+  padding-inline-end: var(--#{$about-modal-box}__close--PaddingInlineEnd);
 
   @media only screen and (min-width: $pf-v6-global--breakpoint--sm) {
     grid-area: 1 / 2;

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -11,11 +11,11 @@
 
   // accordion toggle
   --#{$accordion}__toggle--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__toggle--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__toggle--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$accordion}__toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__toggle--m-expanded--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
@@ -33,9 +33,9 @@
   --#{$accordion}__toggle--m-expanded__toggle-icon--Rotate: 90deg;
 
   // accordion expandable content
-  --#{$accordion}__expandable-content--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$accordion}__expandable-content--MarginBottom: var(--pf-t--global--spacer--md);
-  --#{$accordion}__expandable-content--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
@@ -43,18 +43,18 @@
   --#{$accordion}__expandable-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
 
   // accordion expandable content body
-  --#{$accordion}__expandable-content-body--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__expandable-content-body--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__expandable-content-body--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__expandable-content-body--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$accordion}__expandable-content-body--expandable-content-body--PaddingTop: 0;
+  --#{$accordion}__expandable-content-body--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content-body--expandable-content-body--PaddingBlockStart: 0;
 
   // large
-  --#{$accordion}--m-display-lg__toggle--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$accordion}--m-display-lg__toggle--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}--m-display-lg__toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$accordion}--m-display-lg__toggle--FontSize: var(--pf-t--global--font--size--heading--sm);
   --#{$accordion}--m-display-lg__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading);
@@ -64,8 +64,8 @@
 
   // bordered
   --#{$accordion}--m-bordered--RowGap: 0;
-  --#{$accordion}__item--m-bordered--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$accordion}__item--m-bordered--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$accordion}__item--m-bordered--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$accordion}__item--m-bordered--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 }
 
 .#{$accordion} {
@@ -79,11 +79,11 @@
   }
 
   &.pf-m-display-lg {
-    --#{$accordion}__toggle--PaddingTop: var(--#{$accordion}--m-display-lg__toggle--PaddingTop);
-    --#{$accordion}__toggle--PaddingRight: var(--#{$accordion}--m-display-lg__toggle--PaddingRight);
-    --#{$accordion}__toggle--PaddingBottom: var(--#{$accordion}--m-display-lg__toggle--PaddingBottom);
-    --#{$accordion}__toggle--m-expanded--PaddingBottom: var(--#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBottom);
-    --#{$accordion}__toggle--PaddingLeft: var(--#{$accordion}--m-display-lg__toggle--PaddingLeft);
+    --#{$accordion}__toggle--PaddingBlockStart: var(--#{$accordion}--m-display-lg__toggle--PaddingBlockStart);
+    --#{$accordion}__toggle--PaddingInlineEnd: var(--#{$accordion}--m-display-lg__toggle--PaddingInlineEnd);
+    --#{$accordion}__toggle--PaddingBlockEnd: var(--#{$accordion}--m-display-lg__toggle--PaddingBlockEnd);
+    --#{$accordion}__toggle--m-expanded--PaddingBlockEnd: var(--#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBlockEnd);
+    --#{$accordion}__toggle--PaddingInlineStart: var(--#{$accordion}--m-display-lg__toggle--PaddingInlineStart);
     --#{$accordion}__toggle--FontFamily: var(--#{$accordion}--m-display-lg__toggle--FontFamily);
     --#{$accordion}__toggle--FontSize: var(--#{$accordion}--m-display-lg__toggle--FontSize);
     --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}--m-display-lg__toggle-text--FontWeight);
@@ -98,7 +98,7 @@
     --#{$accordion}__toggle--BorderRadius: 0;
 
     .#{$accordion}__item {
-      border-block-end: var(--#{$accordion}__item--m-bordered--BorderBottomWidth) solid var(--#{$accordion}__item--m-bordered--BorderBottomColor);
+      border-block-end: var(--#{$accordion}__item--m-bordered--BorderBlockEndWidth) solid var(--#{$accordion}__item--m-bordered--BorderBlockEndColor);
     }
   }
 }
@@ -107,7 +107,7 @@
   border-radius: var(--#{$accordion}__item--BorderRadius);
 
   &.pf-m-expanded {
-    --#{$accordion}__toggle--PaddingBottom: var(--#{$accordion}__toggle--m-expanded--PaddingBottom);
+    --#{$accordion}__toggle--PaddingBlockEnd: var(--#{$accordion}__toggle--m-expanded--PaddingBlockEnd);
     --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
 
     background-color: var(--#{$accordion}__item--m-expanded--BackgroundColor);
@@ -123,10 +123,10 @@
   column-gap: var(--#{$accordion}__toggle--ColumnGap);
   align-items: center;
   width: 100%;
-  padding-block-start: var(--#{$accordion}__toggle--PaddingTop);
-  padding-block-end: var(--#{$accordion}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$accordion}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$accordion}__toggle--PaddingRight);
+  padding-block-start: var(--#{$accordion}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$accordion}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$accordion}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$accordion}__toggle--PaddingInlineEnd);
   font-family: var(--#{$accordion}__toggle--FontFamily, inherit);
   font-size: var(--#{$accordion}__toggle--FontSize, inherit);
   text-align: start;
@@ -154,9 +154,9 @@
 }
 
 .#{$accordion}__expandable-content {
-  margin-block-end: var(--#{$accordion}__expandable-content--MarginBottom);
-  margin-inline-start: var(--#{$accordion}__expandable-content--MarginLeft);
-  margin-inline-end: var(--#{$accordion}__expandable-content--MarginRight);
+  margin-block-end: var(--#{$accordion}__expandable-content--MarginBlockEnd);
+  margin-inline-start: var(--#{$accordion}__expandable-content--MarginInlineStart);
+  margin-inline-end: var(--#{$accordion}__expandable-content--MarginInlineEnd);
   font-size: var(--#{$accordion}__expandable-content--FontSize);
   color: var(--#{$accordion}__expandable-content--Color);
   background-color: var(--#{$accordion}__expandable-content--BackgroundColor);
@@ -169,12 +169,12 @@
 }
 
 .#{$accordion}__expandable-content-body {
-  padding-block-start: var(--#{$accordion}__expandable-content-body--PaddingTop);
-  padding-block-end: var(--#{$accordion}__expandable-content-body--PaddingBottom);
-  padding-inline-start: var(--#{$accordion}__expandable-content-body--PaddingLeft);
-  padding-inline-end: var(--#{$accordion}__expandable-content-body--PaddingRight);
+  padding-block-start: var(--#{$accordion}__expandable-content-body--PaddingBlockStart);
+  padding-block-end: var(--#{$accordion}__expandable-content-body--PaddingBlockEnd);
+  padding-inline-start: var(--#{$accordion}__expandable-content-body--PaddingInlineStart);
+  padding-inline-end: var(--#{$accordion}__expandable-content-body--PaddingInlineEnd);
 
   & + & {
-    --#{$accordion}__expandable-content-body--PaddingTop: var(--#{$accordion}__expandable-content-body--expandable-content-body--PaddingTop);
+    --#{$accordion}__expandable-content-body--PaddingBlockStart: var(--#{$accordion}__expandable-content-body--expandable-content-body--PaddingBlockStart);
   }
 }

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -6,8 +6,8 @@
   --#{$alert-group}__item--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Toast variables
-  --#{$alert-group}--m-toast--BlockStart: var(--pf-t--global--spacer--2xl);
-  --#{$alert-group}--m-toast--InlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$alert-group}--m-toast--InsetBlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$alert-group}--m-toast--InsetInlineEnd: var(--pf-t--global--spacer--xl);
   --#{$alert-group}--m-toast--MaxWidth: #{pf-size-prem(600px)};
   --#{$alert-group}--m-toast--ZIndex: var(--pf-t--global--z-index--2xl);
 
@@ -37,10 +37,10 @@
   // Toast positioning modifier
   &.pf-m-toast {
     position: fixed;
-    inset-block-start: var(--#{$alert-group}--m-toast--BlockStart);
-    inset-inline-end: var(--#{$alert-group}--m-toast--InlineEnd);
+    inset-block-start: var(--#{$alert-group}--m-toast--InsetBlockStart);
+    inset-inline-end: var(--#{$alert-group}--m-toast--InsetInlineEnd);
     z-index: var(--#{$alert-group}--m-toast--ZIndex);
-    width: calc(100% - calc(var(--#{$alert-group}--m-toast--InlineEnd) * 2));
+    width: calc(100% - calc(var(--#{$alert-group}--m-toast--InsetInlineEnd) * 2));
     max-width: var(--#{$alert-group}--m-toast--MaxWidth);
   }
 }

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -3,21 +3,21 @@
 // Tabs
 .#{$alert-group} {
   // Alert group variables
-  --#{$alert-group}__item--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__item--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Toast variables
-  --#{$alert-group}--m-toast--Top: var(--pf-t--global--spacer--2xl);
-  --#{$alert-group}--m-toast--Right: var(--pf-t--global--spacer--xl);
+  --#{$alert-group}--m-toast--BlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$alert-group}--m-toast--InlineEnd: var(--pf-t--global--spacer--xl);
   --#{$alert-group}--m-toast--MaxWidth: #{pf-size-prem(600px)};
   --#{$alert-group}--m-toast--ZIndex: var(--pf-t--global--z-index--2xl);
 
   // Overflow button
   --#{$alert-group}__overflow-button--BorderWidth: 0;
   --#{$alert-group}__overflow-button--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$alert-group}__overflow-button--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$alert-group}__overflow-button--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$alert-group}__overflow-button--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$alert-group}__overflow-button--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__overflow-button--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__overflow-button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__overflow-button--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$alert-group}__overflow-button--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$alert-group}__overflow-button--Color: var(--pf-t--global--text--color--link--default);
   --#{$alert-group}__overflow-button--BoxShadow: var(--pf-t--global--box-shadow--lg);
   --#{$alert-group}__overflow-button--BackgroundColor: var(--pf-t--global--background--color--floating--default);
@@ -31,16 +31,16 @@
 
   // Spacing between alerts
   > * + * {
-    margin-block-start: var(--#{$alert-group}__item--MarginTop);
+    margin-block-start: var(--#{$alert-group}__item--MarginBlockStart);
   }
 
   // Toast positioning modifier
   &.pf-m-toast {
     position: fixed;
-    inset-block-start: var(--#{$alert-group}--m-toast--Top);
-    inset-inline-end: var(--#{$alert-group}--m-toast--Right);
+    inset-block-start: var(--#{$alert-group}--m-toast--BlockStart);
+    inset-inline-end: var(--#{$alert-group}--m-toast--InlineEnd);
     z-index: var(--#{$alert-group}--m-toast--ZIndex);
-    width: calc(100% - calc(var(--#{$alert-group}--m-toast--Right) * 2));
+    width: calc(100% - calc(var(--#{$alert-group}--m-toast--InlineEnd) * 2));
     max-width: var(--#{$alert-group}--m-toast--MaxWidth);
   }
 }
@@ -48,10 +48,10 @@
 .#{$alert-group}__overflow-button {
   position: relative;
   width: 100%;
-  padding-block-start: var(--#{$alert-group}__overflow-button--PaddingTop);
-  padding-block-end: var(--#{$alert-group}__overflow-button--PaddingBottom);
-  padding-inline-start: var(--#{$alert-group}__overflow-button--PaddingLeft);
-  padding-inline-end: var(--#{$alert-group}__overflow-button--PaddingRight);
+  padding-block-start: var(--#{$alert-group}__overflow-button--PaddingBlockStart);
+  padding-block-end: var(--#{$alert-group}__overflow-button--PaddingBlockEnd);
+  padding-inline-start: var(--#{$alert-group}__overflow-button--PaddingInlineStart);
+  padding-inline-end: var(--#{$alert-group}__overflow-button--PaddingInlineEnd);
   color: var(--#{$alert-group}__overflow-button--Color);
   background-color: var(--#{$alert-group}__overflow-button--BackgroundColor);
   border-width: var(--#{$alert-group}__overflow-button--BorderWidth);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -12,16 +12,16 @@
   --#{$alert}--BorderWidth: var(--pf-t--global--border--width--box--status--default);
   --#{$alert}--BorderColor: transparent;
   --#{$alert}--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$alert}--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$alert}--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$alert}--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$alert}--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$alert}--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$alert}--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$alert}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$alert}--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$alert}--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Toggle
-  --#{$alert}__toggle--MarginTop: calc(-1 * var(--pf-t--global--spacer--button--vertical--default) - #{pf-size-prem(1px)});
-  --#{$alert}__toggle--MarginBottom: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
-  --#{$alert}__toggle--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$alert}__toggle--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--button--vertical--default) - #{pf-size-prem(1px)});
+  --#{$alert}__toggle--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
+  --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Toggle icon
   --#{$alert}__toggle-icon--Rotate: 0;
@@ -29,8 +29,8 @@
 
   // Icon
   --#{$alert}__icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$alert}__icon--MarginTop: #{pf-size-prem(4px)};
-  --#{$alert}__icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$alert}__icon--MarginBlockStart: #{pf-size-prem(4px)};
+  --#{$alert}__icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$alert}__icon--FontSize: var(--pf-t--global--icon--size--md);
 
   // Title
@@ -42,20 +42,20 @@
   --#{$alert}__title--max-lines: 1;
 
   // Action
-  --#{$alert}__action--MarginTop: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$alert}__action--MarginBottom: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$alert}__action--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$alert}__action--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$alert}__action--TranslateY: #{pf-size-prem(2px)};
-  --#{$alert}__action--MarginRight: calc(var(--pf-t--global--spacer--sm) * -1);
+  --#{$alert}__action--MarginInlineEnd: calc(var(--pf-t--global--spacer--sm) * -1);
 
   // Description
-  --#{$alert}__description--PaddingTop: var(--pf-t--global--spacer--xs);
+  --#{$alert}__description--PaddingBlockStart: var(--pf-t--global--spacer--xs);
 
   // Action group
-  --#{$alert}__action-group--PaddingTop-base: var(--pf-t--global--spacer--xs);
-  --#{$alert}__action-group--PaddingTop: var(--#{$alert}__action-group--PaddingTop-base);
-  --#{$alert}__description--action-group--PaddingTop-base: var(--pf-t--global--spacer--sm);
-  --#{$alert}__description--action-group--PaddingTop: var(--#{$alert}__description--action-group--PaddingTop-base);
-  --#{$alert}__action-group__c-button--not-last-child--MarginRight: var(--pf-t--global--spacer--lg);
+  --#{$alert}__action-group--PaddingBlockStart-base: var(--pf-t--global--spacer--xs);
+  --#{$alert}__action-group--PaddingBlockStart: var(--#{$alert}__action-group--PaddingBlockStart-base);
+  --#{$alert}__description--action-group--PaddingBlockStart-base: var(--pf-t--global--spacer--sm);
+  --#{$alert}__description--action-group--PaddingBlockStart: var(--#{$alert}__description--action-group--PaddingBlockStart-base);
+  --#{$alert}__action-group__c-button--not-last-child--MarginInlineEnd: var(--pf-t--global--spacer--lg);
 
   // Custom
   --#{$alert}--m-custom--BorderColor: var(--pf-t--global--border--color--status--custom--default);
@@ -89,10 +89,10 @@
   // Inline plain
   --#{$alert}--m-inline--m-plain--BorderWidth: 0;
   --#{$alert}--m-inline--m-plain--BackgroundColor: transparent;
-  --#{$alert}--m-inline--m-plain--PaddingTop: 0;
-  --#{$alert}--m-inline--m-plain--PaddingRight: 0;
-  --#{$alert}--m-inline--m-plain--PaddingBottom: 0;
-  --#{$alert}--m-inline--m-plain--PaddingLeft: 0;
+  --#{$alert}--m-inline--m-plain--PaddingBlockStart: 0;
+  --#{$alert}--m-inline--m-plain--PaddingInlineEnd: 0;
+  --#{$alert}--m-inline--m-plain--PaddingBlockEnd: 0;
+  --#{$alert}--m-inline--m-plain--PaddingInlineStart: 0;
 
   // Expandable
   --#{$alert}--m-expandable--GridTemplateColumns: auto max-content 1fr max-content;
@@ -100,11 +100,11 @@
     "toggle icon title action"
     ". . description description"
     ". . actiongroup actiongroup";
-  --#{$alert}--m-expandable__description--action-group--PaddingTop: var(--#{$alert}__action-group--PaddingTop-base);
+  --#{$alert}--m-expandable__description--action-group--PaddingBlockStart: var(--#{$alert}__action-group--PaddingBlockStart-base);
 
   // Expanded
   --#{$alert}--m-expanded__toggle-icon--Rotate: 90deg;
-  --#{$alert}--m-expanded__description--action-group--PaddingTop: var(--#{$alert}__description--action-group--PaddingTop-base);
+  --#{$alert}--m-expanded__description--action-group--PaddingBlockStart: var(--#{$alert}__description--action-group--PaddingBlockStart-base);
 }
 
 .#{$alert} {
@@ -112,10 +112,10 @@
   display: grid;
   grid-template-areas: var(--#{$alert}--GridTemplateAreas);
   grid-template-columns: var(--#{$alert}--GridTemplateColumns);
-  padding-block-start: var(--#{$alert}--PaddingTop);
-  padding-block-end: var(--#{$alert}--PaddingBottom);
-  padding-inline-start: var(--#{$alert}--PaddingLeft);
-  padding-inline-end: var(--#{$alert}--PaddingRight);
+  padding-block-start: var(--#{$alert}--PaddingBlockStart);
+  padding-block-end: var(--#{$alert}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$alert}--PaddingInlineStart);
+  padding-inline-end: var(--#{$alert}--PaddingInlineEnd);
   font-size: var(--#{$alert}--FontSize);
   background-color: var(--#{$alert}--BackgroundColor);
   border: var(--#{$alert}--BorderWidth) solid var(--#{$alert}--BorderColor);
@@ -160,28 +160,28 @@
   &.pf-m-plain {
     --#{$alert}--BorderWidth: var(--#{$alert}--m-inline--m-plain--BorderWidth);
     --#{$alert}--BackgroundColor: var(--#{$alert}--m-inline--m-plain--BackgroundColor);
-    --#{$alert}--PaddingTop: var(--#{$alert}--m-inline--m-plain--PaddingTop);
-    --#{$alert}--PaddingRight: var(--#{$alert}--m-inline--m-plain--PaddingRight);
-    --#{$alert}--PaddingBottom: var(--#{$alert}--m-inline--m-plain--PaddingBottom);
-    --#{$alert}--PaddingLeft: var(--#{$alert}--m-inline--m-plain--PaddingLeft);
+    --#{$alert}--PaddingBlockStart: var(--#{$alert}--m-inline--m-plain--PaddingBlockStart);
+    --#{$alert}--PaddingInlineEnd: var(--#{$alert}--m-inline--m-plain--PaddingInlineEnd);
+    --#{$alert}--PaddingBlockEnd: var(--#{$alert}--m-inline--m-plain--PaddingBlockEnd);
+    --#{$alert}--PaddingInlineStart: var(--#{$alert}--m-inline--m-plain--PaddingInlineStart);
   }
 
   &.pf-m-expandable {
     --#{$alert}--GridTemplateColumns: var(--#{$alert}--m-expandable--GridTemplateColumns);
     --#{$alert}--GridTemplateAreas: var(--#{$alert}--m-expandable--GridTemplateAreas);
-    --#{$alert}__description--action-group--PaddingTop: var(--#{$alert}--m-expandable__description--action-group--PaddingTop);
+    --#{$alert}__description--action-group--PaddingBlockStart: var(--#{$alert}--m-expandable__description--action-group--PaddingBlockStart);
   }
 
   &.pf-m-expanded {
     --#{$alert}__toggle-icon--Rotate: var(--#{$alert}--m-expanded__toggle-icon--Rotate);
-    --#{$alert}__description--action-group--PaddingTop: var(--#{$alert}--m-expanded__description--action-group--PaddingTop);
+    --#{$alert}__description--action-group--PaddingBlockStart: var(--#{$alert}--m-expanded__description--action-group--PaddingBlockStart);
   }
 }
 
 .#{$alert}__toggle {
-  margin-block-start: var(--#{$alert}__toggle--MarginTop);
-  margin-block-end: var(--#{$alert}__toggle--MarginBottom);
-  margin-inline-end: var(--#{$alert}__toggle--MarginRight);
+  margin-block-start: var(--#{$alert}__toggle--MarginBlockStart);
+  margin-block-end: var(--#{$alert}__toggle--MarginBlockEnd);
+  margin-inline-end: var(--#{$alert}__toggle--MarginInlineEnd);
 }
 
 .#{$alert}__toggle-icon {
@@ -195,8 +195,8 @@
 .#{$alert}__icon {
   display: flex;
   grid-area: icon;
-  margin-block-start: var(--#{$alert}__icon--MarginTop);
-  margin-inline-end: var(--#{$alert}__icon--MarginRight);
+  margin-block-start: var(--#{$alert}__icon--MarginBlockStart);
+  margin-inline-end: var(--#{$alert}__icon--MarginInlineEnd);
   font-size: var(--#{$alert}__icon--FontSize);
   color: var(--#{$alert}__icon--Color);
 }
@@ -217,19 +217,19 @@
 
 .#{$alert}__description {
   grid-area: description;
-  padding-block-start: var(--#{$alert}__description--PaddingTop);
+  padding-block-start: var(--#{$alert}__description--PaddingBlockStart);
   word-break: break-word;
 
   + .#{$alert}__action-group {
-    --#{$alert}__action-group--PaddingTop: var(--#{$alert}__description--action-group--PaddingTop);
+    --#{$alert}__action-group--PaddingBlockStart: var(--#{$alert}__description--action-group--PaddingBlockStart);
   }
 }
 
 .#{$alert}__action {
   grid-area: action;
-  margin-block-start: var(--#{$alert}__action--MarginTop);
-  margin-block-end: var(--#{$alert}__action--MarginBottom);
-  margin-inline-end: var(--#{$alert}__action--MarginRight);
+  margin-block-start: var(--#{$alert}__action--MarginBlockStart);
+  margin-block-end: var(--#{$alert}__action--MarginBlockEnd);
+  margin-inline-end: var(--#{$alert}__action--MarginInlineEnd);
   transform: translateY(var(--#{$alert}__action--TranslateY));
 
   > .#{$button} {
@@ -239,13 +239,13 @@
 
 .#{$alert}__action-group {
   grid-area: actiongroup;
-  padding-block-start: var(--#{$alert}__action-group--PaddingTop);
+  padding-block-start: var(--#{$alert}__action-group--PaddingBlockStart);
 
   > .#{$button} {
     --#{$button}--m-link--m-inline--hover--TextDecoration: none;
 
     &:not(:last-child) {
-      margin-inline-end: var(--#{$alert}__action-group__c-button--not-last-child--MarginRight);
+      margin-inline-end: var(--#{$alert}__action-group__c-button--not-last-child--MarginInlineEnd);
     }
   }
 }

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -4,18 +4,18 @@
   // Menu
   --#{$app-launcher}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
   --#{$app-launcher}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$app-launcher}__menu--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$app-launcher}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$app-launcher}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$app-launcher}--m-top__menu--Top: 0;
+  --#{$app-launcher}--m-top__menu--BlockStart: 0;
   --#{$app-launcher}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Expanded
-  --#{$app-launcher}__toggle--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$app-launcher}__toggle--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$app-launcher}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$app-launcher}__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$app-launcher}__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$app-launcher}__toggle--Color: var(--#{$pf-global}--Color--200);
   --#{$app-launcher}__toggle--hover--Color: var(--#{$pf-global}--Color--100);
   --#{$app-launcher}__toggle--active--Color: var(--#{$pf-global}--Color--100);
@@ -25,25 +25,25 @@
   --#{$app-launcher}__toggle--BackgroundColor: transparent;
 
   // Menu input
-  --#{$app-launcher}__menu-search--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu-search--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__menu-search--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__menu-search--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__menu-search--BottomBorderColor: var(--#{$pf-global}--BorderColor--100);
-  --#{$app-launcher}__menu-search--BottomBorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$app-launcher}__menu-search--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu-search--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu-search--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-search--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-search--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-search--BlockEndBorderColor: var(--#{$pf-global}--BorderColor--100);
+  --#{$app-launcher}__menu-search--BlockEndBorderWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$app-launcher}__menu-search--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   // Menu item
-  --#{$app-launcher}__menu-item--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu-item--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__menu-item--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu-item--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-item--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-item--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu-item--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$app-launcher}__menu-item--Color: var(--#{$pf-global}--Color--dark-100);
   --#{$app-launcher}__menu-item--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$app-launcher}__menu-item--Width: 100%;
   --#{$app-launcher}__menu-item--disabled--Color: var(--#{$pf-global}--Color--dark-200);
   --#{$app-launcher}__menu-item--hover--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-300);
-  --#{$app-launcher}__menu-item--m-link--PaddingRight: 0;
+  --#{$app-launcher}__menu-item--m-link--PaddingInlineEnd: 0;
   --#{$app-launcher}__menu-item--m-link--hover--BackgroundColor: transparent;
   --#{$app-launcher}__menu-item--m-action--Color: var(--#{$pf-global}--Color--200);
   --#{$app-launcher}__menu-item--m-action--Width: auto;
@@ -56,29 +56,29 @@
   --#{$app-launcher}__menu-item--m-favorite__menu-item--m-action--hover--Color: var(--#{$pf-global}--palette--gold-500);
 
   // Menu item icon
-  --#{$app-launcher}__menu-item-icon--MarginRight: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__menu-item-icon--MarginInlineEnd: var(--#{$pf-global}--spacer--sm);
   --#{$app-launcher}__menu-item-icon--Width: var(--#{$pf-global}--icon--FontSize--lg);
   --#{$app-launcher}__menu-item-icon--Height: var(--#{$pf-global}--icon--FontSize--lg);
 
   // Menu item external icon
   --#{$app-launcher}__menu-item-external-icon--Color: var(--#{$pf-global}--link--Color);
-  --#{$app-launcher}__menu-item-external-icon--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$app-launcher}__menu-item-external-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$app-launcher}__menu-item-external-icon--TranslateY: #{pf-size-prem(-1px)};
   --#{$app-launcher}__menu-item-external-icon--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
 
   // Groups
-  --#{$app-launcher}__group--group--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__group-title--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__group-title--PaddingRight: var(--#{$app-launcher}__menu-item--PaddingRight);
-  --#{$app-launcher}__group-title--PaddingBottom: var(--#{$app-launcher}__menu-item--PaddingBottom);
-  --#{$app-launcher}__group-title--PaddingLeft: var(--#{$app-launcher}__menu-item--PaddingLeft);
+  --#{$app-launcher}__group--group--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__group-title--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}__group-title--PaddingInlineEnd: var(--#{$app-launcher}__menu-item--PaddingInlineEnd);
+  --#{$app-launcher}__group-title--PaddingBlockEnd: var(--#{$app-launcher}__menu-item--PaddingBlockEnd);
+  --#{$app-launcher}__group-title--PaddingInlineStart: var(--#{$app-launcher}__menu-item--PaddingInlineStart);
   --#{$app-launcher}__group-title--FontSize: var(--#{$pf-global}--FontSize--xs);
   --#{$app-launcher}__group-title--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$app-launcher}__group-title--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Divider
-  --#{$app-launcher}--c-divider--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}--c-divider--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}--c-divider--MarginBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$app-launcher}--c-divider--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   position: relative;
   display: inline-block;
@@ -91,21 +91,21 @@
   }
 
   .#{$divider} {
-    margin-block-start: var(--#{$app-launcher}--c-divider--MarginTop);
-    margin-block-end: var(--#{$app-launcher}--c-divider--MarginBottom);
+    margin-block-start: var(--#{$app-launcher}--c-divider--MarginBlockStart);
+    margin-block-end: var(--#{$app-launcher}--c-divider--MarginBlockEnd);
 
     // Support divider as last item in group to separate groups
     &:last-child {
-      --#{$app-launcher}--c-divider--MarginBottom: 0;
+      --#{$app-launcher}--c-divider--MarginBlockEnd: 0;
     }
   }
 }
 
 .#{$app-launcher}__toggle {
-  padding-block-start: var(--#{$app-launcher}__toggle--PaddingTop);
-  padding-block-end: var(--#{$app-launcher}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$app-launcher}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$app-launcher}__toggle--PaddingRight);
+  padding-block-start: var(--#{$app-launcher}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$app-launcher}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$app-launcher}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$app-launcher}__toggle--PaddingInlineEnd);
   color: var(--#{$app-launcher}__toggle--Color);
   background-color: var(--#{$app-launcher}__toggle--BackgroundColor);
   border: none;
@@ -132,11 +132,11 @@
 
 .#{$app-launcher}__menu {
   position: absolute;
-  inset-block-start: var(--#{$app-launcher}__menu--Top);
+  inset-block-start: var(--#{$app-launcher}__menu--BlockStart);
   z-index: var(--#{$app-launcher}__menu--ZIndex);
   min-width: 100%;
-  padding-block-start: var(--#{$app-launcher}__menu--PaddingTop);
-  padding-block-end: var(--#{$app-launcher}__menu--PaddingBottom);
+  padding-block-start: var(--#{$app-launcher}__menu--PaddingBlockStart);
+  padding-block-end: var(--#{$app-launcher}__menu--PaddingBlockEnd);
   background-color: var(--#{$app-launcher}__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--#{$app-launcher}__menu--BoxShadow);
@@ -146,7 +146,7 @@
   }
 
   .#{$app-launcher}.pf-m-top & {
-    --#{$app-launcher}__menu--Top: var(--#{$app-launcher}--m-top__menu--Top);
+    --#{$app-launcher}__menu--BlockStart: var(--#{$app-launcher}--m-top__menu--BlockStart);
 
     transform: translateY(var(--#{$app-launcher}--m-top__menu--TranslateY));
   }
@@ -165,12 +165,12 @@
 }
 
 .#{$app-launcher}__menu-search {
-  padding-block-start: var(--#{$app-launcher}__menu-search--PaddingTop);
-  padding-block-end: var(--#{$app-launcher}__menu-search--PaddingBottom);
-  padding-inline-start: var(--#{$app-launcher}__menu-search--PaddingLeft);
-  padding-inline-end: var(--#{$app-launcher}__menu-search--PaddingRight);
-  margin-block-end: var(--#{$app-launcher}__menu-search--MarginBottom);
-  border-block-end: var(--#{$app-launcher}__menu-search--BottomBorderWidth) solid var(--#{$app-launcher}__menu-search--BottomBorderColor);
+  padding-block-start: var(--#{$app-launcher}__menu-search--PaddingBlockStart);
+  padding-block-end: var(--#{$app-launcher}__menu-search--PaddingBlockEnd);
+  padding-inline-start: var(--#{$app-launcher}__menu-search--PaddingInlineStart);
+  padding-inline-end: var(--#{$app-launcher}__menu-search--PaddingInlineEnd);
+  margin-block-end: var(--#{$app-launcher}__menu-search--MarginBlockEnd);
+  border-block-end: var(--#{$app-launcher}__menu-search--BlockEndBorderWidth) solid var(--#{$app-launcher}__menu-search--BlockEndBorderColor);
 }
 
 .#{$app-launcher}__menu-wrapper {
@@ -186,10 +186,10 @@
   display: flex;
   align-items: center;
   width: var(--#{$app-launcher}__menu-item--Width);
-  padding-block-start: var(--#{$app-launcher}__menu-item--PaddingTop);
-  padding-block-end: var(--#{$app-launcher}__menu-item--PaddingBottom);
-  padding-inline-start: var(--#{$app-launcher}__menu-item--PaddingLeft);
-  padding-inline-end: var(--#{$app-launcher}__menu-item--PaddingRight);
+  padding-block-start: var(--#{$app-launcher}__menu-item--PaddingBlockStart);
+  padding-block-end: var(--#{$app-launcher}__menu-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$app-launcher}__menu-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$app-launcher}__menu-item--PaddingInlineEnd);
   font-weight: var(--#{$app-launcher}__menu-item--FontWeight);
   color: var(--#{$app-launcher}__menu-item--Color);
   white-space: nowrap;
@@ -241,7 +241,7 @@
   }
 
   &.pf-m-link {
-    --#{$app-launcher}__menu-item--PaddingRight: var(--#{$app-launcher}__menu-item--m-link--PaddingRight);
+    --#{$app-launcher}__menu-item--PaddingInlineEnd: var(--#{$app-launcher}__menu-item--m-link--PaddingInlineEnd);
     --#{$app-launcher}__menu-item--hover--BackgroundColor: var(--#{$app-launcher}__menu-item--m-link--hover--BackgroundColor);
   }
 
@@ -265,7 +265,7 @@
   justify-content: center;
   width: var(--#{$app-launcher}__menu-item-icon--Width);
   height: var(--#{$app-launcher}__menu-item-icon--Height);
-  margin-inline-end: var(--#{$app-launcher}__menu-item-icon--MarginRight);
+  margin-inline-end: var(--#{$app-launcher}__menu-item-icon--MarginInlineEnd);
 
   > * {
     max-width: 100%;
@@ -274,7 +274,7 @@
 }
 
 .#{$app-launcher}__menu-item-external-icon {
-  padding-inline-start: var(--#{$app-launcher}__menu-item-external-icon--PaddingLeft);
+  padding-inline-start: var(--#{$app-launcher}__menu-item-external-icon--PaddingInlineStart);
   margin-inline-start: auto;
   font-size: var(--#{$app-launcher}__menu-item-external-icon--FontSize);
   color: var(--#{$app-launcher}__menu-item-external-icon--Color);
@@ -284,15 +284,15 @@
 
 .#{$app-launcher}__group {
   & + & {
-    padding-block-start: var(--#{$app-launcher}__group--group--PaddingTop);
+    padding-block-start: var(--#{$app-launcher}__group--group--PaddingBlockStart);
   }
 }
 
 .#{$app-launcher}__group-title {
-  padding-block-start: var(--#{$app-launcher}__group-title--PaddingTop);
-  padding-block-end: var(--#{$app-launcher}__group-title--PaddingBottom);
-  padding-inline-start: var(--#{$app-launcher}__group-title--PaddingLeft);
-  padding-inline-end: var(--#{$app-launcher}__group-title--PaddingRight);
+  padding-block-start: var(--#{$app-launcher}__group-title--PaddingBlockStart);
+  padding-block-end: var(--#{$app-launcher}__group-title--PaddingBlockEnd);
+  padding-inline-start: var(--#{$app-launcher}__group-title--PaddingInlineStart);
+  padding-inline-end: var(--#{$app-launcher}__group-title--PaddingInlineEnd);
   font-size: var(--#{$app-launcher}__group-title--FontSize);
   font-weight: var(--#{$app-launcher}__group-title--FontWeight);
   color: var(--#{$app-launcher}__group-title--Color);

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -29,8 +29,8 @@
   --#{$app-launcher}__menu-search--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
   --#{$app-launcher}__menu-search--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
   --#{$app-launcher}__menu-search--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
-  --#{$app-launcher}__menu-search--BlockEndBorderColor: var(--#{$pf-global}--BorderColor--100);
-  --#{$app-launcher}__menu-search--BlockEndBorderWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$app-launcher}__menu-search--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--100);
+  --#{$app-launcher}__menu-search--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--sm);
   --#{$app-launcher}__menu-search--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   // Menu item
@@ -170,7 +170,7 @@
   padding-inline-start: var(--#{$app-launcher}__menu-search--PaddingInlineStart);
   padding-inline-end: var(--#{$app-launcher}__menu-search--PaddingInlineEnd);
   margin-block-end: var(--#{$app-launcher}__menu-search--MarginBlockEnd);
-  border-block-end: var(--#{$app-launcher}__menu-search--BlockEndBorderWidth) solid var(--#{$app-launcher}__menu-search--BlockEndBorderColor);
+  border-block-end: var(--#{$app-launcher}__menu-search--BorderBlockEndWidth) solid var(--#{$app-launcher}__menu-search--BorderBlockEndColor);
 }
 
 .#{$app-launcher}__menu-wrapper {

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -6,9 +6,9 @@
   --#{$app-launcher}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$app-launcher}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
   --#{$app-launcher}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
-  --#{$app-launcher}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$app-launcher}__menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$app-launcher}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$app-launcher}--m-top__menu--BlockStart: 0;
+  --#{$app-launcher}--m-top__menu--InsetBlockStart: 0;
   --#{$app-launcher}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Expanded
@@ -132,7 +132,7 @@
 
 .#{$app-launcher}__menu {
   position: absolute;
-  inset-block-start: var(--#{$app-launcher}__menu--BlockStart);
+  inset-block-start: var(--#{$app-launcher}__menu--InsetBlockStart);
   z-index: var(--#{$app-launcher}__menu--ZIndex);
   min-width: 100%;
   padding-block-start: var(--#{$app-launcher}__menu--PaddingBlockStart);
@@ -146,7 +146,7 @@
   }
 
   .#{$app-launcher}.pf-m-top & {
-    --#{$app-launcher}__menu--BlockStart: var(--#{$app-launcher}--m-top__menu--BlockStart);
+    --#{$app-launcher}__menu--InsetBlockStart: var(--#{$app-launcher}--m-top__menu--InsetBlockStart);
 
     transform: translateY(var(--#{$app-launcher}--m-top__menu--TranslateY));
   }

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -1,25 +1,25 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$back-to-top}) {
-  --#{$back-to-top}--Right: var(--pf-t--global--spacer--2xl);
-  --#{$back-to-top}--Bottom: var(--pf-t--global--spacer--lg);
-  --#{$back-to-top}--md--Bottom: var(--pf-t--global--spacer--2xl);
+  --#{$back-to-top}--InlineEnd: var(--pf-t--global--spacer--2xl);
+  --#{$back-to-top}--BlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$back-to-top}--md--BlockEnd: var(--pf-t--global--spacer--2xl);
   --#{$back-to-top}--c-button--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$back-to-top}--c-button--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$back-to-top}--c-button--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$back-to-top}--c-button--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$back-to-top}--c-button--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$back-to-top}--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$back-to-top}--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$back-to-top}--c-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$back-to-top}--c-button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$back-to-top}--c-button--BoxShadow: var(--pf-t--global--box-shadow--sm);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$back-to-top}--Bottom: var(--#{$back-to-top}--md--Bottom);
+    --#{$back-to-top}--BlockEnd: var(--#{$back-to-top}--md--BlockEnd);
   }
 }
 
 .#{$back-to-top} {
   position: absolute;
-  inset-block-end: var(--#{$back-to-top}--Bottom);
-  inset-inline-end: var(--#{$back-to-top}--Right);
+  inset-block-end: var(--#{$back-to-top}--BlockEnd);
+  inset-inline-end: var(--#{$back-to-top}--InlineEnd);
 
   &.pf-m-hidden {
     display: none;
@@ -27,10 +27,10 @@
 
   .#{$button} {
     --#{$button}--FontSize: var(--#{$back-to-top}--c-button--FontSize);
-    --#{$button}--PaddingTop: var(--#{$back-to-top}--c-button--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$back-to-top}--c-button--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$back-to-top}--c-button--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$back-to-top}--c-button--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$back-to-top}--c-button--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$back-to-top}--c-button--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$back-to-top}--c-button--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$back-to-top}--c-button--PaddingInlineStart);
 
     box-shadow: var(--#{$back-to-top}--c-button--BoxShadow);
   }

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -1,9 +1,9 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$back-to-top}) {
-  --#{$back-to-top}--InlineEnd: var(--pf-t--global--spacer--2xl);
-  --#{$back-to-top}--BlockEnd: var(--pf-t--global--spacer--lg);
-  --#{$back-to-top}--md--BlockEnd: var(--pf-t--global--spacer--2xl);
+  --#{$back-to-top}--InsetInlineEnd: var(--pf-t--global--spacer--2xl);
+  --#{$back-to-top}--InsetBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$back-to-top}--md--InsetBlockEnd: var(--pf-t--global--spacer--2xl);
   --#{$back-to-top}--c-button--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$back-to-top}--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$back-to-top}--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
@@ -12,14 +12,14 @@
   --#{$back-to-top}--c-button--BoxShadow: var(--pf-t--global--box-shadow--sm);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$back-to-top}--BlockEnd: var(--#{$back-to-top}--md--BlockEnd);
+    --#{$back-to-top}--InsetBlockEnd: var(--#{$back-to-top}--md--InsetBlockEnd);
   }
 }
 
 .#{$back-to-top} {
   position: absolute;
-  inset-block-end: var(--#{$back-to-top}--BlockEnd);
-  inset-inline-end: var(--#{$back-to-top}--InlineEnd);
+  inset-block-end: var(--#{$back-to-top}--InsetBlockEnd);
+  inset-inline-end: var(--#{$back-to-top}--InsetInlineEnd);
 
   &.pf-m-hidden {
     display: none;

--- a/src/patternfly/components/Badge/badge.scss
+++ b/src/patternfly/components/Badge/badge.scss
@@ -5,13 +5,13 @@
   --#{$badge}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$badge}--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$badge}--FontWeight: var(--pf-t--global--font--weight--body--bold); // TODO - design calls for 500/semi-bold, do we need a token for that or is bold ok
-  --#{$badge}--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$badge}--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$badge}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$badge}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$badge}--Color: var(--pf-t--global--text--color--nonstatus--on-gray--default);
   --#{$badge}--MinWidth: var(--pf-t--global--spacer--xl);
 
   // Toggle icon
-  --#{$badge}__toggle-icon--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$badge}__toggle-icon--MarginInlineStart: var(--pf-t--global--spacer--xs);
   --#{$badge}__toggle-icon--Color: var(--pf-t--global--icon--color--nonstatus--on-gray--default);
 
   // Modifiers
@@ -26,8 +26,8 @@
 .#{$badge} {
   display: inline-block;
   min-width: var(--#{$badge}--MinWidth);
-  padding-inline-start: var(--#{$badge}--PaddingLeft);
-  padding-inline-end: var(--#{$badge}--PaddingRight);
+  padding-inline-start: var(--#{$badge}--PaddingInlineStart);
+  padding-inline-end: var(--#{$badge}--PaddingInlineEnd);
   font-size: var(--#{$badge}--FontSize);
   font-weight: var(--#{$badge}--FontWeight);
   color: var(--#{$badge}--Color);
@@ -50,6 +50,6 @@
 }
 
 .#{$badge}__toggle-icon {
-  margin-inline-start: var(--#{$badge}__toggle-icon--MarginLeft);
+  margin-inline-start: var(--#{$badge}__toggle-icon--MarginInlineStart);
   color: var(--#{$badge}__toggle-icon--Color);
 }

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -1,19 +1,19 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$banner}) {
-  --#{$banner}--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$banner}--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$banner}--md--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$banner}--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$banner}--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$banner}--md--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$banner}--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$banner}--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$banner}--md--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$banner}--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$banner}--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$banner}--md--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$banner}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$banner}--Color: var(--pf-t--global--text--color--nonstatus--on-gray--default);
   --#{$banner}--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$banner}--PaddingRight: var(--#{$banner}--md--PaddingRight);
-    --#{$banner}--PaddingLeft: var(--#{$banner}--md--PaddingLeft);
+    --#{$banner}--PaddingInlineEnd: var(--#{$banner}--md--PaddingInlineEnd);
+    --#{$banner}--PaddingInlineStart: var(--#{$banner}--md--PaddingInlineStart);
   }
 
   // banner link variables
@@ -61,10 +61,10 @@
 
 .#{$banner} {
   flex-shrink: 0;
-  padding-block-start: var(--#{$banner}--PaddingTop);
-  padding-block-end: var(--#{$banner}--PaddingBottom);
-  padding-inline-start: var(--#{$banner}--PaddingLeft);
-  padding-inline-end: var(--#{$banner}--PaddingRight);
+  padding-block-start: var(--#{$banner}--PaddingBlockStart);
+  padding-block-end: var(--#{$banner}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$banner}--PaddingInlineStart);
+  padding-inline-end: var(--#{$banner}--PaddingInlineEnd);
   font-size: var(--#{$banner}--FontSize);
   color: var(--#{$banner}--Color);
   white-space: nowrap;

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -4,11 +4,11 @@
   // Breadcrumb item
   --#{$breadcrumb}__item--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$breadcrumb}__item--LineHeight: var(--pf-t--global--font--line-height--body);
-  --#{$breadcrumb}__item--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$breadcrumb}__item--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Breadcrumb divider
   --#{$breadcrumb}__item-divider--Color: var(--pf-t--global--icon--color--regular);
-  --#{$breadcrumb}__item-divider--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$breadcrumb}__item-divider--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$breadcrumb}__item-divider--FontSize: var( --pf-t--global--font--size--body--sm);
 
   // Breadcrumb link
@@ -25,10 +25,10 @@
   --#{$breadcrumb}__heading--FontSize: var( --pf-t--global--font--size--body--sm);
 
   // breadcrumb dropdown
-  --#{$breadcrumb}__dropdown--MarginTop: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$breadcrumb}__dropdown--MarginRight: calc(var(--#{$breadcrumb}__item--MarginRight) * -1);
-  --#{$breadcrumb}__dropdown--MarginBottom: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$breadcrumb}__dropdown--MarginLeft: calc(var(--#{$breadcrumb}__item-divider--MarginRight) * -1);
+  --#{$breadcrumb}__dropdown--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$breadcrumb}__dropdown--MarginInlineEnd: calc(var(--#{$breadcrumb}__item--MarginInlineEnd) * -1);
+  --#{$breadcrumb}__dropdown--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$breadcrumb}__dropdown--MarginInlineStart: calc(var(--#{$breadcrumb}__item-divider--MarginInlineEnd) * -1);
 
   // breadcrumb toggle
   --#{$breadcrumb}__dropdown--c-dropdown__toggle--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -60,7 +60,7 @@
   }
 
   &:not(:last-child) {
-    margin-inline-end: var(--#{$breadcrumb}__item--MarginRight);
+    margin-inline-end: var(--#{$breadcrumb}__item--MarginInlineEnd);
   }
 }
 
@@ -68,7 +68,7 @@
 .#{$breadcrumb}__item-divider {
   @include pf-v6-mirror-inline-on-rtl;
 
-  margin-inline-end: var(--#{$breadcrumb}__item-divider--MarginRight);
+  margin-inline-end: var(--#{$breadcrumb}__item-divider--MarginInlineEnd);
   font-size: var(--#{$breadcrumb}__item-divider--FontSize);
   line-height: 1;
   color: var(--#{$breadcrumb}__item-divider--Color);
@@ -110,10 +110,10 @@
 }
 
 .#{$breadcrumb}__dropdown {
-  margin-block-start: var(--#{$breadcrumb}__dropdown--MarginTop);
-  margin-block-end: var(--#{$breadcrumb}__dropdown--MarginBottom);
-  margin-inline-start: var(--#{$breadcrumb}__dropdown--MarginLeft);
-  margin-inline-end: var(--#{$breadcrumb}__dropdown--MarginRight);
+  margin-block-start: var(--#{$breadcrumb}__dropdown--MarginBlockStart);
+  margin-block-end: var(--#{$breadcrumb}__dropdown--MarginBlockEnd);
+  margin-inline-start: var(--#{$breadcrumb}__dropdown--MarginInlineStart);
+  margin-inline-end: var(--#{$breadcrumb}__dropdown--MarginInlineEnd);
 
   .#{$dropdown}__toggle {
     line-height: var(--#{$breadcrumb}__dropdown--c-dropdown__toggle--LineHeight);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -103,8 +103,8 @@
   --#{$button}--m-link--m-inline--PaddingBlockEnd: 0;
   --#{$button}--m-link--m-inline--PaddingInlineStart: 0;
   --#{$button}--m-link--m-inline--hover--TextDecoration: var(--pf-t--global--link--text-decoration--hover);
-  --#{$button}--m-link--m-inline__progress--InlineStart: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InlineStart) + 1rem + var(--pf-t--global--spacer--sm));
+  --#{$button}--m-link--m-inline__progress--InsetInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InsetInlineStart) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--m-link--m-inline--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
 
@@ -248,8 +248,8 @@
   --#{$button}__progress--Opacity: 0;
   --#{$button}__progress--TranslateY: -50%;
   --#{$button}__progress--TranslateX: 0;
-  --#{$button}__progress--BlockStart: 50%;
-  --#{$button}__progress--InlineStart: var(--pf-t--global--spacer--md);
+  --#{$button}__progress--InsetBlockStart: 50%;
+  --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--md);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
   --#{$button}--m-progress--TransitionProperty: padding;
   --#{$button}--m-progress--TransitionDuration: var(--pf-t--global--transition--duration);
@@ -258,7 +258,7 @@
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$button}--m-in-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width));
   --#{$button}--m-in-progress--m-plain--Color: var(--#{$spinner}--Color);
-  --#{$button}--m-in-progress--m-plain__progress--InlineStart: 50%;
+  --#{$button}--m-in-progress--m-plain__progress--InsetInlineStart: 50%;
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
 
   // Count
@@ -387,7 +387,7 @@
       --#{$button}--PaddingBlockEnd: var(--#{$button}--m-link--m-inline--PaddingBlockEnd);
       --#{$button}--PaddingInlineStart: var(--#{$button}--m-link--m-inline--PaddingInlineStart);
       --#{$button}--BackgroundColor: transparent;
-      --#{$button}__progress--InlineStart: var(--#{$button}--m-link--m-inline__progress--InlineStart);
+      --#{$button}__progress--InsetInlineStart: var(--#{$button}--m-link--m-inline__progress--InsetInlineStart);
       --#{$button}--hover--TextDecoration: var(--#{$button}--m-link--m-inline--hover--TextDecoration);
       --#{$button}--hover--BackgroundColor: transparent;
       --#{$button}--m-clicked--BackgroundColor: transparent;
@@ -631,7 +631,7 @@
     }
 
     &.pf-m-plain {
-      --#{$button}__progress--InlineStart: var(--#{$button}--m-in-progress--m-plain__progress--InlineStart);
+      --#{$button}__progress--InsetInlineStart: var(--#{$button}--m-in-progress--m-plain__progress--InsetInlineStart);
       --#{$button}__progress--TranslateX: var(--#{$button}--m-in-progress--m-plain__progress--TranslateX);
 
       > :not(.#{$button}__progress) {
@@ -655,8 +655,8 @@
 
 .#{$button}__progress {
   position: absolute;
-  inset-block-start: var(--#{$button}__progress--BlockStart);
-  inset-inline-start: var(--#{$button}__progress--InlineStart);
+  inset-block-start: var(--#{$button}__progress--InsetBlockStart);
+  inset-inline-start: var(--#{$button}__progress--InsetInlineStart);
   line-height: 1;
   color: var(--#{$button}__progress--Color);
   transform: translate(var(--#{$button}__progress--TranslateX), var(--#{$button}__progress--TranslateY));

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -2,10 +2,10 @@
 
 :where(:root, .#{$button}) {
   --#{$button}--Display: inline-block;
-  --#{$button}--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$button}--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$button}--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$button}--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$button}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$button}--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body);
@@ -71,8 +71,8 @@
 
   // Link
   --#{$button}--m-link--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$button}--m-link--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$button}--m-link--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$button}--m-link--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$button}--m-link--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$button}--m-link--Color: var(--pf-t--global--text--color--brand--default);
   --#{$button}--m-link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$button}--m-link__icon--Color: var(--pf-t--global--icon--color--brand--default);
@@ -98,42 +98,42 @@
   --#{$button}--m-link--m-inline--FontSize: initial;
   --#{$button}--m-link--m-inline--LineHeight: initial;
   --#{$button}--m-link--m-inline--FontWeight: initial;
-  --#{$button}--m-link--m-inline--PaddingTop: 0;
-  --#{$button}--m-link--m-inline--PaddingRight: 0;
-  --#{$button}--m-link--m-inline--PaddingBottom: 0;
-  --#{$button}--m-link--m-inline--PaddingLeft: 0;
+  --#{$button}--m-link--m-inline--PaddingBlockStart: 0;
+  --#{$button}--m-link--m-inline--PaddingInlineEnd: 0;
+  --#{$button}--m-link--m-inline--PaddingBlockEnd: 0;
+  --#{$button}--m-link--m-inline--PaddingInlineStart: 0;
   --#{$button}--m-link--m-inline--hover--TextDecoration: var(--pf-t--global--link--text-decoration--hover);
-  --#{$button}--m-link--m-inline__progress--Left: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-link--m-inline--m-in-progress--PaddingLeft: calc(var(--#{$button}--m-link--m-inline__progress--Left) + 1rem + var(--pf-t--global--spacer--sm));
+  --#{$button}--m-link--m-inline__progress--InlineStart: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InlineStart) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--m-link--m-inline--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
 
   // Plain
   --#{$button}--m-plain--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$button}--m-plain--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$button}--m-plain--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$button}--m-plain--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$button}--m-plain--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$button}--m-plain--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$button}--m-plain--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$button}--m-plain--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$button}--m-plain--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$button}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$button}--m-plain--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--m-plain--PaddingTop) + var(--#{$button}--m-plain--PaddingBottom));
+  --#{$button}--m-plain--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--m-plain--PaddingBlockStart) + var(--#{$button}--m-plain--PaddingBlockEnd));
   --#{$button}--m-plain--hover--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$button}--m-plain--m-clicked--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--m-clicked--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$button}--m-plain--disabled--Color: var(--pf-t--global--icon--color--disabled);
   --#{$button}--m-plain--disabled--BackgroundColor: transparent;
-  --#{$button}--m-plain--m-small--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-plain--m-small--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-plain--m-small--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-plain--m-small--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-plain--m-small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-plain--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-plain--m-small--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-plain--m-small--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // Plain no padding
   --#{$button}--m-plain--m-no-padding--MinWidth: auto;
-  --#{$button}--m-plain--m-no-padding--PaddingTop: 0;
-  --#{$button}--m-plain--m-no-padding--PaddingRight: 0;
-  --#{$button}--m-plain--m-no-padding--PaddingBottom: 0;
-  --#{$button}--m-plain--m-no-padding--PaddingLeft: 0;
+  --#{$button}--m-plain--m-no-padding--PaddingBlockStart: 0;
+  --#{$button}--m-plain--m-no-padding--PaddingInlineEnd: 0;
+  --#{$button}--m-plain--m-no-padding--PaddingBlockEnd: 0;
+  --#{$button}--m-plain--m-no-padding--PaddingInlineStart: 0;
   --#{$button}--m-plain--m-no-padding--BackgroundColor: transparent;
   --#{$button}--m-plain--m-no-padding--hover--BackgroundColor: transparent;
   --#{$button}--m-plain--m-no-padding--m-clicked--BackgroundColor: transparent;
@@ -141,8 +141,8 @@
 
   // Control
   --#{$button}--m-control--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$button}--m-control--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$button}--m-control--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$button}--m-control--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$button}--m-control--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$button}--m-control--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--m-control--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$button}--m-control--BorderColor: var(--pf-t--global--border--color--default);
@@ -161,8 +161,8 @@
 
   // Stateful
   --#{$button}--m-stateful--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$button}--m-stateful--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$button}--m-stateful--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$button}--m-stateful--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$button}--m-stateful--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   // Read
   --#{$button}--m-read--BackgroundColor: var(--pf-t--global--background--color--control--default);
@@ -217,18 +217,18 @@
   --#{$button}--m-danger--m-clicked__icon--Color: var(--pf-t--global--icon--color--status--on-danger--clicked);
 
   // CTA
-  --#{$button}--m-display-lg--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$button}--m-display-lg--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$button}--m-display-lg--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$button}--m-display-lg--PaddingLeft: var(--pf-t--global--spacer--xl);
+  --#{$button}--m-display-lg--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$button}--m-display-lg--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$button}--m-display-lg--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$button}--m-display-lg--PaddingInlineStart: var(--pf-t--global--spacer--xl);
   --#{$button}--m-display-lg--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$button}--m-link--m-display-lg--FontSize: var(--pf-t--global--font--size--body--lg);
 
   // Small
-  --#{$button}--m-small--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-small--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$button}--m-small--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$button}--m-small--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$button}--m-small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$button}--m-small--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$button}--m-small--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // Disabled
   --#{$button}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
@@ -240,29 +240,29 @@
   --#{$button}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--hover__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-clicked__icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$button}__icon--m-start--MarginRight: var(--pf-t--global--spacer--xs);
-  --#{$button}__icon--m-end--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$button}__icon--m-start--MarginInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$button}__icon--m-end--MarginInlineStart: var(--pf-t--global--spacer--xs);
 
   // Progress
   --#{$button}__progress--width: calc(var(--#{$spinner}--m-md--diameter) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
   --#{$button}__progress--Opacity: 0;
   --#{$button}__progress--TranslateY: -50%;
   --#{$button}__progress--TranslateX: 0;
-  --#{$button}__progress--Top: 50%;
-  --#{$button}__progress--Left: var(--pf-t--global--spacer--md);
+  --#{$button}__progress--BlockStart: 50%;
+  --#{$button}__progress--InlineStart: var(--pf-t--global--spacer--md);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
   --#{$button}--m-progress--TransitionProperty: padding;
   --#{$button}--m-progress--TransitionDuration: var(--pf-t--global--transition--duration);
-  --#{$button}--m-progress--PaddingRight: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width) / 2);
-  --#{$button}--m-progress--PaddingLeft: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width) / 2);
-  --#{$button}--m-in-progress--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$button}--m-in-progress--PaddingLeft: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width));
+  --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width) / 2);
+  --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width) / 2);
+  --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$button}--m-in-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--md) + var(--#{$button}__progress--width));
   --#{$button}--m-in-progress--m-plain--Color: var(--#{$spinner}--Color);
-  --#{$button}--m-in-progress--m-plain__progress--Left: 50%;
+  --#{$button}--m-in-progress--m-plain__progress--InlineStart: 50%;
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
 
   // Count
-  --#{$button}__count--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$button}__count--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$button}--disabled__c-badge--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--disabled__c-badge--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$button}--m-primary__c-badge--BorderColor: var(--pf-t--global--border--color--default);
@@ -275,10 +275,10 @@
   flex: var(--#{$button}--Flex, initial);
   align-items: var(--#{$button}--AlignItems, initial);
   justify-content: var(--#{$button}--JustifyContent, initial);
-  padding-block-start: var(--#{$button}--PaddingTop);
-  padding-block-end: var(--#{$button}--PaddingBottom);
-  padding-inline-start: var(--#{$button}--PaddingLeft);
-  padding-inline-end: var(--#{$button}--PaddingRight);
+  padding-block-start: var(--#{$button}--PaddingBlockStart);
+  padding-block-end: var(--#{$button}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$button}--PaddingInlineStart);
+  padding-inline-end: var(--#{$button}--PaddingInlineEnd);
   font-size: var(--#{$button}--FontSize, inherit);
   font-weight: var(--#{$button}--FontWeight, inherit);
   line-height: var(--#{$button}--LineHeight, inherit);
@@ -365,8 +365,8 @@
 
   // Link
   &.pf-m-link {
-    --#{$button}--PaddingRight: var(--#{$button}--m-link--PaddingRight);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-link--PaddingLeft);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-link--PaddingInlineEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-link--PaddingInlineStart);
     --#{$button}--Color: var(--#{$button}--m-link--Color);
     --#{$button}--BorderRadius: var(--#{$button}--m-link--BorderRadius);
     --#{$button}--BackgroundColor: var(--#{$button}--m-link--BackgroundColor);
@@ -382,12 +382,12 @@
       --#{$button}--FontSize: var(--#{$button}--m-link--m-inline--FontSize);
       --#{$button}--LineHeight: var(--#{$button}--m-link--m-inline--LineHeight);
       --#{$button}--FontWeight: var(--#{$button}--m-link--m-inline--FontWeight);
-      --#{$button}--PaddingTop: var(--#{$button}--m-link--m-inline--PaddingTop);
-      --#{$button}--PaddingRight: var(--#{$button}--m-link--m-inline--PaddingRight);
-      --#{$button}--PaddingBottom: var(--#{$button}--m-link--m-inline--PaddingBottom);
-      --#{$button}--PaddingLeft: var(--#{$button}--m-link--m-inline--PaddingLeft);
+      --#{$button}--PaddingBlockStart: var(--#{$button}--m-link--m-inline--PaddingBlockStart);
+      --#{$button}--PaddingInlineEnd: var(--#{$button}--m-link--m-inline--PaddingInlineEnd);
+      --#{$button}--PaddingBlockEnd: var(--#{$button}--m-link--m-inline--PaddingBlockEnd);
+      --#{$button}--PaddingInlineStart: var(--#{$button}--m-link--m-inline--PaddingInlineStart);
       --#{$button}--BackgroundColor: transparent;
-      --#{$button}__progress--Left: var(--#{$button}--m-link--m-inline__progress--Left);
+      --#{$button}__progress--InlineStart: var(--#{$button}--m-link--m-inline__progress--InlineStart);
       --#{$button}--hover--TextDecoration: var(--#{$button}--m-link--m-inline--hover--TextDecoration);
       --#{$button}--hover--BackgroundColor: transparent;
       --#{$button}--m-clicked--BackgroundColor: transparent;
@@ -447,8 +447,8 @@
   // Control
   &.pf-m-control {
     --#{$button}--BorderRadius: var(--#{$button}--m-control--BorderRadius);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-control--PaddingLeft);
-    --#{$button}--PaddingRight: var(--#{$button}--m-control--PaddingRight);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-control--PaddingInlineStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-control--PaddingInlineEnd);
     --#{$button}--Color: var(--#{$button}--m-control--Color);
     --#{$button}--BackgroundColor: var(--#{$button}--m-control--BackgroundColor);
     --#{$button}--BorderColor: var(--#{$button}--m-control--BorderColor);
@@ -469,8 +469,8 @@
   // Stateful
   &.pf-m-stateful {
     --#{$button}--BorderRadius: var(--#{$button}--m-stateful--BorderRadius);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-stateful--PaddingLeft);
-    --#{$button}--PaddingRight: var(--#{$button}--m-stateful--PaddingRight);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-stateful--PaddingInlineStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-stateful--PaddingInlineEnd);
   }
 
   // Read
@@ -514,10 +514,10 @@
     --#{$button}--BorderRadius: var(--#{$button}--m-plain--BorderRadius);
     --#{$button}--Color: var(--#{$button}--m-plain--Color);
     --#{$button}--BackgroundColor: var(--#{$button}--m-plain--BackgroundColor);
-    --#{$button}--PaddingTop: var(--#{$button}--m-plain--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$button}--m-plain--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$button}--m-plain--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-plain--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$button}--m-plain--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-plain--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$button}--m-plain--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-plain--PaddingInlineStart);
     --#{$button}__progress--Color: var(--#{$button}--m-in-progress--m-plain--Color);
     --#{$button}--hover--Color: var(--#{$button}--m-plain--hover--Color);
     --#{$button}--hover--BackgroundColor: var(--#{$button}--m-plain--hover--BackgroundColor);
@@ -525,19 +525,19 @@
     --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
     --#{$button}--disabled--Color: var(--#{$button}--m-plain--disabled--Color);
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
-    --#{$button}--m-small--PaddingTop: var(--#{$button}--m-plain--m-small--PaddingTop);
-    --#{$button}--m-small--PaddingRight: var(--#{$button}--m-plain--m-small--PaddingRight);
-    --#{$button}--m-small--PaddingBottom: var(--#{$button}--m-plain--m-small--PaddingBottom);
-    --#{$button}--m-small--PaddingLeft: var(--#{$button}--m-plain--m-small--PaddingLeft);
+    --#{$button}--m-small--PaddingBlockStart: var(--#{$button}--m-plain--m-small--PaddingBlockStart);
+    --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-small--PaddingInlineEnd);
+    --#{$button}--m-small--PaddingBlockEnd: var(--#{$button}--m-plain--m-small--PaddingBlockEnd);
+    --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-small--PaddingInlineStart);
 
     &.pf-m-no-padding {
       --#{$button}--BackgroundColor: var(--#{$button}--m-plain--m-no-padding--BackgroundColor);
       --#{$button}--hover--BackgroundColor: var(--#{$button}--m-plain--m-no-padding--hover--BackgroundColor);
       --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-no-padding--m-clicked--BackgroundColor);
-      --#{$button}--m-plain--PaddingTop: var(--#{$button}--m-plain--m-no-padding--PaddingTop);
-      --#{$button}--m-plain--PaddingRight: var(--#{$button}--m-plain--m-no-padding--PaddingRight);
-      --#{$button}--m-plain--PaddingBottom: var(--#{$button}--m-plain--m-no-padding--PaddingBottom);
-      --#{$button}--m-plain--PaddingLeft: var(--#{$button}--m-plain--m-no-padding--PaddingLeft);
+      --#{$button}--m-plain--PaddingBlockStart: var(--#{$button}--m-plain--m-no-padding--PaddingBlockStart);
+      --#{$button}--m-plain--PaddingInlineEnd: var(--#{$button}--m-plain--m-no-padding--PaddingInlineEnd);
+      --#{$button}--m-plain--PaddingBlockEnd: var(--#{$button}--m-plain--m-no-padding--PaddingBlockEnd);
+      --#{$button}--m-plain--PaddingInlineStart: var(--#{$button}--m-plain--m-no-padding--PaddingInlineStart);
 
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
     }
@@ -551,17 +551,17 @@
   }
 
   &.pf-m-small {
-    --#{$button}--PaddingTop: var(--#{$button}--m-small--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$button}--m-small--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$button}--m-small--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-small--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$button}--m-small--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-small--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$button}--m-small--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-small--PaddingInlineStart);
   }
 
   &.pf-m-display-lg {
-    --#{$button}--PaddingTop: var(--#{$button}--m-display-lg--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$button}--m-display-lg--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$button}--m-display-lg--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-display-lg--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$button}--m-display-lg--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-display-lg--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$button}--m-display-lg--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-display-lg--PaddingInlineStart);
     --#{$button}--FontSize: var(--#{$button}--m-display-lg--FontSize);
   }
 
@@ -616,22 +616,22 @@
   }
 
   &.pf-m-progress {
-    --#{$button}--PaddingRight: var(--#{$button}--m-progress--PaddingRight);
-    --#{$button}--PaddingLeft: var(--#{$button}--m-progress--PaddingLeft);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
 
     transition: var(--#{$button}--m-progress--TransitionProperty) var(--#{$button}--m-progress--TransitionDuration);
   }
 
   &.pf-m-in-progress {
-    --#{$button}--m-link--m-inline--PaddingLeft: var(--#{$button}--m-link--m-inline--m-in-progress--PaddingLeft);
+    --#{$button}--m-link--m-inline--PaddingInlineStart: var(--#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart);
 
     &:not(.pf-m-plain) {
-      --#{$button}--PaddingRight: var(--#{$button}--m-in-progress--PaddingRight);
-      --#{$button}--PaddingLeft: var(--#{$button}--m-in-progress--PaddingLeft);
+      --#{$button}--PaddingInlineEnd: var(--#{$button}--m-in-progress--PaddingInlineEnd);
+      --#{$button}--PaddingInlineStart: var(--#{$button}--m-in-progress--PaddingInlineStart);
     }
 
     &.pf-m-plain {
-      --#{$button}__progress--Left: var(--#{$button}--m-in-progress--m-plain__progress--Left);
+      --#{$button}__progress--InlineStart: var(--#{$button}--m-in-progress--m-plain__progress--InlineStart);
       --#{$button}__progress--TranslateX: var(--#{$button}--m-in-progress--m-plain__progress--TranslateX);
 
       > :not(.#{$button}__progress) {
@@ -645,18 +645,18 @@
   color: var(--#{$button}__icon--Color);
 
   &.pf-m-start {
-    margin-inline-end: var(--#{$button}__icon--m-start--MarginRight);
+    margin-inline-end: var(--#{$button}__icon--m-start--MarginInlineEnd);
   }
 
   &.pf-m-end {
-    margin-inline-start: var(--#{$button}__icon--m-end--MarginLeft);
+    margin-inline-start: var(--#{$button}__icon--m-end--MarginInlineStart);
   }
 }
 
 .#{$button}__progress {
   position: absolute;
-  inset-block-start: var(--#{$button}__progress--Top);
-  inset-inline-start: var(--#{$button}__progress--Left);
+  inset-block-start: var(--#{$button}__progress--BlockStart);
+  inset-inline-start: var(--#{$button}__progress--InlineStart);
   line-height: 1;
   color: var(--#{$button}__progress--Color);
   transform: translate(var(--#{$button}__progress--TranslateX), var(--#{$button}__progress--TranslateY));
@@ -669,5 +669,5 @@
 .#{$button}__count {
   display: inline-flex;
   align-items: center;
-  margin-inline-start: var(--#{$button}__count--MarginLeft);
+  margin-inline-start: var(--#{$button}__count--MarginInlineStart);
 }

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -2,35 +2,35 @@
 
 :where(:root, .#{$calendar-month}) {
   --#{$calendar-month}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$calendar-month}--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$calendar-month}--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$calendar-month}--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$calendar-month}--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$calendar-month}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$calendar-month}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$calendar-month}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$calendar-month}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$calendar-month}--FontSize: var(--pf-t--global--font--size--sm);
 
   // header
-  --#{$calendar-month}__header--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$calendar-month}__header--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$calendar-month}__header--Gap: var(--pf-t--global--spacer--xs);
   --#{$calendar-month}__header-year--Width: 9ch;
-  --#{$calendar-month}__header-nav-control--MarginRight: 0;
-  --#{$calendar-month}__header-nav-control--MarginLeft: 0;
+  --#{$calendar-month}__header-nav-control--MarginInlineEnd: 0;
+  --#{$calendar-month}__header-nav-control--MarginInlineStart: 0;
 
   // week days thead
-  --#{$calendar-month}__days--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$calendar-month}__days--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$calendar-month}__days--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$calendar-month}__days--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   // day th
-  --#{$calendar-month}__day--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$calendar-month}__day--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$calendar-month}__day--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$calendar-month}__day--Color: var(--pf-t--global--text--color--regular);
 
 
   // dates td
-  --#{$calendar-month}__dates-cell--PaddingTop: #{pf-size-prem(2px)};
-  --#{$calendar-month}__dates-cell--PaddingRight: #{pf-size-prem(2px)};
-  --#{$calendar-month}__dates-cell--PaddingBottom: #{pf-size-prem(2px)};
-  --#{$calendar-month}__dates-cell--PaddingLeft: #{pf-size-prem(2px)};
-  --#{$calendar-month}__dates-row--first-child__dates-cell--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$calendar-month}__dates-cell--PaddingBlockStart: #{pf-size-prem(2px)};
+  --#{$calendar-month}__dates-cell--PaddingInlineEnd: #{pf-size-prem(2px)};
+  --#{$calendar-month}__dates-cell--PaddingBlockEnd: #{pf-size-prem(2px)};
+  --#{$calendar-month}__dates-cell--PaddingInlineStart: #{pf-size-prem(2px)};
+  --#{$calendar-month}__dates-row--first-child__dates-cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$calendar-month}__dates-cell--m-current__date--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$calendar-month}__dates-cell--m-selected__date--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$calendar-month}__dates-cell--m-selected__date--hover--BackgroundColor: var(--pf-t--global--color--brand--default);
@@ -38,13 +38,13 @@
   --#{$calendar-month}__dates-cell--m-selected__date--focus--after--BorderColor: var(--pf-t--global--border--color--brand--default);
   --#{$calendar-month}__dates-cell--m-selected__date--Color: var(--pf-t--global--text--color--on-brand--default);
   --#{$calendar-month}__dates-cell--before--BackgroundColor: transparent;
-  --#{$calendar-month}__dates-cell--before--Top: 0;
-  --#{$calendar-month}__dates-cell--before--Right: 0;
-  --#{$calendar-month}__dates-cell--before--Bottom: var(--#{$calendar-month}__dates-cell--PaddingBottom);
-  --#{$calendar-month}__dates-cell--before--Left: 0;
+  --#{$calendar-month}__dates-cell--before--BlockStart: 0;
+  --#{$calendar-month}__dates-cell--before--InlineEnd: 0;
+  --#{$calendar-month}__dates-cell--before--BlockEnd: var(--#{$calendar-month}__dates-cell--PaddingBlockEnd);
+  --#{$calendar-month}__dates-cell--before--InlineStart: 0;
   --#{$calendar-month}__dates-cell--m-in-range--before--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--Left: 50%;
-  --#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--Right: 50%;
+  --#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InlineStart: 50%;
+  --#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InlineEnd: 50%;
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BorderColor: var(--pf-t--global--border--color--hover);
@@ -74,10 +74,10 @@
 :where(.#{$calendar-month}) {
   display: inline-flex;
   flex-direction: column;
-  padding-block-start: var(--#{$calendar-month}--PaddingTop);
-  padding-block-end: var(--#{$calendar-month}--PaddingBottom);
-  padding-inline-start: var(--#{$calendar-month}--PaddingLeft);
-  padding-inline-end: var(--#{$calendar-month}--PaddingRight);
+  padding-block-start: var(--#{$calendar-month}--PaddingBlockStart);
+  padding-block-end: var(--#{$calendar-month}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$calendar-month}--PaddingInlineStart);
+  padding-inline-end: var(--#{$calendar-month}--PaddingInlineEnd);
   font-size: var(--#{$calendar-month}--FontSize);
   background-color: var(--#{$calendar-month}--BackgroundColor);
 }
@@ -85,14 +85,14 @@
 .#{$calendar-month}__header {
   display: flex;
   gap: var(--#{$calendar-month}__header--Gap);
-  margin-block-end: var(--#{$calendar-month}__header--MarginBottom);
+  margin-block-end: var(--#{$calendar-month}__header--MarginBlockEnd);
 }
 
 .#{$calendar-month}__header-nav-control {
   @include pf-v6-mirror-inline-on-rtl;
 
-  margin-inline-start: var(--#{$calendar-month}__header-nav-control--MarginLeft);
-  margin-inline-end: var(--#{$calendar-month}__header-nav-control--MarginRight);
+  margin-inline-start: var(--#{$calendar-month}__header-nav-control--MarginInlineStart);
+  margin-inline-end: var(--#{$calendar-month}__header-nav-control--MarginInlineEnd);
 
 }
 
@@ -114,35 +114,35 @@
 
 .#{$calendar-month}__days {
   color: var(--#{$calendar-month}__day--Color);
-  border-block-end: var(--#{$calendar-month}__days--BorderBottomWidth) solid var(--#{$calendar-month}__days--BorderBottomColor);
+  border-block-end: var(--#{$calendar-month}__days--BorderBlockEndWidth) solid var(--#{$calendar-month}__days--BorderBlockEndColor);
 }
 
 .#{$calendar-month}__day {
-  padding-block-end: var(--#{$calendar-month}__day--PaddingBottom);
+  padding-block-end: var(--#{$calendar-month}__day--PaddingBlockEnd);
   font-weight: var(--#{$calendar-month}__day--FontWeight);
   text-align: center;
 }
 
 .#{$calendar-month}__dates-row:first-child {
-  --#{$calendar-month}__dates-cell--PaddingTop: var(--#{$calendar-month}__dates-row--first-child__dates-cell--PaddingTop);
+  --#{$calendar-month}__dates-cell--PaddingBlockStart: var(--#{$calendar-month}__dates-row--first-child__dates-cell--PaddingBlockStart);
 }
 
 .#{$calendar-month}__dates-cell {
-  --#{$calendar-month}__dates-cell--before--Top: var(--#{$calendar-month}__dates-cell--PaddingTop);
+  --#{$calendar-month}__dates-cell--before--BlockStart: var(--#{$calendar-month}__dates-cell--PaddingBlockStart);
 
   position: relative;
-  padding-block-start: var(--#{$calendar-month}__dates-cell--PaddingTop);
-  padding-block-end: var(--#{$calendar-month}__dates-cell--PaddingBottom);
-  padding-inline-start: var(--#{$calendar-month}__dates-cell--PaddingLeft);
-  padding-inline-end: var(--#{$calendar-month}__dates-cell--PaddingRight);
+  padding-block-start: var(--#{$calendar-month}__dates-cell--PaddingBlockStart);
+  padding-block-end: var(--#{$calendar-month}__dates-cell--PaddingBlockEnd);
+  padding-inline-start: var(--#{$calendar-month}__dates-cell--PaddingInlineStart);
+  padding-inline-end: var(--#{$calendar-month}__dates-cell--PaddingInlineEnd);
   text-align: center;
 
   &::before {
     position: absolute;
-    inset-block-start: var(--#{$calendar-month}__dates-cell--before--Top);
-    inset-block-end: var(--#{$calendar-month}__dates-cell--before--Bottom);
-    inset-inline-start: var(--#{$calendar-month}__dates-cell--before--Left);
-    inset-inline-end: var(--#{$calendar-month}__dates-cell--before--Right);
+    inset-block-start: var(--#{$calendar-month}__dates-cell--before--BlockStart);
+    inset-block-end: var(--#{$calendar-month}__dates-cell--before--BlockEnd);
+    inset-inline-start: var(--#{$calendar-month}__dates-cell--before--InlineStart);
+    inset-inline-end: var(--#{$calendar-month}__dates-cell--before--InlineEnd);
     content: "";
     background-color: var(--#{$calendar-month}__dates-cell--before--BackgroundColor);
   }
@@ -160,11 +160,11 @@
   }
 
   &.pf-m-start-range {
-    --#{$calendar-month}__dates-cell--before--Left: var(--#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--Left);
+    --#{$calendar-month}__dates-cell--before--InlineStart: var(--#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InlineStart);
   }
 
   &.pf-m-end-range {
-    --#{$calendar-month}__dates-cell--before--Right: var(--#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--Right);
+    --#{$calendar-month}__dates-cell--before--InlineEnd: var(--#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InlineEnd);
   }
 
   &.pf-m-adjacent-month {

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -38,13 +38,13 @@
   --#{$calendar-month}__dates-cell--m-selected__date--focus--after--BorderColor: var(--pf-t--global--border--color--brand--default);
   --#{$calendar-month}__dates-cell--m-selected__date--Color: var(--pf-t--global--text--color--on-brand--default);
   --#{$calendar-month}__dates-cell--before--BackgroundColor: transparent;
-  --#{$calendar-month}__dates-cell--before--BlockStart: 0;
-  --#{$calendar-month}__dates-cell--before--InlineEnd: 0;
-  --#{$calendar-month}__dates-cell--before--BlockEnd: var(--#{$calendar-month}__dates-cell--PaddingBlockEnd);
-  --#{$calendar-month}__dates-cell--before--InlineStart: 0;
+  --#{$calendar-month}__dates-cell--before--InsetBlockStart: 0;
+  --#{$calendar-month}__dates-cell--before--InsetInlineEnd: 0;
+  --#{$calendar-month}__dates-cell--before--InsetBlockEnd: var(--#{$calendar-month}__dates-cell--PaddingBlockEnd);
+  --#{$calendar-month}__dates-cell--before--InsetInlineStart: 0;
   --#{$calendar-month}__dates-cell--m-in-range--before--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InlineStart: 50%;
-  --#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InlineEnd: 50%;
+  --#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InsetInlineStart: 50%;
+  --#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InsetInlineEnd: 50%;
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$calendar-month}__dates-cell--m-in-range__date--hover--BorderColor: var(--pf-t--global--border--color--hover);
@@ -128,7 +128,7 @@
 }
 
 .#{$calendar-month}__dates-cell {
-  --#{$calendar-month}__dates-cell--before--BlockStart: var(--#{$calendar-month}__dates-cell--PaddingBlockStart);
+  --#{$calendar-month}__dates-cell--before--InsetBlockStart: var(--#{$calendar-month}__dates-cell--PaddingBlockStart);
 
   position: relative;
   padding-block-start: var(--#{$calendar-month}__dates-cell--PaddingBlockStart);
@@ -139,10 +139,10 @@
 
   &::before {
     position: absolute;
-    inset-block-start: var(--#{$calendar-month}__dates-cell--before--BlockStart);
-    inset-block-end: var(--#{$calendar-month}__dates-cell--before--BlockEnd);
-    inset-inline-start: var(--#{$calendar-month}__dates-cell--before--InlineStart);
-    inset-inline-end: var(--#{$calendar-month}__dates-cell--before--InlineEnd);
+    inset-block-start: var(--#{$calendar-month}__dates-cell--before--InsetBlockStart);
+    inset-block-end: var(--#{$calendar-month}__dates-cell--before--InsetBlockEnd);
+    inset-inline-start: var(--#{$calendar-month}__dates-cell--before--InsetInlineStart);
+    inset-inline-end: var(--#{$calendar-month}__dates-cell--before--InsetInlineEnd);
     content: "";
     background-color: var(--#{$calendar-month}__dates-cell--before--BackgroundColor);
   }
@@ -160,11 +160,11 @@
   }
 
   &.pf-m-start-range {
-    --#{$calendar-month}__dates-cell--before--InlineStart: var(--#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InlineStart);
+    --#{$calendar-month}__dates-cell--before--InsetInlineStart: var(--#{$calendar-month}__dates-cell--m-in-range--m-start-range--before--InsetInlineStart);
   }
 
   &.pf-m-end-range {
-    --#{$calendar-month}__dates-cell--before--InlineEnd: var(--#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InlineEnd);
+    --#{$calendar-month}__dates-cell--before--InsetInlineEnd: var(--#{$calendar-month}__dates-cell--m-in-range--m-end-range--before--InsetInlineEnd);
   }
 
   &.pf-m-adjacent-month {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -6,12 +6,12 @@
   --#{$card}--BorderStyle: solid;
   --#{$card}--BorderWidth: var(--pf-t--global--border--width--box--default);
   --#{$card}--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$card}--first-child--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$card}--child--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$card}--child--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$card}--child--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$card}--c-divider--child--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$card}__title--not--last-child--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$card}--first-child--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$card}--child--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$card}--child--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$card}--child--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$card}--c-divider--child--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$card}__title--not--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$card}__title-text--Color: var(--pf-t--global--text--color--regular);
   --#{$card}__title-text--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$card}__title-text--FontSize: var(--pf-t--global--font--size--heading--sm);
@@ -21,16 +21,16 @@
   --#{$card}__body--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$card}__footer--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$card}__footer--Color: var(--pf-t--global--text--color--subtle);
-  --#{$card}__actions--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$card}__actions--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$card}__actions--Gap: var(--pf-t--global--spacer--sm);
-  --#{$card}__actions--MarginTop: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$card}__actions--MarginBottom: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$card}__actions--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$card}__actions--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
 
   // Expandable
-  --#{$card}__header-toggle--MarginTop: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
-  --#{$card}__header-toggle--MarginRight: var(--pf-t--global--spacer--xs);
-  --#{$card}__header-toggle--MarginBottom: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
-  --#{$card}__header-toggle--MarginLeft: calc(var(--pf-t--global--spacer--md) * -1);
+  --#{$card}__header-toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
+  --#{$card}__header-toggle--MarginInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$card}__header-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
+  --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--md) * -1);
   --#{$card}__header-toggle-icon--Transition: var(--pf-t--global--transition);
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
@@ -69,23 +69,23 @@
   --#{$card}--m-compact__title-text--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$card}--m-compact__body--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$card}--m-compact__footer--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$card}--m-compact--first-child--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$card}--m-compact--child--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$card}--m-compact--child--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$card}--m-compact--child--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$card}--m-compact--c-divider--child--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$card}--m-compact__title--not--last-child--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$card}--m-compact--first-child--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$card}--m-compact--child--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$card}--m-compact--child--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$card}--m-compact--child--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$card}--m-compact--c-divider--child--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$card}--m-compact__title--not--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Display large
   --#{$card}--m-display-lg__title-text--FontSize: var(--pf-t--global--font--size--heading--md);
   --#{$card}--m-display-lg__body--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$card}--m-display-lg__footer--FontSize: var(--pf-t--global--font--size--body--default);
-  --#{$card}--m-display-lg--first-child--PaddingTop: var(--pf-t--global--spacer--xl);
-  --#{$card}--m-display-lg--child--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$card}--m-display-lg--child--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$card}--m-display-lg--child--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$card}--m-display-lg--c-divider--child--PaddingTop: var(--pf-t--global--spacer--xl);
-  --#{$card}--m-display-lg__title--not--last-child--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$card}--m-display-lg--first-child--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$card}--m-display-lg--child--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$card}--m-display-lg--child--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$card}--m-display-lg--child--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$card}--m-display-lg--c-divider--child--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$card}--m-display-lg__title--not--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
 
   // Secondary
   --#{$card}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
@@ -99,8 +99,8 @@
   --#{$card}--m-plain--BackgroundColor: transparent;
 
   // Toggle right
-  --#{$card}__header--m-toggle-right--toggle--MarginRight: calc(var(--pf-t--global--spacer--button--horizontal--compact) * -1);
-  --#{$card}__header--m-toggle-right--toggle--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$card}__header--m-toggle-right--toggle--MarginInlineEnd: calc(var(--pf-t--global--spacer--button--horizontal--compact) * -1);
+  --#{$card}__header--m-toggle-right--toggle--MarginInlineStart: var(--pf-t--global--spacer--xs);
 }
 
 .#{$card} {
@@ -175,24 +175,24 @@
     --#{$card}__title-text--FontSize: var(--#{$card}--m-compact__title-text--FontSize);
     --#{$card}__body--FontSize: var(--#{$card}--m-compact__body--FontSize);
     --#{$card}__footer--FontSize: var(--#{$card}--m-compact__footer--FontSize);
-    --#{$card}--first-child--PaddingTop: var(--#{$card}--m-compact--first-child--PaddingTop);
-    --#{$card}--child--PaddingRight: var(--#{$card}--m-compact--child--PaddingRight);
-    --#{$card}--child--PaddingBottom: var(--#{$card}--m-compact--child--PaddingBottom);
-    --#{$card}--child--PaddingLeft: var(--#{$card}--m-compact--child--PaddingLeft);
-    --#{$card}--c-divider--child--PaddingTop: var(--#{$card}--m-compact--c-divider--child--PaddingTop);
-    --#{$card}__title--not--last-child--PaddingBottom: var(--#{$card}--m-compact__title--not--last-child--PaddingBottom);
+    --#{$card}--first-child--PaddingBlockStart: var(--#{$card}--m-compact--first-child--PaddingBlockStart);
+    --#{$card}--child--PaddingInlineEnd: var(--#{$card}--m-compact--child--PaddingInlineEnd);
+    --#{$card}--child--PaddingBlockEnd: var(--#{$card}--m-compact--child--PaddingBlockEnd);
+    --#{$card}--child--PaddingInlineStart: var(--#{$card}--m-compact--child--PaddingInlineStart);
+    --#{$card}--c-divider--child--PaddingBlockStart: var(--#{$card}--m-compact--c-divider--child--PaddingBlockStart);
+    --#{$card}__title--not--last-child--PaddingBlockEnd: var(--#{$card}--m-compact__title--not--last-child--PaddingBlockEnd);
   }
 
   &.pf-m-display-lg {
     --#{$card}__title-text--FontSize: var(--#{$card}--m-display-lg__title-text--FontSize);
     --#{$card}__body--FontSize: var(--#{$card}--m-display-lg__body--FontSize);
     --#{$card}__footer--FontSize: var(--#{$card}--m-display-lg__footer--FontSize);
-    --#{$card}--first-child--PaddingTop: var(--#{$card}--m-display-lg--first-child--PaddingTop);
-    --#{$card}--child--PaddingRight: var(--#{$card}--m-display-lg--child--PaddingRight);
-    --#{$card}--child--PaddingBottom: var(--#{$card}--m-display-lg--child--PaddingBottom);
-    --#{$card}--child--PaddingLeft: var(--#{$card}--m-display-lg--child--PaddingLeft);
-    --#{$card}--c-divider--child--PaddingTop: var(--#{$card}--m-display-lg--c-divider--child--PaddingTop);
-    --#{$card}__title--not--last-child--PaddingBottom: var(--#{$card}--m-display-lg__title--not--last-child--PaddingBottom);
+    --#{$card}--first-child--PaddingBlockStart: var(--#{$card}--m-display-lg--first-child--PaddingBlockStart);
+    --#{$card}--child--PaddingInlineEnd: var(--#{$card}--m-display-lg--child--PaddingInlineEnd);
+    --#{$card}--child--PaddingBlockEnd: var(--#{$card}--m-display-lg--child--PaddingBlockEnd);
+    --#{$card}--child--PaddingInlineStart: var(--#{$card}--m-display-lg--child--PaddingInlineStart);
+    --#{$card}--c-divider--child--PaddingBlockStart: var(--#{$card}--m-display-lg--c-divider--child--PaddingBlockStart);
+    --#{$card}__title--not--last-child--PaddingBlockEnd: var(--#{$card}--m-display-lg__title--not--last-child--PaddingBlockEnd);
   }
 
   &.pf-m-secondary {
@@ -220,7 +220,7 @@
     & + .#{$card}__title,
     & + .#{$card}__body,
     & + .#{$card}__footer {
-      padding-block-start: var(--#{$card}--c-divider--child--PaddingTop);
+      padding-block-start: var(--#{$card}--c-divider--child--PaddingBlockStart);
     }
   }
 }
@@ -231,15 +231,15 @@
   align-items: center;
 
   .#{$card}__title {
-    --#{$card}--first-child--PaddingTop: 0;
-    --#{$card}__title--not--last-child--PaddingBottom: 0;
+    --#{$card}--first-child--PaddingBlockStart: 0;
+    --#{$card}__title--not--last-child--PaddingBlockEnd: 0;
 
     padding: 0;
   }
 
   &.pf-m-toggle-right {
-    --#{$card}__header-toggle--MarginRight: var(--#{$card}__header--m-toggle-right--toggle--MarginRight);
-    --#{$card}__header-toggle--MarginLeft: var(--#{$card}__header--m-toggle-right--toggle--MarginLeft);
+    --#{$card}__header-toggle--MarginInlineEnd: var(--#{$card}__header--m-toggle-right--toggle--MarginInlineEnd);
+    --#{$card}__header-toggle--MarginInlineStart: var(--#{$card}__header--m-toggle-right--toggle--MarginInlineStart);
 
     .#{$card}__header-toggle {
       order: 2;
@@ -253,10 +253,10 @@
 
 .#{$card}__header-toggle {
   align-self: flex-start;
-  margin-block-start: var(--#{$card}__header-toggle--MarginTop);
-  margin-block-end: var(--#{$card}__header-toggle--MarginBottom);
-  margin-inline-start: var(--#{$card}__header-toggle--MarginLeft);
-  margin-inline-end: var(--#{$card}__header-toggle--MarginRight);
+  margin-block-start: var(--#{$card}__header-toggle--MarginBlockStart);
+  margin-block-end: var(--#{$card}__header-toggle--MarginBlockEnd);
+  margin-inline-start: var(--#{$card}__header-toggle--MarginInlineStart);
+  margin-inline-end: var(--#{$card}__header-toggle--MarginInlineEnd);
 }
 
 .#{$card}__header-toggle-icon {
@@ -280,9 +280,9 @@
   align-items: center;
   align-self: flex-start;
   order: 1;
-  padding-inline-start: var(--#{$card}__actions--PaddingLeft);
-  margin-block-start: var(--#{$card}__actions--MarginTop);
-  margin-block-end: var(--#{$card}__actions--MarginBottom);
+  padding-inline-start: var(--#{$card}__actions--PaddingInlineStart);
+  margin-block-start: var(--#{$card}__actions--MarginBlockStart);
+  margin-block-end: var(--#{$card}__actions--MarginBlockEnd);
   margin-inline-start: auto;
 
   + .#{$card}__title,
@@ -292,8 +292,8 @@
   }
 
   &.pf-m-no-offset {
-    --#{$card}__actions--MarginTop: 0;
-    --#{$card}__actions--MarginBottom: 0;
+    --#{$card}__actions--MarginBlockStart: 0;
+    --#{$card}__actions--MarginBlockEnd: 0;
   }
 }
 
@@ -357,19 +357,19 @@
 .#{$card}__title,
 .#{$card}__body,
 .#{$card}__footer {
-  padding-block-end: var(--#{$card}--child--PaddingBottom);
-  padding-inline-start: var(--#{$card}--child--PaddingLeft);
-  padding-inline-end: var(--#{$card}--child--PaddingRight);
+  padding-block-end: var(--#{$card}--child--PaddingBlockEnd);
+  padding-inline-start: var(--#{$card}--child--PaddingInlineStart);
+  padding-inline-end: var(--#{$card}--child--PaddingInlineEnd);
 
   &:first-child {
-    padding-block-start: var(--#{$card}--first-child--PaddingTop);
+    padding-block-start: var(--#{$card}--first-child--PaddingBlockStart);
   }
 }
 
 .#{$card}__header,
 .#{$card}__title {
   &:not(:last-child) {
-    padding-block-end: var(--#{$card}__title--not--last-child--PaddingBottom);
+    padding-block-end: var(--#{$card}__title--not--last-child--PaddingBlockEnd);
   }
 
   // Normal disabled button color won't show on the disabled card
@@ -379,7 +379,7 @@
 }
 
 .#{$card}__expandable-content {
-  --#{$card}--first-child--PaddingTop: 0;
+  --#{$card}--first-child--PaddingBlockStart: 0;
 }
 
 .#{$card}__body:not(.pf-m-no-fill) {

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -15,7 +15,7 @@
   --#{$check}__description--Color: var(--pf-t--global--text--color--subtle);
 
   // Required checkbox
-  --#{$check}__label-required--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$check}__label-required--MarginInlineStart: var(--pf-t--global--spacer--xs);
   --#{$check}__label-required--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$check}__label-required--Color: var(--pf-t--global--color--status--danger--default);
 
@@ -87,7 +87,7 @@
 }
 
 .#{$check}__label-required {
-  margin-inline-start: var(--#{$check}__label-required--MarginLeft);
+  margin-inline-start: var(--#{$check}__label-required--MarginInlineStart);
   font-size: var(--#{$check}__label-required--FontSize);
   color: var(--#{$check}__label-required--Color);
 }

--- a/src/patternfly/components/Chip/chip-group.scss
+++ b/src/patternfly/components/Chip/chip-group.scss
@@ -3,10 +3,10 @@
 .#{$chip}-group {
   // Chip group - spaces main and close
   // column-gap spacer supports legacy chip group
-  --#{$chip}-group--PaddingTop: 0;
-  --#{$chip}-group--PaddingRight: 0;
-  --#{$chip}-group--PaddingBottom: 0;
-  --#{$chip}-group--PaddingLeft: 0;
+  --#{$chip}-group--PaddingBlockStart: 0;
+  --#{$chip}-group--PaddingInlineEnd: 0;
+  --#{$chip}-group--PaddingBlockEnd: 0;
+  --#{$chip}-group--PaddingInlineStart: 0;
   --#{$chip}-group--RowGap: var(--#{$pf-global}--spacer--sm);
   --#{$chip}-group--ColumnGap: 0;
 
@@ -19,10 +19,10 @@
   --#{$chip}-group__list--ColumnGap: var(--#{$pf-global}--spacer--xs);
 
   // Category modifier
-  --#{$chip}-group--m-category--PaddingTop: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}-group--m-category--PaddingRight: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}-group--m-category--PaddingBottom: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}-group--m-category--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}-group--m-category--PaddingBlockStart: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}-group--m-category--PaddingInlineEnd: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}-group--m-category--PaddingBlockEnd: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}-group--m-category--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$chip}-group--m-category--BorderRadius: var(--#{$pf-global}--BorderRadius--sm);
   --#{$chip}-group--m-category--BackgroundColor: var(--#{$pf-global}--BackgroundColor--200);
 
@@ -31,22 +31,22 @@
   --#{$chip}-group__label--MaxWidth: 18ch;
 
   // Chip group close - negative margin stretches height for click area
-  --#{$chip}-group__close--MarginTop: calc(var(--#{$pf-global}--spacer--xs) * -1);
-  --#{$chip}-group__close--MarginBottom: calc(var(--#{$pf-global}--spacer--xs) * -1);
+  --#{$chip}-group__close--MarginBlockStart: calc(var(--#{$pf-global}--spacer--xs) * -1);
+  --#{$chip}-group__close--MarginBlockEnd: calc(var(--#{$pf-global}--spacer--xs) * -1);
 
   row-gap: var(--#{$chip}-group--RowGap);
   column-gap: var(--#{$chip}-group--ColumnGap);
   max-width: 100%;
-  padding-block-start: var(--#{$chip}-group--PaddingTop);
-  padding-block-end: var(--#{$chip}-group--PaddingBottom);
-  padding-inline-start: var(--#{$chip}-group--PaddingLeft);
-  padding-inline-end: var(--#{$chip}-group--PaddingRight);
+  padding-block-start: var(--#{$chip}-group--PaddingBlockStart);
+  padding-block-end: var(--#{$chip}-group--PaddingBlockEnd);
+  padding-inline-start: var(--#{$chip}-group--PaddingInlineStart);
+  padding-inline-end: var(--#{$chip}-group--PaddingInlineEnd);
 
   &.pf-m-category {
-    --#{$chip}-group--PaddingTop: var(--#{$chip}-group--m-category--PaddingTop);
-    --#{$chip}-group--PaddingRight: var(--#{$chip}-group--m-category--PaddingRight);
-    --#{$chip}-group--PaddingBottom: var(--#{$chip}-group--m-category--PaddingBottom);
-    --#{$chip}-group--PaddingLeft: var(--#{$chip}-group--m-category--PaddingLeft);
+    --#{$chip}-group--PaddingBlockStart: var(--#{$chip}-group--m-category--PaddingBlockStart);
+    --#{$chip}-group--PaddingInlineEnd: var(--#{$chip}-group--m-category--PaddingInlineEnd);
+    --#{$chip}-group--PaddingBlockEnd: var(--#{$chip}-group--m-category--PaddingBlockEnd);
+    --#{$chip}-group--PaddingInlineStart: var(--#{$chip}-group--m-category--PaddingInlineStart);
 
     background-color: var(--#{$chip}-group--m-category--BackgroundColor);
     border-radius: var(--#{$chip}-group--m-category--BorderRadius);
@@ -91,6 +91,6 @@
 .#{$chip}-group__close {
   display: flex;
   align-self: flex-start;
-  margin-block-start: var(--#{$chip}-group__close--MarginTop);
-  margin-block-end: var(--#{$chip}-group__close--MarginBottom);
+  margin-block-start: var(--#{$chip}-group__close--MarginBlockStart);
+  margin-block-end: var(--#{$chip}-group__close--MarginBlockEnd);
 }

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -1,10 +1,10 @@
 @use '../../sass-utilities' as *;
 
 .#{$chip} {
-  --#{$chip}--PaddingTop: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$chip}--PaddingBottom: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}--PaddingBlockStart: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}--PaddingBlockEnd: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$chip}--BackgroundColor: var(--#{$pf-global}--Color--light-100);
   --#{$chip}--BorderRadius: var(--#{$pf-global}--BorderRadius--sm);
   --#{$chip}--before--BorderColor: var(--#{$pf-global}--BorderColor--300);
@@ -26,32 +26,32 @@
   // chip text
   --#{$chip}__text--Color: var(--#{$pf-global}--Color--100);
   --#{$chip}__text--MaxWidth: 16ch;
-  --#{$chip}__c-badge--MarginLeft: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}__c-badge--MarginInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // chip actions
   --#{$chip}__actions--FontSize: var(--#{$pf-global}--FontSize--xs);
 
   // buttons within chip actions
-  --#{$chip}__actions--c-button--PaddingTop: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}__actions--c-button--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$chip}__actions--c-button--PaddingBottom: var(--#{$pf-global}--spacer--xs);
-  --#{$chip}__actions--c-button--PaddingLeft: var(--#{$pf-global}--spacer--sm);
-  --#{$chip}__actions--c-button--MarginTop: calc(var(--#{$chip}--PaddingTop) * -1);
-  --#{$chip}__actions--c-button--MarginRight: calc(var(--#{$chip}--PaddingRight) / 2 * -1);
-  --#{$chip}__actions--c-button--MarginBottom: calc(var(--#{$chip}--PaddingBottom) * -1);
+  --#{$chip}__actions--c-button--PaddingBlockStart: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}__actions--c-button--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}__actions--c-button--PaddingBlockEnd: var(--#{$pf-global}--spacer--xs);
+  --#{$chip}__actions--c-button--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}__actions--c-button--MarginBlockStart: calc(var(--#{$chip}--PaddingBlockStart) * -1);
+  --#{$chip}__actions--c-button--MarginInlineEnd: calc(var(--#{$chip}--PaddingInlineEnd) / 2 * -1);
+  --#{$chip}__actions--c-button--MarginBlockEnd: calc(var(--#{$chip}--PaddingBlockEnd) * -1);
   --#{$chip}__actions--c-button--FontSize: var(--#{$pf-global}--FontSize--xs);
 
   // icon
-  --#{$chip}__icon--MarginLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$chip}__icon--MarginInlineStart: var(--#{$pf-global}--spacer--sm);
 
   position: relative;
   display: inline-flex;
   align-items: center;
   min-width: 0;
-  padding-block-start: var(--#{$chip}--PaddingTop);
-  padding-block-end: var(--#{$chip}--PaddingBottom);
-  padding-inline-start: var(--#{$chip}--PaddingLeft);
-  padding-inline-end: var(--#{$chip}--PaddingRight);
+  padding-block-start: var(--#{$chip}--PaddingBlockStart);
+  padding-block-end: var(--#{$chip}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$chip}--PaddingInlineStart);
+  padding-inline-end: var(--#{$chip}--PaddingInlineEnd);
   list-style: none;
   background-color: var(--#{$chip}--BackgroundColor);
   border-radius: var(--#{$chip}--BorderRadius);
@@ -96,13 +96,13 @@
   color: var(--#{$chip}__text--Color);
 
   .#{$badge} {
-    margin-inline-start: var(--#{$chip}__c-badge--MarginLeft); // remove in breaking change
+    margin-inline-start: var(--#{$chip}__c-badge--MarginInlineStart); // remove in breaking change
   }
 }
 
 .#{$chip}__icon + .#{$chip}__text,
 .#{$chip}__text + .#{$chip}__icon {
-  margin-inline-start: var(--#{$chip}__icon--MarginLeft);
+  margin-inline-start: var(--#{$chip}__icon--MarginInlineStart);
 }
 
 .#{$chip}__content {
@@ -117,15 +117,15 @@
 
   // Actions Button
   .#{$button} {
-    --#{$button}--PaddingTop: var(--#{$chip}__actions--c-button--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$chip}__actions--c-button--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$chip}__actions--c-button--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$chip}__actions--c-button--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$chip}__actions--c-button--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$chip}__actions--c-button--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$chip}__actions--c-button--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$chip}__actions--c-button--PaddingInlineStart);
     --#{$button}--FontSize: var(--#{$chip}__actions--c-button--FontSize);
 
-    margin-block-start: var(--#{$chip}__actions--c-button--MarginTop);
-    margin-block-end: var(--#{$chip}__actions--c-button--MarginBottom);
-    margin-inline-end: var(--#{$chip}__actions--c-button--MarginRight);
+    margin-block-start: var(--#{$chip}__actions--c-button--MarginBlockStart);
+    margin-block-end: var(--#{$chip}__actions--c-button--MarginBlockEnd);
+    margin-inline-end: var(--#{$chip}__actions--c-button--MarginInlineEnd);
     line-height: 1;
   }
 }

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -6,16 +6,16 @@
   --#{$clipboard-copy}--m-expanded__toggle-icon--Rotate: 90deg;
 
   // Clipboard copy expanded content
-  --#{$clipboard-copy}__expandable-content--MarginTop: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__expandable-content--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$clipboard-copy}__expandable-content--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$clipboard-copy}__expandable-content--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$clipboard-copy}__expandable-content--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$clipboard-copy}__expandable-content--MarginBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__expandable-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$clipboard-copy}__expandable-content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$clipboard-copy}__expandable-content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$clipboard-copy}__expandable-content--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$clipboard-copy}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$clipboard-copy}__expandable-content--BorderTopWidth: var(--pf-t--global--border--width--control--default);
-  --#{$clipboard-copy}__expandable-content--BorderRightWidth: var(--pf-t--global--border--width--control--default);
-  --#{$clipboard-copy}__expandable-content--BorderBottomWidth: var(--pf-t--global--border--width--control--default);
-  --#{$clipboard-copy}__expandable-content--BorderLeftWidth: var(--pf-t--global--border--width--control--default);
+  --#{$clipboard-copy}__expandable-content--BorderBlockStartWidth: var(--pf-t--global--border--width--control--default);
+  --#{$clipboard-copy}__expandable-content--BorderInlineEndWidth: var(--pf-t--global--border--width--control--default);
+  --#{$clipboard-copy}__expandable-content--BorderBlockEndWidth: var(--pf-t--global--border--width--control--default);
+  --#{$clipboard-copy}__expandable-content--BorderInlineStartWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderColor: var(--pf-t--global--border--color--default);
   --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$clipboard-copy}__expandable-content--OutlineOffset: var(--pf-t--global--spacer--xs);
@@ -24,9 +24,9 @@
   --#{$clipboard-copy}__group--Gap: var(--pf-t--global--spacer--xs);
 
   // Inline
-  --#{$clipboard-copy}--m-inline--PaddingTop: 0; // remove at breaking change
-  --#{$clipboard-copy}--m-inline--PaddingBottom: 0; // remove at breaking change
-  --#{$clipboard-copy}--m-inline--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}--m-inline--PaddingBlockStart: 0; // remove at breaking change
+  --#{$clipboard-copy}--m-inline--PaddingBlockEnd: 0; // remove at breaking change
+  --#{$clipboard-copy}--m-inline--PaddingInlineStart: var(--pf-t--global--spacer--xs);
   --#{$clipboard-copy}--m-inline--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // Text
@@ -34,12 +34,12 @@
   --#{$clipboard-copy}__text--m-code--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Actions
-  --#{$clipboard-copy}__actions-item--MarginTop: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$clipboard-copy}__actions-item--MarginBottom: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$clipboard-copy}__actions-item--button--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__actions-item--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--xs));
+  --#{$clipboard-copy}__actions-item--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--xs));
+  --#{$clipboard-copy}__actions-item--button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__actions-item--button--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__actions-item--button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__actions-item--button--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 }
 
 .#{$clipboard-copy} {
@@ -52,9 +52,9 @@
 
   &.pf-m-inline {
     display: inline;
-    padding-block-start: var(--#{$clipboard-copy}--m-inline--PaddingTop);
-    padding-block-end: var(--#{$clipboard-copy}--m-inline--PaddingBottom);
-    padding-inline-start: var(--#{$clipboard-copy}--m-inline--PaddingLeft);
+    padding-block-start: var(--#{$clipboard-copy}--m-inline--PaddingBlockStart);
+    padding-block-end: var(--#{$clipboard-copy}--m-inline--PaddingBlockEnd);
+    padding-inline-start: var(--#{$clipboard-copy}--m-inline--PaddingInlineStart);
     white-space: nowrap;
     background-color: var(--#{$clipboard-copy}--m-inline--BackgroundColor);
 
@@ -81,19 +81,19 @@
 }
 
 .#{$clipboard-copy}__expandable-content {
-  padding-block-start: var(--#{$clipboard-copy}__expandable-content--PaddingTop);
-  padding-block-end: var(--#{$clipboard-copy}__expandable-content--PaddingBottom);
-  padding-inline-start: var(--#{$clipboard-copy}__expandable-content--PaddingLeft);
-  padding-inline-end: var(--#{$clipboard-copy}__expandable-content--PaddingRight);
-  margin-block-start: var(--#{$clipboard-copy}__expandable-content--MarginTop);
+  padding-block-start: var(--#{$clipboard-copy}__expandable-content--PaddingBlockStart);
+  padding-block-end: var(--#{$clipboard-copy}__expandable-content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$clipboard-copy}__expandable-content--PaddingInlineStart);
+  padding-inline-end: var(--#{$clipboard-copy}__expandable-content--PaddingInlineEnd);
+  margin-block-start: var(--#{$clipboard-copy}__expandable-content--MarginBlockStart);
   word-wrap: break-word;
   background-color: var(--#{$clipboard-copy}__expandable-content--BackgroundColor);
   background-clip: padding-box;
   border: solid var(--#{$clipboard-copy}__expandable-content--BorderColor);
-  border-block-start-width: var(--#{$clipboard-copy}__expandable-content--BorderTopWidth);
-  border-block-end-width: var(--#{$clipboard-copy}__expandable-content--BorderBottomWidth);
-  border-inline-start-width: var(--#{$clipboard-copy}__expandable-content--BorderLeftWidth);
-  border-inline-end-width: var(--#{$clipboard-copy}__expandable-content--BorderRightWidth);
+  border-block-start-width: var(--#{$clipboard-copy}__expandable-content--BorderBlockStartWidth);
+  border-block-end-width: var(--#{$clipboard-copy}__expandable-content--BorderBlockEndWidth);
+  border-inline-start-width: var(--#{$clipboard-copy}__expandable-content--BorderInlineStartWidth);
+  border-inline-end-width: var(--#{$clipboard-copy}__expandable-content--BorderInlineEndWidth);
   border-radius: var(--#{$clipboard-copy}__expandable-content--BorderRadius);
   box-shadow: var(--#{$clipboard-copy}__expandable-content--BoxShadow);
 
@@ -117,14 +117,14 @@
 }
 
 .#{$clipboard-copy}__actions-item {
-  margin-block-start: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingTop));
-  margin-block-end: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingBottom));
+  margin-block-start: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingBlockStart));
+  margin-block-end: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingBlockEnd));
 
   .#{$button} {
-    --#{$button}--PaddingTop: var(--#{$clipboard-copy}__actions-item--button--PaddingTop);
-    --#{$button}--PaddingRight: var(--#{$clipboard-copy}__actions-item--button--PaddingRight);
-    --#{$button}--PaddingBottom: var(--#{$clipboard-copy}__actions-item--button--PaddingBottom);
-    --#{$button}--PaddingLeft: var(--#{$clipboard-copy}__actions-item--button--PaddingLeft);
+    --#{$button}--PaddingBlockStart: var(--#{$clipboard-copy}__actions-item--button--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$clipboard-copy}__actions-item--button--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$clipboard-copy}__actions-item--button--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$clipboard-copy}__actions-item--button--PaddingInlineStart);
   }
 }
 

--- a/src/patternfly/components/CodeBlock/code-block.scss
+++ b/src/patternfly/components/CodeBlock/code-block.scss
@@ -3,16 +3,16 @@
 :where(:root, .#{$code-block}) {
   --#{$code-block}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$code-block}--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$code-block}__header--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$code-block}__header--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$code-block}__header--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$code-block}__header--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$code-block}__header--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$code-block}__header--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$code-block}__content--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$code-block}__content--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$code-block}__content--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$code-block}__content--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$code-block}__header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$code-block}__header--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$code-block}__header--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$code-block}__header--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$code-block}__header--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$code-block}__header--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$code-block}__content--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$code-block}__content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$code-block}__content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$code-block}__content--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$code-block}__pre--FontFamily: var(--pf-t--global--font--family--mono);
   --#{$code-block}__pre--FontSize: var(--pf-t--global--font--size--xs);
 }
@@ -24,11 +24,11 @@
 
 .#{$code-block}__header {
   display: flex;
-  padding-block-start: var(--#{$code-block}__header--PaddingTop);
-  padding-block-end: var(--#{$code-block}__header--PaddingBottom);
-  padding-inline-start: var(--#{$code-block}__header--PaddingLeft);
-  padding-inline-end: var(--#{$code-block}__header--PaddingRight);
-  border-block-end: var(--#{$code-block}__header--BorderBottomWidth) solid var(--#{$code-block}__header--BorderBottomColor);
+  padding-block-start: var(--#{$code-block}__header--PaddingBlockStart);
+  padding-block-end: var(--#{$code-block}__header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$code-block}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$code-block}__header--PaddingInlineEnd);
+  border-block-end: var(--#{$code-block}__header--BorderBlockEndWidth) solid var(--#{$code-block}__header--BorderBlockEndColor);
 }
 
 .#{$code-block}__actions {
@@ -37,10 +37,10 @@
 }
 
 .#{$code-block}__content {
-  padding-block-start: var(--#{$code-block}__content--PaddingTop);
-  padding-block-end: var(--#{$code-block}__content--PaddingBottom);
-  padding-inline-start: var(--#{$code-block}__content--PaddingLeft);
-  padding-inline-end: var(--#{$code-block}__content--PaddingRight);
+  padding-block-start: var(--#{$code-block}__content--PaddingBlockStart);
+  padding-block-end: var(--#{$code-block}__content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$code-block}__content--PaddingInlineStart);
+  padding-inline-end: var(--#{$code-block}__content--PaddingInlineEnd);
 }
 
 .#{$code-block}__pre {

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -6,8 +6,8 @@
   --#{$code-editor}__controls--Gap: var(--pf-t--global--spacer--xs);
 
   // header
-  --#{$code-editor}__header--before--BorderBottomWidth: var(--pf-t--global--border--width--box--default);
-  --#{$code-editor}__header--before--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$code-editor}__header--before--BorderBlockEndWidth: var(--pf-t--global--border--width--box--default);
+  --#{$code-editor}__header--before--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   // header content
   --#{$code-editor}__header-content--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
@@ -41,33 +41,33 @@
   --#{$code-editor}__main--m-drag-hover--after--Opacity: .1;
 
   // code
-  --#{$code-editor}__code--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__code--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__code--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__code--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__code--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__code--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__code--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__code--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$code-editor}__code-pre--FontSize: var(--pf-t--global--font--size--sm);
   --#{$code-editor}__code-pre--FontFamily: var(--pf-t--global--font--family--mono);
 
   // content
-  --#{$code-editor}__header-main--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__header-main--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__header-main--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__header-main--PaddingInlineStart: var(--pf-t--global--spacer--sm);
 
   // tab
   --#{$code-editor}__tab--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$code-editor}__tab--Color: var(--pf-t--global--text--color--subtle);
-  --#{$code-editor}__tab--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__tab--PaddingRight: var( --pf-t--global--spacer--sm);
-  --#{$code-editor}__tab--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$code-editor}__tab--PaddingLeft: var( --pf-t--global--spacer--sm);
-  --#{$code-editor}__tab--BorderTopWidth: var(--pf-t--global--border--width--box--default);
-  --#{$code-editor}__tab--BorderRightWidth: var(--pf-t--global--border--width--box--default);
-  --#{$code-editor}__tab--BorderBottomWidth: 0;
-  --#{$code-editor}__tab--BorderLeftWidth: var(--pf-t--global--border--width--box--default);
+  --#{$code-editor}__tab--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__tab--PaddingInlineEnd: var( --pf-t--global--spacer--sm);
+  --#{$code-editor}__tab--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__tab--PaddingInlineStart: var( --pf-t--global--spacer--sm);
+  --#{$code-editor}__tab--BorderBlockStartWidth: var(--pf-t--global--border--width--box--default);
+  --#{$code-editor}__tab--BorderInlineEndWidth: var(--pf-t--global--border--width--box--default);
+  --#{$code-editor}__tab--BorderBlockEndWidth: 0;
+  --#{$code-editor}__tab--BorderInlineStartWidth: var(--pf-t--global--border--width--box--default);
   --#{$code-editor}__tab--BorderColor: var(--pf-t--global--border--color--default);
   --#{$code-editor}__tab--BorderStartEndRadius: var(--pf-t--global--border--radius--medium);
 
   // tab text
-  --#{$code-editor}__tab-icon--text--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$code-editor}__tab-icon--text--MarginInlineStart: var(--pf-t--global--spacer--sm);
 }
 
 .#{$code-editor} {
@@ -87,7 +87,7 @@
     inset-inline-end: 0;
     pointer-events: none;
     content: "";
-    border-block-end: var(--#{$code-editor}__header--before--BorderBottomWidth) solid var(--#{$code-editor}__header--before--BorderBottomColor);
+    border-block-end: var(--#{$code-editor}__header--before--BorderBlockEndWidth) solid var(--#{$code-editor}__header--before--BorderBlockEndColor);
   }
 
   &.pf-m-plain {
@@ -120,8 +120,8 @@
 .#{$code-editor}__header-main {
   flex-grow: 1;
   align-self: center;
-  padding-inline-start: var(--#{$code-editor}__header-main--PaddingLeft);
-  padding-inline-end: var(--#{$code-editor}__header-main--PaddingRight);
+  padding-inline-start: var(--#{$code-editor}__header-main--PaddingInlineStart);
+  padding-inline-end: var(--#{$code-editor}__header-main--PaddingInlineEnd);
 }
 
 .#{$code-editor}__upload {
@@ -170,10 +170,10 @@
 
 .#{$code-editor}__code {
   position: relative;
-  padding-block-start: var(--#{$code-editor}__code--PaddingTop);
-  padding-block-end: var(--#{$code-editor}__code--PaddingBottom);
-  padding-inline-start: var(--#{$code-editor}__code--PaddingLeft);
-  padding-inline-end: var(--#{$code-editor}__code--PaddingRight);
+  padding-block-start: var(--#{$code-editor}__code--PaddingBlockStart);
+  padding-block-end: var(--#{$code-editor}__code--PaddingBlockEnd);
+  padding-inline-start: var(--#{$code-editor}__code--PaddingInlineStart);
+  padding-inline-end: var(--#{$code-editor}__code--PaddingInlineEnd);
 
   .#{$code-editor}__code-pre {
     font-family: var(--#{$code-editor}__code-pre--FontFamily);
@@ -186,21 +186,21 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding-block-start: var(--#{$code-editor}__tab--PaddingTop);
-  padding-block-end: var(--#{$code-editor}__tab--PaddingBottom);
-  padding-inline-start: var(--#{$code-editor}__tab--PaddingLeft);
-  padding-inline-end: var(--#{$code-editor}__tab--PaddingRight);
+  padding-block-start: var(--#{$code-editor}__tab--PaddingBlockStart);
+  padding-block-end: var(--#{$code-editor}__tab--PaddingBlockEnd);
+  padding-inline-start: var(--#{$code-editor}__tab--PaddingInlineStart);
+  padding-inline-end: var(--#{$code-editor}__tab--PaddingInlineEnd);
   color: var(--#{$code-editor}__tab--Color);
   background-color: var(--#{$code-editor}__tab--BackgroundColor);
   border-color: var(--#{$code-editor}__tab--BorderColor);
   border-style: solid;
-  border-block-start-width: var(--#{$code-editor}__tab--BorderTopWidth);
-  border-block-end-width: var(--#{$code-editor}__tab--BorderBottomWidth);
-  border-inline-start-width: var(--#{$code-editor}__tab--BorderLeftWidth);
-  border-inline-end-width: var(--#{$code-editor}__tab--BorderRightWidth);
+  border-block-start-width: var(--#{$code-editor}__tab--BorderBlockStartWidth);
+  border-block-end-width: var(--#{$code-editor}__tab--BorderBlockEndWidth);
+  border-inline-start-width: var(--#{$code-editor}__tab--BorderInlineStartWidth);
+  border-inline-end-width: var(--#{$code-editor}__tab--BorderInlineEndWidth);
   border-start-end-radius: var(--#{$code-editor}__tab--BorderStartEndRadius);
 }
 
 .#{$code-editor}__tab-icon + .#{$code-editor}__tab-text {
-  margin-inline-start: var(--#{$code-editor}__tab-icon--text--MarginLeft);
+  margin-inline-start: var(--#{$code-editor}__tab-icon--text--MarginInlineStart);
 }

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -2,7 +2,7 @@
 
 :where(:root, .#{$content}) {
   // Body
-  --#{$content}--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$content}--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$content}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$content}--FontWeight: var(--pf-t--global--font--weight--body);
@@ -14,49 +14,49 @@
   --#{$content}--heading--FontFamily: var(--pf-t--global--font--family--heading);
 
   // h1
-  --#{$content}--h1--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h1--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h1--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h1--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h1--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h1--FontSize: var(--pf-t--global--font--size--heading--h1);
   --#{$content}--h1--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h2
-  --#{$content}--h2--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h2--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h2--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h2--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h2--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h2--FontSize: var(--pf-t--global--font--size--heading--h2);
   --#{$content}--h2--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h3
-  --#{$content}--h3--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h3--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h3--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h3--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h3--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h3--FontSize: var(--pf-t--global--font--size--heading--h3);
   --#{$content}--h3--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h4
-  --#{$content}--h4--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h4--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h4--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h4--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h4--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h4--FontSize: var(--pf-t--global--font--size--heading--h4);
   --#{$content}--h4--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h5
-  --#{$content}--h5--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h5--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h5--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h5--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h5--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h5--FontSize: var(--pf-t--global--font--size--heading--h5);
   --#{$content}--h5--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // h6
-  --#{$content}--h6--MarginTop: var(--pf-t--global--spacer--lg);
-  --#{$content}--h6--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$content}--h6--MarginBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--h6--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$content}--h6--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$content}--h6--FontSize: var(--pf-t--global--font--size--heading--h6);
   --#{$content}--h6--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // Small text
-  --#{$content}--small--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$content}--small--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--small--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$content}--small--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$content}--small--Color: var(--pf-t--global--text--color--subtle);
@@ -69,30 +69,30 @@
   --#{$content}--a--visited--Color: var(--pf-t--global--text--color--link--visited);
 
   // Blockquote
-  --#{$content}--blockquote--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$content}--blockquote--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$content}--blockquote--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$content}--blockquote--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$content}--blockquote--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$content}--blockquote--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$content}--blockquote--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$content}--blockquote--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$content}--blockquote--Color: var(--pf-t--global--text--color--subtle);
-  --#{$content}--blockquote--BorderLeftColor: var(--pf-t--global--border--color--default);
-  --#{$content}--blockquote--BorderLeftWidth: var(--pf-t--global--border--width--300); // TODO semantic value?
+  --#{$content}--blockquote--BorderInlineStartColor: var(--pf-t--global--border--color--default);
+  --#{$content}--blockquote--BorderInlineStartWidth: var(--pf-t--global--border--width--300); // TODO semantic value?
 
   // Lists
-  --#{$content}--ol--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$content}--ol--MarginLeft: var(--pf-t--global--spacer--lg);
-  --#{$content}--ol--nested--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$content}--ol--nested--MarginLeft: var(--pf-t--global--spacer--sm);
-  --#{$content}--ul--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$content}--ul--MarginLeft: var(--pf-t--global--spacer--lg);
-  --#{$content}--ul--nested--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$content}--ul--nested--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$content}--ol--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--ol--MarginInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--ol--nested--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$content}--ol--nested--MarginInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$content}--ul--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--ul--MarginInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$content}--ul--nested--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$content}--ul--nested--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$content}--ul--ListStyle: var(--pf-t--global--list-style);
-  --#{$content}--li--MarginTop: var(--pf-t--global--spacer--sm);
+  --#{$content}--li--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$content}--dl--ColumnGap: var(--pf-t--global--spacer--2xl);
   --#{$content}--dl--RowGap: var(--pf-t--global--spacer--md);
   --#{$content}--dt--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$content}--dt--MarginTop: var(--pf-t--global--spacer--md);
-  --#{$content}--dt--sm--MarginTop: 0;
+  --#{$content}--dt--MarginBlockStart: var(--pf-t--global--spacer--md);
+  --#{$content}--dt--sm--MarginBlockStart: 0;
 
   // hr
   --#{$content}--hr--Height: var(--pf-t--global--border--width--divider--default);
@@ -133,7 +133,7 @@
     .#{$content}--li + .#{$content}--li,
     & li + li
   ) {
-    margin-block-start: var(--#{$content}--li--MarginTop);
+    margin-block-start: var(--#{$content}--li--MarginBlockStart);
   }
 
   @at-root :is(
@@ -158,7 +158,7 @@
   ) {
     &:not(:last-child) {
       // This variable name doesn't reflect the selector, it's an excpection to the variable system.
-      margin-block-end: var(--#{$content}--MarginBottom);
+      margin-block-end: var(--#{$content}--MarginBlockEnd);
     }
   }
 
@@ -209,8 +209,8 @@
     .#{$content}--h1,
     & h1
   ) {
-    margin-block-start: var(--#{$content}--h1--MarginTop);
-    margin-block-end: var(--#{$content}--h1--MarginBottom);
+    margin-block-start: var(--#{$content}--h1--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h1--MarginBlockEnd);
     font-size: var(--#{$content}--h1--FontSize);
     font-weight: var(--#{$content}--h1--FontWeight);
     line-height: var(--#{$content}--h1--LineHeight);
@@ -220,8 +220,8 @@
     .#{$content}--h2,
     & h2
   ) {
-    margin-block-start: var(--#{$content}--h2--MarginTop);
-    margin-block-end: var(--#{$content}--h2--MarginBottom);
+    margin-block-start: var(--#{$content}--h2--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h2--MarginBlockEnd);
     font-size: var(--#{$content}--h2--FontSize);
     font-weight: var(--#{$content}--h2--FontWeight);
     line-height: var(--#{$content}--h2--LineHeight);
@@ -231,8 +231,8 @@
     .#{$content}--h3,
     & h3
   ) {
-    margin-block-start: var(--#{$content}--h3--MarginTop);
-    margin-block-end: var(--#{$content}--h3--MarginBottom);
+    margin-block-start: var(--#{$content}--h3--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h3--MarginBlockEnd);
     font-size: var(--#{$content}--h3--FontSize);
     font-weight: var(--#{$content}--h3--FontWeight);
     line-height: var(--#{$content}--h3--LineHeight);
@@ -242,8 +242,8 @@
     .#{$content}--h4,
     & h4
   ) {
-    margin-block-start: var(--#{$content}--h4--MarginTop);
-    margin-block-end: var(--#{$content}--h4--MarginBottom);
+    margin-block-start: var(--#{$content}--h4--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h4--MarginBlockEnd);
     font-size: var(--#{$content}--h4--FontSize);
     font-weight: var(--#{$content}--h4--FontWeight);
     line-height: var(--#{$content}--h4--LineHeight);
@@ -253,8 +253,8 @@
     .#{$content}--h5,
     & h5
   ) {
-    margin-block-start: var(--#{$content}--h5--MarginTop);
-    margin-block-end: var(--#{$content}--h5--MarginBottom);
+    margin-block-start: var(--#{$content}--h5--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h5--MarginBlockEnd);
     font-size: var(--#{$content}--h5--FontSize);
     font-weight: var(--#{$content}--h5--FontWeight);
     line-height: var(--#{$content}--h5--LineHeight);
@@ -264,8 +264,8 @@
     .#{$content}--h6,
     & h6
   ) {
-    margin-block-start: var(--#{$content}--h6--MarginTop);
-    margin-block-end: var(--#{$content}--h6--MarginBottom);
+    margin-block-start: var(--#{$content}--h6--MarginBlockStart);
+    margin-block-end: var(--#{$content}--h6--MarginBlockEnd);
     font-size: var(--#{$content}--h6--FontSize);
     font-weight: var(--#{$content}--h6--FontWeight);
     line-height: var(--#{$content}--h6--LineHeight);
@@ -281,7 +281,7 @@
     color: var(--#{$content}--small--Color);
 
     &:not(:last-child) {
-      margin-block-end: var(--#{$content}--small--MarginBottom);
+      margin-block-end: var(--#{$content}--small--MarginBlockEnd);
     }
   }
 
@@ -289,12 +289,12 @@
     .#{$content}--blockquote,
     & blockquote
   ) {
-    padding-block-start: var(--#{$content}--blockquote--PaddingTop);
-    padding-block-end: var(--#{$content}--blockquote--PaddingBottom);
-    padding-inline-start: var(--#{$content}--blockquote--PaddingLeft);
-    padding-inline-end: var(--#{$content}--blockquote--PaddingRight);
+    padding-block-start: var(--#{$content}--blockquote--PaddingBlockStart);
+    padding-block-end: var(--#{$content}--blockquote--PaddingBlockEnd);
+    padding-inline-start: var(--#{$content}--blockquote--PaddingInlineStart);
+    padding-inline-end: var(--#{$content}--blockquote--PaddingInlineEnd);
     color: var(--#{$content}--blockquote--Color);
-    border-inline-start: var(--#{$content}--blockquote--BorderLeftWidth) solid var(--#{$content}--blockquote--BorderLeftColor);
+    border-inline-start: var(--#{$content}--blockquote--BorderInlineStartWidth) solid var(--#{$content}--blockquote--BorderInlineStartColor);
   }
 
   @at-root :is(
@@ -310,25 +310,25 @@
     .#{$content}--ol,
     & ol
   ) {
-    padding-inline-start: var(--#{$content}--ol--PaddingLeft);
-    margin-inline-start: var(--#{$content}--ol--MarginLeft);
+    padding-inline-start: var(--#{$content}--ol--PaddingInlineStart);
+    margin-inline-start: var(--#{$content}--ol--MarginInlineStart);
 
     :is(
       .#{$content}--ul,
       ul
     ) {
-      --#{$content}--ul--MarginLeft: var(--#{$content}--ul--nested--MarginLeft);
+      --#{$content}--ul--MarginInlineStart: var(--#{$content}--ul--nested--MarginInlineStart);
 
-      margin-block-start: var(--#{$content}--ul--nested--MarginTop);
+      margin-block-start: var(--#{$content}--ul--nested--MarginBlockStart);
     }
 
     :is(
       .#{$content}--ol,
       ol
     ) {
-      --#{$content}--ol--MarginLeft: var(--#{$content}--ol--nested--MarginLeft);
+      --#{$content}--ol--MarginInlineStart: var(--#{$content}--ol--nested--MarginInlineStart);
 
-      margin-block-start: var(--#{$content}--ol--nested--MarginTop);
+      margin-block-start: var(--#{$content}--ol--nested--MarginBlockStart);
     }
   }
 
@@ -336,26 +336,26 @@
     .#{$content}--ul,
     & ul
   ) {
-    padding-inline-start: var(--#{$content}--ul--PaddingLeft);
-    margin-inline-start: var(--#{$content}--ul--MarginLeft);
+    padding-inline-start: var(--#{$content}--ul--PaddingInlineStart);
+    margin-inline-start: var(--#{$content}--ul--MarginInlineStart);
     list-style: var(--#{$content}--ul--ListStyle);
 
     :is(
       .#{$content}--ul,
       ul
     ) {
-      --#{$content}--ul--MarginLeft: var(--#{$content}--ul--nested--MarginLeft);
+      --#{$content}--ul--MarginInlineStart: var(--#{$content}--ul--nested--MarginInlineStart);
 
-      margin-block-start: var(--#{$content}--ul--nested--MarginTop);
+      margin-block-start: var(--#{$content}--ul--nested--MarginBlockStart);
     }
 
     :is(
       .#{$content}--ol,
       ol
     ) {
-      --#{$content}--ol--MarginLeft: var(--#{$content}--ol--nested--MarginLeft);
+      --#{$content}--ol--MarginInlineStart: var(--#{$content}--ol--nested--MarginInlineStart);
 
-      margin-block-start: var(--#{$content}--ol--nested--MarginTop);
+      margin-block-start: var(--#{$content}--ol--nested--MarginBlockStart);
     }
   }
 
@@ -380,10 +380,10 @@
     font-weight: var(--#{$content}--dt--FontWeight);
 
     &:not(:first-child) {
-      margin-block-start: var(--#{$content}--dt--MarginTop);
+      margin-block-start: var(--#{$content}--dt--MarginBlockStart);
 
       @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-        --#{$content}--dt--MarginTop: var(--#{$content}--dt--sm--MarginTop);
+        --#{$content}--dt--MarginBlockStart: var(--#{$content}--dt--sm--MarginBlockStart);
       }
     }
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -5,31 +5,31 @@
   --#{$context-selector}--Width: #{pf-size-prem(250px)};
 
   // Toggle
-  --#{$context-selector}__toggle--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$context-selector}__toggle--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$context-selector}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$context-selector}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$context-selector}__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$context-selector}__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$context-selector}__toggle--ColumnGap: var(--#{$pf-global}--spacer--sm);
   --#{$context-selector}__toggle--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$context-selector}__toggle--BorderTopColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$context-selector}__toggle--BorderRightColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$context-selector}__toggle--BorderBottomColor: var(--#{$pf-global}--BorderColor--200);
-  --#{$context-selector}__toggle--BorderLeftColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$context-selector}__toggle--BorderBlockStartColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$context-selector}__toggle--BorderInlineEndColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--200);
+  --#{$context-selector}__toggle--BorderInlineStartColor: var(--#{$pf-global}--BorderColor--300);
   --#{$context-selector}__toggle--Color: var(--#{$pf-global}--Color--100);
-  --#{$context-selector}__toggle--hover--BorderBottomWidth: var(--#{$context-selector}__toggle--BorderWidth);
-  --#{$context-selector}__toggle--hover--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$context-selector}__toggle--active--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$context-selector}__toggle--active--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$context-selector}__toggle--expanded--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$context-selector}__toggle--expanded--BorderBottomColor: var(--#{$pf-global}--active-color--100);
+  --#{$context-selector}__toggle--hover--BorderBlockEndWidth: var(--#{$context-selector}__toggle--BorderWidth);
+  --#{$context-selector}__toggle--hover--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$context-selector}__toggle--active--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$context-selector}__toggle--active--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$context-selector}__toggle--expanded--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$context-selector}__toggle--expanded--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
   --#{$context-selector}__toggle--BackgroundColor: transparent;
   --#{$context-selector}__toggle--m-plain--Color: var(--#{$pf-global}--Color--200);
   --#{$context-selector}__toggle--m-plain--hover--Color: var(--#{$pf-global}--Color--100);
   --#{$context-selector}__toggle--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
-  --#{$context-selector}__toggle--m-plain--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__toggle--m-plain--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__toggle--m-plain--m-text--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$context-selector}__toggle--m-plain--m-text--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle--m-plain--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__toggle--m-plain--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__toggle--m-plain--m-text--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle--m-plain--m-text--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
 
   // Toggle text
   --#{$context-selector}__toggle-text--FontSize: var(--#{$pf-global}--FontSize--md);
@@ -37,44 +37,44 @@
   --#{$context-selector}__toggle-text--LineHeight: var(--#{$pf-global}--LineHeight--md);
 
   // Toggle icon arrow
-  --#{$context-selector}__toggle-icon--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$context-selector}__toggle-icon--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle-icon--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__toggle-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$context-selector}--m-plain__toggle-icon--Color: var(--#{$pf-global}--Color--200);
   --#{$context-selector}--m-plain--hover__toggle-icon--Color: var(--#{$pf-global}--Color--100);
 
   // Menu
-  --#{$context-selector}__menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$context-selector}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$context-selector}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$context-selector}__menu--PaddingTop: var(--#{$pf-global}--spacer--sm); // remove at breaking change
+  --#{$context-selector}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm); // remove at breaking change
   --#{$context-selector}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
   --#{$context-selector}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
 
   // Menu input
-  --#{$context-selector}__menu-search--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-search--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-search--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-search--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-search--BorderBottomColor: var(--#{$pf-global}--BorderColor--100);
-  --#{$context-selector}__menu-search--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$context-selector}__menu-search--PaddingBlockStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-search--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-search--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-search--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-search--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--100);
+  --#{$context-selector}__menu-search--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--sm);
 
   // Menu footer
   --#{$context-selector}__menu-footer--BoxShadow: var(--#{$pf-global}--BoxShadow--sm-top);
-  --#{$context-selector}__menu-footer--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-footer--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-footer--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}__menu-footer--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-footer--PaddingBlockStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-footer--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-footer--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}__menu-footer--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
 
   // Menu list
   --#{$context-selector}__menu-list--MaxHeight: #{pf-size-prem(200px)};
-  --#{$context-selector}__menu-list--PaddingTop: var(--#{$context-selector}__menu--PaddingTop); // reference spacer directly at breaking change
-  --#{$context-selector}__menu-list--PaddingBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__menu-list--PaddingBlockStart: var(--#{$context-selector}__menu--PaddingBlockStart); // reference spacer directly at breaking change
+  --#{$context-selector}__menu-list--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   // Menu item
   --#{$context-selector}__menu-list-item--Color: var(--#{$pf-global}--Color--dark-100);
-  --#{$context-selector}__menu-list-item--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$context-selector}__menu-list-item--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}__menu-list-item--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$context-selector}__menu-list-item--PaddingLeft: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}__menu-list-item--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__menu-list-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}__menu-list-item--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$context-selector}__menu-list-item--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
   --#{$context-selector}__menu-list-item--BackgroundColor: transparent;
   --#{$context-selector}__menu-list-item--hover--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-300);
   --#{$context-selector}__menu-list-item--disabled--Color: var(--#{$pf-global}--Color--dark-200);
@@ -82,62 +82,62 @@
   // Menu item icon
   --#{$context-selector}__menu-item-icon--Color: var(--#{$pf-global}--active-color--100);
   --#{$context-selector}__menu-item-icon--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$context-selector}__menu-item-icon--PaddingLeft: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}__menu-item-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
 
   // Full height
-  --#{$context-selector}--m-full-height__toggle--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-full-height__toggle--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-full-height__toggle--before--BorderTopWidth: 0;
-  --#{$context-selector}--m-full-height__toggle--hover--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$context-selector}--m-full-height__toggle--active--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$context-selector}--m-full-height__toggle--expanded--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-full-height__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-full-height__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-full-height__toggle--before--BorderBlockStartWidth: 0;
+  --#{$context-selector}--m-full-height__toggle--hover--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-full-height__toggle--active--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-full-height__toggle--expanded--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
 
   // Large
-  --#{$context-selector}--m-large__toggle--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-large__toggle--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-large__toggle--hover--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$context-selector}--m-large__toggle--active--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$context-selector}--m-large__toggle--expanded--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-large__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-large__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-large__toggle--hover--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-large__toggle--active--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$context-selector}--m-large__toggle--expanded--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
 
   // Page insets
-  --#{$context-selector}--m-page-insets__toggle--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__toggle--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-list-item--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-list-item--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-search--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-search--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-search--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-search--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-footer--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-footer--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__menu-footer--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__menu-footer--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingLeft: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-search--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-search--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-search--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-search--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-footer--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-footer--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__menu-footer--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__menu-footer--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$context-selector}--m-page-insets__toggle--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__toggle--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--xl--PaddingLeft);
-    --#{$context-selector}--m-page-insets__menu-list-item--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__menu-list-item--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingLeft);
-    --#{$context-selector}--m-page-insets__menu-search--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-search--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__menu-search--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-search--xl--PaddingLeft);
-    --#{$context-selector}--m-page-insets__menu-footer--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-footer--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__menu-footer--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-footer--xl--PaddingLeft);
-    --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingLeft);
-    --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingRight);
-    --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingLeft);
+    --#{$context-selector}--m-page-insets__toggle--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__toggle--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--xl--PaddingInlineStart);
+    --#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-list-item--xl--PaddingInlineStart);
+    --#{$context-selector}--m-page-insets__menu-search--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-search--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__menu-search--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-search--xl--PaddingInlineStart);
+    --#{$context-selector}--m-page-insets__menu-footer--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-footer--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__menu-footer--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-footer--xl--PaddingInlineStart);
+    --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--m-plain--xl--PaddingInlineStart);
+    --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingInlineEnd);
+    --#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--xl--PaddingInlineStart);
   }
 
   position: relative;
@@ -146,10 +146,10 @@
   max-width: 100%;
 
   &.pf-m-full-height {
-    --#{$context-selector}__toggle--active--BorderBottomWidth: var(--#{$context-selector}--m-full-height__toggle--active--BorderBottomWidth);
-    --#{$context-selector}__toggle--expanded--BorderBottomWidth: var(--#{$context-selector}--m-full-height__toggle--expanded--BorderBottomWidth);
-    --#{$context-selector}__toggle--PaddingRight: var(--#{$context-selector}--m-full-height__toggle--PaddingRight);
-    --#{$context-selector}__toggle--PaddingLeft: var(--#{$context-selector}--m-full-height__toggle--PaddingLeft);
+    --#{$context-selector}__toggle--active--BorderBlockEndWidth: var(--#{$context-selector}--m-full-height__toggle--active--BorderBlockEndWidth);
+    --#{$context-selector}__toggle--expanded--BorderBlockEndWidth: var(--#{$context-selector}--m-full-height__toggle--expanded--BorderBlockEndWidth);
+    --#{$context-selector}__toggle--PaddingInlineEnd: var(--#{$context-selector}--m-full-height__toggle--PaddingInlineEnd);
+    --#{$context-selector}__toggle--PaddingInlineStart: var(--#{$context-selector}--m-full-height__toggle--PaddingInlineStart);
 
     display: inline-flex;
     align-items: center;
@@ -159,38 +159,38 @@
       align-self: stretch;
 
       &::before {
-        border-block-start-width: var(--#{$context-selector}--m-full-height__toggle--before--BorderTopWidth);
+        border-block-start-width: var(--#{$context-selector}--m-full-height__toggle--before--BorderBlockStartWidth);
       }
     }
 
     &:hover {
       .#{$context-selector}__toggle::before {
-        border-block-end-width: var(--#{$context-selector}--m-full-height__toggle--hover--BorderBottomWidth);
+        border-block-end-width: var(--#{$context-selector}--m-full-height__toggle--hover--BorderBlockEndWidth);
       }
     }
   }
 
   &.pf-m-large {
-    --#{$context-selector}__toggle--PaddingTop: var(--#{$context-selector}--m-large__toggle--PaddingTop);
-    --#{$context-selector}__toggle--PaddingBottom: var(--#{$context-selector}--m-large__toggle--PaddingBottom);
-    --#{$context-selector}__toggle--hover--BorderBottomWidth: var(--#{$context-selector}--m-large__toggle--hover--BorderBottomWidth);
-    --#{$context-selector}__toggle--active--BorderBottomWidth: var(--#{$context-selector}--m-large__toggle--active--BorderBottomWidth);
-    --#{$context-selector}__toggle--expanded--BorderBottomWidth: var(--#{$context-selector}--m-large__toggle--expanded--BorderBottomWidth);
+    --#{$context-selector}__toggle--PaddingBlockStart: var(--#{$context-selector}--m-large__toggle--PaddingBlockStart);
+    --#{$context-selector}__toggle--PaddingBlockEnd: var(--#{$context-selector}--m-large__toggle--PaddingBlockEnd);
+    --#{$context-selector}__toggle--hover--BorderBlockEndWidth: var(--#{$context-selector}--m-large__toggle--hover--BorderBlockEndWidth);
+    --#{$context-selector}__toggle--active--BorderBlockEndWidth: var(--#{$context-selector}--m-large__toggle--active--BorderBlockEndWidth);
+    --#{$context-selector}__toggle--expanded--BorderBlockEndWidth: var(--#{$context-selector}--m-large__toggle--expanded--BorderBlockEndWidth);
   }
 
   &.pf-m-page-insets {
-    --#{$context-selector}__toggle--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--PaddingRight);
-    --#{$context-selector}__toggle--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--PaddingLeft);
-    --#{$context-selector}__menu-list-item--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-list-item--PaddingRight);
-    --#{$context-selector}__menu-list-item--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-list-item--PaddingLeft);
-    --#{$context-selector}__menu-search--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-search--PaddingRight);
-    --#{$context-selector}__menu-search--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-search--PaddingLeft);
-    --#{$context-selector}__menu-footer--PaddingRight: var(--#{$context-selector}--m-page-insets__menu-footer--PaddingRight);
-    --#{$context-selector}__menu-footer--PaddingLeft: var(--#{$context-selector}--m-page-insets__menu-footer--PaddingLeft);
-    --#{$context-selector}__toggle--m-plain--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--m-plain--PaddingRight);
-    --#{$context-selector}__toggle--m-plain--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--m-plain--PaddingLeft);
-    --#{$context-selector}__toggle--m-plain--m-text--PaddingRight: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingRight);
-    --#{$context-selector}__toggle--m-plain--m-text--PaddingLeft: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingLeft);
+    --#{$context-selector}__toggle--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--PaddingInlineEnd);
+    --#{$context-selector}__toggle--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--PaddingInlineStart);
+    --#{$context-selector}__menu-list-item--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineEnd);
+    --#{$context-selector}__menu-list-item--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-list-item--PaddingInlineStart);
+    --#{$context-selector}__menu-search--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-search--PaddingInlineEnd);
+    --#{$context-selector}__menu-search--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-search--PaddingInlineStart);
+    --#{$context-selector}__menu-footer--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__menu-footer--PaddingInlineEnd);
+    --#{$context-selector}__menu-footer--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__menu-footer--PaddingInlineStart);
+    --#{$context-selector}__toggle--m-plain--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineEnd);
+    --#{$context-selector}__toggle--m-plain--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--m-plain--PaddingInlineStart);
+    --#{$context-selector}__toggle--m-plain--m-text--PaddingInlineEnd: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineEnd);
+    --#{$context-selector}__toggle--m-plain--m-text--PaddingInlineStart: var(--#{$context-selector}--m-page-insets__toggle--m-plain--m-text--PaddingInlineStart);
   }
 }
 
@@ -200,10 +200,10 @@
   column-gap: var(--#{$context-selector}__toggle--ColumnGap);
   align-items: center;
   width: 100%;
-  padding-block-start: var(--#{$context-selector}__toggle--PaddingTop);
-  padding-block-end: var(--#{$context-selector}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$context-selector}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$context-selector}__toggle--PaddingRight);
+  padding-block-start: var(--#{$context-selector}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$context-selector}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$context-selector}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$context-selector}__toggle--PaddingInlineEnd);
   color: var(--#{$context-selector}__toggle--Color);
   white-space: nowrap;
   cursor: pointer;
@@ -218,17 +218,17 @@
     inset-inline-end: 0;
     content: "";
     border: var(--#{$context-selector}__toggle--BorderWidth) solid;
-    border-block-start-color: var(--#{$context-selector}__toggle--BorderTopColor);
-    border-block-end-color: var(--#{$context-selector}__toggle--BorderBottomColor);
-    border-inline-start-color: var(--#{$context-selector}__toggle--BorderLeftColor);
-    border-inline-end-color: var(--#{$context-selector}__toggle--BorderRightColor);
+    border-block-start-color: var(--#{$context-selector}__toggle--BorderBlockStartColor);
+    border-block-end-color: var(--#{$context-selector}__toggle--BorderBlockEndColor);
+    border-inline-start-color: var(--#{$context-selector}__toggle--BorderInlineStartColor);
+    border-inline-end-color: var(--#{$context-selector}__toggle--BorderInlineEndColor);
   }
 
   &:hover {
     &::before {
-      --#{$context-selector}__toggle--BorderBottomColor: var(--#{$context-selector}__toggle--hover--BorderBottomColor);
+      --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$context-selector}__toggle--hover--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$context-selector}__toggle--hover--BorderBottomWidth);
+      border-block-end-width: var(--#{$context-selector}__toggle--hover--BorderBlockEndWidth);
     }
   }
 
@@ -236,28 +236,28 @@
   &.pf-m-active,
   &:focus-within {
     &::before {
-      --#{$context-selector}__toggle--BorderBottomColor: var(--#{$context-selector}__toggle--active--BorderBottomColor);
+      --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$context-selector}__toggle--active--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$context-selector}__toggle--active--BorderBottomWidth);
+      border-block-end-width: var(--#{$context-selector}__toggle--active--BorderBlockEndWidth);
     }
   }
 
   .pf-m-expanded > & {
     &::before {
-      --#{$context-selector}__toggle--BorderBottomColor: var(--#{$context-selector}__toggle--expanded--BorderBottomColor);
+      --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$context-selector}__toggle--expanded--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$context-selector}__toggle--expanded--BorderBottomWidth);
+      border-block-end-width: var(--#{$context-selector}__toggle--expanded--BorderBlockEndWidth);
     }
   }
 
   &.pf-m-plain {
-    --#{$context-selector}__toggle--PaddingRight: var(--#{$context-selector}__toggle--m-plain--PaddingRight);
-    --#{$context-selector}__toggle--PaddingLeft: var(--#{$context-selector}__toggle--m-plain--PaddingLeft);
+    --#{$context-selector}__toggle--PaddingInlineEnd: var(--#{$context-selector}__toggle--m-plain--PaddingInlineEnd);
+    --#{$context-selector}__toggle--PaddingInlineStart: var(--#{$context-selector}__toggle--m-plain--PaddingInlineStart);
     --#{$context-selector}__toggle-icon--Color: var(--#{$context-selector}--m-plain__toggle-icon--Color);
 
     &.pf-m-text {
-      --#{$context-selector}__toggle--PaddingRight: var(--#{$context-selector}__toggle--m-plain--m-text--PaddingRight);
-      --#{$context-selector}__toggle--PaddingLeft: var(--#{$context-selector}__toggle--m-plain--m-text--PaddingLeft);
+      --#{$context-selector}__toggle--PaddingInlineEnd: var(--#{$context-selector}__toggle--m-plain--m-text--PaddingInlineEnd);
+      --#{$context-selector}__toggle--PaddingInlineStart: var(--#{$context-selector}__toggle--m-plain--m-text--PaddingInlineStart);
     }
 
     &:not(.pf-m-text) {
@@ -297,14 +297,14 @@
 }
 
 .#{$context-selector}__toggle-icon {
-  padding-inline-start: var(--#{$context-selector}__toggle-icon--PaddingLeft);
-  padding-inline-end: var(--#{$context-selector}__toggle-icon--PaddingRight);
+  padding-inline-start: var(--#{$context-selector}__toggle-icon--PaddingInlineStart);
+  padding-inline-end: var(--#{$context-selector}__toggle-icon--PaddingInlineEnd);
   color: var(--#{$context-selector}__toggle-icon--Color, inherit);
 }
 
 .#{$context-selector}__menu {
   position: absolute;
-  inset-block-start: var(--#{$context-selector}__menu--Top);
+  inset-block-start: var(--#{$context-selector}__menu--BlockStart);
   z-index: var(--#{$context-selector}__menu--ZIndex);
   min-width: 100%;
   background-color: var(--#{$context-selector}__menu--BackgroundColor);
@@ -324,25 +324,25 @@
 
 .#{$context-selector}__menu-search {
   position: relative;
-  padding-block-start: var(--#{$context-selector}__menu-search--PaddingTop);
-  padding-block-end: var(--#{$context-selector}__menu-search--PaddingBottom);
-  padding-inline-start: var(--#{$context-selector}__menu-search--PaddingLeft);
-  padding-inline-end: var(--#{$context-selector}__menu-search--PaddingRight);
-  border-block-end: var(--#{$context-selector}__menu-search--BorderBottomWidth) solid var(--#{$context-selector}__menu-search--BorderBottomColor);
+  padding-block-start: var(--#{$context-selector}__menu-search--PaddingBlockStart);
+  padding-block-end: var(--#{$context-selector}__menu-search--PaddingBlockEnd);
+  padding-inline-start: var(--#{$context-selector}__menu-search--PaddingInlineStart);
+  padding-inline-end: var(--#{$context-selector}__menu-search--PaddingInlineEnd);
+  border-block-end: var(--#{$context-selector}__menu-search--BorderBlockEndWidth) solid var(--#{$context-selector}__menu-search--BorderBlockEndColor);
 }
 
 .#{$context-selector}__menu-footer {
-  padding-block-start: var(--#{$context-selector}__menu-footer--PaddingTop);
-  padding-block-end: var(--#{$context-selector}__menu-footer--PaddingBottom);
-  padding-inline-start: var(--#{$context-selector}__menu-footer--PaddingLeft);
-  padding-inline-end: var(--#{$context-selector}__menu-footer--PaddingRight);
+  padding-block-start: var(--#{$context-selector}__menu-footer--PaddingBlockStart);
+  padding-block-end: var(--#{$context-selector}__menu-footer--PaddingBlockEnd);
+  padding-inline-start: var(--#{$context-selector}__menu-footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$context-selector}__menu-footer--PaddingInlineEnd);
   box-shadow: var(--#{$context-selector}__menu-footer--BoxShadow);
 }
 
 .#{$context-selector}__menu-list {
   max-height: var(--#{$context-selector}__menu-list--MaxHeight);
-  padding-block-start: var(--#{$context-selector}__menu-list--PaddingTop);
-  padding-block-end: var(--#{$context-selector}__menu-list--PaddingBottom);
+  padding-block-start: var(--#{$context-selector}__menu-list--PaddingBlockStart);
+  padding-block-end: var(--#{$context-selector}__menu-list--PaddingBlockEnd);
   overflow-y: auto;
 }
 
@@ -350,10 +350,10 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding-block-start: var(--#{$context-selector}__menu-list-item--PaddingTop);
-  padding-block-end: var(--#{$context-selector}__menu-list-item--PaddingBottom);
-  padding-inline-start: var(--#{$context-selector}__menu-list-item--PaddingLeft);
-  padding-inline-end: var(--#{$context-selector}__menu-list-item--PaddingRight);
+  padding-block-start: var(--#{$context-selector}__menu-list-item--PaddingBlockStart);
+  padding-block-end: var(--#{$context-selector}__menu-list-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$context-selector}__menu-list-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$context-selector}__menu-list-item--PaddingInlineEnd);
   color: var(--#{$context-selector}__menu-list-item--Color);
   white-space: nowrap;
   background-color: var(--#{$context-selector}__menu-list-item--BackgroundColor);

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -43,7 +43,7 @@
   --#{$context-selector}--m-plain--hover__toggle-icon--Color: var(--#{$pf-global}--Color--100);
 
   // Menu
-  --#{$context-selector}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$context-selector}__menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$context-selector}__menu--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$context-selector}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm); // remove at breaking change
   --#{$context-selector}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
@@ -304,7 +304,7 @@
 
 .#{$context-selector}__menu {
   position: absolute;
-  inset-block-start: var(--#{$context-selector}__menu--BlockStart);
+  inset-block-start: var(--#{$context-selector}__menu--InsetBlockStart);
   z-index: var(--#{$context-selector}__menu--ZIndex);
   min-width: 100%;
   background-color: var(--#{$context-selector}__menu--BackgroundColor);

--- a/src/patternfly/components/DataList/data-list-grid.scss
+++ b/src/patternfly/components/DataList/data-list-grid.scss
@@ -25,34 +25,34 @@
 }
 
 @include pf-v6-c-data-list-responsive-block {
-  --#{$data-list}__cell--cell--PaddingTop: var(--#{$data-list}__cell--cell--md--PaddingTop);
-  --#{$data-list}__cell--PaddingBottom: var(--#{$data-list}__cell--md--PaddingBottom);
-  --#{$data-list}__item-control--MarginRight: var(--#{$data-list}__item-control--md--MarginRight);
-  --#{$data-list}__item-action--MarginLeft: var(--#{$data-list}__item-action--md--MarginLeft);
-  --#{$data-list}__expandable-content-body--PaddingTop: var(--#{$data-list}__expandable-content-body--md--PaddingTop);
-  --#{$data-list}__expandable-content-body--PaddingBottom: var(--#{$data-list}__expandable-content-body--md--PaddingBottom);
-  --#{$data-list}--m-compact__cell--PaddingBottom: var(--#{$data-list}--m-compact__cell--md--PaddingBottom);
-  --#{$data-list}--m-compact__cell-cell--PaddingTop: var(--#{$data-list}--m-compact__cell-cell--md--PaddingTop);
+  --#{$data-list}__cell--cell--PaddingBlockStart: var(--#{$data-list}__cell--cell--md--PaddingBlockStart);
+  --#{$data-list}__cell--PaddingBlockEnd: var(--#{$data-list}__cell--md--PaddingBlockEnd);
+  --#{$data-list}__item-control--MarginInlineEnd: var(--#{$data-list}__item-control--md--MarginInlineEnd);
+  --#{$data-list}__item-action--MarginInlineStart: var(--#{$data-list}__item-action--md--MarginInlineStart);
+  --#{$data-list}__expandable-content-body--PaddingBlockStart: var(--#{$data-list}__expandable-content-body--md--PaddingBlockStart);
+  --#{$data-list}__expandable-content-body--PaddingBlockEnd: var(--#{$data-list}__expandable-content-body--md--PaddingBlockEnd);
+  --#{$data-list}--m-compact__cell--PaddingBlockEnd: var(--#{$data-list}--m-compact__cell--md--PaddingBlockEnd);
+  --#{$data-list}--m-compact__cell-cell--PaddingBlockStart: var(--#{$data-list}--m-compact__cell-cell--md--PaddingBlockStart);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$data-list}__item-row--PaddingRight: var(--#{$data-list}__item-row--xl--PaddingRight);
-    --#{$data-list}__item-row--PaddingLeft: var(--#{$data-list}__item-row--xl--PaddingLeft);
-    --#{$data-list}__expandable-content-body--PaddingRight: var(--#{$data-list}__expandable-content-body--xl--PaddingRight);
-    --#{$data-list}__expandable-content-body--PaddingLeft: var(--#{$data-list}__expandable-content-body--xl--PaddingLeft);
+    --#{$data-list}__item-row--PaddingInlineEnd: var(--#{$data-list}__item-row--xl--PaddingInlineEnd);
+    --#{$data-list}__item-row--PaddingInlineStart: var(--#{$data-list}__item-row--xl--PaddingInlineStart);
+    --#{$data-list}__expandable-content-body--PaddingInlineEnd: var(--#{$data-list}__expandable-content-body--xl--PaddingInlineEnd);
+    --#{$data-list}__expandable-content-body--PaddingInlineStart: var(--#{$data-list}__expandable-content-body--xl--PaddingInlineStart);
   }
 
   .#{$data-list}__item-content {
     display: flex;
     flex-grow: 1;
     flex-wrap: wrap;
-    padding-block-end: var(--#{$data-list}__item-content--md--PaddingBottom);
+    padding-block-end: var(--#{$data-list}__item-content--md--PaddingBlockEnd);
   }
 
   .#{$data-list}__cell {
     // stylelint-disable selector-not-notation
     // update to single :not() in breaking change
     &:not(:last-child):not(.pf-m-icon) {
-      margin-inline-end: var(--#{$data-list}__cell--MarginRight);
+      margin-inline-end: var(--#{$data-list}__cell--MarginInlineEnd);
     }
 
     // for all subsequent .#{$data-list}__cell's, set to full width

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -4,15 +4,15 @@
 :where(:root, .#{$data-list}) {
   --#{$data-list}--FontSize: var( --pf-t--global--font--size--body);
   --#{$data-list}--LineHeight: var(--pf-t--global--font--line-height--body);
-  --#{$data-list}--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$data-list}--BorderTopWidth: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--sm--BorderTopWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$data-list}--sm--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$data-list}--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$data-list}--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$data-list}--BorderBlockStartWidth: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--sm--BorderBlockStartWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$data-list}--sm--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$data-list}--MarginInlineStart: var(--pf-t--global--spacer--md);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$data-list}--BorderTopColor: var(--#{$data-list}--sm--BorderTopColor);
-    --#{$data-list}--BorderTopWidth: var(--#{$data-list}--sm--BorderTopWidth);
+    --#{$data-list}--BorderBlockStartColor: var(--#{$data-list}--sm--BorderBlockStartColor);
+    --#{$data-list}--BorderBlockStartWidth: var(--#{$data-list}--sm--BorderBlockStartWidth);
   }
 
   // item
@@ -20,34 +20,34 @@
   --#{$data-list}__item--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
   --#{$data-list}__item--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$data-list}__item--m-clickable--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$data-list}__item--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$data-list}__item--BorderBottomWidth: var(--pf-t--global--spacer--sm);
-  --#{$data-list}__item--sm--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$data-list}__item--sm--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$data-list}__item--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$data-list}__item--BorderBlockEndWidth: var(--pf-t--global--spacer--sm);
+  --#{$data-list}__item--sm--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$data-list}__item--sm--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$data-list}__item--BorderBottomWidth: var(--#{$data-list}__item--sm--BorderBottomWidth);
-    --#{$data-list}__item--BorderBottomColor: var(--#{$data-list}__item--sm--BorderBottomColor);
+    --#{$data-list}__item--BorderBlockEndWidth: var(--#{$data-list}__item--sm--BorderBlockEndWidth);
+    --#{$data-list}__item--BorderBlockEndColor: var(--#{$data-list}__item--sm--BorderBlockEndColor);
   }
 
   // data list item row
-  --#{$data-list}__item-row--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-row--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-row--xl--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-row--xl--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-row--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-row--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-row--xl--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-row--xl--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // data list item content
-  --#{$data-list}__item-content--md--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-content--md--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
 
   // cell
-  --#{$data-list}__cell--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__cell--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__cell--MarginRight: var(--pf-t--global--spacer--xl);
-  --#{$data-list}__cell--md--PaddingBottom: 0;
-  --#{$data-list}__cell--m-icon--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__cell--cell--PaddingTop: 0;
-  --#{$data-list}__cell--cell--md--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__cell--m-icon--cell--PaddingTop: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__cell--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__cell--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__cell--MarginInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$data-list}__cell--md--PaddingBlockEnd: 0;
+  --#{$data-list}__cell--m-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__cell--cell--PaddingBlockStart: 0;
+  --#{$data-list}__cell--cell--md--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__cell--m-icon--cell--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$data-list}--cell--MinWidth: initial;
   --#{$data-list}--cell--Overflow: visible;
   --#{$data-list}--cell--TextOverflow: clip;
@@ -56,9 +56,9 @@
   --#{$data-list}--cell--m-truncate--MinWidth: 5ch;
 
   // toggle
-  --#{$data-list}__toggle--MarginLeft: calc(var(--pf-t--global--spacer--sm) * -1); // offset toggle to align left
-  --#{$data-list}__toggle--MarginTop: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
-  --#{$data-list}__toggle--MarginBottom: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
+  --#{$data-list}__toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--sm) * -1); // offset toggle to align left
+  --#{$data-list}__toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
+  --#{$data-list}__toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--button--vertical--default) * -1);
   --#{$data-list}__toggle-icon--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   --#{$data-list}__toggle-icon--Transition: .2s ease-in 0s;
   --#{$data-list}__toggle-icon--Rotate: 0;
@@ -66,13 +66,13 @@
 
   // draggable button/icon
   --#{$data-list}__item-draggable-button--BackgroundColor: transparent;
-  --#{$data-list}__item-draggable-button--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-draggable-button--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-draggable-button--MarginTop: calc(var(--pf-t--global--spacer--lg) * -1);
-  --#{$data-list}__item-draggable-button--MarginBottom: calc(var(--pf-t--global--spacer--lg) * -1);
-  --#{$data-list}__item-draggable-button--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-draggable-button--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-draggable-button--MarginLeft: calc(var(--pf-t--global--spacer--md) * -1);
+  --#{$data-list}__item-draggable-button--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-draggable-button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--lg) * -1);
+  --#{$data-list}__item-draggable-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--lg) * -1);
+  --#{$data-list}__item-draggable-button--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-draggable-button--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-draggable-button--MarginInlineStart: calc(var(--pf-t--global--spacer--md) * -1);
   --#{$data-list}__item-draggable-button-icon--Color: var(--pf-t--global--icon--color--subtle);
   --#{$data-list}__item-draggable-button--m-disabled__draggable-icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$data-list}__item-draggable-button--hover__draggable-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -81,27 +81,27 @@
   --#{$data-list}__item--m-ghost-row--after--Opacity: .6;
 
   // controls
-  --#{$data-list}__item-control--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-control--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-control--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-control--md--MarginRight: var(--pf-t--global--spacer--xl);
-  --#{$data-list}__item-control--not-last-child--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-control--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-control--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-control--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-control--md--MarginInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$data-list}__item-control--not-last-child--MarginInlineEnd: var(--pf-t--global--spacer--md);
 
   // check
   --#{$data-list}__check--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
-  --#{$data-list}__check--MarginTop: #{pf-size-prem(-1px)}; // slightly offset input
+  --#{$data-list}__check--MarginBlockStart: #{pf-size-prem(-1px)}; // slightly offset input
 
 
   // actions
   --#{$data-list}__item-action--Display: flex;
-  --#{$data-list}__item-action--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-action--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__item-action--MarginLeft: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-action--md--MarginLeft: var(--pf-t--global--spacer--xl);
-  --#{$data-list}__item-action--not-last-child--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__item-action__action--MarginTop: calc(var(--pf-t--global--spacer--sm) * -1); // former form-element
-  --#{$data-list}__action--MarginTop: var(--#{$data-list}__item-action__action--MarginTop); // update at breaking change
-  --#{$data-list}__item-action__action--MarginBottom: calc(var(--pf-t--global--spacer--sm) * -1); // former form-element
+  --#{$data-list}__item-action--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-action--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-action--MarginInlineStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-action--md--MarginInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$data-list}__item-action--not-last-child--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__item-action__action--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1); // former form-element
+  --#{$data-list}__action--MarginBlockStart: var(--#{$data-list}__item-action__action--MarginBlockStart); // update at breaking change
+  --#{$data-list}__item-action__action--MarginBlockEnd: calc(var(--pf-t--global--spacer--sm) * -1); // former form-element
 
   // expandable content
   --#{$data-list}__expandable-content--BackgroundColor: var( --pf-t--global--background--color--primary--default);
@@ -109,75 +109,75 @@
   --#{$data-list}__expandable-content--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$data-list}__expandable-content--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$data-list}__expandable-content--MaxHeight: #{pf-size-prem(600px)};
-  --#{$data-list}__expandable-content-body--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$data-list}__expandable-content-body--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}__expandable-content-body--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$data-list}__expandable-content-body--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$data-list}__expandable-content-body--md--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__expandable-content-body--xl--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__expandable-content-body--md--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$data-list}__expandable-content-body--xl--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__expandable-content-body--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}__expandable-content-body--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__expandable-content-body--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}__expandable-content-body--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}__expandable-content-body--md--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__expandable-content-body--xl--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__expandable-content-body--md--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__expandable-content-body--xl--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$data-list}__expandable-content-body--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // compact
   --#{$data-list}--m-compact--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$data-list}--m-compact--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$data-list}--m-compact__check--FontSize: var(--pf-t--global--font--size--body--default);
-  --#{$data-list}--m-compact__cell--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__cell--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__cell--md--PaddingBottom: 0;
-  --#{$data-list}--m-compact__cell-cell--PaddingTop: 0;
-  --#{$data-list}--m-compact__cell-cell--md--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__cell--cell--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}--m-compact__item-control--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-control--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-control--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$data-list}--m-compact__item-action--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-action--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-action--MarginLeft: var(--pf-t--global--spacer--md);
-  --#{$data-list}--m-compact__item-action__action--MarginTop: calc(var(--#{$data-list}--m-compact__item-action--PaddingTop) * -1);
-  --#{$data-list}--m-compact__item-action__action--MarginBottom: calc(var(--#{$data-list}--m-compact__item-action--PaddingBottom) * -1);
-  --#{$data-list}--m-compact__action--MarginTop: var(--#{$data-list}--m-compact__item-action__action--MarginTop);
-  --#{$data-list}--m-compact__item-content--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-draggable-button--MarginTop: calc(var(--pf-t--global--spacer--sm) * -1);
-  --#{$data-list}--m-compact__item-draggable-button--MarginBottom: calc(var(--pf-t--global--spacer--sm) * -1);
-  --#{$data-list}--m-compact__item-draggable-button--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__item-draggable-button--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$data-list}--m-compact__cell--m-icon--cell--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__cell--md--PaddingBlockEnd: 0;
+  --#{$data-list}--m-compact__cell-cell--PaddingBlockStart: 0;
+  --#{$data-list}--m-compact__cell-cell--md--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__cell--cell--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}--m-compact__item-control--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-control--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-control--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$data-list}--m-compact__item-action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-action--MarginInlineStart: var(--pf-t--global--spacer--md);
+  --#{$data-list}--m-compact__item-action__action--MarginBlockStart: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockStart) * -1);
+  --#{$data-list}--m-compact__item-action__action--MarginBlockEnd: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd) * -1);
+  --#{$data-list}--m-compact__action--MarginBlockStart: var(--#{$data-list}--m-compact__item-action__action--MarginBlockStart);
+  --#{$data-list}--m-compact__item-content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1);
+  --#{$data-list}--m-compact__item-draggable-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--sm) * -1);
+  --#{$data-list}--m-compact__item-draggable-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-draggable-button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__cell--m-icon--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
 }
 
 .#{$data-list} {
   font-size: var(--#{$data-list}--FontSize);
   line-height: var(--#{$data-list}--LineHeight);
   overflow-wrap: break-word;
-  border-block-start: var(--#{$data-list}--BorderTopWidth) solid var(--#{$data-list}--BorderTopColor);
+  border-block-start: var(--#{$data-list}--BorderBlockStartWidth) solid var(--#{$data-list}--BorderBlockStartColor);
 
   &.pf-m-compact {
     --#{$data-list}__check--FontSize: var(--#{$data-list}--m-compact__check--FontSize);
-    --#{$data-list}__action--MarginTop: var(--#{$data-list}--m-compact__action--MarginTop);
+    --#{$data-list}__action--MarginBlockStart: var(--#{$data-list}--m-compact__action--MarginBlockStart);
     --#{$data-list}--FontSize: var(--#{$data-list}--m-compact--FontSize);
-    --#{$data-list}__item-action--MarginLeft: var(--#{$data-list}--m-compact__item-action--MarginLeft);
-    --#{$data-list}__item-action--PaddingTop: var(--#{$data-list}--m-compact__item-action--PaddingTop);
-    --#{$data-list}__item-action--PaddingBottom: var(--#{$data-list}--m-compact__item-action--PaddingBottom);
-    --#{$data-list}__item-action__action--MarginTop: var(--#{$data-list}--m-compact__item-action__action--MarginTop);
-    --#{$data-list}__item-action__action--MarginBottom: var(--#{$data-list}--m-compact__item-action__action--MarginBottom);
-    --#{$data-list}__item-control--MarginRight: var(--#{$data-list}--m-compact__item-control--MarginRight);
-    --#{$data-list}__item-control--PaddingTop: var(--#{$data-list}--m-compact__item-control--PaddingTop);
-    --#{$data-list}__item-control--PaddingBottom: var(--#{$data-list}--m-compact__item-control--PaddingBottom);
-    --#{$data-list}__item-content--md--PaddingBottom: var(--#{$data-list}--m-compact__item-content--PaddingBottom);
-    --#{$data-list}__item-draggable-button--MarginTop: var(--#{$data-list}--m-compact__item-draggable-button--MarginTop);
-    --#{$data-list}__item-draggable-button--MarginBottom: var(--#{$data-list}--m-compact__item-draggable-button--MarginBottom);
-    --#{$data-list}__item-draggable-button--PaddingTop: var(--#{$data-list}--m-compact__item-draggable-button--PaddingTop);
-    --#{$data-list}__item-draggable-button--PaddingBottom: var(--#{$data-list}--m-compact__item-draggable-button--PaddingBottom);
-    --#{$data-list}__cell--m-icon--cell--PaddingTop: var(--#{$data-list}--m-compact__cell--m-icon--cell--PaddingTop);
+    --#{$data-list}__item-action--MarginInlineStart: var(--#{$data-list}--m-compact__item-action--MarginInlineStart);
+    --#{$data-list}__item-action--PaddingBlockStart: var(--#{$data-list}--m-compact__item-action--PaddingBlockStart);
+    --#{$data-list}__item-action--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd);
+    --#{$data-list}__item-action__action--MarginBlockStart: var(--#{$data-list}--m-compact__item-action__action--MarginBlockStart);
+    --#{$data-list}__item-action__action--MarginBlockEnd: var(--#{$data-list}--m-compact__item-action__action--MarginBlockEnd);
+    --#{$data-list}__item-control--MarginInlineEnd: var(--#{$data-list}--m-compact__item-control--MarginInlineEnd);
+    --#{$data-list}__item-control--PaddingBlockStart: var(--#{$data-list}--m-compact__item-control--PaddingBlockStart);
+    --#{$data-list}__item-control--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-control--PaddingBlockEnd);
+    --#{$data-list}__item-content--md--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-content--PaddingBlockEnd);
+    --#{$data-list}__item-draggable-button--MarginBlockStart: var(--#{$data-list}--m-compact__item-draggable-button--MarginBlockStart);
+    --#{$data-list}__item-draggable-button--MarginBlockEnd: var(--#{$data-list}--m-compact__item-draggable-button--MarginBlockEnd);
+    --#{$data-list}__item-draggable-button--PaddingBlockStart: var(--#{$data-list}--m-compact__item-draggable-button--PaddingBlockStart);
+    --#{$data-list}__item-draggable-button--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-draggable-button--PaddingBlockEnd);
+    --#{$data-list}__cell--m-icon--cell--PaddingBlockStart: var(--#{$data-list}--m-compact__cell--m-icon--cell--PaddingBlockStart);
 
     font-size: var(--#{$data-list}--m-compact--FontSize);
 
     .#{$data-list}__cell {
-      --#{$data-list}__cell--PaddingTop: var(--#{$data-list}--m-compact__cell--PaddingTop);
-      --#{$data-list}__cell--PaddingBottom: var(--#{$data-list}--m-compact__cell--PaddingBottom);
-      --#{$data-list}__cell--MarginRight: var(--#{$data-list}--m-compact__cell--cell--MarginRight);
-      --#{$data-list}__cell--cell--PaddingTop: var(--#{$data-list}--m-compact__cell-cell--PaddingTop);
+      --#{$data-list}__cell--PaddingBlockStart: var(--#{$data-list}--m-compact__cell--PaddingBlockStart);
+      --#{$data-list}__cell--PaddingBlockEnd: var(--#{$data-list}--m-compact__cell--PaddingBlockEnd);
+      --#{$data-list}__cell--MarginInlineEnd: var(--#{$data-list}--m-compact__cell--cell--MarginInlineEnd);
+      --#{$data-list}__cell--cell--PaddingBlockStart: var(--#{$data-list}--m-compact__cell-cell--PaddingBlockStart);
     }
 
     .#{$data-list}__check {
@@ -216,7 +216,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--#{$data-list}__item--BackgroundColor);
-  border-block-end: var(--#{$data-list}__item--BorderBottomWidth) solid var(--#{$data-list}__item--BorderBottomColor);
+  border-block-end: var(--#{$data-list}__item--BorderBlockEndWidth) solid var(--#{$data-list}__item--BorderBlockEndColor);
 
   &.pf-m-clickable {
     cursor: pointer;
@@ -253,19 +253,19 @@
 .#{$data-list}__item-row {
   display: flex;
   flex-wrap: nowrap;
-  padding-inline-start: var(--#{$data-list}__item-row--PaddingLeft);
-  padding-inline-end: var(--#{$data-list}__item-row--PaddingRight);
+  padding-inline-start: var(--#{$data-list}__item-row--PaddingInlineStart);
+  padding-inline-end: var(--#{$data-list}__item-row--PaddingInlineEnd);
 }
 
 .#{$data-list}__item-control {
   display: flex;
   flex-wrap: nowrap;
-  padding-block-start: var(--#{$data-list}__item-control--PaddingTop);
-  padding-block-end: var(--#{$data-list}__item-control--PaddingBottom);
-  margin-inline-end: var(--#{$data-list}__item-control--MarginRight);
+  padding-block-start: var(--#{$data-list}__item-control--PaddingBlockStart);
+  padding-block-end: var(--#{$data-list}__item-control--PaddingBlockEnd);
+  margin-inline-end: var(--#{$data-list}__item-control--MarginInlineEnd);
 
   > *:not(:last-child) {
-    margin-inline-end: var(--#{$data-list}__item-control--not-last-child--MarginRight);
+    margin-inline-end: var(--#{$data-list}__item-control--not-last-child--MarginInlineEnd);
   }
 }
 
@@ -274,7 +274,7 @@
   align-items: center;
   align-self: flex-start;
   height: var(--#{$data-list}__check--Height);
-  margin-block-start: var(--#{$data-list}__check--MarginTop);
+  margin-block-start: var(--#{$data-list}__check--MarginBlockStart);
 
   > input {
     cursor: pointer;
@@ -284,13 +284,13 @@
 .#{$data-list}__item-draggable-button {
   display: flex;
   flex-direction: column; // fixes safari alignment
-  padding-block-start: var(--#{$data-list}__item-draggable-button--PaddingTop);
-  padding-block-end: var(--#{$data-list}__item-draggable-button--PaddingBottom);
-  padding-inline-start: var(--#{$data-list}__item-draggable-button--PaddingLeft);
-  padding-inline-end: var(--#{$data-list}__item-draggable-button--PaddingRight);
-  margin-block-start: var(--#{$data-list}__item-draggable-button--MarginTop);
-  margin-block-end: var(--#{$data-list}__item-draggable-button--MarginBottom);
-  margin-inline-start: var(--#{$data-list}__item-draggable-button--MarginLeft);
+  padding-block-start: var(--#{$data-list}__item-draggable-button--PaddingBlockStart);
+  padding-block-end: var(--#{$data-list}__item-draggable-button--PaddingBlockEnd);
+  padding-inline-start: var(--#{$data-list}__item-draggable-button--PaddingInlineStart);
+  padding-inline-end: var(--#{$data-list}__item-draggable-button--PaddingInlineEnd);
+  margin-block-start: var(--#{$data-list}__item-draggable-button--MarginBlockStart);
+  margin-block-end: var(--#{$data-list}__item-draggable-button--MarginBlockEnd);
+  margin-inline-start: var(--#{$data-list}__item-draggable-button--MarginInlineStart);
   background-color: var(--#{$data-list}__item-draggable-button--BackgroundColor);
   border: 0;
 
@@ -324,26 +324,26 @@
 
   align-content: flex-start;
   align-items: flex-start;
-  padding-block-start: var(--#{$data-list}__item-action--PaddingTop);
-  padding-block-end: var(--#{$data-list}__item-action--PaddingBottom);
-  margin-inline-start: var(--#{$data-list}__item-action--MarginLeft);
+  padding-block-start: var(--#{$data-list}__item-action--PaddingBlockStart);
+  padding-block-end: var(--#{$data-list}__item-action--PaddingBlockEnd);
+  margin-inline-start: var(--#{$data-list}__item-action--MarginInlineStart);
 
   > *:not(:last-child) {
-    margin-inline-end: var(--#{$data-list}__item-action--not-last-child--MarginRight);
+    margin-inline-end: var(--#{$data-list}__item-action--not-last-child--MarginInlineEnd);
   }
 
   // offset action button
   .#{$data-list}__action {
-    margin-block-start: var(--#{$data-list}__action--MarginTop);
-    margin-block-end: var(--#{$data-list}__item-action__action--MarginBottom);
+    margin-block-start: var(--#{$data-list}__action--MarginBlockStart);
+    margin-block-end: var(--#{$data-list}__item-action__action--MarginBlockEnd);
   }
 }
 
 // toggle
 .#{$data-list}__toggle {
-  margin-block-start: var(--#{$data-list}__toggle--MarginTop);
-  margin-block-end: var(--#{$data-list}__toggle--MarginBottom);
-  margin-inline-start: var(--#{$data-list}__toggle--MarginLeft);
+  margin-block-start: var(--#{$data-list}__toggle--MarginBlockStart);
+  margin-block-end: var(--#{$data-list}__toggle--MarginBlockEnd);
+  margin-inline-start: var(--#{$data-list}__toggle--MarginInlineStart);
 }
 
 // toggle icon rotate
@@ -366,25 +366,25 @@
 .#{$data-list}__cell {
   flex: 1;
   grid-column: 1 / -1;
-  padding-block-start: var(--#{$data-list}__cell--PaddingTop);
-  padding-block-end: var(--#{$data-list}__cell--PaddingBottom);
+  padding-block-start: var(--#{$data-list}__cell--PaddingBlockStart);
+  padding-block-end: var(--#{$data-list}__cell--PaddingBlockEnd);
 
   // for all subsequent .#{$data-list}__cell's, set to full width
   & + & {
     flex: 1 0 100%;
     order: 1;
-    padding-block-start: var(--#{$data-list}__cell--cell--PaddingTop);
+    padding-block-start: var(--#{$data-list}__cell--cell--PaddingBlockStart);
   }
 
   &.pf-m-icon {
     flex-grow: 0;
     grid-column: 1 / 2;
-    margin-inline-end: var(--#{$data-list}__cell--m-icon--MarginRight);
+    margin-inline-end: var(--#{$data-list}__cell--m-icon--MarginInlineEnd);
   }
 
   &.pf-m-icon + & {
     grid-column: 2 / 3;
-    padding-block-start: var(--#{$data-list}__cell--m-icon--cell--PaddingTop);
+    padding-block-start: var(--#{$data-list}__cell--m-icon--cell--PaddingBlockStart);
   }
 
   &.pf-m-align-right {
@@ -418,13 +418,13 @@
   border-radius: var(--#{$data-list}__expandable-content-body--BorderRadius);
 
   .#{$data-list}__expandable-content-body {
-    padding-block-start: var(--#{$data-list}__expandable-content-body--PaddingTop);
-    padding-block-end: var(--#{$data-list}__expandable-content-body--PaddingBottom);
-    padding-inline-start: var(--#{$data-list}__expandable-content-body--PaddingLeft);
-    padding-inline-end: var(--#{$data-list}__expandable-content-body--PaddingRight);
+    padding-block-start: var(--#{$data-list}__expandable-content-body--PaddingBlockStart);
+    padding-block-end: var(--#{$data-list}__expandable-content-body--PaddingBlockEnd);
+    padding-inline-start: var(--#{$data-list}__expandable-content-body--PaddingInlineStart);
+    padding-inline-end: var(--#{$data-list}__expandable-content-body--PaddingInlineEnd);
 
     > .#{$data-list} {
-      margin-inline-start: var(--#{$data-list}--MarginLeft);
+      margin-inline-start: var(--#{$data-list}--MarginInlineStart);
     }
 
     .#{$data-list}__item:last-child {
@@ -432,11 +432,11 @@
     }
 
     .#{$data-list}__item-row {
-      --#{$data-list}__item-row--PaddingLeft: 0;
+      --#{$data-list}__item-row--PaddingInlineStart: 0;
     }
 
     .#{$data-list}__expandable-content-body {
-      --#{$data-list}__expandable-content-body--PaddingLeft: 0;
+      --#{$data-list}__expandable-content-body--PaddingInlineStart: 0;
     }
 
     &.pf-m-no-padding {

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$date-picker}) {
-  --#{$date-picker}--m-top__calendar--BlockStart: 0;
+  --#{$date-picker}--m-top__calendar--InsetBlockStart: 0;
   --#{$date-picker}--m-top__calendar--TranslateY: calc(-100% - var(--pf-t--global--spacer--xs));
   --#{$date-picker}__helper-text--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$date-picker}__input--c-form-control--Width: calc(var(--#{$date-picker}__input--c-form-control--width-chars) * 1ch + var(--#{$date-picker}__input--c-form-control--width-base));
@@ -10,11 +10,11 @@
   --#{$date-picker}__calendar--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$date-picker}__calendar--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$date-picker}__calendar--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$date-picker}__calendar--BlockStart: calc(100% + var(--pf-t--global--spacer--xs));
-  --#{$date-picker}__calendar--InlineEnd: auto;
-  --#{$date-picker}__calendar--InlineStart: 0;
-  --#{$date-picker}__calendar--m-align-right--InlineEnd: 0;
-  --#{$date-picker}__calendar--m-align-right--InlineStart: auto;
+  --#{$date-picker}__calendar--InsetBlockStart: calc(100% + var(--pf-t--global--spacer--xs));
+  --#{$date-picker}__calendar--InsetInlineEnd: auto;
+  --#{$date-picker}__calendar--InsetInlineStart: 0;
+  --#{$date-picker}__calendar--m-align-right--InsetInlineEnd: 0;
+  --#{$date-picker}__calendar--m-align-right--InsetInlineStart: auto;
 }
 
 .#{$date-picker} {
@@ -34,20 +34,20 @@
 
 .#{$date-picker}__calendar {
   position: absolute;
-  inset-block-start: var(--#{$date-picker}__calendar--BlockStart);
-  inset-inline-start: var(--#{$date-picker}__calendar--InlineStart);
-  inset-inline-end: var(--#{$date-picker}__calendar--InlineEnd);
+  inset-block-start: var(--#{$date-picker}__calendar--InsetBlockStart);
+  inset-inline-start: var(--#{$date-picker}__calendar--InsetInlineStart);
+  inset-inline-end: var(--#{$date-picker}__calendar--InsetInlineEnd);
   z-index: var(--#{$date-picker}__calendar--ZIndex);
   background-color: var(--#{$date-picker}__calendar--BackgroundColor);
   box-shadow: var(--#{$date-picker}__calendar--BoxShadow);
 
   &.pf-m-align-right {
-    --#{$date-picker}__calendar--InlineEnd: var(--#{$date-picker}__calendar--m-align-right--InlineEnd);
-    --#{$date-picker}__calendar--InlineStart: var(--#{$date-picker}__calendar--m-align-right--InlineStart);
+    --#{$date-picker}__calendar--InsetInlineEnd: var(--#{$date-picker}__calendar--m-align-right--InsetInlineEnd);
+    --#{$date-picker}__calendar--InsetInlineStart: var(--#{$date-picker}__calendar--m-align-right--InsetInlineStart);
   }
 
   .#{$date-picker}.pf-m-top & {
-    --#{$date-picker}__calendar--BlockStart: var(--#{$date-picker}--m-top__calendar--BlockStart);
+    --#{$date-picker}__calendar--InsetBlockStart: var(--#{$date-picker}--m-top__calendar--InsetBlockStart);
 
     transform: translateY(var(--#{$date-picker}--m-top__calendar--TranslateY));
   }

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,20 +1,20 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$date-picker}) {
-  --#{$date-picker}--m-top__calendar--Top: 0;
+  --#{$date-picker}--m-top__calendar--BlockStart: 0;
   --#{$date-picker}--m-top__calendar--TranslateY: calc(-100% - var(--pf-t--global--spacer--xs));
-  --#{$date-picker}__helper-text--MarginTop: var(--pf-t--global--spacer--sm);
+  --#{$date-picker}__helper-text--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$date-picker}__input--c-form-control--Width: calc(var(--#{$date-picker}__input--c-form-control--width-chars) * 1ch + var(--#{$date-picker}__input--c-form-control--width-base));
   --#{$date-picker}__input--c-form-control--width-base: calc(var(--pf-t--global--spacer--xl) + var(--pf-t--global--spacer--sm)); // form control left/right padding + status icon width and spacer
   --#{$date-picker}__input--c-form-control--width-chars: 11;
   --#{$date-picker}__calendar--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$date-picker}__calendar--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$date-picker}__calendar--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$date-picker}__calendar--Top: calc(100% + var(--pf-t--global--spacer--xs));
-  --#{$date-picker}__calendar--Right: auto;
-  --#{$date-picker}__calendar--Left: 0;
-  --#{$date-picker}__calendar--m-align-right--Right: 0;
-  --#{$date-picker}__calendar--m-align-right--Left: auto;
+  --#{$date-picker}__calendar--BlockStart: calc(100% + var(--pf-t--global--spacer--xs));
+  --#{$date-picker}__calendar--InlineEnd: auto;
+  --#{$date-picker}__calendar--InlineStart: 0;
+  --#{$date-picker}__calendar--m-align-right--InlineEnd: 0;
+  --#{$date-picker}__calendar--m-align-right--InlineStart: auto;
 }
 
 .#{$date-picker} {
@@ -23,7 +23,7 @@
 }
 
 .#{$date-picker}__helper-text {
-  margin-block-start: var(--#{$date-picker}__helper-text--MarginTop);
+  margin-block-start: var(--#{$date-picker}__helper-text--MarginBlockStart);
 }
 
 .#{$date-picker}__input {
@@ -34,20 +34,20 @@
 
 .#{$date-picker}__calendar {
   position: absolute;
-  inset-block-start: var(--#{$date-picker}__calendar--Top);
-  inset-inline-start: var(--#{$date-picker}__calendar--Left);
-  inset-inline-end: var(--#{$date-picker}__calendar--Right);
+  inset-block-start: var(--#{$date-picker}__calendar--BlockStart);
+  inset-inline-start: var(--#{$date-picker}__calendar--InlineStart);
+  inset-inline-end: var(--#{$date-picker}__calendar--InlineEnd);
   z-index: var(--#{$date-picker}__calendar--ZIndex);
   background-color: var(--#{$date-picker}__calendar--BackgroundColor);
   box-shadow: var(--#{$date-picker}__calendar--BoxShadow);
 
   &.pf-m-align-right {
-    --#{$date-picker}__calendar--Right: var(--#{$date-picker}__calendar--m-align-right--Right);
-    --#{$date-picker}__calendar--Left: var(--#{$date-picker}__calendar--m-align-right--Left);
+    --#{$date-picker}__calendar--InlineEnd: var(--#{$date-picker}__calendar--m-align-right--InlineEnd);
+    --#{$date-picker}__calendar--InlineStart: var(--#{$date-picker}__calendar--m-align-right--InlineStart);
   }
 
   .#{$date-picker}.pf-m-top & {
-    --#{$date-picker}__calendar--Top: var(--#{$date-picker}--m-top__calendar--Top);
+    --#{$date-picker}__calendar--BlockStart: var(--#{$date-picker}--m-top__calendar--BlockStart);
 
     transform: translateY(var(--#{$date-picker}--m-top__calendar--TranslateY));
   }

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -33,7 +33,7 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 
   // icon
   --#{$description-list}__term-icon--MinWidth: var(--pf-t--global--font--size--body--sm);
-  --#{$description-list}__term-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$description-list}__term-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$description-list}__term-icon--Color: var(--pf-t--global--icon--color--subtle);
 
   // vertical
@@ -128,10 +128,10 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 
   > .#{$card} {
     align-self: stretch;
-    padding-block-start: var(--#{$card}--first-child--PaddingTop);
-    padding-block-end: var(--#{$card}--child--PaddingBottom);
-    padding-inline-start: var(--#{$card}--child--PaddingLeft);
-    padding-inline-end: var(--#{$card}--child--PaddingRight);
+    padding-block-start: var(--#{$card}--first-child--PaddingBlockStart);
+    padding-block-end: var(--#{$card}--child--PaddingBlockEnd);
+    padding-inline-start: var(--#{$card}--child--PaddingInlineStart);
+    padding-inline-end: var(--#{$card}--child--PaddingInlineEnd);
   }
 }
 
@@ -167,7 +167,7 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 .#{$description-list}__term-icon {
   flex-shrink: 0;
   min-width: var(--#{$description-list}__term-icon--MinWidth);
-  margin-inline-end: var(--#{$description-list}__term-icon--MarginRight);
+  margin-inline-end: var(--#{$description-list}__term-icon--MarginInlineEnd);
   color: var(--#{$description-list}__term-icon--Color);
 }
 

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -99,16 +99,16 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}--m-panel-bottom__splitter--after--BorderBlockStartWidth: var(--#{$drawer}__splitter--after--border-width--base);
   --#{$drawer}--m-panel-bottom__splitter--after--BorderBlockEndWidth: var(--#{$drawer}__splitter--after--border-width--base);
   --#{$drawer}--m-inline__splitter--m-vertical--Width: #{pf-size-prem(10px)};
-  --#{$drawer}--m-inline__splitter-handle--InlineStart: 50%;
+  --#{$drawer}--m-inline__splitter-handle--InsetInlineStart: 50%;
   --#{$drawer}--m-inline--m-panel-bottom__splitter--Height: #{pf-size-prem(10px)};
-  --#{$drawer}--m-inline--m-panel-bottom__splitter-handle--BlockStart: 50%;
+  --#{$drawer}--m-inline--m-panel-bottom__splitter-handle--InsetBlockStart: 50%;
   --#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderBlockStartWidth: var(--#{$drawer}__splitter--after--border-width--base);
 
   // Splitter handle
-  --#{$drawer}__splitter-handle--BlockStart: 50%;
-  --#{$drawer}__splitter-handle--InlineStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
-  --#{$drawer}--m-panel-left__splitter-handle--InlineStart: 50%;
-  --#{$drawer}--m-panel-bottom__splitter-handle--BlockStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
+  --#{$drawer}__splitter-handle--InsetBlockStart: 50%;
+  --#{$drawer}__splitter-handle--InsetInlineStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
+  --#{$drawer}--m-panel-left__splitter-handle--InsetInlineStart: 50%;
+  --#{$drawer}--m-panel-bottom__splitter-handle--InsetBlockStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
 
   // Splitter handle line
   --#{$drawer}__splitter-handle--after--BorderColor: var(--pf-t--global--border--color--default);
@@ -461,8 +461,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 .#{$drawer}__splitter-handle {
   position: absolute;
-  inset-block-start: var(--#{$drawer}__splitter-handle--BlockStart);
-  inset-inline-start: var(--#{$drawer}__splitter-handle--InlineStart);
+  inset-block-start: var(--#{$drawer}__splitter-handle--InsetBlockStart);
+  inset-inline-start: var(--#{$drawer}__splitter-handle--InsetInlineStart);
 
   @include pf-v6-bidirectional-style(
     $prop: transform,
@@ -543,7 +543,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
     > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
       > .#{$drawer}__splitter {
-        --#{$drawer}__splitter-handle--InlineStart: var(--#{$drawer}--m-panel-left__splitter-handle--InlineStart);
+        --#{$drawer}__splitter-handle--InsetInlineStart: var(--#{$drawer}--m-panel-left__splitter-handle--InsetInlineStart);
 
         order: 1;
       }
@@ -581,7 +581,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       min-height: var(--#{$drawer}--m-panel-bottom__panel--m-resizable--MinHeight);
 
       > .#{$drawer}__splitter {
-        --#{$drawer}__splitter-handle--BlockStart: var(--#{$drawer}--m-panel-bottom__splitter-handle--BlockStart);
+        --#{$drawer}__splitter-handle--InsetBlockStart: var(--#{$drawer}--m-panel-bottom__splitter-handle--InsetBlockStart);
         --#{$drawer}__splitter--after--BorderBlockStartWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderBlockStartWidth);
         --#{$drawer}__splitter--after--BorderInlineEndWidth: 0;
         --#{$drawer}__splitter--after--BorderBlockEndWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderBlockEndWidth);
@@ -594,7 +594,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
       > .#{$drawer}__splitter {
         --#{$drawer}__splitter--m-vertical--Width: var(--#{$drawer}--m-inline__splitter--m-vertical--Width);
-        --#{$drawer}__splitter-handle--InlineStart: var(--#{$drawer}--m-inline__splitter-handle--InlineStart);
+        --#{$drawer}__splitter-handle--InsetInlineStart: var(--#{$drawer}--m-inline__splitter-handle--InsetInlineStart);
 
         outline-offset: var(--#{$drawer}--m-inline__splitter--focus--OutlineOffset);
       }
@@ -604,7 +604,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
         > .#{$drawer}__splitter {
           --#{$drawer}__splitter--Height: var(--#{$drawer}--m-inline--m-panel-bottom__splitter--Height);
-          --#{$drawer}__splitter-handle--BlockStart: var(--#{$drawer}--m-inline--m-panel-bottom__splitter-handle--BlockStart);
+          --#{$drawer}__splitter-handle--InsetBlockStart: var(--#{$drawer}--m-inline--m-panel-bottom__splitter-handle--InsetBlockStart);
           --#{$drawer}__splitter--after--BorderBlockStartWidth: var(--#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderBlockStartWidth);
           --#{$drawer}__splitter--after--BorderInlineEndWidth: 0;
           --#{$drawer}__splitter--after--BorderInlineStartWidth: 0;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -56,28 +56,28 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}__description--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   // Drawer body padding
-  --#{$drawer}__body--PaddingTop--base: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--PaddingRight--base: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--PaddingBottom--base: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--PaddingLeft--base: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--PaddingBlockStart--base: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--PaddingInlineEnd--base: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--PaddingBlockEnd--base: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--PaddingInlineStart--base: var(--pf-t--global--spacer--md);
 
   // Drawer content body
-  --#{$drawer}__content__body--PaddingTop: 0;
-  --#{$drawer}__content__body--PaddingRight: 0;
-  --#{$drawer}__content__body--PaddingBottom: 0;
-  --#{$drawer}__content__body--PaddingLeft: 0;
+  --#{$drawer}__content__body--PaddingBlockStart: 0;
+  --#{$drawer}__content__body--PaddingInlineEnd: 0;
+  --#{$drawer}__content__body--PaddingBlockEnd: 0;
+  --#{$drawer}__content__body--PaddingInlineStart: 0;
 
   // Drawer panel body
-  --#{$drawer}__panel__body--PaddingTop: var(--#{$drawer}__body--PaddingTop--base);
-  --#{$drawer}__panel__body--PaddingRight: var(--#{$drawer}__body--PaddingRight--base);
-  --#{$drawer}__panel__body--PaddingBottom: var(--#{$drawer}__body--PaddingBottom--base);
-  --#{$drawer}__panel__body--PaddingLeft: var(--#{$drawer}__body--PaddingLeft--base);
+  --#{$drawer}__panel__body--PaddingBlockStart: var(--#{$drawer}__body--PaddingBlockStart--base);
+  --#{$drawer}__panel__body--PaddingInlineEnd: var(--#{$drawer}__body--PaddingInlineEnd--base);
+  --#{$drawer}__panel__body--PaddingBlockEnd: var(--#{$drawer}__body--PaddingBlockEnd--base);
+  --#{$drawer}__panel__body--PaddingInlineStart: var(--#{$drawer}__body--PaddingInlineStart--base);
 
   // Modified body padding
-  --#{$drawer}__body--m-padding--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--m-padding--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--m-padding--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$drawer}__body--m-padding--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--m-padding--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--m-padding--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--m-padding--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$drawer}__body--m-padding--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // Splitter
   --#{$drawer}__splitter--Height: #{pf-size-prem(9px)};
@@ -92,35 +92,35 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // Splitter border
   --#{$drawer}__splitter--after--BorderColor: var(--pf-t--global--border--color--default);
   --#{$drawer}__splitter--after--border-width--base: var(--pf-t--global--border--width--divider--default);
-  --#{$drawer}__splitter--after--BorderTopWidth: 0;
-  --#{$drawer}__splitter--after--BorderRightWidth: var(--#{$drawer}__splitter--after--border-width--base);
-  --#{$drawer}__splitter--after--BorderBottomWidth: 0;
-  --#{$drawer}__splitter--after--BorderLeftWidth: var(--#{$drawer}__splitter--after--border-width--base);
-  --#{$drawer}--m-panel-bottom__splitter--after--BorderTopWidth: var(--#{$drawer}__splitter--after--border-width--base);
-  --#{$drawer}--m-panel-bottom__splitter--after--BorderBottomWidth: var(--#{$drawer}__splitter--after--border-width--base);
+  --#{$drawer}__splitter--after--BorderBlockStartWidth: 0;
+  --#{$drawer}__splitter--after--BorderInlineEndWidth: var(--#{$drawer}__splitter--after--border-width--base);
+  --#{$drawer}__splitter--after--BorderBlockEndWidth: 0;
+  --#{$drawer}__splitter--after--BorderInlineStartWidth: var(--#{$drawer}__splitter--after--border-width--base);
+  --#{$drawer}--m-panel-bottom__splitter--after--BorderBlockStartWidth: var(--#{$drawer}__splitter--after--border-width--base);
+  --#{$drawer}--m-panel-bottom__splitter--after--BorderBlockEndWidth: var(--#{$drawer}__splitter--after--border-width--base);
   --#{$drawer}--m-inline__splitter--m-vertical--Width: #{pf-size-prem(10px)};
-  --#{$drawer}--m-inline__splitter-handle--Left: 50%;
+  --#{$drawer}--m-inline__splitter-handle--InlineStart: 50%;
   --#{$drawer}--m-inline--m-panel-bottom__splitter--Height: #{pf-size-prem(10px)};
-  --#{$drawer}--m-inline--m-panel-bottom__splitter-handle--Top: 50%;
-  --#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderTopWidth: var(--#{$drawer}__splitter--after--border-width--base);
+  --#{$drawer}--m-inline--m-panel-bottom__splitter-handle--BlockStart: 50%;
+  --#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderBlockStartWidth: var(--#{$drawer}__splitter--after--border-width--base);
 
   // Splitter handle
-  --#{$drawer}__splitter-handle--Top: 50%;
-  --#{$drawer}__splitter-handle--Left: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
-  --#{$drawer}--m-panel-left__splitter-handle--Left: 50%;
-  --#{$drawer}--m-panel-bottom__splitter-handle--Top: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
+  --#{$drawer}__splitter-handle--BlockStart: 50%;
+  --#{$drawer}__splitter-handle--InlineStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
+  --#{$drawer}--m-panel-left__splitter-handle--InlineStart: 50%;
+  --#{$drawer}--m-panel-bottom__splitter-handle--BlockStart: calc(50% - var(--#{$drawer}__splitter--after--border-width--base));
 
   // Splitter handle line
   --#{$drawer}__splitter-handle--after--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$drawer}__splitter-handle--after--BorderTopWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$drawer}__splitter-handle--after--BorderRightWidth: 0;
-  --#{$drawer}__splitter-handle--after--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$drawer}__splitter-handle--after--BorderLeftWidth: 0;
+  --#{$drawer}__splitter-handle--after--BorderBlockStartWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$drawer}__splitter-handle--after--BorderInlineEndWidth: 0;
+  --#{$drawer}__splitter-handle--after--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$drawer}__splitter-handle--after--BorderInlineStartWidth: 0;
   --#{$drawer}__splitter--hover__splitter-handle--after--BorderColor: var(--pf-t--global--border--color--hover);
-  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderTopWidth: 0;
-  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderRightWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBottomWidth: 0;
-  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderLeftWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBlockStartWidth: 0;
+  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBlockEndWidth: 0;
+  --#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderInlineStartWidth: var(--pf-t--global--border--width--divider--default);
   --#{$drawer}__splitter-handle--after--Width: #{pf-size-prem(12px)};
   --#{$drawer}__splitter-handle--after--Height: #{pf-size-prem(4px)};
   --#{$drawer}__splitter--m-vertical__splitter-handle--after--Width: #{pf-size-prem(4px)};
@@ -136,8 +136,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   // Actions
-  --#{$drawer}__actions--MarginTop: calc(var(--pf-t--global--spacer--control--vertical--compact) * -1.5);
-  --#{$drawer}__actions--MarginRight: calc(var(--pf-t--global--spacer--control--horizontal--compact) * -1.5);
+  --#{$drawer}__actions--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--compact) * -1.5);
+  --#{$drawer}__actions--MarginInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--compact) * -1.5);
 
   // Box shadow
   --#{$drawer}__panel--BoxShadow: none;
@@ -148,9 +148,9 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}--m-panel-bottom__panel--after--Height: var(--pf-t--global--border--width--divider--default);
   --#{$drawer}__panel--after--BackgroundColor: transparent;
   --#{$drawer}--m-inline--m-expanded__panel--after--BackgroundColor: var(--pf-t--global--border--color--default);
-  --#{$drawer}--m-inline__panel--PaddingLeft: var(--#{$drawer}__panel--after--Width);
-  --#{$drawer}--m-panel-left--m-inline__panel--PaddingRight: var(--#{$drawer}__panel--after--Width);
-  --#{$drawer}--m-panel-bottom--m-inline__panel--PaddingTop: var(--#{$drawer}__panel--after--Width);
+  --#{$drawer}--m-inline__panel--PaddingInlineStart: var(--#{$drawer}__panel--after--Width);
+  --#{$drawer}--m-panel-left--m-inline__panel--PaddingInlineEnd: var(--#{$drawer}__panel--after--Width);
+  --#{$drawer}--m-panel-bottom--m-inline__panel--PaddingBlockStart: var(--#{$drawer}__panel--after--Width);
 }
 
 .#{$drawer} {
@@ -173,7 +173,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   &.pf-m-inline,
   &.pf-m-static {
     > .#{$drawer}__main > .#{$drawer}__panel:not(.pf-m-no-border, .pf-m-resizable) {
-      padding-inline-start: var(--#{$drawer}--m-inline__panel--PaddingLeft);
+      padding-inline-start: var(--#{$drawer}--m-inline__panel--PaddingInlineStart);
     }
   }
 
@@ -277,10 +277,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   }
 
   > .#{$drawer}__body {
-    padding-block-start: var(--#{$drawer}__content__body--PaddingTop);
-    padding-block-end: var(--#{$drawer}__content__body--PaddingBottom);
-    padding-inline-start: var(--#{$drawer}__content__body--PaddingLeft);
-    padding-inline-end: var(--#{$drawer}__content__body--PaddingRight);
+    padding-block-start: var(--#{$drawer}__content__body--PaddingBlockStart);
+    padding-block-end: var(--#{$drawer}__content__body--PaddingBlockEnd);
+    padding-inline-start: var(--#{$drawer}__content__body--PaddingInlineStart);
+    padding-inline-end: var(--#{$drawer}__content__body--PaddingInlineEnd);
   }
 }
 
@@ -342,10 +342,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 .#{$drawer}__panel,
 .#{$drawer}__panel-main {
   > .#{$drawer}__body {
-    padding-block-start: var(--#{$drawer}__panel__body--PaddingTop);
-    padding-block-end: var(--#{$drawer}__panel__body--PaddingBottom);
-    padding-inline-start: var(--#{$drawer}__panel__body--PaddingLeft);
-    padding-inline-end: var(--#{$drawer}__panel__body--PaddingRight);
+    padding-block-start: var(--#{$drawer}__panel__body--PaddingBlockStart);
+    padding-block-end: var(--#{$drawer}__panel__body--PaddingBlockEnd);
+    padding-inline-start: var(--#{$drawer}__panel__body--PaddingInlineStart);
+    padding-inline-end: var(--#{$drawer}__panel__body--PaddingInlineEnd);
   }
 }
 
@@ -380,8 +380,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   grid-row: 1;
   grid-column: 2;
   align-self: baseline;
-  margin-block-start: var(--#{$drawer}__actions--MarginTop);
-  margin-inline-end: var(--#{$drawer}__actions--MarginRight);
+  margin-block-start: var(--#{$drawer}__actions--MarginBlockStart);
+  margin-inline-end: var(--#{$drawer}__actions--MarginInlineEnd);
 }
 
 // Drawer panel description
@@ -399,10 +399,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   // Padding
   &.pf-m-padding {
-    padding-block-start: var(--#{$drawer}__body--m-padding--PaddingTop);
-    padding-block-end: var(--#{$drawer}__body--m-padding--PaddingBottom);
-    padding-inline-start: var(--#{$drawer}__body--m-padding--PaddingLeft);
-    padding-inline-end: var(--#{$drawer}__body--m-padding--PaddingRight);
+    padding-block-start: var(--#{$drawer}__body--m-padding--PaddingBlockStart);
+    padding-block-end: var(--#{$drawer}__body--m-padding--PaddingBlockEnd);
+    padding-inline-start: var(--#{$drawer}__body--m-padding--PaddingInlineStart);
+    padding-inline-end: var(--#{$drawer}__body--m-padding--PaddingInlineEnd);
   }
 
   &:not(.pf-m-no-padding) + * {
@@ -433,10 +433,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     --#{$drawer}__splitter--Cursor: var(--#{$drawer}__splitter--m-vertical--Cursor);
     --#{$drawer}__splitter-handle--after--Width: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--Width);
     --#{$drawer}__splitter-handle--after--Height: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--Height);
-    --#{$drawer}__splitter-handle--after--BorderTopWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderTopWidth);
-    --#{$drawer}__splitter-handle--after--BorderRightWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderRightWidth);
-    --#{$drawer}__splitter-handle--after--BorderBottomWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBottomWidth);
-    --#{$drawer}__splitter-handle--after--BorderLeftWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderLeftWidth);
+    --#{$drawer}__splitter-handle--after--BorderBlockStartWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBlockStartWidth);
+    --#{$drawer}__splitter-handle--after--BorderInlineEndWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderInlineEndWidth);
+    --#{$drawer}__splitter-handle--after--BorderBlockEndWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderBlockEndWidth);
+    --#{$drawer}__splitter-handle--after--BorderInlineStartWidth: var(--#{$drawer}__splitter--m-vertical__splitter-handle--after--BorderInlineStartWidth);
   }
 
   &:hover,
@@ -452,17 +452,17 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     inset-inline-end: 0;
     content: "";
     border: solid var(--#{$drawer}__splitter--after--BorderColor);
-    border-block-start-width: var(--#{$drawer}__splitter--after--BorderTopWidth);
-    border-block-end-width: var(--#{$drawer}__splitter--after--BorderBottomWidth);
-    border-inline-start-width: var(--#{$drawer}__splitter--after--BorderLeftWidth);
-    border-inline-end-width: var(--#{$drawer}__splitter--after--BorderRightWidth);
+    border-block-start-width: var(--#{$drawer}__splitter--after--BorderBlockStartWidth);
+    border-block-end-width: var(--#{$drawer}__splitter--after--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$drawer}__splitter--after--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$drawer}__splitter--after--BorderInlineEndWidth);
   }
 }
 
 .#{$drawer}__splitter-handle {
   position: absolute;
-  inset-block-start: var(--#{$drawer}__splitter-handle--Top);
-  inset-inline-start: var(--#{$drawer}__splitter-handle--Left);
+  inset-block-start: var(--#{$drawer}__splitter-handle--BlockStart);
+  inset-inline-start: var(--#{$drawer}__splitter-handle--InlineStart);
 
   @include pf-v6-bidirectional-style(
     $prop: transform,
@@ -478,10 +478,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     content: "";
     border-color: var(--#{$drawer}__splitter-handle--after--BorderColor);
     border-style: solid;
-    border-block-start-width: var(--#{$drawer}__splitter-handle--after--BorderTopWidth);
-    border-block-end-width: var(--#{$drawer}__splitter-handle--after--BorderBottomWidth);
-    border-inline-start-width: var(--#{$drawer}__splitter-handle--after--BorderLeftWidth);
-    border-inline-end-width: var(--#{$drawer}__splitter-handle--after--BorderRightWidth);
+    border-block-start-width: var(--#{$drawer}__splitter-handle--after--BorderBlockStartWidth);
+    border-block-end-width: var(--#{$drawer}__splitter-handle--after--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$drawer}__splitter-handle--after--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$drawer}__splitter-handle--after--BorderInlineEndWidth);
   }
 }
 
@@ -528,7 +528,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     &.pf-m-static {
       > .#{$drawer}__main > .#{$drawer}__panel:not(.pf-m-no-border, .pf-m-resizable) {
         padding-inline-start: 0;
-        padding-inline-end: var(--#{$drawer}--m-panel-left--m-inline__panel--PaddingRight);
+        padding-inline-end: var(--#{$drawer}--m-panel-left--m-inline__panel--PaddingInlineEnd);
       }
     }
 
@@ -543,7 +543,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
     > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
       > .#{$drawer}__splitter {
-        --#{$drawer}__splitter-handle--Left: var(--#{$drawer}--m-panel-left__splitter-handle--Left);
+        --#{$drawer}__splitter-handle--InlineStart: var(--#{$drawer}--m-panel-left__splitter-handle--InlineStart);
 
         order: 1;
       }
@@ -561,7 +561,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     &.pf-m-inline,
     &.pf-m-static {
       > .#{$drawer}__main > .#{$drawer}__panel:not(.pf-m-no-border, .pf-m-resizable) {
-        padding-block-start: var(--#{$drawer}--m-panel-bottom--m-inline__panel--PaddingTop);
+        padding-block-start: var(--#{$drawer}--m-panel-bottom--m-inline__panel--PaddingBlockStart);
         padding-inline-start: 0;
       }
     }
@@ -581,11 +581,11 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       min-height: var(--#{$drawer}--m-panel-bottom__panel--m-resizable--MinHeight);
 
       > .#{$drawer}__splitter {
-        --#{$drawer}__splitter-handle--Top: var(--#{$drawer}--m-panel-bottom__splitter-handle--Top);
-        --#{$drawer}__splitter--after--BorderTopWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderTopWidth);
-        --#{$drawer}__splitter--after--BorderRightWidth: 0;
-        --#{$drawer}__splitter--after--BorderBottomWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderBottomWidth);
-        --#{$drawer}__splitter--after--BorderLeftWidth: 0;
+        --#{$drawer}__splitter-handle--BlockStart: var(--#{$drawer}--m-panel-bottom__splitter-handle--BlockStart);
+        --#{$drawer}__splitter--after--BorderBlockStartWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderBlockStartWidth);
+        --#{$drawer}__splitter--after--BorderInlineEndWidth: 0;
+        --#{$drawer}__splitter--after--BorderBlockEndWidth: var(--#{$drawer}--m-panel-bottom__splitter--after--BorderBlockEndWidth);
+        --#{$drawer}__splitter--after--BorderInlineStartWidth: 0;
       }
     }
   }
@@ -594,7 +594,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
       > .#{$drawer}__splitter {
         --#{$drawer}__splitter--m-vertical--Width: var(--#{$drawer}--m-inline__splitter--m-vertical--Width);
-        --#{$drawer}__splitter-handle--Left: var(--#{$drawer}--m-inline__splitter-handle--Left);
+        --#{$drawer}__splitter-handle--InlineStart: var(--#{$drawer}--m-inline__splitter-handle--InlineStart);
 
         outline-offset: var(--#{$drawer}--m-inline__splitter--focus--OutlineOffset);
       }
@@ -604,10 +604,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       > .#{$drawer}__main > .#{$drawer}__panel.pf-m-resizable {
         > .#{$drawer}__splitter {
           --#{$drawer}__splitter--Height: var(--#{$drawer}--m-inline--m-panel-bottom__splitter--Height);
-          --#{$drawer}__splitter-handle--Top: var(--#{$drawer}--m-inline--m-panel-bottom__splitter-handle--Top);
-          --#{$drawer}__splitter--after--BorderTopWidth: var(--#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderTopWidth);
-          --#{$drawer}__splitter--after--BorderRightWidth: 0;
-          --#{$drawer}__splitter--after--BorderLeftWidth: 0;
+          --#{$drawer}__splitter-handle--BlockStart: var(--#{$drawer}--m-inline--m-panel-bottom__splitter-handle--BlockStart);
+          --#{$drawer}__splitter--after--BorderBlockStartWidth: var(--#{$drawer}--m-inline--m-panel-bottom__splitter--after--BorderBlockStartWidth);
+          --#{$drawer}__splitter--after--BorderInlineEndWidth: 0;
+          --#{$drawer}__splitter--after--BorderInlineStartWidth: 0;
         }
       }
     }

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -185,7 +185,7 @@ import './Drawer.css'
       {{#> drawer-body}}
         Drawer panel body content
       {{/drawer-body}}
-      {{#> drawer-body drawer-body--HasPadding=true drawer-body--attribute="style='--pf-v6-c-drawer__panel__body--PaddingLeft: 48px;'"}}
+      {{#> drawer-body drawer-body--HasPadding=true drawer-body--attribute="style='--pf-v6-c-drawer__panel__body--PaddingInlineStart: 48px;'"}}
         Drawer panel body content with modified inline start padding
       {{/drawer-body}}
     {{/drawer-panel}}

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -4,10 +4,10 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
 .#{$dropdown} {
   // Toggle
-  --#{$dropdown}__toggle--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$dropdown}__toggle--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$dropdown}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$dropdown}__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$dropdown}__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$dropdown}__toggle--ColumnGap: var(--#{$pf-global}--spacer--sm);
   --#{$dropdown}__toggle--MinWidth: 0;
   --#{$dropdown}__toggle--FontSize: var(--#{$pf-global}--FontSize--md);
@@ -16,25 +16,25 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__toggle--LineHeight: var(--#{$pf-global}--LineHeight--md);
   --#{$dropdown}__toggle--BackgroundColor: transparent;
   --#{$dropdown}__toggle--before--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$dropdown}__toggle--before--BorderTopColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$dropdown}__toggle--before--BorderRightColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$dropdown}__toggle--before--BorderBottomColor: var(--#{$pf-global}--BorderColor--200);
-  --#{$dropdown}__toggle--before--BorderLeftColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$dropdown}__toggle--hover--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$dropdown}__toggle--focus--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$dropdown}__toggle--focus--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$dropdown}__toggle--active--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$dropdown}__toggle--active--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$dropdown}--m-expanded__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$dropdown}--m-expanded__toggle--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
+  --#{$dropdown}__toggle--before--BorderBlockStartColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$dropdown}__toggle--before--BorderInlineEndColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$dropdown}__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--200);
+  --#{$dropdown}__toggle--before--BorderInlineStartColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$dropdown}__toggle--hover--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$dropdown}__toggle--focus--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$dropdown}__toggle--focus--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$dropdown}__toggle--active--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$dropdown}__toggle--active--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$dropdown}--m-expanded__toggle--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$dropdown}--m-expanded__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
   --#{$dropdown}__toggle--disabled--BackgroundColor: var(--#{$pf-global}--disabled-color--300);
 
   // Plain
   --#{$dropdown}__toggle--m-plain--Color: var(--#{$pf-global}--Color--200);
   --#{$dropdown}__toggle--m-plain--hover--Color: var(--#{$pf-global}--Color--100);
   --#{$dropdown}__toggle--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
-  --#{$dropdown}__toggle--m-plain--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$dropdown}__toggle--m-plain--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$dropdown}__toggle--m-plain--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$dropdown}__toggle--m-plain--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$dropdown}__toggle--m-plain--child--LineHeight: normal; // remove at breaking change
 
   // Primary
@@ -71,17 +71,17 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__toggle-progress--c-spinner--diameter: var(--#{$pf-global}--FontSize--sm); // should match the checkbox input size
 
   // split buttons
-  --#{$dropdown}__toggle--m-split-button--child--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$dropdown}__toggle--m-split-button--child--PaddingRight: var(--#{$pf-global}--spacer--xs);
-  --#{$dropdown}__toggle--m-split-button--child--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$dropdown}__toggle--m-split-button--child--PaddingLeft: var(--#{$pf-global}--spacer--xs);
+  --#{$dropdown}__toggle--m-split-button--child--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$dropdown}__toggle--m-split-button--child--PaddingInlineEnd: var(--#{$pf-global}--spacer--xs);
+  --#{$dropdown}__toggle--m-split-button--child--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$dropdown}__toggle--m-split-button--child--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
   --#{$dropdown}__toggle--m-split-button--child--BackgroundColor: transparent;
-  --#{$dropdown}__toggle--m-split-button--first-child--PaddingLeft: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle--m-split-button--last-child--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle--m-split-button--m-action--child--PaddingLeft: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle--m-split-button--m-action--child--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginRight: calc(-1 * var(--#{$pf-global}--BorderWidth--sm));
-  --#{$dropdown}__toggle--m-split-button__toggle-text--MarginLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--m-split-button--first-child--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--m-split-button--last-child--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--m-split-button--m-action--child--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--m-split-button--m-action--child--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginInlineEnd: calc(-1 * var(--#{$pf-global}--BorderWidth--sm));
+  --#{$dropdown}__toggle--m-split-button__toggle-text--MarginInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$dropdown}__toggle--m-split-button--child--BorderRadius: var(--#{$pf-global}--BorderRadius--sm);
 
   // Split button
@@ -93,8 +93,8 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__toggle--m-split-button--m-primary--child--m-expanded--BackgroundColor: var(--#{$pf-global}--primary-color--200);
 
   // Split button, action, primary
-  --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderLeftColor: var(--#{$pf-global}--primary-color--200);
-  --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderLeftWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderInlineStartColor: var(--#{$pf-global}--primary-color--200);
+  --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderInlineStartWidth: var(--#{$pf-global}--BorderWidth--sm);
 
   // Split button
   --#{$dropdown}--m-expanded__toggle--m-secondary--m-split-button--child--before--BorderWidth: var(--#{$pf-global}--BorderWidth--md);
@@ -112,9 +112,9 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
   // Toggle Arrow
   --#{$dropdown}__toggle-icon--LineHeight: var(--#{$pf-global}--LineHeight--md);
-  --#{$dropdown}__toggle-icon--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle-icon--PaddingLeft: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__toggle-icon--MarginLeft: 0;
+  --#{$dropdown}__toggle-icon--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__toggle-icon--MarginInlineStart: 0;
   --#{$dropdown}--m-top--m-expanded__toggle-icon--Rotate: 180deg;
   --#{$dropdown}--m-plain__toggle-icon--Color: var(--#{$pf-global}--Color--200);
   --#{$dropdown}--m-plain--hover__toggle-icon--Color: var(--#{$pf-global}--Color--100);
@@ -122,19 +122,19 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   // Menu
   --#{$dropdown}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
   --#{$dropdown}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$dropdown}__menu--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__menu--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$dropdown}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$dropdown}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$dropdown}--m-top__menu--Top: 0;
+  --#{$dropdown}--m-top__menu--BlockStart: 0;
   --#{$dropdown}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu Item
   --#{$dropdown}__menu-item--BackgroundColor: transparent;
-  --#{$dropdown}__menu-item--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__menu-item--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$dropdown}__menu-item--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__menu-item--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$dropdown}__menu-item--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__menu-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$dropdown}__menu-item--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__menu-item--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$dropdown}__menu-item--FontSize: var(--#{$pf-global}--FontSize--md);
   --#{$dropdown}__menu-item--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$dropdown}__menu-item--LineHeight: var(--#{$pf-global}--LineHeight--md);
@@ -146,7 +146,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__menu-item--m-text--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Menu item icon
-  --#{$dropdown}__menu-item-icon--MarginRight: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__menu-item-icon--MarginInlineEnd: var(--#{$pf-global}--spacer--sm);
   --#{$dropdown}__menu-item-icon--Width: var(--#{$pf-global}--icon--FontSize--lg);
   --#{$dropdown}__menu-item-icon--Height: var(--#{$pf-global}--icon--FontSize--lg);
 
@@ -155,39 +155,39 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__menu-item-description--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Groups
-  --#{$dropdown}__group--group--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__group-title--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__group-title--PaddingRight: var(--#{$dropdown}__menu-item--PaddingRight);
-  --#{$dropdown}__group-title--PaddingBottom: var(--#{$dropdown}__menu-item--PaddingBottom);
-  --#{$dropdown}__group-title--PaddingLeft: var(--#{$dropdown}__menu-item--PaddingLeft);
+  --#{$dropdown}__group--group--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__group-title--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}__group-title--PaddingInlineEnd: var(--#{$dropdown}__menu-item--PaddingInlineEnd);
+  --#{$dropdown}__group-title--PaddingBlockEnd: var(--#{$dropdown}__menu-item--PaddingBlockEnd);
+  --#{$dropdown}__group-title--PaddingInlineStart: var(--#{$dropdown}__menu-item--PaddingInlineStart);
   --#{$dropdown}__group-title--FontSize: var(--#{$pf-global}--FontSize--xs);
   --#{$dropdown}__group-title--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$dropdown}__group-title--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Divider
-  --#{$dropdown}--c-divider--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}--c-divider--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}--c-divider--MarginBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$dropdown}--c-divider--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   // badge toggle icon
-  --#{$dropdown}__toggle--c-badge__toggle-icon--PaddingRight: 0;
-  --#{$dropdown}__toggle--c-badge__toggle-icon--PaddingLeft: 0;
-  --#{$dropdown}__toggle--c-badge__toggle-icon--MarginLeft: var(--#{$pf-global}--spacer--xs);
-  --#{$dropdown}__toggle--c-badge__toggle-icon--MarginRight: 0;
+  --#{$dropdown}__toggle--c-badge__toggle-icon--PaddingInlineEnd: 0;
+  --#{$dropdown}__toggle--c-badge__toggle-icon--PaddingInlineStart: 0;
+  --#{$dropdown}__toggle--c-badge__toggle-icon--MarginInlineStart: var(--#{$pf-global}--spacer--xs);
+  --#{$dropdown}__toggle--c-badge__toggle-icon--MarginInlineEnd: 0;
 
   // menu
-  --#{$dropdown}--c-menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$dropdown}--c-menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$dropdown}--c-menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$dropdown}--m-top--c-menu--Top: 0;
+  --#{$dropdown}--m-top--c-menu--BlockStart: 0;
   --#{$dropdown}--m-top--c-menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Dropdown
-  --#{$dropdown}--m-full-height__toggle--before--BorderTopWidth: 0;
-  --#{$dropdown}--m-full-height__toggle--expanded--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$dropdown}--m-full-height__toggle--hover--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$dropdown}--m-full-height__toggle--active--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$dropdown}--m-full-height__toggle--focus--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--xl);
-  --#{$dropdown}--m-full-height__toggle--PaddingRight: var(--#{$pf-global}--spacer--lg);
-  --#{$dropdown}--m-full-height__toggle--PaddingLeft: var(--#{$pf-global}--spacer--lg);
+  --#{$dropdown}--m-full-height__toggle--before--BorderBlockStartWidth: 0;
+  --#{$dropdown}--m-full-height__toggle--expanded--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$dropdown}--m-full-height__toggle--hover--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$dropdown}--m-full-height__toggle--active--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$dropdown}--m-full-height__toggle--focus--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--xl);
+  --#{$dropdown}--m-full-height__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--lg);
+  --#{$dropdown}--m-full-height__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
 
   position: relative;
   display: inline-flex;
@@ -195,27 +195,27 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   max-width: 100%;
 
   .#{$divider} {
-    margin-block-start: var(--#{$dropdown}--c-divider--MarginTop);
-    margin-block-end: var(--#{$dropdown}--c-divider--MarginBottom);
+    margin-block-start: var(--#{$dropdown}--c-divider--MarginBlockStart);
+    margin-block-end: var(--#{$dropdown}--c-divider--MarginBlockEnd);
 
     // Support divider as last item in group to separate groups
     &:last-child {
-      --#{$dropdown}--c-divider--MarginBottom: 0;
+      --#{$dropdown}--c-divider--MarginBlockEnd: 0;
     }
   }
 
   > .#{$menu} {
     position: absolute;
-   inset-block-start: var(--#{$dropdown}--c-menu--Top);
+   inset-block-start: var(--#{$dropdown}--c-menu--BlockStart);
     z-index: var(--#{$dropdown}--c-menu--ZIndex);
   }
 
   &.pf-m-full-height {
-    --#{$dropdown}__toggle--PaddingRight: var(--#{$dropdown}--m-full-height__toggle--PaddingRight);
-    --#{$dropdown}__toggle--PaddingLeft: var(--#{$dropdown}--m-full-height__toggle--PaddingLeft);
-    --#{$dropdown}__toggle--active--before--BorderBottomWidth: var(--#{$dropdown}--m-full-height__toggle--active--before--BorderBottomWidth);
-    --#{$dropdown}__toggle--focus--before--BorderBottomWidth: var(--#{$dropdown}--m-full-height__toggle--focus--before--BorderBottomWidth);
-    --#{$dropdown}--m-expanded__toggle--before--BorderBottomWidth: var(--#{$dropdown}--m-full-height__toggle--expanded--before--BorderBottomWidth);
+    --#{$dropdown}__toggle--PaddingInlineEnd: var(--#{$dropdown}--m-full-height__toggle--PaddingInlineEnd);
+    --#{$dropdown}__toggle--PaddingInlineStart: var(--#{$dropdown}--m-full-height__toggle--PaddingInlineStart);
+    --#{$dropdown}__toggle--active--before--BorderBlockEndWidth: var(--#{$dropdown}--m-full-height__toggle--active--before--BorderBlockEndWidth);
+    --#{$dropdown}__toggle--focus--before--BorderBlockEndWidth: var(--#{$dropdown}--m-full-height__toggle--focus--before--BorderBlockEndWidth);
+    --#{$dropdown}--m-expanded__toggle--before--BorderBlockEndWidth: var(--#{$dropdown}--m-full-height__toggle--expanded--before--BorderBlockEndWidth);
 
     display: inline-flex;
     align-items: center;
@@ -225,13 +225,13 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
       align-self: stretch;
 
       &::before {
-        border-block-start-width: var(--#{$dropdown}--m-full-height__toggle--before--BorderTopWidth);
+        border-block-start-width: var(--#{$dropdown}--m-full-height__toggle--before--BorderBlockStartWidth);
       }
     }
 
     &:hover {
       .#{$dropdown}__toggle::before {
-        border-block-end-width: var(--#{$dropdown}--m-full-height__toggle--hover--before--BorderBottomWidth);
+        border-block-end-width: var(--#{$dropdown}--m-full-height__toggle--hover--before--BorderBlockEndWidth);
       }
     }
   }
@@ -249,10 +249,10 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   align-items: center;
   min-width: var(--#{$dropdown}__toggle--MinWidth);
   max-width: 100%;
-  padding-block-start: var(--#{$dropdown}__toggle--PaddingTop);
-  padding-block-end: var(--#{$dropdown}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$dropdown}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$dropdown}__toggle--PaddingRight);
+  padding-block-start: var(--#{$dropdown}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$dropdown}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$dropdown}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$dropdown}__toggle--PaddingInlineEnd);
   font-size: var(--#{$dropdown}__toggle--FontSize);
   font-weight: var(--#{$dropdown}__toggle--FontWeight);
   line-height: var(--#{$dropdown}__toggle--LineHeight);
@@ -269,16 +269,16 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
     inset-inline-end: 0;
     content: "";
     border: var(--#{$dropdown}__toggle--before--BorderWidth) solid;
-    border-block-start-color: var(--#{$dropdown}__toggle--before--BorderTopColor);
-    border-block-end-color: var(--#{$dropdown}__toggle--before--BorderBottomColor);
-    border-inline-start-color: var(--#{$dropdown}__toggle--before--BorderLeftColor);
-    border-inline-end-color: var(--#{$dropdown}__toggle--before--BorderRightColor);
+    border-block-start-color: var(--#{$dropdown}__toggle--before--BorderBlockStartColor);
+    border-block-end-color: var(--#{$dropdown}__toggle--before--BorderBlockEndColor);
+    border-inline-start-color: var(--#{$dropdown}__toggle--before--BorderInlineStartColor);
+    border-inline-end-color: var(--#{$dropdown}__toggle--before--BorderInlineEndColor);
   }
 
   &.pf-m-disabled,
   &:disabled {
     --#{$dropdown}__toggle--m-primary--Color: var(--#{$dropdown}__toggle--m-primary--disabled--Color);
-    --#{$dropdown}__toggle--before--BorderBottomColor: transparent;
+    --#{$dropdown}__toggle--before--BorderBlockEndColor: transparent;
 
     pointer-events: none;
 
@@ -303,26 +303,26 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
     > * {
       position: relative;
-      padding-block-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingTop);
-      padding-block-end: var(--#{$dropdown}__toggle--m-split-button--child--PaddingBottom);
-      padding-inline-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingLeft);
-      padding-inline-end: var(--#{$dropdown}__toggle--m-split-button--child--PaddingRight);
+      padding-block-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingBlockStart);
+      padding-block-end: var(--#{$dropdown}__toggle--m-split-button--child--PaddingBlockEnd);
+      padding-inline-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingInlineStart);
+      padding-inline-end: var(--#{$dropdown}__toggle--m-split-button--child--PaddingInlineEnd);
 
       &:first-child {
-        --#{$dropdown}__toggle--m-split-button--child--PaddingLeft: var(--#{$dropdown}__toggle--m-split-button--first-child--PaddingLeft);
+        --#{$dropdown}__toggle--m-split-button--child--PaddingInlineStart: var(--#{$dropdown}__toggle--m-split-button--first-child--PaddingInlineStart);
       }
 
       &:last-child {
-        --#{$dropdown}__toggle--m-split-button--child--PaddingRight: var(--#{$dropdown}__toggle--m-split-button--last-child--PaddingRight);
+        --#{$dropdown}__toggle--m-split-button--child--PaddingInlineEnd: var(--#{$dropdown}__toggle--m-split-button--last-child--PaddingInlineEnd);
       }
     }
 
     &.pf-m-action {
-      --#{$dropdown}__toggle--m-split-button--child--PaddingRight: var(--#{$dropdown}__toggle--m-split-button--m-action--child--PaddingRight);
-      --#{$dropdown}__toggle--m-split-button--child--PaddingLeft: var(--#{$dropdown}__toggle--m-split-button--m-action--child--PaddingLeft);
+      --#{$dropdown}__toggle--m-split-button--child--PaddingInlineEnd: var(--#{$dropdown}__toggle--m-split-button--m-action--child--PaddingInlineEnd);
+      --#{$dropdown}__toggle--m-split-button--child--PaddingInlineStart: var(--#{$dropdown}__toggle--m-split-button--m-action--child--PaddingInlineStart);
 
       .#{$dropdown}__toggle-button {
-        margin-inline-end: var(--#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginRight);
+        margin-inline-end: var(--#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginInlineEnd);
 
         // stylelint-disable max-nesting-depth
         &::before {
@@ -330,7 +330,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
         }
 
         &:last-child {
-          --#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginRight: 0;
+          --#{$dropdown}__toggle--m-split-button--m-action__toggle-button--MarginInlineEnd: 0;
         }
         // stylelint-enable
       }
@@ -338,12 +338,12 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
       &.pf-m-primary {
         // stylelint-disable max-nesting-depth, selector-max-class
         > :not(:first-child) {
-          border-inline-start: var(--#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderLeftWidth) solid var(--#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderLeftColor);
+          border-inline-start: var(--#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderInlineStartWidth) solid var(--#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderInlineStartColor);
         }
 
         &.pf-m-disabled,
         &[disabled] {
-          --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderLeftWidth: 0;
+          --#{$dropdown}__toggle--m-split-button--m-primary--m-action--child--BorderInlineStartWidth: 0;
         }
         // stylelint-enable
       }
@@ -378,13 +378,13 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
     }
 
     .#{$dropdown}__toggle-text {
-      margin-inline-start: var(--#{$dropdown}__toggle--m-split-button__toggle-text--MarginLeft);
+      margin-inline-start: var(--#{$dropdown}__toggle--m-split-button__toggle-text--MarginInlineStart);
     }
   }
 
   &.pf-m-primary.pf-m-split-button:not(.pf-m-disabled) {
     --#{$dropdown}__toggle--before--BorderWidth: 0;
-    --#{$dropdown}--m-expanded__toggle--before--BorderBottomWidth: 0;
+    --#{$dropdown}--m-expanded__toggle--before--BorderBlockEndWidth: 0;
 
     > * {
       background-color: var(--#{$dropdown}__toggle--m-split-button--m-primary--child--BackgroundColor);
@@ -420,16 +420,16 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   &:not(.pf-m-action):not(.pf-m-secondary):hover,
   &.pf-m-action .#{$dropdown}__toggle-button:hover {
     &::before {
-      --#{$dropdown}__toggle--before--BorderBottomColor: var(--#{$dropdown}__toggle--hover--before--BorderBottomColor);
+      --#{$dropdown}__toggle--before--BorderBlockEndColor: var(--#{$dropdown}__toggle--hover--before--BorderBlockEndColor);
     }
   }
 
   &:not(.pf-m-action):not(.pf-m-secondary):focus,
   &.pf-m-action .#{$dropdown}__toggle-button:focus {
     &::before {
-      --#{$dropdown}__toggle--before--BorderBottomColor: var(--#{$dropdown}__toggle--focus--before--BorderBottomColor);
+      --#{$dropdown}__toggle--before--BorderBlockEndColor: var(--#{$dropdown}__toggle--focus--before--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$dropdown}__toggle--focus--before--BorderBottomWidth);
+      border-block-end-width: var(--#{$dropdown}__toggle--focus--before--BorderBlockEndWidth);
     }
   }
 
@@ -437,18 +437,18 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   &:not(.pf-m-action):not(.pf-m-secondary).pf-m-active,
   &.pf-m-action .#{$dropdown}__toggle-button:active {
     &::before {
-      --#{$dropdown}__toggle--before--BorderBottomColor: var(--#{$dropdown}__toggle--active--before--BorderBottomColor);
+      --#{$dropdown}__toggle--before--BorderBlockEndColor: var(--#{$dropdown}__toggle--active--before--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$dropdown}__toggle--active--before--BorderBottomWidth);
+      border-block-end-width: var(--#{$dropdown}__toggle--active--before--BorderBlockEndWidth);
     }
   }
 
   .pf-m-expanded > &:not(.pf-m-action):not(.pf-m-secondary),
   .pf-m-expanded > &.pf-m-action .#{$dropdown}__toggle-button {
     &::before {
-      --#{$dropdown}__toggle--before--BorderBottomColor: var(--#{$dropdown}--m-expanded__toggle--before--BorderBottomColor);
+      --#{$dropdown}__toggle--before--BorderBlockEndColor: var(--#{$dropdown}--m-expanded__toggle--before--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$dropdown}--m-expanded__toggle--before--BorderBottomWidth);
+      border-block-end-width: var(--#{$dropdown}--m-expanded__toggle--before--BorderBlockEndWidth);
     }
   }
 
@@ -456,8 +456,8 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
     --#{$dropdown}__toggle-icon--Color: var(--#{$dropdown}--m-plain__toggle-icon--Color);
 
     &:not(.pf-m-text) {
-      --#{$dropdown}__toggle--PaddingRight: var(--#{$dropdown}__toggle--m-plain--PaddingRight);
-      --#{$dropdown}__toggle--PaddingLeft: var(--#{$dropdown}__toggle--m-plain--PaddingLeft);
+      --#{$dropdown}__toggle--PaddingInlineEnd: var(--#{$dropdown}__toggle--m-plain--PaddingInlineEnd);
+      --#{$dropdown}__toggle--PaddingInlineStart: var(--#{$dropdown}__toggle--m-plain--PaddingInlineStart);
 
       display: inline-block;
       color: var(--#{$dropdown}__toggle--m-plain--Color);
@@ -608,9 +608,9 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   }
 
   > .#{$badge} {
-    --#{$dropdown}__toggle-icon--PaddingRight: var(--#{$dropdown}__toggle--c-badge__toggle-icon--PaddingRight);
-    --#{$dropdown}__toggle-icon--PaddingLeft: var(--#{$dropdown}__toggle--c-badge__toggle-icon--PaddingLeft);
-    --#{$dropdown}__toggle-icon--MarginLeft: var(--#{$dropdown}__toggle--c-badge__toggle-icon--MarginLeft);
+    --#{$dropdown}__toggle-icon--PaddingInlineEnd: var(--#{$dropdown}__toggle--c-badge__toggle-icon--PaddingInlineEnd);
+    --#{$dropdown}__toggle-icon--PaddingInlineStart: var(--#{$dropdown}__toggle--c-badge__toggle-icon--PaddingInlineStart);
+    --#{$dropdown}__toggle-icon--MarginInlineStart: var(--#{$dropdown}__toggle--c-badge__toggle-icon--MarginInlineStart);
   }
 
   .#{$dropdown}__toggle-text {
@@ -628,9 +628,9 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 }
 
 .#{$dropdown}__toggle-icon {
-  padding-inline-start: var(--#{$dropdown}__toggle-icon--PaddingLeft);
-  padding-inline-end: var(--#{$dropdown}__toggle-icon--PaddingRight);
-  margin-inline-start: var(--#{$dropdown}__toggle-icon--MarginLeft);
+  padding-inline-start: var(--#{$dropdown}__toggle-icon--PaddingInlineStart);
+  padding-inline-end: var(--#{$dropdown}__toggle-icon--PaddingInlineEnd);
+  margin-inline-start: var(--#{$dropdown}__toggle-icon--MarginInlineStart);
   line-height: var(--#{$dropdown}__toggle-icon--LineHeight);
   color: var(--#{$dropdown}__toggle-icon--Color, inherit);
 
@@ -650,7 +650,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 // Loading spinner
 .#{$dropdown}__toggle-progress {
   position: absolute;
- inset-inline-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingLeft);
+ inset-inline-start: var(--#{$dropdown}__toggle--m-split-button--child--PaddingInlineStart);
   visibility: var(--#{$dropdown}__toggle-progress--Visibility);
 
   .#{$spinner} {
@@ -660,10 +660,10 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
 .#{$dropdown}__menu {
   position: absolute;
- inset-block-start: var(--#{$dropdown}__menu--Top);
+ inset-block-start: var(--#{$dropdown}__menu--BlockStart);
   z-index: var(--#{$dropdown}__menu--ZIndex);
-  padding-block-start: var(--#{$dropdown}__menu--PaddingTop);
-  padding-block-end: var(--#{$dropdown}__menu--PaddingBottom);
+  padding-block-start: var(--#{$dropdown}__menu--PaddingBlockStart);
+  padding-block-end: var(--#{$dropdown}__menu--PaddingBlockEnd);
   background: var(--#{$dropdown}__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--#{$dropdown}__menu--BoxShadow);
@@ -703,13 +703,13 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
 .#{$dropdown}.pf-m-top {
   .#{$dropdown}__menu {
-    --#{$dropdown}__menu--Top: var(--#{$dropdown}--m-top__menu--Top);
+    --#{$dropdown}__menu--BlockStart: var(--#{$dropdown}--m-top__menu--BlockStart);
 
     transform: translateY(var(--#{$dropdown}--m-top__menu--TranslateY));
   }
 
   > .#{$menu} {
-    --#{$dropdown}--c-menu--Top: var(--#{$dropdown}--m-top--c-menu--Top);
+    --#{$dropdown}--c-menu--BlockStart: var(--#{$dropdown}--m-top--c-menu--BlockStart);
 
     transform: translateY(var(--#{$dropdown}--m-top--c-menu--TranslateY));
   }
@@ -718,10 +718,10 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 .#{$dropdown}__menu-item {
   display: block;
   width: 100%;
-  padding-block-start: var(--#{$dropdown}__menu-item--PaddingTop);
-  padding-block-end: var(--#{$dropdown}__menu-item--PaddingBottom);
-  padding-inline-start: var(--#{$dropdown}__menu-item--PaddingLeft);
-  padding-inline-end: var(--#{$dropdown}__menu-item--PaddingRight);
+  padding-block-start: var(--#{$dropdown}__menu-item--PaddingBlockStart);
+  padding-block-end: var(--#{$dropdown}__menu-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$dropdown}__menu-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$dropdown}__menu-item--PaddingInlineEnd);
   font-size: var(--#{$dropdown}__menu-item--FontSize);
   font-weight: var(--#{$dropdown}__menu-item--FontWeight);
   line-height: var(--#{$dropdown}__menu-item--LineHeight);
@@ -786,7 +786,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   justify-content: center;
   width: var(--#{$dropdown}__menu-item-icon--Width);
   height: var(--#{$dropdown}__menu-item-icon--Height);
-  margin-inline-end: var(--#{$dropdown}__menu-item-icon--MarginRight);
+  margin-inline-end: var(--#{$dropdown}__menu-item-icon--MarginInlineEnd);
 
   > * {
     max-width: 100%;
@@ -800,14 +800,14 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 }
 
 .#{$dropdown}__group + .#{$dropdown}__group {
-  padding-block-start: var(--#{$dropdown}__group--group--PaddingTop);
+  padding-block-start: var(--#{$dropdown}__group--group--PaddingBlockStart);
 }
 
 .#{$dropdown}__group-title {
-  padding-block-start: var(--#{$dropdown}__group-title--PaddingTop);
-  padding-block-end: var(--#{$dropdown}__group-title--PaddingBottom);
-  padding-inline-start: var(--#{$dropdown}__group-title--PaddingLeft);
-  padding-inline-end: var(--#{$dropdown}__group-title--PaddingRight);
+  padding-block-start: var(--#{$dropdown}__group-title--PaddingBlockStart);
+  padding-block-end: var(--#{$dropdown}__group-title--PaddingBlockEnd);
+  padding-inline-start: var(--#{$dropdown}__group-title--PaddingInlineStart);
+  padding-inline-end: var(--#{$dropdown}__group-title--PaddingInlineEnd);
   font-size: var(--#{$dropdown}__group-title--FontSize);
   font-weight: var(--#{$dropdown}__group-title--FontWeight);
   color: var(--#{$dropdown}__group-title--Color);

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -124,9 +124,9 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$dropdown}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
   --#{$dropdown}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
-  --#{$dropdown}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$dropdown}__menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$dropdown}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$dropdown}--m-top__menu--BlockStart: 0;
+  --#{$dropdown}--m-top__menu--InsetBlockStart: 0;
   --#{$dropdown}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu Item
@@ -175,9 +175,9 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
   --#{$dropdown}__toggle--c-badge__toggle-icon--MarginInlineEnd: 0;
 
   // menu
-  --#{$dropdown}--c-menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$dropdown}--c-menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$dropdown}--c-menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$dropdown}--m-top--c-menu--BlockStart: 0;
+  --#{$dropdown}--m-top--c-menu--InsetBlockStart: 0;
   --#{$dropdown}--m-top--c-menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Dropdown
@@ -206,7 +206,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
   > .#{$menu} {
     position: absolute;
-   inset-block-start: var(--#{$dropdown}--c-menu--BlockStart);
+   inset-block-start: var(--#{$dropdown}--c-menu--InsetBlockStart);
     z-index: var(--#{$dropdown}--c-menu--ZIndex);
   }
 
@@ -660,7 +660,7 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
 .#{$dropdown}__menu {
   position: absolute;
- inset-block-start: var(--#{$dropdown}__menu--BlockStart);
+ inset-block-start: var(--#{$dropdown}__menu--InsetBlockStart);
   z-index: var(--#{$dropdown}__menu--ZIndex);
   padding-block-start: var(--#{$dropdown}__menu--PaddingBlockStart);
   padding-block-end: var(--#{$dropdown}__menu--PaddingBlockEnd);
@@ -703,13 +703,13 @@ $pf-v6-c-dropdown--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg"
 
 .#{$dropdown}.pf-m-top {
   .#{$dropdown}__menu {
-    --#{$dropdown}__menu--BlockStart: var(--#{$dropdown}--m-top__menu--BlockStart);
+    --#{$dropdown}__menu--InsetBlockStart: var(--#{$dropdown}--m-top__menu--InsetBlockStart);
 
     transform: translateY(var(--#{$dropdown}--m-top__menu--TranslateY));
   }
 
   > .#{$menu} {
-    --#{$dropdown}--c-menu--BlockStart: var(--#{$dropdown}--m-top--c-menu--BlockStart);
+    --#{$dropdown}--c-menu--InsetBlockStart: var(--#{$dropdown}--m-top--c-menu--InsetBlockStart);
 
     transform: translateY(var(--#{$dropdown}--m-top--c-menu--TranslateY));
   }

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -71,7 +71,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
   // Toggle
   --#{$dual-list-selector}__item-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$dual-list-selector}__list__list__item-toggle--InlineStart: 0;
+  --#{$dual-list-selector}__list__list__item-toggle--InsetInlineStart: 0;
   --#{$dual-list-selector}__list__list__item-toggle--TranslateX: -100%;
 
   // Check
@@ -178,7 +178,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
       );
 
       position: absolute;
-      inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--InlineStart);
+      inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--InsetInlineStart);
     }
   }
 
@@ -349,7 +349,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   @for $i from 1 through $pf-v6-c-dual-list-selector__item--MaxNesting {
     #{$nested-item} {
       --#{$dual-list-selector}__item--PaddingInlineStart: calc(var(--#{$dual-list-selector}__item--nested-indent--base) * #{$i} + var(--#{$dual-list-selector}__item--indent--base));
-      --#{$dual-list-selector}__list__list__item-toggle--InlineStart: var(--#{$dual-list-selector}__item--PaddingInlineStart);
+      --#{$dual-list-selector}__list__list__item-toggle--InsetInlineStart: var(--#{$dual-list-selector}__item--PaddingInlineStart);
     }
 
     $nested-item: $nested-item + " " + $root;

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -17,15 +17,15 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}--GridTemplateColumns--pane--MinMax--max: #{pf-size-prem(450px)};
 
   // Header
-  --#{$dual-list-selector}__header--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__header--MarginBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Title
   --#{$dual-list-selector}__title-text--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$dual-list-selector}__title-text--FontSize: var(--pf-t--global--font--size--body--lg);
 
   // Tools
-  --#{$dual-list-selector}__tools--MarginBottom: var(--pf-t--global--spacer--md);
-  --#{$dual-list-selector}__tools-filter--tools-actions--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__tools--MarginBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__tools-filter--tools-actions--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // Menu
   --#{$dual-list-selector}__menu--BorderWidth: var(--pf-t--global--border--width--regular);
@@ -44,14 +44,14 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item--m-ghost-row--Opacity: .4;
 
   // Item
-  --#{$dual-list-selector}__item--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$dual-list-selector}__item--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$dual-list-selector}__item--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$dual-list-selector}__item--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$dual-list-selector}__item--m-expandable--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__item--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__item--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__item--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__item--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__item--m-expandable--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$dual-list-selector}__item--indent--base: calc(var(--pf-t--global--spacer--md) + var(--pf-t--global--spacer--sm) + var(--#{$dual-list-selector}__list-item-row--FontSize));
   --#{$dual-list-selector}__item--nested-indent--base: calc(var(--#{$dual-list-selector}__item--indent--base) - var(--pf-t--global--spacer--md));
-  --#{$dual-list-selector}__draggable--item--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$dual-list-selector}__draggable--item--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // Item text
   --#{$dual-list-selector}__item-text--Color: var(--pf-t--global--text--color--subtle);
@@ -59,23 +59,23 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item--m-disabled__item-text--Color: var(--pf-t--global--text--color--disabled);
 
   // Status
-  --#{$dual-list-selector}__status--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__status--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$dual-list-selector}__status-text--FontSize: var(--pf-t--global--font--size--sm);
   --#{$dual-list-selector}__status-text--Color: var(--pf-t--global--text--color--subtle);
 
   // Controls
-  --#{$dual-list-selector}__controls--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$dual-list-selector}__controls--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__controls--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$dual-list-selector}__controls--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$dual-list-selector}__controls--Gap: var(--pf-t--global--spacer--sm);
   --#{$dual-list-selector}__controls--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Toggle
-  --#{$dual-list-selector}__item-toggle--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$dual-list-selector}__list__list__item-toggle--Left: 0;
+  --#{$dual-list-selector}__item-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__list__list__item-toggle--InlineStart: 0;
   --#{$dual-list-selector}__list__list__item-toggle--TranslateX: -100%;
 
   // Check
-  --#{$dual-list-selector}__item-check--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$dual-list-selector}__item-check--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Badge
   --#{$dual-list-selector}__item--c-badge--m-read--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
@@ -115,7 +115,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
 .#{$dual-list-selector}__header {
   grid-area: var(--#{$dual-list-selector}__header--GridArea);
-  margin-block-end: var(--#{$dual-list-selector}__header--MarginBottom);
+  margin-block-end: var(--#{$dual-list-selector}__header--MarginBlockEnd);
 }
 
 .#{$dual-list-selector}__title-text {
@@ -126,7 +126,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 .#{$dual-list-selector}__tools {
   display: flex;
   grid-area: var(--#{$dual-list-selector}__tools--GridArea);
-  margin-block-end: var(--#{$dual-list-selector}__tools--MarginBottom);
+  margin-block-end: var(--#{$dual-list-selector}__tools--MarginBlockEnd);
 }
 
 .#{$dual-list-selector}__tools-filter {
@@ -137,14 +137,14 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   display: flex;
 
   .#{$dual-list-selector}__tools-filter ~ & {
-    margin-inline-start: var(--#{$dual-list-selector}__tools-filter--tools-actions--MarginLeft);
+    margin-inline-start: var(--#{$dual-list-selector}__tools-filter--tools-actions--MarginInlineStart);
   }
 }
 
 .#{$dual-list-selector}__status {
   display: flex;
   grid-area: var(--#{$dual-list-selector}__status--GridArea);
-  margin-block-end: var(--#{$dual-list-selector}__status--MarginBottom);
+  margin-block-end: var(--#{$dual-list-selector}__status--MarginBlockEnd);
 }
 
 .#{$dual-list-selector}__status-text {
@@ -167,8 +167,8 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__item-toggle-icon--Rotate: 0;
 
   & & {
-    --#{$dual-list-selector}__item-toggle--MarginTop: 0;
-    --#{$dual-list-selector}__item-toggle--MarginBottom: 0;
+    --#{$dual-list-selector}__item-toggle--MarginBlockStart: 0;
+    --#{$dual-list-selector}__item-toggle--MarginBlockEnd: 0;
 
     .#{$dual-list-selector}__item-toggle {
       @include pf-v6-bidirectional-style(
@@ -178,7 +178,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
       );
 
       position: absolute;
-      inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--Left);
+      inset-inline-start: var(--#{$dual-list-selector}__list__list__item-toggle--InlineStart);
     }
   }
 
@@ -196,7 +196,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   }
 
   &.pf-m-expandable {
-    --#{$dual-list-selector}__item--PaddingLeft: var(--#{$dual-list-selector}__item--m-expandable--PaddingLeft);
+    --#{$dual-list-selector}__item--PaddingInlineStart: var(--#{$dual-list-selector}__item--m-expandable--PaddingInlineStart);
   }
 
   &.pf-m-expanded {
@@ -255,7 +255,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   display: flex;
 
   + .#{$dual-list-selector}__item {
-    --#{$dual-list-selector}__item--PaddingLeft: var(--#{$dual-list-selector}__draggable--item--PaddingLeft);
+    --#{$dual-list-selector}__item--PaddingInlineStart: var(--#{$dual-list-selector}__draggable--item--PaddingInlineStart);
   }
 
   .#{$button} {
@@ -272,10 +272,10 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 .#{$dual-list-selector}__item {
   position: relative;
   width: 100%;
-  padding-block-start: var(--#{$dual-list-selector}__item--PaddingTop);
-  padding-block-end: var(--#{$dual-list-selector}__item--PaddingBottom);
-  padding-inline-start: var(--#{$dual-list-selector}__item--PaddingLeft);
-  padding-inline-end: var(--#{$dual-list-selector}__item--PaddingRight);
+  padding-block-start: var(--#{$dual-list-selector}__item--PaddingBlockStart);
+  padding-block-end: var(--#{$dual-list-selector}__item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$dual-list-selector}__item--PaddingInlineStart);
+  padding-inline-end: var(--#{$dual-list-selector}__item--PaddingInlineEnd);
   cursor: pointer;
   outline-offset: -2px;
 }
@@ -303,8 +303,8 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   align-items: center;
   align-self: center;
   justify-content: center;
-  padding-inline-start: var(--#{$dual-list-selector}__controls--PaddingLeft);
-  padding-inline-end: var(--#{$dual-list-selector}__controls--PaddingRight);
+  padding-inline-start: var(--#{$dual-list-selector}__controls--PaddingInlineStart);
+  padding-inline-end: var(--#{$dual-list-selector}__controls--PaddingInlineEnd);
   margin-block-start: var(--#{$dual-list-selector}__controls--MarginBlockStart);
 }
 
@@ -318,18 +318,18 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 .#{$dual-list-selector}__item-toggle {
-  padding-block-start: var(--#{$dual-list-selector}__item-toggle--PaddingTop);
-  padding-block-end: var(--#{$dual-list-selector}__item-toggle--PaddingBottom);
-  padding-inline-start: var(--#{$dual-list-selector}__item-toggle--PaddingLeft);
-  padding-inline-end: var(--#{$dual-list-selector}__item-toggle--PaddingRight);
-  margin-block-start: var(--#{$dual-list-selector}__item-toggle--MarginTop);
-  margin-block-end: var(--#{$dual-list-selector}__item-toggle--MarginBottom);
+  padding-block-start: var(--#{$dual-list-selector}__item-toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$dual-list-selector}__item-toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$dual-list-selector}__item-toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$dual-list-selector}__item-toggle--PaddingInlineEnd);
+  margin-block-start: var(--#{$dual-list-selector}__item-toggle--MarginBlockStart);
+  margin-block-end: var(--#{$dual-list-selector}__item-toggle--MarginBlockEnd);
 }
 
 .#{$dual-list-selector}__item-check {
   display: flex;
   align-items: center;
-  margin-inline-end: var(--#{$dual-list-selector}__item-check--MarginRight);
+  margin-inline-end: var(--#{$dual-list-selector}__item-check--MarginInlineEnd);
 }
 
 .#{$dual-list-selector}__item-toggle-icon {
@@ -348,8 +348,8 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
   @for $i from 1 through $pf-v6-c-dual-list-selector__item--MaxNesting {
     #{$nested-item} {
-      --#{$dual-list-selector}__item--PaddingLeft: calc(var(--#{$dual-list-selector}__item--nested-indent--base) * #{$i} + var(--#{$dual-list-selector}__item--indent--base));
-      --#{$dual-list-selector}__list__list__item-toggle--Left: var(--#{$dual-list-selector}__item--PaddingLeft);
+      --#{$dual-list-selector}__item--PaddingInlineStart: calc(var(--#{$dual-list-selector}__item--nested-indent--base) * #{$i} + var(--#{$dual-list-selector}__item--indent--base));
+      --#{$dual-list-selector}__list__list__item-toggle--InlineStart: var(--#{$dual-list-selector}__item--PaddingInlineStart);
     }
 
     $nested-item: $nested-item + " " + $root;

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -78,6 +78,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__item-check--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Badge
+  --#{$dual-list-selector}__item-count--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$dual-list-selector}__item--c-badge--m-read--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
 
   // Icon
@@ -281,7 +282,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 .#{$dual-list-selector}__item-count {
-  margin-inline-start: var(--#{$dual-list-selector}__item-count--Marginleft);
+  margin-inline-start: var(--#{$dual-list-selector}__item-count--MarginInlineStart);
 
   .#{$badge}.pf-m-read {
     --#{$badge}--m-read--BackgroundColor: var(--#{$dual-list-selector}__item--c-badge--m-read--BackgroundColor);

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,14 +1,14 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$empty-state}) {
-  --#{$empty-state}--PaddingTop: var(--pf-t--global--spacer--xl);
-  --#{$empty-state}--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$empty-state}--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$empty-state}--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$empty-state}--m-xs--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$empty-state}--m-xs--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$empty-state}--m-xs--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$empty-state}--m-xs--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$empty-state}--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--m-xs--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$empty-state}--m-xs--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$empty-state}--m-xs--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$empty-state}--m-xs--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // Content
   --#{$empty-state}__content--MaxWidth: none;
@@ -17,11 +17,11 @@
   --#{$empty-state}--m-lg__content--MaxWidth: #{pf-size-prem(600px)};
 
   // Icon
-  --#{$empty-state}__icon--MarginBottom: var(--pf-t--global--spacer--lg);
+  --#{$empty-state}__icon--MarginBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$empty-state}__icon--FontSize: var(--pf-t--global--icon--size--2xl);
   --#{$empty-state}__icon--Color: var(--pf-t--global--icon--color--subtle);
-  --#{$empty-state}--m-xs__icon--MarginBottom: var(--pf-t--global--spacer--lg);
-  --#{$empty-state}--m-xl__icon--MarginBottom: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--m-xs__icon--MarginBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$empty-state}--m-xl__icon--MarginBlockEnd: var(--pf-t--global--spacer--xl);
   --#{$empty-state}--m-xl__icon--FontSize: var(--pf-t--global--icon--size--3xl);
 
   // Status variant icon color
@@ -41,18 +41,18 @@
   --#{$empty-state}--m-xl__title-text--LineHeight: var(--pf-t--global--font--line-height--heading);
 
   // Body
-  --#{$empty-state}__body--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$empty-state}__body--MarginBlockStart: var(--pf-t--global--spacer--md);
   --#{$empty-state}__body--Color: var(--pf-t--global--text--color--subtle);
   --#{$empty-state}--body--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$empty-state}--m-xs__body--FontSize: var(--pf-t--global--font--size--body--lg);
-  --#{$empty-state}--m-xs__body--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$empty-state}--m-xs__body--MarginBlockStart: var(--pf-t--global--spacer--md);
   --#{$empty-state}--m-xl__body--FontSize: var(--pf-t--global--font--size--body--lg);
-  --#{$empty-state}--m-xl__body--MarginTop: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--m-xl__body--MarginBlockStart: var(--pf-t--global--spacer--xl);
 
   // Footer
   --#{$empty-state}__footer--RowGap: var(--pf-t--global--spacer--sm);
-  --#{$empty-state}__footer--MarginTop: var(--pf-t--global--spacer--xl);
-  --#{$empty-state}--m-xs__footer--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$empty-state}__footer--MarginBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$empty-state}--m-xs__footer--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Actions
   --#{$empty-state}__actions--RowGap: var(--pf-t--global--spacer--sm);
@@ -63,23 +63,23 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-block-start: var(--#{$empty-state}--PaddingTop);
-  padding-block-end: var(--#{$empty-state}--PaddingBottom);
-  padding-inline-start: var(--#{$empty-state}--PaddingLeft);
-  padding-inline-end: var(--#{$empty-state}--PaddingRight);
+  padding-block-start: var(--#{$empty-state}--PaddingBlockStart);
+  padding-block-end: var(--#{$empty-state}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$empty-state}--PaddingInlineStart);
+  padding-inline-end: var(--#{$empty-state}--PaddingInlineEnd);
   text-align: center;
 
   &.pf-m-xs {
-    --#{$empty-state}--PaddingTop: var(--#{$empty-state}--m-xs--PaddingTop);
-    --#{$empty-state}--PaddingRight: var(--#{$empty-state}--m-xs--PaddingRight);
-    --#{$empty-state}--PaddingBottom: var(--#{$empty-state}--m-xs--PaddingBottom);
-    --#{$empty-state}--PaddingLeft: var(--#{$empty-state}--m-xs--PaddingLeft);
+    --#{$empty-state}--PaddingBlockStart: var(--#{$empty-state}--m-xs--PaddingBlockStart);
+    --#{$empty-state}--PaddingInlineEnd: var(--#{$empty-state}--m-xs--PaddingInlineEnd);
+    --#{$empty-state}--PaddingBlockEnd: var(--#{$empty-state}--m-xs--PaddingBlockEnd);
+    --#{$empty-state}--PaddingInlineStart: var(--#{$empty-state}--m-xs--PaddingInlineStart);
     --#{$empty-state}__title-text--FontSize: var(--#{$empty-state}--m-xs__title-text--FontSize);
     --#{$empty-state}__content--MaxWidth: var(--#{$empty-state}--m-xs__content--MaxWidth);
-    --#{$empty-state}__icon--MarginBottom: var(--#{$empty-state}--m-xs__icon--MarginBottom);
-    --#{$empty-state}__body--MarginTop: var(--#{$empty-state}--m-xs__body--MarginTop);
+    --#{$empty-state}__icon--MarginBlockEnd: var(--#{$empty-state}--m-xs__icon--MarginBlockEnd);
+    --#{$empty-state}__body--MarginBlockStart: var(--#{$empty-state}--m-xs__body--MarginBlockStart);
     --#{$empty-state}--body--FontSize: var(--#{$empty-state}--m-xs__body--FontSize);
-    --#{$empty-state}__footer--MarginTop: var(--#{$empty-state}--m-xs__footer--MarginTop);
+    --#{$empty-state}__footer--MarginBlockStart: var(--#{$empty-state}--m-xs__footer--MarginBlockStart);
   }
 
   &.pf-m-sm {
@@ -91,9 +91,9 @@
   }
 
   &.pf-m-xl {
-    --#{$empty-state}__body--MarginTop: var(--#{$empty-state}--m-xl__body--MarginTop);
+    --#{$empty-state}__body--MarginBlockStart: var(--#{$empty-state}--m-xl__body--MarginBlockStart);
     --#{$empty-state}--body--FontSize: var(--#{$empty-state}--m-xl__body--FontSize);
-    --#{$empty-state}__icon--MarginBottom: var(--#{$empty-state}--m-xl__icon--MarginBottom);
+    --#{$empty-state}__icon--MarginBlockEnd: var(--#{$empty-state}--m-xl__icon--MarginBlockEnd);
     --#{$empty-state}__icon--FontSize: var(--#{$empty-state}--m-xl__icon--FontSize);
     --#{$empty-state}__title-text--FontSize: var(--#{$empty-state}--m-xl__title-text--FontSize);
     --#{$empty-state}__title-text--LineHeight: var(--#{$empty-state}--m-xl__title-text--LineHeight);
@@ -129,7 +129,7 @@
 }
 
 .#{$empty-state}__icon {
-  margin-block-end: var(--#{$empty-state}__icon--MarginBottom);
+  margin-block-end: var(--#{$empty-state}__icon--MarginBlockEnd);
   font-size: var(--#{$empty-state}__icon--FontSize);
   line-height: 1;
   color: var(--#{$empty-state}__icon--Color);
@@ -143,7 +143,7 @@
 }
 
 .#{$empty-state}__body {
-  margin-block-start: var(--#{$empty-state}__body--MarginTop);
+  margin-block-start: var(--#{$empty-state}__body--MarginBlockStart);
   font-size: var(--#{$empty-state}--body--FontSize);
   color: var(--#{$empty-state}__body--Color);
 }
@@ -153,7 +153,7 @@
   flex-direction: column;
   row-gap: var(--#{$empty-state}__footer--RowGap);
   align-items: center;
-  margin-block-start: var(--#{$empty-state}__footer--MarginTop);
+  margin-block-start: var(--#{$empty-state}__footer--MarginBlockStart);
 }
 
 .#{$empty-state}__actions {

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -2,10 +2,10 @@
 
 :where(:root, .#{$expandable-section}) {
   // Toggle
-  --#{$expandable-section}__toggle--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__toggle--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}__toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__toggle--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}__toggle--BackgroundColor: transparent;
   --#{$expandable-section}__toggle--ColumnGap: calc(var(--pf-t--global--spacer--xs) + var(--pf-t--global--spacer--sm));
 
@@ -24,10 +24,10 @@
   --#{$expandable-section}--m-expanded__toggle-text--Color: var(--pf-t--global--color--brand--hover);
 
   // Content
-  --#{$expandable-section}__content--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__content--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__content--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}__content--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}__content--MaxWidth: auto;
 
   // Limit Width
@@ -37,31 +37,31 @@
   --#{$expandable-section}--m-display-lg--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$expandable-section}--m-display-lg--BorderColor: var(--pf-t--global--border--color--default);
   --#{$expandable-section}--m-display-lg--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$expandable-section}--m-display-lg__toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-display-lg__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$expandable-section}--m-display-lg__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-display-lg__toggle--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$expandable-section}--m-display-lg__toggle--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$expandable-section}--m-display-lg__toggle--Width: 100%;
   --#{$expandable-section}--m-display-lg__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
   --#{$expandable-section}--m-display-lg__toggle--active--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
   --#{$expandable-section}--m-display-lg__toggle--focus--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
-  --#{$expandable-section}--m-display-lg__content--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-display-lg__content--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__content--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$expandable-section}--m-display-lg__content--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$expandable-section}--m-display-lg__content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-display-lg__content--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$expandable-section}--m-expanded--m-display-lg__toggle--BorderRadius: var(--pf-t--global--border--radius--medium) var(--pf-t--global--border--radius--medium) 0 0;
 
   // Indented
-  --#{$expandable-section}--m-indented__content--PaddingLeft--base: calc(var(--#{$expandable-section}__toggle--ColumnGap) + var(--#{$expandable-section}__toggle-icon--MinWidth));
-  --#{$expandable-section}--m-indented__content--PaddingLeft: calc(var(--#{$expandable-section}--m-indented__content--PaddingLeft--base) + var(--#{$expandable-section}__toggle--PaddingLeft));
-  --#{$expandable-section}--m-display-lg--m-indented__content--PaddingLeft: calc(var(--#{$expandable-section}--m-indented__content--PaddingLeft--base) + var(--#{$expandable-section}--m-display-lg__content--PaddingLeft));
+  --#{$expandable-section}--m-indented__content--PaddingInlineStart--base: calc(var(--#{$expandable-section}__toggle--ColumnGap) + var(--#{$expandable-section}__toggle-icon--MinWidth));
+  --#{$expandable-section}--m-indented__content--PaddingInlineStart: calc(var(--#{$expandable-section}--m-indented__content--PaddingInlineStart--base) + var(--#{$expandable-section}__toggle--PaddingInlineStart));
+  --#{$expandable-section}--m-display-lg--m-indented__content--PaddingInlineStart: calc(var(--#{$expandable-section}--m-indented__content--PaddingInlineStart--base) + var(--#{$expandable-section}--m-display-lg__content--PaddingInlineStart));
 
   // Truncate
-  --#{$expandable-section}--m-truncate--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}--m-truncate--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-truncate--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}--m-truncate--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-truncate__toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}--m-truncate--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}--m-truncate--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-truncate--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}--m-truncate--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-truncate__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}--m-truncate__content--LineClamp: 3;
 }
 
@@ -79,19 +79,19 @@
   }
 
   &.pf-m-display-lg {
-    --#{$expandable-section}__toggle--PaddingTop: var(--#{$expandable-section}--m-display-lg__toggle--PaddingTop);
-    --#{$expandable-section}__toggle--PaddingRight: var(--#{$expandable-section}--m-display-lg__toggle--PaddingRight);
-    --#{$expandable-section}__toggle--PaddingBottom: var(--#{$expandable-section}--m-display-lg__toggle--PaddingBottom);
-    --#{$expandable-section}__toggle--PaddingLeft: var(--#{$expandable-section}--m-display-lg__toggle--PaddingLeft);
+    --#{$expandable-section}__toggle--PaddingBlockStart: var(--#{$expandable-section}--m-display-lg__toggle--PaddingBlockStart);
+    --#{$expandable-section}__toggle--PaddingInlineEnd: var(--#{$expandable-section}--m-display-lg__toggle--PaddingInlineEnd);
+    --#{$expandable-section}__toggle--PaddingBlockEnd: var(--#{$expandable-section}--m-display-lg__toggle--PaddingBlockEnd);
+    --#{$expandable-section}__toggle--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg__toggle--PaddingInlineStart);
     --#{$expandable-section}__toggle--hover--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--hover--BackgroundColor);
     --#{$expandable-section}__toggle--active--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--active--BackgroundColor);
     --#{$expandable-section}__toggle--focus--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--focus--BackgroundColor);
     --#{$expandable-section}__toggle--BorderRadius: var(--#{$expandable-section}--m-display-lg__toggle--BorderRadius);
     --#{$expandable-section}__toggle--Width: var(--#{$expandable-section}--m-display-lg__toggle--Width);
-    --#{$expandable-section}__content--PaddingRight: var(--#{$expandable-section}--m-display-lg__content--PaddingRight);
-    --#{$expandable-section}__content--PaddingBottom: var(--#{$expandable-section}--m-display-lg__content--PaddingBottom);
-    --#{$expandable-section}__content--PaddingLeft: var(--#{$expandable-section}--m-display-lg__content--PaddingLeft);
-    --#{$expandable-section}--m-indented__content--PaddingLeft: var(--#{$expandable-section}--m-display-lg--m-indented__content--PaddingLeft);
+    --#{$expandable-section}__content--PaddingInlineEnd: var(--#{$expandable-section}--m-display-lg__content--PaddingInlineEnd);
+    --#{$expandable-section}__content--PaddingBlockEnd: var(--#{$expandable-section}--m-display-lg__content--PaddingBlockEnd);
+    --#{$expandable-section}__content--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg__content--PaddingInlineStart);
+    --#{$expandable-section}--m-indented__content--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg--m-indented__content--PaddingInlineStart);
 
     background-color: var(--#{$expandable-section}--m-display-lg--BackgroundColor);
     border: solid 1px var(--#{$expandable-section}--m-display-lg--BorderColor);
@@ -99,18 +99,18 @@
   }
 
   &.pf-m-indented {
-    --#{$expandable-section}__content--PaddingLeft: var(--#{$expandable-section}--m-indented__content--PaddingLeft);
+    --#{$expandable-section}__content--PaddingInlineStart: var(--#{$expandable-section}--m-indented__content--PaddingInlineStart);
   }
 
   &.pf-m-truncate {
-    --#{$expandable-section}__toggle--PaddingTop: 0;
-    --#{$expandable-section}__toggle--PaddingRight: 0;
-    --#{$expandable-section}__toggle--PaddingBottom: var(--#{$expandable-section}--m-truncate__toggle--PaddingBottom);
-    --#{$expandable-section}__toggle--PaddingLeft: 0;
-    --#{$expandable-section}__content--PaddingTop: 0;
-    --#{$expandable-section}__content--PaddingRight: 0;
-    --#{$expandable-section}__content--PaddingBottom: 0;
-    --#{$expandable-section}__content--PaddingLeft: 0;
+    --#{$expandable-section}__toggle--PaddingBlockStart: 0;
+    --#{$expandable-section}__toggle--PaddingInlineEnd: 0;
+    --#{$expandable-section}__toggle--PaddingBlockEnd: var(--#{$expandable-section}--m-truncate__toggle--PaddingBlockEnd);
+    --#{$expandable-section}__toggle--PaddingInlineStart: 0;
+    --#{$expandable-section}__content--PaddingBlockStart: 0;
+    --#{$expandable-section}__content--PaddingInlineEnd: 0;
+    --#{$expandable-section}__content--PaddingBlockEnd: 0;
+    --#{$expandable-section}__content--PaddingInlineStart: 0;
 
     &:not(.pf-m-expanded) .#{$expandable-section}__content {
       // stylelint-disable
@@ -127,10 +127,10 @@
   display: flex;
   column-gap: var(--#{$expandable-section}__toggle--ColumnGap);
   width: var(--#{$expandable-section}__toggle--Width, initial);
-  padding-block-start: var(--#{$expandable-section}__toggle--PaddingTop);
-  padding-block-end: var(--#{$expandable-section}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$expandable-section}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$expandable-section}__toggle--PaddingRight);
+  padding-block-start: var(--#{$expandable-section}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$expandable-section}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$expandable-section}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$expandable-section}__toggle--PaddingInlineEnd);
   background-color: var(--#{$expandable-section}__toggle--BackgroundColor);
   border: none;
   border-radius: var(--#{$expandable-section}__toggle--BorderRadius, 0);
@@ -160,8 +160,8 @@
 
 .#{$expandable-section}__content {
   max-width: var(--#{$expandable-section}__content--MaxWidth);
-  padding-block-start: var(--#{$expandable-section}__content--PaddingTop);
-  padding-block-end: var(--#{$expandable-section}__content--PaddingBottom);
-  padding-inline-start: var(--#{$expandable-section}__content--PaddingLeft);
-  padding-inline-end: var(--#{$expandable-section}__content--PaddingRight);
+  padding-block-start: var(--#{$expandable-section}__content--PaddingBlockStart);
+  padding-block-end: var(--#{$expandable-section}__content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$expandable-section}__content--PaddingInlineStart);
+  padding-inline-end: var(--#{$expandable-section}__content--PaddingInlineEnd);
 }

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -30,7 +30,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 
   // Group
   --#{$form}__group--Gap: var(--pf-t--global--spacer--sm);
-  --#{$form}__group--m-action--MarginTop: var(--pf-t--global--spacer--xl);
+  --#{$form}__group--m-action--MarginBlockStart: var(--pf-t--global--spacer--xl);
   --#{$form}--m-horizontal__group-label--md--GridColumnWidth: #{pf-size-prem(150px)};
   --#{$form}--m-horizontal__group-label--md--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$form}--m-horizontal__group-control--md--GridColumnWidth: 1fr;
@@ -54,8 +54,8 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   // plus the border width used by the text inputs is 1px
   // So we need to adjust by 21 - 16.1 + 1 = 5.9px
 
-  --#{$form}--m-horizontal__group-label--md--PaddingTop: calc((((((var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)) + (2 * var(--pf-t--global--border--width--control--default))) - var(--pf-t--global--font--size--body--default)) / 2) + var(--pf-t--global--font--size--body--default)) - ((((var(--pf-t--global--font--size--body--sm) * var(--pf-t--global--font--line-height--body)) - var(--pf-t--global--font--size--body--sm)) / 2) + var(--pf-t--global--font--size--body--sm)) + var(--pf-t--global--border--width--control--default));
-  --#{$form}__group-label--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$form}--m-horizontal__group-label--md--PaddingBlockStart: calc((((((var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)) + (2 * var(--pf-t--global--border--width--control--default))) - var(--pf-t--global--font--size--body--default)) / 2) + var(--pf-t--global--font--size--body--default)) - ((((var(--pf-t--global--font--size--body--sm) * var(--pf-t--global--font--line-height--body)) - var(--pf-t--global--font--size--body--sm)) / 2) + var(--pf-t--global--font--size--body--sm)) + var(--pf-t--global--border--width--control--default));
+  --#{$form}__group-label--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Use the no-padding modifier to align form groups that aren't text inputs
   // Use the formula above, except
@@ -63,7 +63,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   // - reverse the subtraction so we get a negative number to translate by
   // - controls like checkboxes use the medium font and small line height
   // - This comes out to a difference of 2.3px.
-  --#{$form}--m-horizontal__group-label--m-no-padding--md--PaddingTop: 0;
+  --#{$form}--m-horizontal__group-label--m-no-padding--md--PaddingBlockStart: 0;
   --#{$form}--m-horizontal__group-label--m-no-padding--md--TranslateY: calc(((((var(--pf-t--global--font--size--body--sm) * var(--pf-t--global--font--line-height--body)) - var(--pf-t--global--font--size--body--sm)) / 2) + var(--pf-t--global--font--size--body--sm)) - ((((var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)) - var(--pf-t--global--font--size--body--default)) / 2) + var(--pf-t--global--font--size--body--default)));
 
   // Label
@@ -77,7 +77,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   --#{$form}__label-text--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // Required labels
-  --#{$form}__label-required--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$form}__label-required--MarginInlineStart: var(--pf-t--global--spacer--xs);
   --#{$form}__label-required--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$form}__label-required--Color: var(--pf-t--global--color--status--danger--default);
 
@@ -85,75 +85,75 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   --#{$form}__group-label-help--FontSize: var(--pf-t--global--font--size--body--sm);
 
   // Form group label info
-  --#{$form}__group-label-info--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$form}__group-label-info--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$form}__group-label-info--FontSize: var(--pf-t--global--font--size--body--sm);
 
   // Group control
-  --#{$form}__group-control--m-inline--child--MarginRight: var(--pf-t--global--spacer--lg);
-  --#{$form}__group-control__helper-text--MarginBottom: var(--pf-t--global--spacer--xs);
+  --#{$form}__group-control--m-inline--child--MarginInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$form}__group-control__helper-text--MarginBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$form}__group-control--Gap: var(--pf-t--global--spacer--sm);
   --#{$form}__group-control--m-stack--Gap: var(--pf-t--global--spacer--sm);
-  --#{$form}__group-control--m-stack__helper-text--MarginTop: calc(var(--#{$form}__group-control--m-stack--Gap) * -1 + var(--#{$form}__helper-text--MarginTop--base));
+  --#{$form}__group-control--m-stack__helper-text--MarginBlockStart: calc(var(--#{$form}__group-control--m-stack--Gap) * -1 + var(--#{$form}__helper-text--MarginBlockStart--base));
 
   // Actions
-  --#{$form}__actions--child--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$form}__actions--child--MarginRight: var(--pf-t--global--spacer--sm);
-  --#{$form}__actions--child--MarginBottom: var(--pf-t--global--spacer--sm);
-  --#{$form}__actions--child--MarginLeft: var(--pf-t--global--spacer--sm);
-  --#{$form}__actions--MarginTop: calc(var(--#{$form}__actions--child--MarginTop) * -1);
-  --#{$form}__actions--MarginRight: calc(var(--#{$form}__actions--child--MarginRight) * -1);
-  --#{$form}__actions--MarginBottom: calc(var(--#{$form}__actions--child--MarginBottom) * -1);
-  --#{$form}__actions--MarginLeft: calc(var(--#{$form}__actions--child--MarginLeft) * -1);
+  --#{$form}__actions--child--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$form}__actions--child--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$form}__actions--child--MarginBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$form}__actions--child--MarginInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$form}__actions--MarginBlockStart: calc(var(--#{$form}__actions--child--MarginBlockStart) * -1);
+  --#{$form}__actions--MarginInlineEnd: calc(var(--#{$form}__actions--child--MarginInlineEnd) * -1);
+  --#{$form}__actions--MarginBlockEnd: calc(var(--#{$form}__actions--child--MarginBlockEnd) * -1);
+  --#{$form}__actions--MarginInlineStart: calc(var(--#{$form}__actions--child--MarginInlineStart) * -1);
 
   // Helper text
-  --#{$form}__helper-text--MarginTop--base: var(--pf-t--global--spacer--xs);
-  --#{$form}__helper-text--MarginTop: var(--#{$form}__helper-text--MarginTop--base);
+  --#{$form}__helper-text--MarginBlockStart--base: var(--pf-t--global--spacer--xs);
+  --#{$form}__helper-text--MarginBlockStart: var(--#{$form}__helper-text--MarginBlockStart--base);
 
   // Section
-  --#{$form}__section--MarginTop: var(--pf-t--global--spacer--xl);
+  --#{$form}__section--MarginBlockStart: var(--pf-t--global--spacer--xl);
   --#{$form}__section--Gap: var(--pf-t--global--spacer--md);
 
   // Section title
   --#{$form}__section-title--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$form}__section-title--FontWeight: var(--pf-t--global--font--weight--heading);
-  --#{$form}__section-title--MarginBottom: calc(var(--pf-t--global--spacer--sm) * -1);
+  --#{$form}__section-title--MarginBlockEnd: calc(var(--pf-t--global--spacer--sm) * -1);
 
   // Field groups
   --#{$form}__field-group--border-width-base: var(--pf-t--global--border--width--divider--default);
-  --#{$form}__field-group--BorderTopWidth: var(--#{$form}__field-group--border-width-base);
-  --#{$form}__field-group--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$form}__field-group--BorderBottomWidth: var(--#{$form}__field-group--border-width-base);
-  --#{$form}__field-group--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$form}__field-group--field-group--MarginTop: calc(var(--#{$form}--GridGap) * -1);
+  --#{$form}__field-group--BorderBlockStartWidth: var(--#{$form}__field-group--border-width-base);
+  --#{$form}__field-group--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$form}__field-group--BorderBlockEndWidth: var(--#{$form}__field-group--border-width-base);
+  --#{$form}__field-group--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$form}__field-group--field-group--MarginBlockStart: calc(var(--#{$form}--GridGap) * -1);
   --#{$form}__field-group--GridTemplateColumns--toggle: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$form}__field-group-toggle-icon--MinWidth) + var(--pf-t--global--spacer--xs)); // based off of the expected width of the group toggle, for use to define a column when the toggle is not present
-  --#{$form}__field-group-toggle--PaddingTop: var(--#{$form}__field-group-header--PaddingTop);
-  --#{$form}__field-group-toggle--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$form}__field-group__field-group__field-group-toggle--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$form}__field-group-toggle--PaddingBlockStart: var(--#{$form}__field-group-header--PaddingBlockStart);
+  --#{$form}__field-group-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$form}__field-group__field-group__field-group-toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$form}__field-group-header-toggle--BorderWidth--base: var(--pf-t--global--border--width--divider--default);
-  --#{$form}__field-group__field-group--field-group__field-group-toggle--after--BorderTopWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
-  --#{$form}__field-group-toggle-button--MarginTop: calc(var(--#{$button}--m-plain--PaddingTop) * -1);
-  --#{$form}__field-group-toggle-button--MarginBottom: calc(var(--#{$button}--m-plain--PaddingBottom) * -1);
+  --#{$form}__field-group__field-group--field-group__field-group-toggle--after--BorderBlockStartWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
+  --#{$form}__field-group-toggle-button--MarginBlockStart: calc(var(--#{$button}--m-plain--PaddingBlockStart) * -1);
+  --#{$form}__field-group-toggle-button--MarginBlockEnd: calc(var(--#{$button}--m-plain--PaddingBlockEnd) * -1);
   --#{$form}__field-group-toggle-icon--Transition: var(--pf-t--global--transition);
   --#{$form}__field-group-toggle-icon--MinWidth: var(--pf-t--global--font--size--body--default);
   --#{$form}__field-group-toggle-icon--Rotate: 0;
   --#{$form}__field-group--m-expanded__toggle-icon--Rotate: 90deg;
-  --#{$form}__field-group-header--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$form}__field-group-header--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$form}__field-group-header--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$form}__field-group-header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$form}__field-group-header--GridColumn: 1 / 3;
-  --#{$form}__field-group__field-group__field-group-header--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$form}__field-group__field-group__field-group-header--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$form}__field-group__field-group__field-group-header--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$form}__field-group__field-group__field-group-header--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$form}__field-group-toggle--field-group-header--GridColumn: 2 / 3;
-  --#{$form}__field-group__field-group--field-group__field-group-header--after--BorderTopWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
-  --#{$form}__field-group-header-description--MarginTop: var(--pf-t--global--spacer--xs);
+  --#{$form}__field-group__field-group--field-group__field-group-header--after--BorderBlockStartWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
+  --#{$form}__field-group-header-description--MarginBlockStart: var(--pf-t--global--spacer--xs);
   --#{$form}__field-group-header-description--Color: var(--pf-t--global--text--color--subtle);
-  --#{$form}__field-group-header-actions--MarginLeft: var(--pf-t--global--spacer--sm);
-  --#{$form}__field-group-body--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$form}__field-group-body--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$form}__field-group-header-actions--MarginInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$form}__field-group-body--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$form}__field-group-body--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$form}__field-group-body--Gap: var(--#{$form}--GridGap);
   --#{$form}__field-group-body--GridColumn: 2 / 3;
   --#{$form}__field-group__field-group__field-group-body--GridColumn: 1 / 3;
   --#{$form}__field-group__field-group__field-group-toggle--field-group-body--GridColumn: 2 / 3;
-  --#{$form}__field-group-body__field-group--last-child--MarginBottom: calc(var(--#{$form}__field-group-body--PaddingBottom) * -1);
+  --#{$form}__field-group-body__field-group--last-child--MarginBlockEnd: calc(var(--#{$form}__field-group-body--PaddingBlockEnd) * -1);
 }
 
 .#{$form} {
@@ -168,7 +168,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
     }
 
     @include pf-v6-c-form--m-horizontal {
-      --#{$form}__group-label--PaddingBottom: 0;
+      --#{$form}__group-label--PaddingBlockEnd: 0;
 
       .#{$form}__group {
         display: grid;
@@ -177,11 +177,11 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
       }
 
       .#{$form}__group-label {
-        padding-block-start: var(--#{$form}--m-horizontal__group-label--md--PaddingTop);
+        padding-block-start: var(--#{$form}--m-horizontal__group-label--md--PaddingBlockStart);
 
         // stylelint-disable-next-line
         &.pf-m-no-padding-top {
-          --#{$form}--m-horizontal__group-label--md--PaddingTop: var(--#{$form}--m-horizontal__group-label--m-no-padding--md--PaddingTop);
+          --#{$form}--m-horizontal__group-label--md--PaddingBlockStart: var(--#{$form}--m-horizontal__group-label--m-no-padding--md--PaddingBlockStart);
 
           transform: translateY(var(--#{$form}--m-horizontal__group-label--m-no-padding--md--TranslateY));
         }
@@ -205,7 +205,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   min-width: 0;
 
   &.pf-m-action {
-    margin-block-start: var(--#{$form}__group--m-action--MarginTop);
+    margin-block-start: var(--#{$form}__group--m-action--MarginBlockStart);
     overflow: hidden; // keeps the negative bottom margin bottom on .#{$form}__actions from triggering overflow
   }
 }
@@ -216,18 +216,18 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 
   & + .#{$form}__group:not(.pf-m-action),
   &:not(:first-child) {
-    margin-block-start: var(--#{$form}__section--MarginTop);
+    margin-block-start: var(--#{$form}__section--MarginBlockStart);
   }
 }
 
 .#{$form}__section-title {
-  margin-block-end: var(--#{$form}__section-title--MarginBottom);
+  margin-block-end: var(--#{$form}__section-title--MarginBlockEnd);
   font-size: var(--#{$form}__section-title--FontSize);
   font-weight: var(--#{$form}__section-title--FontWeight);
 }
 
 .#{$form}__group-label {
-  --#{$form}__helper-text--MarginTop: 0;
+  --#{$form}__helper-text--MarginBlockStart: 0;
 
   &.pf-m-info {
     display: flex;
@@ -240,7 +240,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 }
 
 .#{$form}__group-label-info {
-  margin-inline-start: var(--#{$form}__group-label-info--MarginLeft);
+  margin-inline-start: var(--#{$form}__group-label-info--MarginInlineStart);
   font-size: var(--#{$form}__group-label-info--FontSize);
 }
 
@@ -270,7 +270,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 }
 
 .#{$form}__label-required {
-  margin-inline-start: var(--#{$form}__label-required--MarginLeft);
+  margin-inline-start: var(--#{$form}__label-required--MarginInlineStart);
   font-size: var(--#{$form}__label-required--FontSize);
   color: var(--#{$form}__label-required--Color);
 }
@@ -289,30 +289,30 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
     flex-flow: row wrap;
 
     > * {
-      margin-inline-end: var(--#{$form}__group-control--m-inline--child--MarginRight);
+      margin-inline-end: var(--#{$form}__group-control--m-inline--child--MarginInlineEnd);
     }
 
     > :last-child {
-      --#{$form}__group-control--m-inline--child--MarginRight: 0;
+      --#{$form}__group-control--m-inline--child--MarginInlineEnd: 0;
     }
   }
 
   &.pf-m-stack {
-    --#{$form}__helper-text--MarginTop: var(--#{$form}__group-control--m-stack__helper-text--MarginTop);
+    --#{$form}__helper-text--MarginBlockStart: var(--#{$form}__group-control--m-stack__helper-text--MarginBlockStart);
 
     display: grid;
     gap: var(--#{$form}__group-control--m-stack--Gap);
   }
 
   .#{$form}__helper-text:first-child {
-    --#{$form}__helper-text--MarginTop: 0;
+    --#{$form}__helper-text--MarginBlockStart: 0;
 
-    margin-block-end: var(--#{$form}__group-control__helper-text--MarginBottom);
+    margin-block-end: var(--#{$form}__group-control__helper-text--MarginBlockEnd);
   }
 }
 
 .#{$form}__helper-text {
-  margin-block-start: var(--#{$form}__helper-text--MarginTop);
+  margin-block-start: var(--#{$form}__helper-text--MarginBlockStart);
 
   &.pf-m-inactive {
     display: none;
@@ -332,47 +332,47 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 .#{$form}__actions {
   display: flex;
   flex-wrap: wrap;
-  margin-block-start: var(--#{$form}__actions--MarginTop);
-  margin-block-end: var(--#{$form}__actions--MarginBottom);
-  margin-inline-start: var(--#{$form}__actions--MarginLeft);
-  margin-inline-end: var(--#{$form}__actions--MarginRight);
+  margin-block-start: var(--#{$form}__actions--MarginBlockStart);
+  margin-block-end: var(--#{$form}__actions--MarginBlockEnd);
+  margin-inline-start: var(--#{$form}__actions--MarginInlineStart);
+  margin-inline-end: var(--#{$form}__actions--MarginInlineEnd);
 
   > * {
-    margin-block-start: var(--#{$form}__actions--child--MarginTop);
-    margin-block-end: var(--#{$form}__actions--child--MarginBottom);
-    margin-inline-start: var(--#{$form}__actions--child--MarginLeft);
-    margin-inline-end: var(--#{$form}__actions--child--MarginRight);
+    margin-block-start: var(--#{$form}__actions--child--MarginBlockStart);
+    margin-block-end: var(--#{$form}__actions--child--MarginBlockEnd);
+    margin-inline-start: var(--#{$form}__actions--child--MarginInlineStart);
+    margin-inline-end: var(--#{$form}__actions--child--MarginInlineEnd);
   }
 }
 
 .#{$form}__field-group {
-  --#{$form}__field-group--BorderTopWidth: var(--#{$form}__field-group--border-width-base);
+  --#{$form}__field-group--BorderBlockStartWidth: var(--#{$form}__field-group--border-width-base);
 
   display: grid;
   grid-template-columns: minmax(var(--#{$form}__field-group--GridTemplateColumns--toggle), max-content) 1fr;
-  border-block-start: var(--#{$form}__field-group--BorderTopWidth) solid var(--#{$form}__field-group--BorderTopColor);
-  border-block-end: var(--#{$form}__field-group--BorderBottomWidth) solid var(--#{$form}__field-group--BorderBottomColor);
+  border-block-start: var(--#{$form}__field-group--BorderBlockStartWidth) solid var(--#{$form}__field-group--BorderBlockStartColor);
+  border-block-end: var(--#{$form}__field-group--BorderBlockEndWidth) solid var(--#{$form}__field-group--BorderBlockEndColor);
 
   &:last-child {
-    --#{$form}__field-group--BorderBottomWidth: 0;
+    --#{$form}__field-group--BorderBlockEndWidth: 0;
   }
 
   & + &,
   &:first-child {
-    --#{$form}__field-group--BorderTopWidth: 0;
+    --#{$form}__field-group--BorderBlockStartWidth: 0;
   }
 
   & + & {
-    margin-block-start: var(--#{$form}__field-group--field-group--MarginTop);
+    margin-block-start: var(--#{$form}__field-group--field-group--MarginBlockStart);
   }
 
   // nested
   & & {
     --#{$form}__field-group-body--GridColumn: var(--#{$form}__field-group__field-group__field-group-body--GridColumn);
-    --#{$form}__field-group-toggle--PaddingTop: var(--#{$form}__field-group__field-group__field-group-toggle--PaddingTop);
-    --#{$form}__field-group-header--PaddingTop: var(--#{$form}__field-group__field-group__field-group-header--PaddingTop);
-    --#{$form}__field-group-header--PaddingBottom: var(--#{$form}__field-group__field-group__field-group-header--PaddingBottom);
-    --#{$form}__field-group-body--PaddingTop: 0;
+    --#{$form}__field-group-toggle--PaddingBlockStart: var(--#{$form}__field-group__field-group__field-group-toggle--PaddingBlockStart);
+    --#{$form}__field-group-header--PaddingBlockStart: var(--#{$form}__field-group__field-group__field-group-header--PaddingBlockStart);
+    --#{$form}__field-group-header--PaddingBlockEnd: var(--#{$form}__field-group__field-group__field-group-header--PaddingBlockEnd);
+    --#{$form}__field-group-body--PaddingBlockStart: 0;
 
     .#{$form}__field-group-toggle ~ .#{$form}__field-group-body {
       --#{$form}__field-group-body--GridColumn: var(--#{$form}__field-group__field-group__field-group-toggle--field-group-body--GridColumn);
@@ -389,8 +389,8 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 .#{$form}__field-group-toggle {
   grid-row: 1 / 2;
   grid-column: 1 / 2;
-  padding-block-start: var(--#{$form}__field-group-toggle--PaddingTop);
-  padding-inline-end: var(--#{$form}__field-group-toggle--PaddingRight);
+  padding-block-start: var(--#{$form}__field-group-toggle--PaddingBlockStart);
+  padding-inline-end: var(--#{$form}__field-group-toggle--PaddingInlineEnd);
 
   + .#{$form}__field-group-header {
     --#{$form}__field-group-header--GridColumn: var(--#{$form}__field-group-toggle--field-group-header--GridColumn);
@@ -398,8 +398,8 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 }
 
 .#{$form}__field-group-toggle-button {
-  margin-block-start: var(--#{$form}__field-group-toggle-button--MarginTop);
-  margin-block-end: var(--#{$form}__field-group-toggle-button--MarginBottom);
+  margin-block-start: var(--#{$form}__field-group-toggle-button--MarginBlockStart);
+  margin-block-end: var(--#{$form}__field-group-toggle-button--MarginBlockEnd);
 }
 
 .#{$form}__field-group-toggle-icon {
@@ -417,8 +417,8 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   grid-row: 1 / 2;
   grid-column: var(--#{$form}__field-group-header--GridColumn);
   align-items: flex-start;
-  padding-block-start: var(--#{$form}__field-group-header--PaddingTop);
-  padding-block-end: var(--#{$form}__field-group-header--PaddingBottom);
+  padding-block-start: var(--#{$form}__field-group-header--PaddingBlockStart);
+  padding-block-end: var(--#{$form}__field-group-header--PaddingBlockEnd);
 }
 
 .#{$form}__field-group-header-main {
@@ -436,12 +436,12 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 }
 
 .#{$form}__field-group-header-description {
-  margin-block-start: var(--#{$form}__field-group-header-description--MarginTop);
+  margin-block-start: var(--#{$form}__field-group-header-description--MarginBlockStart);
   color: var(--#{$form}__field-group-header-description--Color);
 }
 
 .#{$form}__field-group-header-actions {
-  margin-inline-start: var(--#{$form}__field-group-header-actions--MarginLeft);
+  margin-inline-start: var(--#{$form}__field-group-header-actions--MarginInlineStart);
   white-space: nowrap;
 }
 
@@ -449,17 +449,17 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   display: grid;
   grid-column: var(--#{$form}__field-group-body--GridColumn);
   gap: var(--#{$form}__field-group-body--Gap);
-  padding-block-start: var(--#{$form}__field-group-body--PaddingTop);
-  padding-block-end: var(--#{$form}__field-group-body--PaddingBottom);
+  padding-block-start: var(--#{$form}__field-group-body--PaddingBlockStart);
+  padding-block-end: var(--#{$form}__field-group-body--PaddingBlockEnd);
 
   > .#{$form}__field-group {
     &:first-child {
-      --#{$form}__field-group-toggle--PaddingTop: 0;
-      --#{$form}__field-group-header--PaddingTop: 0;
+      --#{$form}__field-group-toggle--PaddingBlockStart: 0;
+      --#{$form}__field-group-header--PaddingBlockStart: 0;
     }
 
     &:last-child {
-      margin-block-end: var(--#{$form}__field-group-body__field-group--last-child--MarginBottom);
+      margin-block-end: var(--#{$form}__field-group-body__field-group--last-child--MarginBlockEnd);
     }
   }
 }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -19,10 +19,10 @@
 
   // padding
   --#{$form-control}--inset--base: var(--pf-t--global--spacer--md);
-  --#{$form-control}--PaddingTop: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$form-control}--PaddingBottom: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$form-control}--PaddingRight: var(--#{$form-control}--inset--base);
-  --#{$form-control}--PaddingLeft: var(--#{$form-control}--inset--base);
+  --#{$form-control}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$form-control}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--inset--base);
+  --#{$form-control}--PaddingInlineStart: var(--#{$form-control}--inset--base);
 
   // hover
   --#{$form-control}--hover--after--BorderWidth: var(--pf-t--global--border--width--control--hover);
@@ -60,42 +60,42 @@
   // success
   --#{$form-control}--m-success--after--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--m-success--after--BorderColor: var(--pf-t--global--border--color--status--success--default);
-  --#{$form-control}--m-success--PaddingRight: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
+  --#{$form-control}--m-success--PaddingInlineEnd: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
 
   // warning
   --#{$form-control}--m-warning--after--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--m-warning--after--BorderColor: var(--pf-t--global--border--color--status--warning--default);
-  --#{$form-control}--m-warning--PaddingRight: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
+  --#{$form-control}--m-warning--PaddingInlineEnd: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
 
   // error
   --#{$form-control}--m-error--after--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--m-error--after--BorderColor: var(--pf-t--global--border--color--status--danger--default);
-  --#{$form-control}--m-error--PaddingRight: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
+  --#{$form-control}--m-error--PaddingInlineEnd: calc(var(--pf-t--global--spacer--xl) + var(--#{$form-control}--ColumnGap));
   --#{$form-control}--m-error--icon--width: var(--#{$form-control}--FontSize);
 
   // custom icon
-  --#{$form-control}--m-icon--PaddingRight: calc(var(--#{$form-control}--inset--base) + var(--#{$form-control}--m-icon--icon--width) + var(--#{$form-control}--m-icon--icon--spacer));
+  --#{$form-control}--m-icon--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) + var(--#{$form-control}--m-icon--icon--width) + var(--#{$form-control}--m-icon--icon--spacer));
   --#{$form-control}--m-icon--icon--width: var(--#{$form-control}--FontSize);
   --#{$form-control}--m-icon--icon--spacer: var(--pf-t--global--spacer--sm);
-  --#{$form-control}--m-icon--icon--PaddingRight: calc(var(--#{$form-control}--inset--base) + var(--#{$form-control}--m-error--icon--width) + var(--#{$form-control}--m-icon--icon--spacer) + var(--#{$form-control}--m-icon--icon--width) + var(--#{$form-control}--m-icon--icon--spacer));
-  --#{$form-control}__select--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$form-control}__select--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$form-control}--m-icon--icon--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) + var(--#{$form-control}--m-error--icon--width) + var(--#{$form-control}--m-icon--icon--spacer) + var(--#{$form-control}--m-icon--icon--width) + var(--#{$form-control}--m-icon--icon--spacer));
+  --#{$form-control}__select--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$form-control}__select--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // Select success
-  --#{$form-control}__select--m-success--m-status--PaddingRight: var(--pf-t--global--spacer--3xl);
+  --#{$form-control}__select--m-success--m-status--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
 
   // Select warning
-  --#{$form-control}__select--m-warning--m-status--PaddingRight: var(--pf-t--global--spacer--3xl);
+  --#{$form-control}__select--m-warning--m-status--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
 
   // Select invalid
-  --#{$form-control}__select--m-error--m-status--PaddingRight: var(--pf-t--global--spacer--3xl);
+  --#{$form-control}__select--m-error--m-status--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
 
   // Textarea
   --#{$form-control}--textarea--Width: var(--#{$form-control}--Width);
   --#{$form-control}--textarea--Height: auto;
 
   // Form control icon
-  --#{$form-control}__icon--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$form-control}__icon--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}--m-success__icon--m-status--Color: var(--pf-t--global--icon--color--status--success--default);
@@ -104,13 +104,13 @@
 
   // Form control utilities
   --#{$form-control}__utilities--Gap: var(--pf-t--global--spacer--sm);
-  --#{$form-control}__utilities--PaddingTop: var(--#{$form-control}--inset--base);
-  --#{$form-control}__utilities--PaddingRight: var(--#{$form-control}--inset--base);
+  --#{$form-control}__utilities--PaddingBlockStart: var(--#{$form-control}--inset--base);
+  --#{$form-control}__utilities--PaddingInlineEnd: var(--#{$form-control}--inset--base);
 
   // Form control select toggle icon
-  --#{$form-control}__toggle-icon--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$form-control}__toggle-icon--PaddingRight: var(--#{$form-control}--inset--base);
-  --#{$form-control}__toggle-icon--PaddingLeft: var(--#{$form-control}--inset--base);
+  --#{$form-control}__toggle-icon--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$form-control}__toggle-icon--PaddingInlineEnd: var(--#{$form-control}--inset--base);
+  --#{$form-control}__toggle-icon--PaddingInlineStart: var(--#{$form-control}--inset--base);
   --#{$form-control}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}--m-disabled__toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 }
@@ -151,10 +151,10 @@
   > :is(input, select, textarea) {
     grid-row: 1 / 2;
     grid-column: 1 / -1;
-    padding-block-start: var(--#{$form-control}--PaddingTop);
-    padding-block-end: var(--#{$form-control}--PaddingBottom);
-    padding-inline-start: var(--#{$form-control}--PaddingLeft);
-    padding-inline-end: var(--#{$form-control}--PaddingRight);
+    padding-block-start: var(--#{$form-control}--PaddingBlockStart);
+    padding-block-end: var(--#{$form-control}--PaddingBlockEnd);
+    padding-inline-start: var(--#{$form-control}--PaddingInlineStart);
+    padding-inline-end: var(--#{$form-control}--PaddingInlineEnd);
     color: var(--#{$form-control}--Color);
     background-color: transparent;
     border: none;
@@ -224,54 +224,54 @@
   }
 
   &.pf-m-error {
-    --#{$form-control}--PaddingRight: var(--#{$form-control}--m-error--PaddingRight);
+    --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-error--PaddingInlineEnd);
     --#{$form-control}--after--BorderColor: var(--#{$form-control}--m-error--after--BorderColor);
     --#{$form-control}__icon--m-status--Color: var(--#{$form-control}--m-error__icon--m-status--Color);
-    --#{$form-control}__select--PaddingRight: var(--#{$form-control}__select--m-error--m-status--PaddingRight);
+    --#{$form-control}__select--PaddingInlineEnd: var(--#{$form-control}__select--m-error--m-status--PaddingInlineEnd);
     --#{$form-control}--after--BorderWidth: var(--#{$form-control}--m-error--after--BorderWidth);
 
     &.pf-m-icon {
-      --#{$form-control}--PaddingRight: var(--#{$form-control}--m-icon--icon--PaddingRight);
+      --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-icon--icon--PaddingInlineEnd);
     }
   }
 
   &.pf-m-success {
-    --#{$form-control}--PaddingRight: var(--#{$form-control}--m-success--PaddingRight);
+    --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-success--PaddingInlineEnd);
     --#{$form-control}--after--BorderColor: var(--#{$form-control}--m-success--after--BorderColor);
     --#{$form-control}__icon--m-status--Color: var(--#{$form-control}--m-success__icon--m-status--Color);
-    --#{$form-control}__select--PaddingRight: var(--#{$form-control}__select--m-success--m-status--PaddingRight);
+    --#{$form-control}__select--PaddingInlineEnd: var(--#{$form-control}__select--m-success--m-status--PaddingInlineEnd);
     --#{$form-control}--after--BorderWidth: var(--#{$form-control}--m-success--after--BorderWidth);
 
     &.pf-m-icon {
-      --#{$form-control}--PaddingRight: var(--#{$form-control}--m-icon--icon--PaddingRight);
+      --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-icon--icon--PaddingInlineEnd);
     }
   }
 
   &.pf-m-warning {
-    --#{$form-control}--PaddingRight: var(--#{$form-control}--m-warning--PaddingRight);
+    --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-warning--PaddingInlineEnd);
     --#{$form-control}--after--BorderColor: var(--#{$form-control}--m-warning--after--BorderColor);
     --#{$form-control}__icon--m-status--Color: var(--#{$form-control}--m-warning__icon--m-status--Color);
-    --#{$form-control}__select--PaddingRight: var(--#{$form-control}__select--m-warning--m-status--PaddingRight);
+    --#{$form-control}__select--PaddingInlineEnd: var(--#{$form-control}__select--m-warning--m-status--PaddingInlineEnd);
     --#{$form-control}--after--BorderWidth: var(--#{$form-control}--m-warning--after--BorderWidth);
 
     &.pf-m-icon {
-      --#{$form-control}--PaddingRight: var(--#{$form-control}--m-icon--icon--PaddingRight);
+      --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-icon--icon--PaddingInlineEnd);
     }
   }
 
   &.pf-m-icon {
-    --#{$form-control}--PaddingRight: var(--#{$form-control}--m-icon--PaddingRight);
+    --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-icon--PaddingInlineEnd);
   }
 
   > select {
-    --#{$form-control}--PaddingRight: var(--#{$form-control}__select--PaddingRight);
-    --#{$form-control}--PaddingLeft: var(--#{$form-control}__select--PaddingLeft);
+    --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}__select--PaddingInlineEnd);
+    --#{$form-control}--PaddingInlineStart: var(--#{$form-control}__select--PaddingInlineStart);
 
     // Firefox's select text has additional padding
     // stylelint-disable-next-line
     @-moz-document url-prefix() {
-      --#{$form-control}--PaddingRight: calc(var(--#{$form-control}__select--PaddingRight) - 1px);
-      --#{$form-control}--PaddingLeft: calc(var(--#{$form-control}__select--PaddingLeft) - 4px);
+      --#{$form-control}--PaddingInlineEnd: calc(var(--#{$form-control}__select--PaddingInlineEnd) - 1px);
+      --#{$form-control}--PaddingInlineStart: calc(var(--#{$form-control}__select--PaddingInlineStart) - 4px);
     }
 
     // We need this property for certain Linux distros/non-Mac OS where dark theme styles aren't applied properly.
@@ -322,7 +322,7 @@
 }
 
 .#{$form-control}__icon {
-  padding-block-start: var(--#{$form-control}__icon--PaddingTop);
+  padding-block-start: var(--#{$form-control}__icon--PaddingBlockStart);
   color: var(--#{$form-control}__icon--Color);
 
   &.pf-m-status {
@@ -333,9 +333,9 @@
 .#{$form-control}__toggle-icon {
   grid-row: 1 / 2;
   grid-column: 3;
-  padding-block-start: var(--#{$form-control}__toggle-icon--PaddingTop);
-  padding-inline-start: var(--#{$form-control}__toggle-icon--PaddingLeft);
-  padding-inline-end: var(--#{$form-control}__toggle-icon--PaddingRight);
+  padding-block-start: var(--#{$form-control}__toggle-icon--PaddingBlockStart);
+  padding-inline-start: var(--#{$form-control}__toggle-icon--PaddingInlineStart);
+  padding-inline-end: var(--#{$form-control}__toggle-icon--PaddingInlineEnd);
   color: var(--#{$form-control}__toggle-icon--Color);
   pointer-events: none;
 }
@@ -346,10 +346,10 @@
   grid-row: 1 / 2;
   grid-column: 2;
   gap: var(--#{$form-control}__utilities--Gap);
-  padding-inline-end: var(--#{$form-control}__utilities--PaddingRight);
+  padding-inline-end: var(--#{$form-control}__utilities--PaddingInlineEnd);
   pointer-events: none;
 }
 
 select ~ .#{$form-control}__utilities {
-  --#{$form-control}__utilities--PaddingRight: 0;
+  --#{$form-control}__utilities--PaddingInlineEnd: 0;
 }

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -27,7 +27,7 @@
   --#{$helper-text}--m-dynamic--m-error__item-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
 
   // icon
-  --#{$helper-text}__item-icon--MarginRight: var(--pf-t--global--spacer--xs);
+  --#{$helper-text}__item-icon--MarginInlineEnd: var(--pf-t--global--spacer--xs);
 }
 .#{$helper-text} {
   // text
@@ -78,7 +78,7 @@
 }
 
 .#{$helper-text}__item-icon {
-  margin-inline-end: var(--#{$helper-text}__item-icon--MarginRight);
+  margin-inline-end: var(--#{$helper-text}__item-icon--MarginInlineEnd);
   color: var(--#{$helper-text}__item-icon--Color);
 }
 

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -2,10 +2,10 @@
 
 :where(:root, .#{$hint}) {
   --#{$hint}--GridRowGap: var(--pf-t--global--spacer--sm);
-  --#{$hint}--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$hint}--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$hint}--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$hint}--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$hint}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$hint}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$hint}--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$hint}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$hint}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$hint}--BorderColor: var(--pf-t--global--border--color--status--info--default);
   --#{$hint}--BorderWidth: var(--pf-t--global--border--width--box--status--default);
@@ -22,22 +22,22 @@
   --#{$hint}__body--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Hint Footer
-  --#{$hint}__footer--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$hint}__footer--child--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$hint}__footer--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$hint}__footer--child--MarginInlineEnd: var(--pf-t--global--spacer--md);
 
   // Hint Actions
-  --#{$hint}__actions--MarginLeft: var(--pf-t--global--spacer--2xl);
-  --#{$hint}__actions--c-dropdown--MarginTop: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$hint}__actions--MarginInlineStart: var(--pf-t--global--spacer--2xl);
+  --#{$hint}__actions--c-dropdown--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
 }
 
 .#{$hint} {
   display: grid;
   grid-template-columns: 1fr auto;
   grid-row-gap: var(--#{$hint}--GridRowGap);
-  padding-block-start: var(--#{$hint}--PaddingTop);
-  padding-block-end: var(--#{$hint}--PaddingBottom);
-  padding-inline-start: var(--#{$hint}--PaddingLeft);
-  padding-inline-end: var(--#{$hint}--PaddingRight);
+  padding-block-start: var(--#{$hint}--PaddingBlockStart);
+  padding-block-end: var(--#{$hint}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$hint}--PaddingInlineStart);
+  padding-inline-end: var(--#{$hint}--PaddingInlineEnd);
   color: var(--#{$hint}--Color);
   background-color: var(--#{$hint}--BackgroundColor);
   border: var(--#{$hint}--BorderWidth) solid var(--#{$hint}--BorderColor);
@@ -55,12 +55,12 @@
   grid-row: 1;
   grid-column: 2;
   grid-auto-flow: column;
-  margin-inline-start: var(--#{$hint}__actions--MarginLeft);
+  margin-inline-start: var(--#{$hint}__actions--MarginInlineStart);
   text-align: end;
 
   // Only applies to the plain dropdown
   .#{$dropdown} .#{$dropdown}__toggle.pf-m-plain {
-    margin-block-start: var(--#{$hint}__actions--c-dropdown--MarginTop);
+    margin-block-start: var(--#{$hint}__actions--c-dropdown--MarginBlockStart);
   }
 
   + .#{$hint}__body {
@@ -83,9 +83,9 @@
 
 .#{$hint}__footer {
   grid-column: 1 / -1;
-  margin-block-start: var(--#{$hint}__footer--MarginTop);
+  margin-block-start: var(--#{$hint}__footer--MarginBlockStart);
 
   > :not(:last-child) {
-    margin-inline-end: var(--#{$hint}__footer--child--MarginRight);
+    margin-inline-end: var(--#{$hint}__footer--child--MarginInlineEnd);
   }
 }

--- a/src/patternfly/components/InlineEdit/inline-edit.scss
+++ b/src/patternfly/components/InlineEdit/inline-edit.scss
@@ -2,17 +2,17 @@
 
 :where(:root,  .#{$inline-edit}) {
   // Group
-  --#{$inline-edit}__group--item--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$inline-edit}__group--item--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Valid action
   --#{$inline-edit}__action--c-button--m-valid--m-plain--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$inline-edit}__action--c-button--m-valid--m-plain--hover--Color: var(--pf-t--global--icon--color--brand--hover);
 
   // Icon button
-  --#{$inline-edit}__action--m-icon-group--item--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$inline-edit}__action--m-icon-group--item--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Footer group
-  --#{$inline-edit}__group--m-footer--MarginTop: var(--pf-t--global--spacer--xl);
+  --#{$inline-edit}__group--m-footer--MarginBlockStart: var(--pf-t--global--spacer--xl);
 
   // Label
   --#{$inline-edit}__label--m-bold--FontWeight: var(--pf-t--global--font--weight--body--bold);
@@ -24,27 +24,27 @@
   align-items: baseline;
 
   > * {
-    margin-inline-end: var(--#{$inline-edit}__group--item--MarginRight);
+    margin-inline-end: var(--#{$inline-edit}__group--item--MarginInlineEnd);
   }
 
   &.pf-m-icon-group {
-    --#{$inline-edit}__group--item--MarginRight: var(--#{$inline-edit}__action--m-icon-group--item--MarginRight);
+    --#{$inline-edit}__group--item--MarginInlineEnd: var(--#{$inline-edit}__action--m-icon-group--item--MarginInlineEnd);
   }
 
   // Footer
   &.pf-m-footer {
-    margin-block-start: var(--#{$inline-edit}__group--m-footer--MarginTop);
+    margin-block-start: var(--#{$inline-edit}__group--m-footer--MarginBlockStart);
   }
 
   // Column
   &.pf-m-column {
-    --#{$inline-edit}__group--item--MarginRight: 0;
+    --#{$inline-edit}__group--item--MarginInlineEnd: 0;
 
     flex-direction: column;
   }
 
   > :last-child {
-    --#{$inline-edit}__group--item--MarginRight: 0;
+    --#{$inline-edit}__group--item--MarginInlineEnd: 0;
   }
 }
 
@@ -102,8 +102,8 @@
 
 // offset button by top padding
 .#{$inline-edit}__label + .#{$inline-edit}__action.pf-m-enable > .#{$button} {
-  margin-block-start: calc(var(--#{$button}--PaddingTop) * -1);
-  margin-block-end: calc(var(--#{$button}--PaddingBottom) * -1);
+  margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
+  margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
 }
 
 .#{$inline-edit}__label.pf-m-bold {

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -11,15 +11,15 @@
   --#{$input-group}__item--AlignItems: start;
 
   // Input group item, box variant
-  --#{$input-group}__item--m-box--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$input-group}__item--m-box--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$input-group}__item--m-box--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$input-group}__item--m-box--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$input-group}__item--m-box--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$input-group}__item--m-box--BorderWidth: var(--#{$input-group}__item--BorderWidth--base);
   --#{$input-group}__item--m-box--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$input-group}__item--m-box--BorderTopColor: var(--#{$input-group}__item--BorderColor--base);
-  --#{$input-group}__item--m-box--BorderRightColor: var(--#{$input-group}__item--BorderColor--base);
-  --#{$input-group}__item--m-box--BorderBottomColor: var(--#{$input-group}__item--BorderColor--base);
-  --#{$input-group}__item--m-box--BorderLeftColor: var(--#{$input-group}__item--BorderColor--base);
+  --#{$input-group}__item--m-box--BorderBlockStartColor: var(--#{$input-group}__item--BorderColor--base);
+  --#{$input-group}__item--m-box--BorderInlineEndColor: var(--#{$input-group}__item--BorderColor--base);
+  --#{$input-group}__item--m-box--BorderBlockEndColor: var(--#{$input-group}__item--BorderColor--base);
+  --#{$input-group}__item--m-box--BorderInlineStartColor: var(--#{$input-group}__item--BorderColor--base);
 
   // Input group item, plain variant
   --#{$input-group}__item--m-plain--BackgroundColor: transparent;
@@ -46,21 +46,21 @@
   min-width: var(--#{$input-group}__item--MinWidth, revert);
   max-width: var(--#{$input-group}__item--MaxWidth, revert);
   background-color: var(--#{$input-group}__item--BackgroundColor);
-  border-block-start-color: var(--#{$input-group}__item--m-box--BorderTopColor);
-  border-block-end-color: var(--#{$input-group}__item--m-box--BorderBottomColor);
-  border-inline-start-color: var(--#{$input-group}__item--m-box--BorderLeftColor);
-  border-inline-end-color: var(--#{$input-group}__item--m-box--BorderRightColor);
+  border-block-start-color: var(--#{$input-group}__item--m-box--BorderBlockStartColor);
+  border-block-end-color: var(--#{$input-group}__item--m-box--BorderBlockEndColor);
+  border-inline-start-color: var(--#{$input-group}__item--m-box--BorderInlineStartColor);
+  border-inline-end-color: var(--#{$input-group}__item--m-box--BorderInlineEndColor);
 
   &.pf-m-box {
     --#{$input-group}__item--BackgroundColor: var(--#{$input-group}__item--m-box--BackgroundColor);
 
-    padding-inline-start: var(--#{$input-group}__item--m-box--PaddingLeft);
-    padding-inline-end: var(--#{$input-group}__item--m-box--PaddingRight);
+    padding-inline-start: var(--#{$input-group}__item--m-box--PaddingInlineStart);
+    padding-inline-end: var(--#{$input-group}__item--m-box--PaddingInlineEnd);
     border: var(--#{$input-group}__item--m-box--BorderWidth) solid;
-    border-block-start-color: var(--#{$input-group}__item--m-box--BorderTopColor);
-    border-block-end-color: var(--#{$input-group}__item--m-box--BorderBottomColor);
-    border-inline-start-color: var(--#{$input-group}__item--m-box--BorderLeftColor);
-    border-inline-end-color: var(--#{$input-group}__item--m-box--BorderRightColor);
+    border-block-start-color: var(--#{$input-group}__item--m-box--BorderBlockStartColor);
+    border-block-end-color: var(--#{$input-group}__item--m-box--BorderBlockEndColor);
+    border-inline-start-color: var(--#{$input-group}__item--m-box--BorderInlineStartColor);
+    border-inline-end-color: var(--#{$input-group}__item--m-box--BorderInlineEndColor);
     border-radius: var(--#{$input-group}__item--m-box--BorderRadius);
   }
 

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -5,46 +5,46 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 :where(:root, .#{$jump-links}) {
   // list
   --#{$jump-links}__list--Display: flex;
-  --#{$jump-links}__list--PaddingTop: 0;
-  --#{$jump-links}__list--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$jump-links}__list--PaddingBottom: 0;
-  --#{$jump-links}__list--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$jump-links}--m-vertical__list--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$jump-links}--m-vertical__list--PaddingRight: 0;
-  --#{$jump-links}--m-vertical__list--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$jump-links}--m-vertical__list--PaddingLeft: 0;
+  --#{$jump-links}__list--PaddingBlockStart: 0;
+  --#{$jump-links}__list--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$jump-links}__list--PaddingBlockEnd: 0;
+  --#{$jump-links}__list--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$jump-links}--m-vertical__list--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$jump-links}--m-vertical__list--PaddingInlineEnd: 0;
+  --#{$jump-links}--m-vertical__list--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$jump-links}--m-vertical__list--PaddingInlineStart: 0;
   --#{$jump-links}__list--FlexDirection: row;
   --#{$jump-links}--m-vertical__list--FlexDirection: column;
   --#{$jump-links}__list--before--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$jump-links}__list--before--BorderTopWidth: var(--pf-t--global--border--width--box--default);
-  --#{$jump-links}__list--before--BorderRightWidth: 0;
-  --#{$jump-links}__list--before--BorderBottomWidth: 0;
-  --#{$jump-links}__list--before--BorderLeftWidth: 0;
-  --#{$jump-links}--m-vertical__list--before--BorderLeftWidth: var(--pf-t--global--border--width--box--default);
-  --#{$jump-links}--m-vertical__list--before--BorderTopWidth: 0;
-  --#{$jump-links}__list__list--MarginTop: calc(var(--pf-t--global--spacer--sm) * -1);
+  --#{$jump-links}__list--before--BorderBlockStartWidth: var(--pf-t--global--border--width--box--default);
+  --#{$jump-links}__list--before--BorderInlineEndWidth: 0;
+  --#{$jump-links}__list--before--BorderBlockEndWidth: 0;
+  --#{$jump-links}__list--before--BorderInlineStartWidth: 0;
+  --#{$jump-links}--m-vertical__list--before--BorderInlineStartWidth: var(--pf-t--global--border--width--box--default);
+  --#{$jump-links}--m-vertical__list--before--BorderBlockStartWidth: 0;
+  --#{$jump-links}__list__list--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1);
 
   // link
-  --#{$jump-links}__link--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__link--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__link--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__link--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__list__list__link--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__list__list__link--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$jump-links}__list__list__link--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__link--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__link--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__list__list__link--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$jump-links}__list__list__link--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$jump-links}__list__list__link--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$jump-links}__link--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--sm));
 
   // before
-  --#{$jump-links}__link--before--BorderTopWidth: 0;
-  --#{$jump-links}__link--before--BorderRightWidth: 0;
-  --#{$jump-links}__link--before--BorderBottomWidth: 0;
-  --#{$jump-links}__link--before--BorderLeftWidth: 0;
+  --#{$jump-links}__link--before--BorderBlockStartWidth: 0;
+  --#{$jump-links}__link--before--BorderInlineEndWidth: 0;
+  --#{$jump-links}__link--before--BorderBlockEndWidth: 0;
+  --#{$jump-links}__link--before--BorderInlineStartWidth: 0;
   --#{$jump-links}__link--before--BorderColor: transparent;
-  --#{$jump-links}__item--m-current__link--before--BorderTopWidth: var(--pf-t--global--border--width--extra-strong);
-  --#{$jump-links}__item--m-current__link--before--BorderLeftWidth: 0;
+  --#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth: var(--pf-t--global--border--width--extra-strong);
+  --#{$jump-links}__item--m-current__link--before--BorderInlineStartWidth: 0;
   --#{$jump-links}__item--m-current__link--before--BorderColor: var(--pf-t--global--border--color--clicked);
-  --#{$jump-links}--m-vertical__item--m-current__link--before--BorderTopWidth: 0;
-  --#{$jump-links}--m-vertical__item--m-current__link--before--BorderLeftWidth: var(--pf-t--global--border--width--extra-strong);
+  --#{$jump-links}--m-vertical__item--m-current__link--before--BorderBlockStartWidth: 0;
+  --#{$jump-links}--m-vertical__item--m-current__link--before--BorderInlineStartWidth: var(--pf-t--global--border--width--extra-strong);
 
   // text
   --#{$jump-links}__link-text--Color: var(--pf-t--global--text--color--subtle);
@@ -52,15 +52,15 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}__item--m-current__link-text--Color: var(--pf-t--global--text--color--regular);
 
   // label
-  --#{$jump-links}__label--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$jump-links}__label--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$jump-links}__label--Display: block;
 
   // toggle
-  --#{$jump-links}__toggle--MarginTop: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
-  --#{$jump-links}__toggle--MarginBottom--base: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
-  --#{$jump-links}__toggle--MarginBottom: var(--#{$jump-links}__toggle--MarginBottom--base);
-  --#{$jump-links}--m-expanded__toggle--MarginBottom: calc(var(--#{$jump-links}__toggle--MarginBottom--base) + var(--pf-t--global--spacer--md));
-  --#{$jump-links}__toggle--MarginLeft: calc(-1 * var(--pf-t--global--spacer--md));
+  --#{$jump-links}__toggle--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
+  --#{$jump-links}__toggle--MarginBlockEnd--base: calc(-1 * var(--pf-t--global--spacer--button--vertical--default));
+  --#{$jump-links}__toggle--MarginBlockEnd: var(--#{$jump-links}__toggle--MarginBlockEnd--base);
+  --#{$jump-links}--m-expanded__toggle--MarginBlockEnd: calc(var(--#{$jump-links}__toggle--MarginBlockEnd--base) + var(--pf-t--global--spacer--md));
+  --#{$jump-links}__toggle--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--md));
   --#{$jump-links}__toggle--Display: none;
 
   // toggle icon
@@ -71,7 +71,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}--m-expanded__toggle-icon--Rotate: 90deg;
 
   // toggle text
-  --#{$jump-links}__toggle-text--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$jump-links}__toggle-text--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$jump-links}__toggle-text--Color: var(--pf-t--global--text--color--regular);
 }
 
@@ -88,14 +88,14 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   &.pf-m-vertical,
   &.pf-m-expandable {
-    --#{$jump-links}__list--PaddingTop: var(--#{$jump-links}--m-vertical__list--PaddingTop);
-    --#{$jump-links}__list--PaddingRight: var(--#{$jump-links}--m-vertical__list--PaddingRight);
-    --#{$jump-links}__list--PaddingBottom: var(--#{$jump-links}--m-vertical__list--PaddingBottom);
-    --#{$jump-links}__list--PaddingLeft: var(--#{$jump-links}--m-vertical__list--PaddingLeft);
-    --#{$jump-links}__list--before--BorderTopWidth: var(--#{$jump-links}--m-vertical__list--before--BorderTopWidth);
-    --#{$jump-links}__list--before--BorderLeftWidth: var(--#{$jump-links}--m-vertical__list--before--BorderLeftWidth);
-    --#{$jump-links}__item--m-current__link--before--BorderTopWidth: var(--#{$jump-links}--m-vertical__item--m-current__link--before--BorderTopWidth);
-    --#{$jump-links}__item--m-current__link--before--BorderLeftWidth: var(--#{$jump-links}--m-vertical__item--m-current__link--before--BorderLeftWidth);
+    --#{$jump-links}__list--PaddingBlockStart: var(--#{$jump-links}--m-vertical__list--PaddingBlockStart);
+    --#{$jump-links}__list--PaddingInlineEnd: var(--#{$jump-links}--m-vertical__list--PaddingInlineEnd);
+    --#{$jump-links}__list--PaddingBlockEnd: var(--#{$jump-links}--m-vertical__list--PaddingBlockEnd);
+    --#{$jump-links}__list--PaddingInlineStart: var(--#{$jump-links}--m-vertical__list--PaddingInlineStart);
+    --#{$jump-links}__list--before--BorderBlockStartWidth: var(--#{$jump-links}--m-vertical__list--before--BorderBlockStartWidth);
+    --#{$jump-links}__list--before--BorderInlineStartWidth: var(--#{$jump-links}--m-vertical__list--before--BorderInlineStartWidth);
+    --#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth: var(--#{$jump-links}--m-vertical__item--m-current__link--before--BorderBlockStartWidth);
+    --#{$jump-links}__item--m-current__link--before--BorderInlineStartWidth: var(--#{$jump-links}--m-vertical__item--m-current__link--before--BorderInlineStartWidth);
     --#{$jump-links}__list--FlexDirection: var(--#{$jump-links}--m-vertical__list--FlexDirection);
 
     flex-direction: column;
@@ -121,7 +121,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   &.pf-m-expanded {
     --#{$jump-links}__list--Display: flex;
-    --#{$jump-links}__toggle--MarginBottom: var(--#{$jump-links}--m-expanded__toggle--MarginBottom);
+    --#{$jump-links}__toggle--MarginBlockEnd: var(--#{$jump-links}--m-expanded__toggle--MarginBlockEnd);
     --#{$jump-links}__toggle-icon--Rotate: var(--#{$jump-links}--m-expanded__toggle-icon--Rotate);
     --#{$jump-links}__toggle-icon--Color: var(--#{$jump-links}--m-expanded__toggle-icon--Color);
   }
@@ -131,10 +131,10 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   position: relative;
   display: var(--#{$jump-links}__list--Display);
   flex-direction: var(--#{$jump-links}__list--FlexDirection);
-  padding-block-start: var(--#{$jump-links}__list--PaddingTop);
-  padding-block-end: var(--#{$jump-links}__list--PaddingBottom);
-  padding-inline-start: var(--#{$jump-links}__list--PaddingLeft);
-  padding-inline-end: var(--#{$jump-links}__list--PaddingRight);
+  padding-block-start: var(--#{$jump-links}__list--PaddingBlockStart);
+  padding-block-end: var(--#{$jump-links}__list--PaddingBlockEnd);
+  padding-inline-start: var(--#{$jump-links}__list--PaddingInlineStart);
+  padding-inline-end: var(--#{$jump-links}__list--PaddingInlineEnd);
 
   &::before {
     position: absolute;
@@ -142,20 +142,20 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
     pointer-events: none;
     content: "";
     border: solid var(--#{$jump-links}__list--before--BorderColor);
-    border-block-start-width: var(--#{$jump-links}__list--before--BorderTopWidth);
-    border-block-end-width: var(--#{$jump-links}__list--before--BorderBottomWidth);
-    border-inline-start-width: var(--#{$jump-links}__list--before--BorderLeftWidth);
-    border-inline-end-width: var(--#{$jump-links}__list--before--BorderRightWidth);
+    border-block-start-width: var(--#{$jump-links}__list--before--BorderBlockStartWidth);
+    border-block-end-width: var(--#{$jump-links}__list--before--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$jump-links}__list--before--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$jump-links}__list--before--BorderInlineEndWidth);
   }
 
   .#{$jump-links}__list {
-    --#{$jump-links}__list--PaddingTop: 0;
-    --#{$jump-links}__list--PaddingBottom: 0;
-    --#{$jump-links}__link--PaddingTop: var(--#{$jump-links}__list__list__link--PaddingTop);
-    --#{$jump-links}__link--PaddingBottom: var(--#{$jump-links}__list__list__link--PaddingBottom);
-    --#{$jump-links}__link--PaddingLeft: var(--#{$jump-links}__list__list__link--PaddingLeft);
+    --#{$jump-links}__list--PaddingBlockStart: 0;
+    --#{$jump-links}__list--PaddingBlockEnd: 0;
+    --#{$jump-links}__link--PaddingBlockStart: var(--#{$jump-links}__list__list__link--PaddingBlockStart);
+    --#{$jump-links}__link--PaddingBlockEnd: var(--#{$jump-links}__list__list__link--PaddingBlockEnd);
+    --#{$jump-links}__link--PaddingInlineStart: var(--#{$jump-links}__list__list__link--PaddingInlineStart);
 
-    margin-block-start: var(--#{$jump-links}__list__list--MarginTop);
+    margin-block-start: var(--#{$jump-links}__list__list--MarginBlockStart);
   }
 }
 
@@ -163,10 +163,10 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   position: relative;
   display: flex;
   flex: 1;
-  padding-block-start: var(--#{$jump-links}__link--PaddingTop);
-  padding-block-end: var(--#{$jump-links}__link--PaddingBottom);
-  padding-inline-start: var(--#{$jump-links}__link--PaddingLeft);
-  padding-inline-end: var(--#{$jump-links}__link--PaddingRight);
+  padding-block-start: var(--#{$jump-links}__link--PaddingBlockStart);
+  padding-block-end: var(--#{$jump-links}__link--PaddingBlockEnd);
+  padding-inline-start: var(--#{$jump-links}__link--PaddingInlineStart);
+  padding-inline-end: var(--#{$jump-links}__link--PaddingInlineEnd);
   text-decoration: none;
   outline-offset: var(--#{$jump-links}__link--OutlineOffset);
 
@@ -182,10 +182,10 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
     content: "";
     border-color: var(--#{$jump-links}__link--before--BorderColor);
     border-style: solid;
-    border-block-start-width: var(--#{$jump-links}__link--before--BorderTopWidth);
-    border-block-end-width: var(--#{$jump-links}__link--before--BorderBottomWidth);
-    border-inline-start-width: var(--#{$jump-links}__link--before--BorderLeftWidth);
-    border-inline-end-width: var(--#{$jump-links}__link--before--BorderRightWidth);
+    border-block-start-width: var(--#{$jump-links}__link--before--BorderBlockStartWidth);
+    border-block-end-width: var(--#{$jump-links}__link--before--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$jump-links}__link--before--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$jump-links}__link--before--BorderInlineEndWidth);
   }
 }
 
@@ -194,8 +194,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}__list--before--BorderColor: transparent;
 
   &.pf-m-current > .#{$jump-links}__link {
-    --#{$jump-links}__link--before--BorderTopWidth: var(--#{$jump-links}__item--m-current__link--before--BorderTopWidth);
-    --#{$jump-links}__link--before--BorderLeftWidth: var(--#{$jump-links}__item--m-current__link--before--BorderLeftWidth);
+    --#{$jump-links}__link--before--BorderBlockStartWidth: var(--#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth);
+    --#{$jump-links}__link--before--BorderInlineStartWidth: var(--#{$jump-links}__item--m-current__link--before--BorderInlineStartWidth);
     --#{$jump-links}__link--before--BorderColor: var(--#{$jump-links}__item--m-current__link--before--BorderColor);
     --#{$jump-links}__link-text--Color: var(--#{$jump-links}__item--m-current__link-text--Color);
   }
@@ -208,7 +208,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
 .#{$jump-links}__label {
   display: var(--#{$jump-links}__label--Display);
-  margin-block-end: var(--#{$jump-links}__label--MarginBottom);
+  margin-block-end: var(--#{$jump-links}__label--MarginBlockEnd);
 }
 
 .#{$jump-links}__main {
@@ -218,9 +218,9 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
 .#{$jump-links}__toggle {
   display: var(--#{$jump-links}__toggle--Display);
-  margin-block-start: var(--#{$jump-links}__toggle--MarginTop);
-  margin-block-end: var(--#{$jump-links}__toggle--MarginBottom);
-  margin-inline-start: var(--#{$jump-links}__toggle--MarginLeft);
+  margin-block-start: var(--#{$jump-links}__toggle--MarginBlockStart);
+  margin-block-end: var(--#{$jump-links}__toggle--MarginBlockEnd);
+  margin-inline-start: var(--#{$jump-links}__toggle--MarginInlineStart);
 
   .#{$button} {
     display: flex;
@@ -238,6 +238,6 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 }
 
 .#{$jump-links}__toggle-text {
-  margin-inline-start: var(--#{$jump-links}__toggle-text--MarginLeft);
+  margin-inline-start: var(--#{$jump-links}__toggle-text--MarginInlineStart);
   color: var(--#{$jump-links}__toggle-text--Color);
 }

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -20,31 +20,31 @@
   --#{$label-group}--m-vertical__list--ColumnGap: var(--pf-t--global--spacer--xs);
 
   // Category
-  --#{$label-group}--m-category--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$label-group}--m-category--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$label-group}--m-category--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$label-group}--m-category--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$label-group}--m-category--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$label-group}--m-category--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$label-group}--m-category--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$label-group}--m-category--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$label-group}--m-category--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$label-group}--m-category--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$label-group}--m-category--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$label-group}--m-vertical--m-category--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$label-group}--m-vertical--m-category--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Label
   --#{$label-group}__label--MaxWidth: 18ch;
 
   // Close
   --#{$label-group}__close--c-button--FontSize: var(--pf-t--global--icon--size--font--body--sm);
-  --#{$label-group}__close--c-button--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$label-group}__close--c-button--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$label-group}__close--c-button--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$label-group}__close--c-button--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$label-group}__close--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$label-group}__close--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$label-group}__close--c-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$label-group}__close--c-button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
 
   // Textarea
   --#{$label-group}__textarea--MinWidth: #{pf-size-prem(200px)};
-  --#{$label-group}__textarea--PaddingTop: #{pf-size-prem(2px)};
-  --#{$label-group}__textarea--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$label-group}__textarea--PaddingBottom: 0;
-  --#{$label-group}__textarea--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$label-group}__textarea--PaddingBlockStart: #{pf-size-prem(2px)};
+  --#{$label-group}__textarea--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$label-group}__textarea--PaddingBlockEnd: 0;
+  --#{$label-group}__textarea--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 }
 
 .#{$label-group} {
@@ -54,10 +54,10 @@
   align-items: center;
 
   &.pf-m-category {
-    padding-block-start: var(--#{$label-group}--m-category--PaddingTop);
-    padding-block-end: var(--#{$label-group}--m-category--PaddingBottom);
-    padding-inline-start: var(--#{$label-group}--m-category--PaddingLeft);
-    padding-inline-end: var(--#{$label-group}--m-category--PaddingRight);
+    padding-block-start: var(--#{$label-group}--m-category--PaddingBlockStart);
+    padding-block-end: var(--#{$label-group}--m-category--PaddingBlockEnd);
+    padding-inline-start: var(--#{$label-group}--m-category--PaddingInlineStart);
+    padding-inline-end: var(--#{$label-group}--m-category--PaddingInlineEnd);
     background-color: var(--#{$label-group}--m-category--BackgroundColor);
     border: var(--#{$label-group}--m-category--BorderWidth) solid var(--#{$label-group}--m-category--BorderColor);
     border-radius: var(--#{$label-group}--m-category--BorderRadius);
@@ -70,7 +70,7 @@
     --#{$label-group}__main--ColumnGap: var(--#{$label-group}--m-vertical__main--ColumnGap);
     --#{$label-group}__list--RowGap: var(--#{$label-group}--m-vertical__list--RowGap);
     --#{$label-group}__list--ColumnGap: var(--#{$label-group}--m-vertical__list--ColumnGap);
-    --#{$label-group}--m-category--PaddingRight: var(--#{$label-group}--m-vertical--m-category--PaddingRight);
+    --#{$label-group}--m-category--PaddingInlineEnd: var(--#{$label-group}--m-vertical--m-category--PaddingInlineEnd);
 
     &.#{$label-group} {
       align-items: flex-start;
@@ -134,19 +134,19 @@
 
   .#{$button} {
     --#{$button}--FontSize: var(--#{$label-group}__close--c-button--FontSize);
-    --#{$button}--m-plain--m-no-padding--PaddingTop: var(--#{$label-group}__close--c-button--PaddingTop);
-    --#{$button}--m-plain--m-no-padding--PaddingRight: var(--#{$label-group}__close--c-button--PaddingRight);
-    --#{$button}--m-plain--m-no-padding--PaddingBottom: var(--#{$label-group}__close--c-button--PaddingBottom);
-    --#{$button}--m-plain--m-no-padding--PaddingLeft: var(--#{$label-group}__close--c-button--PaddingLeft);
+    --#{$button}--m-plain--m-no-padding--PaddingBlockStart: var(--#{$label-group}__close--c-button--PaddingBlockStart);
+    --#{$button}--m-plain--m-no-padding--PaddingInlineEnd: var(--#{$label-group}__close--c-button--PaddingInlineEnd);
+    --#{$button}--m-plain--m-no-padding--PaddingBlockEnd: var(--#{$label-group}__close--c-button--PaddingBlockEnd);
+    --#{$button}--m-plain--m-no-padding--PaddingInlineStart: var(--#{$label-group}__close--c-button--PaddingInlineStart);
   }
 }
 
 .#{$label-group}__textarea {
   min-width: var(--#{$label-group}__textarea--MinWidth);
-  padding-block-start: var(--#{$label-group}__textarea--PaddingTop);
-  padding-block-end: var(--#{$label-group}__textarea--PaddingBottom);
-  padding-inline-start: var(--#{$label-group}__textarea--PaddingLeft);
-  padding-inline-end: var(--#{$label-group}__textarea--PaddingRight);
+  padding-block-start: var(--#{$label-group}__textarea--PaddingBlockStart);
+  padding-block-end: var(--#{$label-group}__textarea--PaddingBlockEnd);
+  padding-inline-start: var(--#{$label-group}__textarea--PaddingInlineStart);
+  padding-inline-end: var(--#{$label-group}__textarea--PaddingInlineEnd);
   white-space: nowrap;
   resize: none;
   border: 0;

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,10 +1,10 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$label}) {
-  --#{$label}--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$label}--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$label}--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$label}--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$label}--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$label}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$label}--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$label}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$label}--MaxWidth: 100%;
   --#{$label}--BorderWidth: 0;
   --#{$label}--BorderColor: transparent;
@@ -196,10 +196,10 @@
   --#{$label}--m-add--hover--BorderWidth: var(--pf-t--global--border--width--button--hover);
 
   // Compact
-  --#{$label}--m-compact--PaddingTop: 0;
-  --#{$label}--m-compact--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$label}--m-compact--PaddingBottom: 0;
-  --#{$label}--m-compact--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$label}--m-compact--PaddingBlockStart: 0;
+  --#{$label}--m-compact--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$label}--m-compact--PaddingBlockEnd: 0;
+  --#{$label}--m-compact--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$label}--m-compact--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$label}--m-compact--m-editable--TextDecorationOffset: #{pf-size-prem(1px)};
 
@@ -215,17 +215,17 @@
   --#{$label}__text--MaxWidth: 100%;
 
   // Actions
-  --#{$label}__actions--MarginRight: calc(var(--#{$label}__actions--c-button--PaddingRight) * -1);
+  --#{$label}__actions--MarginInlineEnd: calc(var(--#{$label}__actions--c-button--PaddingInlineEnd) * -1);
 
   // Actions button (close)
   --#{$label}__actions--c-button--FontSize: var(--pf-t--global--icon--size--font--body--sm);
   --#{$label}__actions--c-button--OutlineOffset: #{pf-size-prem(-3px)};
-  --#{$label}__actions--c-button--MarginTop: calc(var(--#{$label}__actions--c-button--PaddingTop) * -1);
-  --#{$label}__actions--c-button--MarginBottom: calc(var(--#{$label}__actions--c-button--PaddingBottom) * -1);
-  --#{$label}__actions--c-button--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$label}__actions--c-button--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$label}__actions--c-button--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$label}__actions--c-button--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$label}__actions--c-button--MarginBlockStart: calc(var(--#{$label}__actions--c-button--PaddingBlockStart) * -1);
+  --#{$label}__actions--c-button--MarginBlockEnd: calc(var(--#{$label}__actions--c-button--PaddingBlockEnd) * -1);
+  --#{$label}__actions--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$label}__actions--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$label}__actions--c-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$label}__actions--c-button--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // Editable
   --#{$label}--m-editable--TextDecoration: underline;
@@ -252,10 +252,10 @@
 .#{$label} {
   position: relative;
   max-width: var(--#{$label}--MaxWidth);
-  padding-block-start: var(--#{$label}--PaddingTop);
-  padding-block-end: var(--#{$label}--PaddingBottom);
-  padding-inline-start: var(--#{$label}--PaddingLeft);
-  padding-inline-end: var(--#{$label}--PaddingRight);
+  padding-block-start: var(--#{$label}--PaddingBlockStart);
+  padding-block-end: var(--#{$label}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$label}--PaddingInlineStart);
+  padding-inline-end: var(--#{$label}--PaddingInlineEnd);
   font-size: var(--#{$label}--FontSize);
   white-space: nowrap;
   background: transparent;
@@ -417,10 +417,10 @@
   }
 
   &.pf-m-compact {
-    --#{$label}--PaddingTop: var(--#{$label}--m-compact--PaddingTop);
-    --#{$label}--PaddingRight: var(--#{$label}--m-compact--PaddingRight);
-    --#{$label}--PaddingBottom: var(--#{$label}--m-compact--PaddingBottom);
-    --#{$label}--PaddingLeft: var(--#{$label}--m-compact--PaddingLeft);
+    --#{$label}--PaddingBlockStart: var(--#{$label}--m-compact--PaddingBlockStart);
+    --#{$label}--PaddingInlineEnd: var(--#{$label}--m-compact--PaddingInlineEnd);
+    --#{$label}--PaddingBlockEnd: var(--#{$label}--m-compact--PaddingBlockEnd);
+    --#{$label}--PaddingInlineStart: var(--#{$label}--m-compact--PaddingInlineStart);
     --#{$label}--FontSize: var(--#{$label}--m-compact--FontSize);
     --#{$label}--m-editable--TextDecorationOffset: var(--#{$label}--m-compact--m-editable--TextDecorationOffset);
   }
@@ -571,17 +571,17 @@
 }
 
 .#{$label}__actions {
-  margin-inline-end: var(--#{$label}__actions--MarginRight);
+  margin-inline-end: var(--#{$label}__actions--MarginInlineEnd);
 
   .#{$button} {
     --#{$button}--FontSize: var(--#{$label}__actions--c-button--FontSize);
-    --#{$button}--m-plain--m-no-padding--PaddingTop: var(--#{$label}__actions--c-button--PaddingTop);
-    --#{$button}--m-plain--m-no-padding--PaddingRight: var(--#{$label}__actions--c-button--PaddingRight);
-    --#{$button}--m-plain--m-no-padding--PaddingBottom: var(--#{$label}__actions--c-button--PaddingBottom);
-    --#{$button}--m-plain--m-no-padding--PaddingLeft: var(--#{$label}__actions--c-button--PaddingLeft);
+    --#{$button}--m-plain--m-no-padding--PaddingBlockStart: var(--#{$label}__actions--c-button--PaddingBlockStart);
+    --#{$button}--m-plain--m-no-padding--PaddingInlineEnd: var(--#{$label}__actions--c-button--PaddingInlineEnd);
+    --#{$button}--m-plain--m-no-padding--PaddingBlockEnd: var(--#{$label}__actions--c-button--PaddingBlockEnd);
+    --#{$button}--m-plain--m-no-padding--PaddingInlineStart: var(--#{$label}__actions--c-button--PaddingInlineStart);
 
-    margin-block-start: var(--#{$label}__actions--c-button--MarginTop);
-    margin-block-end: var(--#{$label}__actions--c-button--MarginBottom);
+    margin-block-start: var(--#{$label}__actions--c-button--MarginBlockStart);
+    margin-block-end: var(--#{$label}__actions--c-button--MarginBlockEnd);
     outline-offset: var(--#{$label}__actions--c-button--OutlineOffset);
   }
 }

--- a/src/patternfly/components/List/list.scss
+++ b/src/patternfly/components/List/list.scss
@@ -2,40 +2,40 @@
 
 .#{$list} {
   // list
-  --#{$list}--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$list}--nested--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$list}--nested--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$list}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$list}--nested--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$list}--nested--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$list}--ul--ListStyle: var(--pf-t--global--list-style);
-  --#{$list}--li--MarginTop: var(--pf-t--global--spacer--sm);
+  --#{$list}--li--MarginBlockStart: var(--pf-t--global--spacer--sm);
 
   // inline
-  --#{$list}--m-inline--li--MarginRight: var(--pf-t--global--spacer--lg);
+  --#{$list}--m-inline--li--MarginInlineEnd: var(--pf-t--global--spacer--lg);
 
   // bordered
-  --#{$list}--m-bordered--li--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$list}--m-bordered--li--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$list}--m-bordered--li--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$list}--m-bordered--li--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$list}--m-bordered--li--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$list}--m-bordered--li--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
 
   // icon
   --#{$list}__item-icon--MinWidth: var(--pf-t--global--icon--size--sm);
-  --#{$list}__item-icon--MarginTop: var(--pf-t--global--spacer--xs);
-  --#{$list}__item-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$list}__item-icon--MarginBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$list}__item-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$list}__item-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$list}__item-icon--FontSize: var(--pf-t--global--icon--size--sm);
   --#{$list}--m-icon-lg__item-icon--MinWidth: var(--pf-t--global--icon--size--lg);
-  --#{$list}--m-icon-lg__item-icon--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$list}--m-icon-lg__item-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$list}--m-icon-lg__item-icon--FontSize: var(--pf-t--global--icon--size--lg);
 
-  padding-inline-start: var(--#{$list}--PaddingLeft);
+  padding-inline-start: var(--#{$list}--PaddingInlineStart);
 
   ol,
   ul {
-    margin-block-start: var(--#{$list}--nested--MarginTop);
-    margin-inline-start: var(--#{$list}--nested--MarginLeft);
+    margin-block-start: var(--#{$list}--nested--MarginBlockStart);
+    margin-inline-start: var(--#{$list}--nested--MarginInlineStart);
   }
 
   li + li {
-    margin-block-start: var(--#{$list}--li--MarginTop);
+    margin-block-start: var(--#{$list}--li--MarginBlockStart);
   }
 
   @at-root ul#{&} {
@@ -49,8 +49,8 @@
   .#{$list}__item-icon {
     flex-shrink: 0;
     min-width: var(--#{$list}__item-icon--MinWidth);
-    margin-block-start: var(--#{$list}__item-icon--MarginTop);
-    margin-inline-end: var(--#{$list}__item-icon--MarginRight);
+    margin-block-start: var(--#{$list}__item-icon--MarginBlockStart);
+    margin-inline-end: var(--#{$list}__item-icon--MarginInlineEnd);
     font-size: var(--#{$list}__item-icon--FontSize);
     line-height: 1;
     color: var(--#{$list}__item-icon--Color);
@@ -58,42 +58,42 @@
 
   &.pf-m-icon-lg {
     --#{$list}__item-icon--MinWidth: var(--#{$list}--m-icon-lg__item-icon--MinWidth);
-    --#{$list}__item-icon--MarginTop: 0;
-    --#{$list}__item-icon--MarginRight: var(--#{$list}--m-icon-lg__item-icon--MarginRight);
+    --#{$list}__item-icon--MarginBlockStart: 0;
+    --#{$list}__item-icon--MarginInlineEnd: var(--#{$list}--m-icon-lg__item-icon--MarginInlineEnd);
     --#{$list}__item-icon--FontSize: var(--#{$list}--m-icon-lg__item-icon--FontSize);
   }
 
   &.pf-m-plain {
-    --#{$list}--PaddingLeft: 0;
+    --#{$list}--PaddingInlineStart: 0;
 
     list-style: none;
   }
 
   &.pf-m-inline {
-    --#{$list}--PaddingLeft: 0;
+    --#{$list}--PaddingInlineStart: 0;
 
     display: flex;
     flex-wrap: wrap;
     list-style: none;
 
     li {
-      --#{$list}--li--MarginTop: 0;
+      --#{$list}--li--MarginBlockStart: 0;
 
       &:not(:last-child) {
-        margin-inline-end: var(--#{$list}--m-inline--li--MarginRight);
+        margin-inline-end: var(--#{$list}--m-inline--li--MarginInlineEnd);
       }
     }
   }
 
   &.pf-m-bordered {
     > * {
-      padding-block-end: var(--#{$list}--m-bordered--li--PaddingBottom);
-      border-block-end: var(--#{$list}--m-bordered--li--BorderBottomWidth) solid var(--#{$list}--m-bordered--li--BorderBottomColor);
+      padding-block-end: var(--#{$list}--m-bordered--li--PaddingBlockEnd);
+      border-block-end: var(--#{$list}--m-bordered--li--BorderBlockEndWidth) solid var(--#{$list}--m-bordered--li--BorderBlockEndColor);
     }
 
     > :last-child {
-      --#{$list}--m-bordered--li--PaddingBottom: 0;
-      --#{$list}--m-bordered--li--BorderBottomWidth: 0;
+      --#{$list}--m-bordered--li--PaddingBlockEnd: 0;
+      --#{$list}--m-bordered--li--BorderBlockEndWidth: 0;
     }
   }
 }

--- a/src/patternfly/components/LogViewer/log-viewer.scss
+++ b/src/patternfly/components/LogViewer/log-viewer.scss
@@ -6,7 +6,7 @@
   --#{$log-viewer}--m-line-numbers__index--Display: inline;
 
   // Header
-  --#{$log-viewer}__header--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$log-viewer}__header--MarginBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Main
   --#{$log-viewer}__main--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -15,35 +15,35 @@
 
   // Scroll container
   --#{$log-viewer}__scroll-container--Height: #{pf-size-prem(600px)};
-  --#{$log-viewer}__scroll-container--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$log-viewer}__scroll-container--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$log-viewer}__scroll-container--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$log-viewer}__scroll-container--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Main ::after
-  --#{$log-viewer}--m-line-numbers__main--before--Top: 0;
-  --#{$log-viewer}--m-line-numbers__main--before--Bottom: 0;
-  --#{$log-viewer}--m-line-numbers__main--before--Width: var(--pf-t--global--border--width--divider--default);
-  --#{$log-viewer}--m-line-numbers__main--before--BackgroundColor: var(--pf-t--global--border--color--default);
+  --#{$log-viewer}--m-line-numbers__list--before--InsetBlockStart: 0;
+  --#{$log-viewer}--m-line-numbers__list--before--InsetBlockEnd: 0;
+  --#{$log-viewer}--m-line-numbers__list--before--Width: var(--pf-t--global--border--width--divider--default);
+  --#{$log-viewer}--m-line-numbers__list--before--BackgroundColor: var(--pf-t--global--border--color--default);
 
   // List
   --#{$log-viewer}__list--Height: auto;
-  --#{$log-viewer}--m-line-numbers__list--Left: var(--#{$log-viewer}__index--Width);
+  --#{$log-viewer}--m-line-numbers__list--InsetInlineStart: var(--#{$log-viewer}__index--Width);
   --#{$log-viewer}__list--FontFamily: var(--pf-t--global--font--family--mono);
   --#{$log-viewer}__list--FontSize: var(--pf-t--global--font--size--body--sm);
 
   // Index
   --#{$log-viewer}__index--Display: none;
   --#{$log-viewer}__index--Width: #{pf-size-prem(65px)}; // default width
-  --#{$log-viewer}__index--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$log-viewer}__index--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$log-viewer}__index--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$log-viewer}__index--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$log-viewer}__index--Color: var(--pf-t--global--text--color--subtle);
   --#{$log-viewer}__index--BackgroundColor: transparent;
   --#{$log-viewer}--line-number-chars: 4.4; // it's close enough to the existing default
-  --#{$log-viewer}--m-line-number-chars__index--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$log-viewer}--m-line-number-chars__index--Width: calc(1ch * var(--#{$log-viewer}--line-number-chars) + var(--#{$log-viewer}__index--PaddingRight) + var(--#{$log-viewer}__index--PaddingLeft));
+  --#{$log-viewer}--m-line-number-chars__index--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$log-viewer}--m-line-number-chars__index--Width: calc(1ch * var(--#{$log-viewer}--line-number-chars) + var(--#{$log-viewer}__index--PaddingInlineEnd) + var(--#{$log-viewer}__index--PaddingInlineStart));
 
   // Text
-  --#{$log-viewer}__text--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$log-viewer}__text--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$log-viewer}__text--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$log-viewer}__text--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$log-viewer}__text--Color: var(--pf-t--global--text--color--regular);
   --#{$log-viewer}__text--WordBreak: break-all;
   --#{$log-viewer}__text--WhiteSpace: break-spaces;
@@ -58,10 +58,10 @@
   --#{$log-viewer}__timestamp--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // Toolbar
-  --#{$log-viewer}--c-toolbar--PaddingTop: 0;
-  --#{$log-viewer}--c-toolbar--PaddingBottom: 0;
-  --#{$log-viewer}--c-toolbar__content--PaddingRight: 0;
-  --#{$log-viewer}--c-toolbar__content--PaddingLeft: 0;
+  --#{$log-viewer}--c-toolbar--PaddingBlockStart: 0;
+  --#{$log-viewer}--c-toolbar--PaddingBlockEnd: 0;
+  --#{$log-viewer}--c-toolbar__content--PaddingInlineEnd: 0;
+  --#{$log-viewer}--c-toolbar__content--PaddingInlineStart: 0;
   --#{$log-viewer}--c-toolbar__group--m-toggle-group--spacer: 0;
   --#{$log-viewer}--c-toolbar__group--m-toggle-group--m-show--spacer: var(--pf-t--global--spacer--sm);
 
@@ -76,7 +76,7 @@
       --#{$log-viewer}__main--BorderColor: var(--pf-t--global--border--color--default);
       --#{$log-viewer}__text--Color: var(--pf-t--global--text--color--regular);
       --#{$log-viewer}__index--Color: var(--pf-t--global--text--color--subtle);
-      --#{$log-viewer}--m-line-numbers__main--before--BackgroundColor: var(--pf-t--global--border--color--default);
+      --#{$log-viewer}--m-line-numbers__list--before--BackgroundColor: var(--pf-t--global--border--color--default);
     }
   }
 
@@ -98,33 +98,33 @@
 
     .#{$log-viewer}__list {
       position: absolute;
-      inset-inline-start: var(--#{$log-viewer}--m-line-numbers__list--Left);
+      inset-inline-start: var(--#{$log-viewer}--m-line-numbers__list--InsetInlineStart);
       inset-inline-end: 0;
 
       // Divider
       &::before {
         position: absolute;
-        inset-block-start: var(--#{$log-viewer}--m-line-numbers__main--before--Top); // rename these vars at a breaking change
-        inset-block-end: var(--#{$log-viewer}--m-line-numbers__main--before--Bottom);
+        inset-block-start: var(--#{$log-viewer}--m-line-numbers__list--before--InsetBlockStart);
+        inset-block-end: var(--#{$log-viewer}--m-line-numbers__list--before--InsetBlockEnd);
         inset-inline-start: 0;
-        width: var(--#{$log-viewer}--m-line-numbers__main--before--Width);
+        width: var(--#{$log-viewer}--m-line-numbers__list--before--Width);
         content: "";
-        background: var(--#{$log-viewer}--m-line-numbers__main--before--BackgroundColor);
+        background: var(--#{$log-viewer}--m-line-numbers__list--before--BackgroundColor);
       }
     }
   }
 
   &.pf-m-line-number-chars {
-    --#{$log-viewer}__index--PaddingRight: var(--#{$log-viewer}--m-line-number-chars__index--PaddingRight);
+    --#{$log-viewer}__index--PaddingInlineEnd: var(--#{$log-viewer}--m-line-number-chars__index--PaddingInlineEnd);
     --#{$log-viewer}__index--Width: var(--#{$log-viewer}--m-line-number-chars__index--Width);
   }
 
   // Nested toolbar
   .#{$toolbar} {
-    --#{$toolbar}--PaddingTop: var(--#{$log-viewer}--c-toolbar--PaddingTop);
-    --#{$toolbar}--PaddingBottom: var(--#{$log-viewer}--c-toolbar--PaddingBottom);
-    --#{$toolbar}__content--PaddingRight: var(--#{$log-viewer}--c-toolbar__content--PaddingRight);
-    --#{$toolbar}__content--PaddingLeft: var(--#{$log-viewer}--c-toolbar__content--PaddingLeft);
+    --#{$toolbar}--PaddingBlockStart: var(--#{$log-viewer}--c-toolbar--PaddingBlockStart);
+    --#{$toolbar}--PaddingBlockEnd: var(--#{$log-viewer}--c-toolbar--PaddingBlockEnd);
+    --#{$toolbar}__content--PaddingInlineEnd: var(--#{$log-viewer}--c-toolbar__content--PaddingInlineEnd);
+    --#{$toolbar}__content--PaddingInlineStart: var(--#{$log-viewer}--c-toolbar__content--PaddingInlineStart);
     --#{$toolbar}__group--m-toggle-group--spacer: 0;
     --#{$toolbar}__group--m-toggle-group--m-show--spacer: var(--#{$log-viewer}--c-toolbar__group--m-toggle-group--m-show--spacer);
   }
@@ -136,7 +136,7 @@
 
 // Header
 .#{$log-viewer}__header {
-  margin-block-end: var(--#{$log-viewer}__header--MarginBottom);
+  margin-block-end: var(--#{$log-viewer}__header--MarginBlockEnd);
 }
 
 // Main
@@ -151,8 +151,8 @@
 .#{$log-viewer}__scroll-container {
   position: relative;
   height: var(--#{$log-viewer}__scroll-container--Height);
-  padding-block-start: var(--#{$log-viewer}__scroll-container--PaddingTop);
-  padding-block-end: var(--#{$log-viewer}__scroll-container--PaddingBottom);
+  padding-block-start: var(--#{$log-viewer}__scroll-container--PaddingBlockStart);
+  padding-block-end: var(--#{$log-viewer}__scroll-container--PaddingBlockEnd);
   overflow: auto;
   will-change: transform;
   direction: ltr;
@@ -167,7 +167,7 @@
 }
 
 .#{$log-viewer}__list-item {
- inset-inline-start: 0;
+  inset-inline-start: 0;
   width: 100%;
 }
 
@@ -189,8 +189,8 @@
   inset-inline-start: 0;
   display: var(--#{$log-viewer}__index--Display);
   width: var(--#{$log-viewer}__index--Width);
-  padding-inline-start: var(--#{$log-viewer}__index--PaddingLeft);
-  padding-inline-end: var(--#{$log-viewer}__index--PaddingRight);
+  padding-inline-start: var(--#{$log-viewer}__index--PaddingInlineStart);
+  padding-inline-end: var(--#{$log-viewer}__index--PaddingInlineEnd);
   font-family: var(--#{$log-viewer}__index--FontFamily, inherit);
   font-size: var(--#{$log-viewer}__index--FontSize, inherit);
   color: var(--#{$log-viewer}__index--Color);
@@ -201,8 +201,8 @@
 // Text
 .#{$log-viewer}__text {
   display: block;
-  padding-inline-start: var(--#{$log-viewer}__text--PaddingLeft);
-  padding-inline-end: var(--#{$log-viewer}__text--PaddingRight);
+  padding-inline-start: var(--#{$log-viewer}__text--PaddingInlineStart);
+  padding-inline-end: var(--#{$log-viewer}__text--PaddingInlineEnd);
   font-family: var(--#{$log-viewer}__text--FontFamily, inherit);
   font-size: var(--#{$log-viewer}__text--FontSize, inherit);
   color: var(--#{$log-viewer}__text--Color);

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -1,15 +1,15 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$login}) {
-  --#{$login}--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$login}--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$login}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$login}--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
 
   // container
   --#{$login}__container--xl--GridColumnGap: var(--pf-t--global--spacer--3xl);
   --#{$login}__container--MaxWidth: #{pf-size-prem(500px)}; // This is a magic number to prevent the login layout grow more than what's defined in the specs.
   --#{$login}__container--xl--MaxWidth: none;
-  --#{$login}__container--PaddingLeft: #{pf-size-prem(98px)};
-  --#{$login}__container--PaddingRight: #{pf-size-prem(98px)};
+  --#{$login}__container--PaddingInlineStart: #{pf-size-prem(98px)};
+  --#{$login}__container--PaddingInlineEnd: #{pf-size-prem(98px)};
   --#{$login}__container--xl--GridTemplateColumns: #{pf-size-prem(544px)} minmax(auto, #{pf-size-prem(544px)}); // unique to the login layout
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
@@ -17,99 +17,99 @@
   }
 
   // header
-  --#{$login}__header--MarginBottom: var(--pf-t--global--spacer--md);
-  --#{$login}__header--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$login}__header--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$login}__header--MarginBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$login}__header--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$login}__header--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   @media (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$login}__header--PaddingRight: 0;
-    --#{$login}__header--PaddingLeft: 0;
+    --#{$login}__header--PaddingInlineEnd: 0;
+    --#{$login}__header--PaddingInlineStart: 0;
   }
 
-  --#{$login}__header--xl--MarginBottom: var(--pf-t--global--spacer--2xl);
-  --#{$login}__header--xl--MarginTop: var(--pf-t--global--spacer--3xl);
-  --#{$login}__header--c-brand--MarginBottom: var(--pf-t--global--spacer--lg);
-  --#{$login}__header--c-brand--xl--MarginBottom: var(--pf-t--global--spacer--2xl);
+  --#{$login}__header--xl--MarginBlockEnd: var(--pf-t--global--spacer--2xl);
+  --#{$login}__header--xl--MarginBlockStart: var(--pf-t--global--spacer--3xl);
+  --#{$login}__header--c-brand--MarginBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$login}__header--c-brand--xl--MarginBlockEnd: var(--pf-t--global--spacer--2xl);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$login}__header--MarginBottom: var(--#{$login}__header--xl--MarginBottom);
-    --#{$login}__header--c-brand--MarginBottom: var(--#{$login}__header--c-brand--xl--MarginBottom);
+    --#{$login}__header--MarginBlockEnd: var(--#{$login}__header--xl--MarginBlockEnd);
+    --#{$login}__header--c-brand--MarginBlockEnd: var(--#{$login}__header--c-brand--xl--MarginBlockEnd);
   }
 
   // main
   --#{$login}__main--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$login}__main--MarginBottom: var(--pf-t--global--spacer--lg);
+  --#{$login}__main--MarginBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$login}__main--BorderRadius: var(--pf-t--global--border--radius--large);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$login}__main--MarginBottom: 0;
+    --#{$login}__main--MarginBlockEnd: 0;
   }
 
   // main header
-  --#{$login}__main-header--PaddingTop: var(--pf-t--global--spacer--2xl);
-  --#{$login}__main-header--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-header--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$login}__main-header--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-header--md--PaddingRight: var(--pf-t--global--spacer--2xl);
-  --#{$login}__main-header--md--PaddingLeft: var(--pf-t--global--spacer--2xl);
+  --#{$login}__main-header--PaddingBlockStart: var(--pf-t--global--spacer--2xl);
+  --#{$login}__main-header--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$login}__main-header--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-header--md--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
+  --#{$login}__main-header--md--PaddingInlineStart: var(--pf-t--global--spacer--2xl);
   --#{$login}__main-header--ColumnGap: var(--pf-t--global--spacer--md);
   --#{$login}__main-header--RowGap: var(--pf-t--global--spacer--md);
 
   // main header desc
-  --#{$login}__main-header-desc--MarginBottom: var(--pf-t--global--spacer--sm);
-  --#{$login}__main-header-desc--md--MarginBottom: 0;
+  --#{$login}__main-header-desc--MarginBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$login}__main-header-desc--md--MarginBlockEnd: 0;
   --#{$login}__main-header-desc--FontSize: var(--pf-t--global--font--size--body--default);
 
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$login}__main-header--PaddingRight: var(--#{$login}__main-header--md--PaddingRight);
-    --#{$login}__main-header--PaddingLeft: var(--#{$login}__main-header--md--PaddingLeft);
-    --#{$login}__main-header-desc--MarginBottom: var(--#{$login}__main-header-desc--md--MarginBottom);
+    --#{$login}__main-header--PaddingInlineEnd: var(--#{$login}__main-header--md--PaddingInlineEnd);
+    --#{$login}__main-header--PaddingInlineStart: var(--#{$login}__main-header--md--PaddingInlineStart);
+    --#{$login}__main-header-desc--MarginBlockEnd: var(--#{$login}__main-header-desc--md--MarginBlockEnd);
   }
 
   // main body
-  --#{$login}__main-body--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-body--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-body--PaddingLeft: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-body--md--PaddingRight: var(--pf-t--global--spacer--2xl);
-  --#{$login}__main-body--md--PaddingLeft: var(--pf-t--global--spacer--2xl);
+  --#{$login}__main-body--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-body--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-body--PaddingInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-body--md--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
+  --#{$login}__main-body--md--PaddingInlineStart: var(--pf-t--global--spacer--2xl);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$login}__main-body--PaddingRight: var(--#{$login}__main-body--md--PaddingRight);
-    --#{$login}__main-body--PaddingLeft: var(--#{$login}__main-body--md--PaddingLeft);
+    --#{$login}__main-body--PaddingInlineEnd: var(--#{$login}__main-body--md--PaddingInlineEnd);
+    --#{$login}__main-body--PaddingInlineStart: var(--#{$login}__main-body--md--PaddingInlineStart);
   }
 
   // main footer
-  --#{$login}__main-footer--PaddingBottom: var(--pf-t--global--spacer--3xl);
-  --#{$login}__main-footer--c-title--MarginBottom: var(--pf-t--global--spacer--md);
-  --#{$login}__main-footer-links--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$login}__main-footer-links--PaddingRight: var(--pf-t--global--spacer--3xl);
-  --#{$login}__main-footer-links--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$login}__main-footer-links--PaddingLeft: var(--pf-t--global--spacer--3xl);
+  --#{$login}__main-footer--PaddingBlockEnd: var(--pf-t--global--spacer--3xl);
+  --#{$login}__main-footer--c-title--MarginBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$login}__main-footer-links--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$login}__main-footer-links--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
+  --#{$login}__main-footer-links--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$login}__main-footer-links--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
   --#{$login}__main-footer-links--Gap: var(--pf-t--global--spacer--md);
   --#{$login}__main-footer-links-item--c-button--FontSize: var(--pf-t--global--icon--size--xl);
-  --#{$login}__main-footer-band--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$login}__main-footer-band--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$login}__main-footer-band--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$login}__main-footer-band--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$login}__main-footer-band--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$login}__main-footer-band--BorderTopWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$login}__main-footer-band-item--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$login}__main-footer-band--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$login}__main-footer-band--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$login}__main-footer-band--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$login}__main-footer-band--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$login}__main-footer-band--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$login}__main-footer-band--BorderBlockStartWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$login}__main-footer-band-item--PaddingBlockStart: var(--pf-t--global--spacer--md);
 
   // footer
-  --#{$login}__footer--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$login}__footer--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$login}__footer--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$login}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   @media (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$login}__footer--PaddingRight: 0;
-    --#{$login}__footer--PaddingLeft: 0;
+    --#{$login}__footer--PaddingInlineEnd: 0;
+    --#{$login}__footer--PaddingInlineStart: 0;
   }
 
-  --#{$login}__footer--c-list--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$login}__footer--c-list--xl--PaddingTop: var(--pf-t--global--spacer--2xl);
+  --#{$login}__footer--c-list--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$login}__footer--c-list--xl--PaddingBlockStart: var(--pf-t--global--spacer--2xl);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$login}__footer--c-list--PaddingTop: var(--#{$login}__footer--c-list--xl--PaddingTop);
+    --#{$login}__footer--c-list--PaddingBlockStart: var(--#{$login}__footer--c-list--xl--PaddingBlockStart);
   }
 }
 
@@ -117,8 +117,8 @@
   display: flex;
   justify-content: center;
   min-height: 100vh;
-  padding-block-start: var(--#{$login}--PaddingTop);
-  padding-block-end: var(--#{$login}--PaddingBottom);
+  padding-block-start: var(--#{$login}--PaddingBlockStart);
+  padding-block-end: var(--#{$login}--PaddingBlockEnd);
 
   @media (min-width: $pf-v6-global--breakpoint--sm) {
     align-items: center;
@@ -139,40 +139,40 @@
     grid-template-columns: var(--#{$login}__container--xl--GridTemplateColumns);
     grid-column-gap: var(--#{$login}__container--xl--GridColumnGap);
     justify-content: center;
-    padding-inline-start: var(--#{$login}__container--PaddingLeft);
-    padding-inline-end: var(--#{$login}__container--PaddingRight);
+    padding-inline-start: var(--#{$login}__container--PaddingInlineStart);
+    padding-inline-end: var(--#{$login}__container--PaddingInlineEnd);
   }
 }
 
 .#{$login}__header {
   grid-area: header;
-  padding-inline-start: var(--#{$login}__header--PaddingLeft);
-  padding-inline-end: var(--#{$login}__header--PaddingRight);
+  padding-inline-start: var(--#{$login}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__header--PaddingInlineEnd);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    margin-block-start: var(--#{$login}__header--xl--MarginTop);
+    margin-block-start: var(--#{$login}__header--xl--MarginBlockStart);
   }
 
   .#{$brand} {
-    margin-block-end: var(--#{$login}__header--c-brand--MarginBottom);
+    margin-block-end: var(--#{$login}__header--c-brand--MarginBlockEnd);
   }
 }
 
 .#{$login}__main {
   grid-area: main;
   align-self: start;
-  margin-block-end: var(--#{$login}__main--MarginBottom);
+  margin-block-end: var(--#{$login}__main--MarginBlockEnd);
   background-color: var(--#{$login}__main--BackgroundColor);
   border-radius: var(--#{$login}__main--BorderRadius);
 
   // If the first child isn't a header, then we need to put the header's top padding there
   > :first-child:not(.#{$login}__main-header) {
-    padding-block-start: var(--#{$login}__main-header--PaddingTop);
+    padding-block-start: var(--#{$login}__main-header--PaddingBlockStart);
   }
 
   // If the last child isn't the footer, then we need to put the footer's bottom padding there
   > :last-child:not(.#{$login}__main-footer) {
-    padding-block-end: var(--#{$login}__main-footer--PaddingBottom);
+    padding-block-end: var(--#{$login}__main-footer--PaddingBlockEnd);
   }
 }
 
@@ -182,10 +182,10 @@
   row-gap: var(--#{$login}__main-header--RowGap);
   column-gap: var(--#{$login}__main-header--ColumnGap);
   align-items: center;
-  padding-block-start: var(--#{$login}__main-header--PaddingTop);
-  padding-block-end: var(--#{$login}__main-header--PaddingBottom);
-  padding-inline-start: var(--#{$login}__main-header--PaddingLeft);
-  padding-inline-end: var(--#{$login}__main-header--PaddingRight);
+  padding-block-start: var(--#{$login}__main-header--PaddingBlockStart);
+  padding-block-end: var(--#{$login}__main-header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$login}__main-header--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__main-header--PaddingInlineEnd);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
     grid-template-columns: 1fr auto;
@@ -212,14 +212,14 @@
 
 .#{$login}__main-header-desc {
   grid-column: 1 / -1;
-  margin-block-end: var(--#{$login}__main-header-desc--MarginBottom);
+  margin-block-end: var(--#{$login}__main-header-desc--MarginBlockEnd);
   font-size: var(--#{$login}__main-header-desc--FontSize);
 }
 
 .#{$login}__main-body {
-  padding-block-end: var(--#{$login}__main-body--PaddingBottom);
-  padding-inline-start: var(--#{$login}__main-body--PaddingLeft);
-  padding-inline-end: var(--#{$login}__main-body--PaddingRight);
+  padding-block-end: var(--#{$login}__main-body--PaddingBlockEnd);
+  padding-inline-start: var(--#{$login}__main-body--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__main-body--PaddingInlineEnd);
 }
 
 .#{$login}__main-footer {
@@ -227,7 +227,7 @@
   flex-wrap: wrap;
 
   .#{$title} {
-    margin-block-end: var(--#{$login}__main-footer--c-title--MarginBottom);
+    margin-block-end: var(--#{$login}__main-footer--c-title--MarginBlockEnd);
     text-align: center;
   }
 
@@ -241,10 +241,10 @@
   flex-wrap: wrap;
   gap: var(--#{$login}__main-footer-links--Gap);
   justify-content: center;
-  padding-block-start: var(--#{$login}__main-footer-links--PaddingTop);
-  padding-block-end: var(--#{$login}__main-footer-links--PaddingBottom);
-  padding-inline-start: var(--#{$login}__main-footer-links--PaddingLeft);
-  padding-inline-end: var(--#{$login}__main-footer-links--PaddingRight);
+  padding-block-start: var(--#{$login}__main-footer-links--PaddingBlockStart);
+  padding-block-end: var(--#{$login}__main-footer-links--PaddingBlockEnd);
+  padding-inline-start: var(--#{$login}__main-footer-links--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__main-footer-links--PaddingInlineEnd);
 }
 
 .#{$login}__main-footer-links-item {
@@ -254,22 +254,22 @@
 }
 
 .#{$login}__main-footer-band {
-  padding-block-start: var(--#{$login}__main-footer-band--PaddingTop);
-  padding-block-end: var(--#{$login}__main-footer-band--PaddingBottom);
-  padding-inline-start: var(--#{$login}__main-footer-band--PaddingLeft);
-  padding-inline-end: var(--#{$login}__main-footer-band--PaddingRight);
+  padding-block-start: var(--#{$login}__main-footer-band--PaddingBlockStart);
+  padding-block-end: var(--#{$login}__main-footer-band--PaddingBlockEnd);
+  padding-inline-start: var(--#{$login}__main-footer-band--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__main-footer-band--PaddingInlineEnd);
   text-align: center;
-  border-block-start: var(--#{$login}__main-footer-band--BorderTopWidth) solid var(--#{$login}__main-footer-band--BorderTopColor);
+  border-block-start: var(--#{$login}__main-footer-band--BorderBlockStartWidth) solid var(--#{$login}__main-footer-band--BorderBlockStartColor);
 
   > * + * {
-    padding-block-start: var(--#{$login}__main-footer-band-item--PaddingTop);
+    padding-block-start: var(--#{$login}__main-footer-band-item--PaddingBlockStart);
   }
 }
 
 .#{$login}__footer {
   grid-area: footer;
-  padding-inline-start: var(--#{$login}__footer--PaddingLeft);
-  padding-inline-end: var(--#{$login}__footer--PaddingRight);
+  padding-inline-start: var(--#{$login}__footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$login}__footer--PaddingInlineEnd);
 
   .#{$list} {
     a {
@@ -277,7 +277,7 @@
     }
 
     &:not(:only-child) { // paragraph text might not always be included.
-      padding-block-start: var(--#{$login}__footer--c-list--PaddingTop);
+      padding-block-start: var(--#{$login}__footer--c-list--PaddingBlockStart);
     }
   }
 }

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -114,12 +114,12 @@
 
   // * Menu flyout
   --#{$menu}--m-flyout__Zindex: var(--pf-t--global--z-index--sm);
-  --#{$menu}--m-flyout__menu--BlockStart: calc(var(--#{$menu}__list--PaddingBlockStart) * -1 + var(--#{$menu}--m-flyout__menu--top-offset));
-  --#{$menu}--m-flyout__menu--InlineEnd: auto;
-  --#{$menu}--m-flyout__menu--BlockEnd: auto;
-  --#{$menu}--m-flyout__menu--InlineStart: calc(100% + var(--#{$menu}--m-flyout__menu--left-offset));
-  --#{$menu}--m-flyout__menu--m-top--BlockEnd: calc(var(--#{$menu}__list--PaddingBlockStart) * -1);
-  --#{$menu}--m-flyout__menu--m-left--InlineEnd: calc(100% + var(--#{$menu}--m-flyout__menu--m-left--right-offset));
+  --#{$menu}--m-flyout__menu--InsetBlockStart: calc(var(--#{$menu}__list--PaddingBlockStart) * -1 + var(--#{$menu}--m-flyout__menu--top-offset));
+  --#{$menu}--m-flyout__menu--InsetInlineEnd: auto;
+  --#{$menu}--m-flyout__menu--InsetBlockEnd: auto;
+  --#{$menu}--m-flyout__menu--InsetInlineStart: calc(100% + var(--#{$menu}--m-flyout__menu--left-offset));
+  --#{$menu}--m-flyout__menu--m-top--InsetBlockEnd: calc(var(--#{$menu}__list--PaddingBlockStart) * -1);
+  --#{$menu}--m-flyout__menu--m-left--InsetInlineEnd: calc(100% + var(--#{$menu}--m-flyout__menu--m-left--right-offset));
 
   // * Menu drilldown content
   --#{$menu}--m-drilldown__content--TransitionDuration--height: var(--pf-t--global--transition--duration);
@@ -127,7 +127,7 @@
   --#{$menu}--m-drilldown__content--Transition: transform var(--#{$menu}--m-drilldown__content--TransitionDuration--transform), height var(--#{$menu}--m-drilldown__content--TransitionDuration--height);
 
   // * Menu drilldown menu
-  --#{$menu}--m-drilldown--c-menu--BlockStart: 0;
+  --#{$menu}--m-drilldown--c-menu--InsetBlockStart: 0;
   --#{$menu}--m-drilldown--c-menu--TransitionDuration--transform: var(--pf-t--global--transition--duration);
   --#{$menu}--m-drilldown--c-menu--Transition: transform var(--#{$menu}--m-drilldown--c-menu--TransitionDuration--transform);
 
@@ -223,10 +223,10 @@
   & &.pf-m-flyout,
   &.pf-m-flyout & {
     position: absolute;
-    inset-block-start: var(--#{$menu}--m-flyout__menu--BlockStart);
-    inset-block-end: var(--#{$menu}--m-flyout__menu--BlockEnd);
-    inset-inline-start: var(--#{$menu}--m-flyout__menu--InlineStart);
-    inset-inline-end: var(--#{$menu}--m-flyout__menu--InlineEnd);
+    inset-block-start: var(--#{$menu}--m-flyout__menu--InsetBlockStart);
+    inset-block-end: var(--#{$menu}--m-flyout__menu--InsetBlockEnd);
+    inset-inline-start: var(--#{$menu}--m-flyout__menu--InsetInlineStart);
+    inset-inline-end: var(--#{$menu}--m-flyout__menu--InsetInlineEnd);
     z-index: var(--#{$menu}--m-flyout__Zindex);
     border-radius: var(--#{$menu}--BorderRadius);
 
@@ -236,13 +236,13 @@
   }
 
   &.pf-m-top {
-    --#{$menu}--m-flyout__menu--BlockStart: auto;
-    --#{$menu}--m-flyout__menu--BlockEnd: var(--#{$menu}--m-flyout__menu--m-top--BlockEnd);
+    --#{$menu}--m-flyout__menu--InsetBlockStart: auto;
+    --#{$menu}--m-flyout__menu--InsetBlockEnd: var(--#{$menu}--m-flyout__menu--m-top--InsetBlockEnd);
   }
 
   &.pf-m-left {
-    --#{$menu}--m-flyout__menu--InlineEnd: var(--#{$menu}--m-flyout__menu--m-left--InlineEnd);
-    --#{$menu}--m-flyout__menu--InlineStart: auto;
+    --#{$menu}--m-flyout__menu--InsetInlineEnd: var(--#{$menu}--m-flyout__menu--m-left--InsetInlineEnd);
+    --#{$menu}--m-flyout__menu--InsetInlineStart: auto;
   }
 
   &.pf-m-drilldown {
@@ -272,7 +272,7 @@
     // - Menu nested menu
     > .#{$menu}__content .#{$menu} {
       position: absolute;
-      inset-block-start: var(--#{$menu}--m-drilldown--c-menu--BlockStart);
+      inset-block-start: var(--#{$menu}--m-drilldown--c-menu--InsetBlockStart);
       inset-inline-start: 100%;
       width: 100%;
       box-shadow: none;

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -44,8 +44,8 @@
   --#{$menu}__list-item--has--menu-action--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
 
   // * Menu li divider
-  --#{$menu}__list--divider--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$menu}__list--divider--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$menu}__list--divider--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$menu}__list--divider--MarginBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Menu item
   --#{$menu}__item--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -114,12 +114,12 @@
 
   // * Menu flyout
   --#{$menu}--m-flyout__Zindex: var(--pf-t--global--z-index--sm);
-  --#{$menu}--m-flyout__menu--Top: calc(var(--#{$menu}__list--PaddingBlockStart) * -1 + var(--#{$menu}--m-flyout__menu--top-offset));
-  --#{$menu}--m-flyout__menu--Right: auto;
-  --#{$menu}--m-flyout__menu--Bottom: auto;
-  --#{$menu}--m-flyout__menu--Left: calc(100% + var(--#{$menu}--m-flyout__menu--left-offset));
-  --#{$menu}--m-flyout__menu--m-top--Bottom: calc(var(--#{$menu}__list--PaddingBlockStart) * -1);
-  --#{$menu}--m-flyout__menu--m-left--Right: calc(100% + var(--#{$menu}--m-flyout__menu--m-left--right-offset));
+  --#{$menu}--m-flyout__menu--BlockStart: calc(var(--#{$menu}__list--PaddingBlockStart) * -1 + var(--#{$menu}--m-flyout__menu--top-offset));
+  --#{$menu}--m-flyout__menu--InlineEnd: auto;
+  --#{$menu}--m-flyout__menu--BlockEnd: auto;
+  --#{$menu}--m-flyout__menu--InlineStart: calc(100% + var(--#{$menu}--m-flyout__menu--left-offset));
+  --#{$menu}--m-flyout__menu--m-top--BlockEnd: calc(var(--#{$menu}__list--PaddingBlockStart) * -1);
+  --#{$menu}--m-flyout__menu--m-left--InlineEnd: calc(100% + var(--#{$menu}--m-flyout__menu--m-left--right-offset));
 
   // * Menu drilldown content
   --#{$menu}--m-drilldown__content--TransitionDuration--height: var(--pf-t--global--transition--duration);
@@ -127,7 +127,7 @@
   --#{$menu}--m-drilldown__content--Transition: transform var(--#{$menu}--m-drilldown__content--TransitionDuration--transform), height var(--#{$menu}--m-drilldown__content--TransitionDuration--height);
 
   // * Menu drilldown menu
-  --#{$menu}--m-drilldown--c-menu--Top: 0;
+  --#{$menu}--m-drilldown--c-menu--BlockStart: 0;
   --#{$menu}--m-drilldown--c-menu--TransitionDuration--transform: var(--pf-t--global--transition--duration);
   --#{$menu}--m-drilldown--c-menu--Transition: transform var(--#{$menu}--m-drilldown--c-menu--TransitionDuration--transform);
 
@@ -223,10 +223,10 @@
   & &.pf-m-flyout,
   &.pf-m-flyout & {
     position: absolute;
-    inset-block-start: var(--#{$menu}--m-flyout__menu--Top);
-    inset-block-end: var(--#{$menu}--m-flyout__menu--Bottom);
-    inset-inline-start: var(--#{$menu}--m-flyout__menu--Left);
-    inset-inline-end: var(--#{$menu}--m-flyout__menu--Right);
+    inset-block-start: var(--#{$menu}--m-flyout__menu--BlockStart);
+    inset-block-end: var(--#{$menu}--m-flyout__menu--BlockEnd);
+    inset-inline-start: var(--#{$menu}--m-flyout__menu--InlineStart);
+    inset-inline-end: var(--#{$menu}--m-flyout__menu--InlineEnd);
     z-index: var(--#{$menu}--m-flyout__Zindex);
     border-radius: var(--#{$menu}--BorderRadius);
 
@@ -236,13 +236,13 @@
   }
 
   &.pf-m-top {
-    --#{$menu}--m-flyout__menu--Top: auto;
-    --#{$menu}--m-flyout__menu--Bottom: var(--#{$menu}--m-flyout__menu--m-top--Bottom);
+    --#{$menu}--m-flyout__menu--BlockStart: auto;
+    --#{$menu}--m-flyout__menu--BlockEnd: var(--#{$menu}--m-flyout__menu--m-top--BlockEnd);
   }
 
   &.pf-m-left {
-    --#{$menu}--m-flyout__menu--Right: var(--#{$menu}--m-flyout__menu--m-left--Right);
-    --#{$menu}--m-flyout__menu--Left: auto;
+    --#{$menu}--m-flyout__menu--InlineEnd: var(--#{$menu}--m-flyout__menu--m-left--InlineEnd);
+    --#{$menu}--m-flyout__menu--InlineStart: auto;
   }
 
   &.pf-m-drilldown {
@@ -272,7 +272,7 @@
     // - Menu nested menu
     > .#{$menu}__content .#{$menu} {
       position: absolute;
-      inset-block-start: var(--#{$menu}--m-drilldown--c-menu--Top);
+      inset-block-start: var(--#{$menu}--m-drilldown--c-menu--BlockStart);
       inset-inline-start: 100%;
       width: 100%;
       box-shadow: none;
@@ -425,8 +425,8 @@
 
 // - Menu list
 .#{$menu}__list :where(.#{$divider}:is(li)) {
-  margin-block-start: var(--#{$menu}__list--divider--MarginTop);
-  margin-block-end: var(--#{$menu}__list--divider--MarginBottom);
+  margin-block-start: var(--#{$menu}__list--divider--MarginBlockStart);
+  margin-block-end: var(--#{$menu}__list--divider--MarginBlockEnd);
 }
 
 // - Menu list item

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -10,11 +10,11 @@
 
 :where(:root, .#{$menu-toggle}) {
   --#{$menu-toggle}--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingTop) + var(--#{$menu-toggle}--PaddingBottom));
+  --#{$menu-toggle}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
   --#{$menu-toggle}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$menu-toggle}--Color: var(--pf-t--global--text--color--regular);
   --#{$menu-toggle}--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -55,25 +55,25 @@
 
   // TODO: add pf-m-button modifier here
   // * Menu toggle button
-  --#{$menu-toggle}--m-button--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$menu-toggle}--m-button--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$menu-toggle}--m-button--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$menu-toggle}--m-button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$menu-toggle}--m-button--BorderRadius: var(--pf-t--global--border--radius--pill);
 
   // TODO: add pf-m-button modifier here
   // * Menu toggle control
-  --#{$menu-toggle}--m-control--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}--m-control--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--m-control--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--m-control--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--m-control--BorderRadius: var(--pf-t--global--border--radius--pill);
 
   // TODO: add pf-m-button modifier here
   // * Menu toggle action
-  --#{$menu-toggle}--m-action--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$menu-toggle}--m-action--PaddingRight: var(--pf-t--global--spacer--lg);
+  --#{$menu-toggle}--m-action--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$menu-toggle}--m-action--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$menu-toggle}--m-action--BorderRadius: var(--pf-t--global--border--radius--pill);
 
   // * Menu toggle primary
-  --#{$menu-toggle}--m-primary--PaddingLeft: var(--#{$menu-toggle}--m-button--PaddingLeft);
-  --#{$menu-toggle}--m-primary--PaddingRight: var(--#{$menu-toggle}--m-button--PaddingRight);
+  --#{$menu-toggle}--m-primary--PaddingInlineStart: var(--#{$menu-toggle}--m-button--PaddingInlineStart);
+  --#{$menu-toggle}--m-primary--PaddingInlineEnd: var(--#{$menu-toggle}--m-button--PaddingInlineEnd);
   --#{$menu-toggle}--m-primary--Color: var(--pf-t--global--text--color--on-brand--default);
   --#{$menu-toggle}--m-primary--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$menu-toggle}--m-primary--BorderRadius: var(--#{$menu-toggle}--m-button--BorderRadius);
@@ -93,8 +93,8 @@
 
 
   // * Menu toggle secondary
-  --#{$menu-toggle}--m-secondary--PaddingLeft: var(--#{$menu-toggle}--m-button--PaddingLeft);
-  --#{$menu-toggle}--m-secondary--PaddingRight: var(--#{$menu-toggle}--m-button--PaddingRight);
+  --#{$menu-toggle}--m-secondary--PaddingInlineStart: var(--#{$menu-toggle}--m-button--PaddingInlineStart);
+  --#{$menu-toggle}--m-secondary--PaddingInlineEnd: var(--#{$menu-toggle}--m-button--PaddingInlineEnd);
   --#{$menu-toggle}--m-secondary--Color: var(--pf-t--global--text--color--brand--default);
   --#{$menu-toggle}--m-secondary--BorderColor: var(--pf-t--global--border--color--brand--default);
   --#{$menu-toggle}--m-secondary--BorderRadius: var(--#{$menu-toggle}--m-button--BorderRadius);
@@ -115,35 +115,35 @@
   --#{$menu-toggle}__controls--MinWidth: calc(var(--#{$menu-toggle}--FontSize) + var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--sm));
 
   // Full height
-  --#{$menu-toggle}--m-full-height--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$menu-toggle}--m-full-height--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$menu-toggle}--m-full-height--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$menu-toggle}--m-full-height--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Split button, child
   --#{$menu-toggle}--m-split-button--child--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$menu-toggle}--m-split-button--child--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // Split button, action
-  --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftWidth: var(--pf-t--global--border--width--button--default);
-  --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--pf-t--global--border--color--default);
+  --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartWidth: var(--pf-t--global--border--width--button--default);
+  --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--pf-t--global--border--color--default);
   --#{$menu-toggle}--m-split-button--m-action--child--BorderRadius: var(--#{$menu-toggle}--m-button--BorderRadius);
-  --#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderLeftColor: var(--pf-t--global--icon--color--on-disabled);
+  --#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderInlineStartColor: var(--pf-t--global--icon--color--on-disabled);
 
   // Split button action, primary
   --#{$menu-toggle}--m-split-button--m-action--m-primary--child--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$menu-toggle}--m-split-button--m-action--m-primary--child--hover--BackgroundColor: var(--pf-t--global--color--brand--hover);
   --#{$menu-toggle}--m-split-button--m-action--m-primary--child--active--BackgroundColor: var(--pf-t--global--color--brand--clicked);
-  --#{$menu-toggle}--m-split-button--m-action--m-primary--child--BorderLeftColor: var(--pf-t--global--border--color--default);
+  --#{$menu-toggle}--m-split-button--m-action--m-primary--child--BorderInlineStartColor: var(--pf-t--global--border--color--default);
   --#{$menu-toggle}--m-split-button--m-action--m-primary--expanded--child--BackgroundColor: var(--pf-t--global--color--brand--clicked);
 
   // Split button action, secondary
-  --#{$menu-toggle}--m-split-button--m-action--m-secondary--child--BorderLeftColor: var(--pf-t--global--color--brand--default);
+  --#{$menu-toggle}--m-split-button--m-action--m-secondary--child--BorderInlineStartColor: var(--pf-t--global--color--brand--default);
 
   // Split button, controls, check
   --#{$menu-toggle}__button--BackgroundColor: transparent;
   --#{$menu-toggle}__button--AlignSelf: baseline;
-  --#{$menu-toggle}__button--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}__button--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingTop) + var(--#{$menu-toggle}--PaddingBottom));
+  --#{$menu-toggle}__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
 
   // Menu toggle plain
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);
@@ -156,12 +156,12 @@
   --#{$menu-toggle}--m-plain--disabled--BackgroundColor: transparent; // picking icon color rather than text...?
 
   // Typeahead
-  --#{$menu-toggle}--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--m-typeahead--c-text-input-group__utilities--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--m-typeahead__button--AlignSelf: stretch;
 
   // * Menu toggle small
-  --#{$menu-toggle}--m-small--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$menu-toggle}--m-small--PaddingBottom: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}--m-small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}--m-small--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // Status icon
   --#{$menu-toggle}__status-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
@@ -187,10 +187,10 @@
   justify-content: center;
   min-width: var(--#{$menu-toggle}--MinWidth);
   max-width: 100%;
-  padding-block-start: var(--#{$menu-toggle}--PaddingTop);
-  padding-block-end: var(--#{$menu-toggle}--PaddingBottom);
-  padding-inline-start: var(--#{$menu-toggle}--PaddingLeft);
-  padding-inline-end: var(--#{$menu-toggle}--PaddingRight);
+  padding-block-start: var(--#{$menu-toggle}--PaddingBlockStart);
+  padding-block-end: var(--#{$menu-toggle}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$menu-toggle}--PaddingInlineStart);
+  padding-inline-end: var(--#{$menu-toggle}--PaddingInlineEnd);
   font-size: var(--#{$menu-toggle}--FontSize);
   line-height: var(--#{$menu-toggle}--LineHeight);
   color: var(--#{$menu-toggle}--Color);
@@ -217,8 +217,8 @@
 
   &.pf-m-primary {
     // TODO: abstract padding updates to control/button variant
-    --#{$menu-toggle}--PaddingLeft: var(--#{$menu-toggle}--m-primary--PaddingLeft);
-    --#{$menu-toggle}--PaddingRight: var(--#{$menu-toggle}--m-primary--PaddingRight);
+    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-primary--PaddingInlineStart);
+    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-primary--PaddingInlineEnd);
     --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-primary--Color);
     --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--m-primary--BackgroundColor);
     --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-primary--BorderRadius);
@@ -238,8 +238,8 @@
 
   &.pf-m-secondary {
     // TODO: abstract padding updates to control/button variant
-    --#{$menu-toggle}--PaddingLeft: var(--#{$menu-toggle}--m-secondary--PaddingLeft);
-    --#{$menu-toggle}--PaddingRight: var(--#{$menu-toggle}--m-secondary--PaddingRight);
+    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-secondary--PaddingInlineStart);
+    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-secondary--PaddingInlineEnd);
     --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-secondary--Color);
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-secondary--BorderColor);
     --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-secondary--BorderRadius);
@@ -256,9 +256,9 @@
   }
 
   &.pf-m-full-height {
-    --#{$menu-toggle}--PaddingRight: var(--#{$menu-toggle}--m-full-height--PaddingRight);
-    --#{$menu-toggle}--PaddingLeft: var(--#{$menu-toggle}--m-full-height--PaddingLeft);
-    --#{$menu-toggle}--BorderTopWidth: var(--#{$menu-toggle}--m-full-height__toggle--BorderTopWidth);
+    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-full-height--PaddingInlineEnd);
+    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-full-height--PaddingInlineStart);
+    --#{$menu-toggle}--BorderBlockStartWidth: var(--#{$menu-toggle}--m-full-height__toggle--BorderBlockStartWidth);
 
     align-items: center;
     height: 100%;
@@ -327,8 +327,8 @@
 
   // - Menu item small
   &.pf-m-small {
-    --#{$menu-toggle}--PaddingTop: var(--#{$menu-toggle}--m-small--PaddingTop);
-    --#{$menu-toggle}--PaddingBottom: var(--#{$menu-toggle}--m-small--PaddingBottom);
+    --#{$menu-toggle}--PaddingBlockStart: var(--#{$menu-toggle}--m-small--PaddingBlockStart);
+    --#{$menu-toggle}--PaddingBlockEnd: var(--#{$menu-toggle}--m-small--PaddingBlockEnd);
   }
 
   &:has(.#{$button}) {
@@ -359,10 +359,10 @@
 
   > * {
     position: relative;
-    padding-block-start: var(--#{$menu-toggle}--PaddingTop);
-    padding-block-end: var(--#{$menu-toggle}--PaddingBottom);
-    padding-inline-start: var(--#{$menu-toggle}--PaddingLeft);
-    padding-inline-end: var(--#{$menu-toggle}--PaddingRight);
+    padding-block-start: var(--#{$menu-toggle}--PaddingBlockStart);
+    padding-block-end: var(--#{$menu-toggle}--PaddingBlockEnd);
+    padding-inline-start: var(--#{$menu-toggle}--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--PaddingInlineEnd);
   }
 
   > :first-child {
@@ -376,7 +376,7 @@
   }
 
   > .#{$check} {
-    --#{$menu-toggle}--PaddingRight: 0;
+    --#{$menu-toggle}--PaddingInlineEnd: 0;
     --#{$check}__label--Color: currentcolor;
     --#{$check}__label--disabled--Color: currentcolor;
 
@@ -397,11 +397,11 @@
 
 // - Menu toggle split button action
 .#{$menu-toggle}.pf-m-split-button.pf-m-action {
-  --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--#{$menu-toggle}--BorderColor);
+  --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--BorderColor);
 
   // all subsequent buttons
   > :not(:first-child) {
-    border-inline-start: var(--#{$menu-toggle}--m-split-button--m-action--child--BorderLeftWidth) solid var(--#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor);
+    border-inline-start: var(--#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartWidth) solid var(--#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor);
   }
 
   > :has(.#{$menu-toggle}__controls) {
@@ -410,7 +410,7 @@
 
   // Split button, primary
   &.pf-m-primary {
-    --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--#{$menu-toggle}--m-split-button--m-action--m-primary--child--BorderLeftColor);
+    --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--m-split-button--m-action--m-primary--child--BorderInlineStartColor);
 
     // stylelint-disable max-nesting-depth, selector-max-class, selector-not-notation
     // update to single :not() in breaking change
@@ -434,12 +434,12 @@
 
   // Split button, secondary
   &.pf-m-secondary {
-    --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--#{$menu-toggle}--m-split-button--m-action--m-secondary--child--BorderLeftColor);
+    --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--m-split-button--m-action--m-secondary--child--BorderInlineStartColor);
   }
 
   // disable accent border
   &:is(.pf-m-disabled, :disabled) {
-    --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderLeftColor);
+    --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderInlineStartColor);
 
     &::before {
       content: none;
@@ -448,7 +448,7 @@
 
   // disabled styles for children
   > :is(.pf-m-disabled, :disabled) {
-    --#{$menu-toggle}--m-split-button--m-action--child--BorderLeftColor: var(--#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderLeftColor);
+    --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--m-split-button--m-action--child--disabled--BorderInlineStartColor);
 
     color: var(--#{$menu-toggle}--m-split-button--child--disabled--Color);
     background-color: var(--#{$menu-toggle}--m-split-button--child--disabled--BackgroundColor);
@@ -464,19 +464,19 @@
   padding: 0;
 
   .#{$menu-toggle}__button {
-    --#{$menu-toggle}__button--PaddingRight: 0;
+    --#{$menu-toggle}__button--PaddingInlineEnd: 0;
   }
 
   .#{$menu-toggle}__controls {
-    --#{$menu-toggle}__button--PaddingRight: 0;
+    --#{$menu-toggle}__button--PaddingInlineEnd: 0;
 
     display: flex;
     align-items: stretch;
   }
 
   .#{$text-input-group} {
-    --#{$text-input-group}__utilities--c-button--PaddingRight: var(--#{$menu-toggle}--m-typeahead--c-text-input-group__utilities--c-button--PaddingRight);
-    --#{$text-input-group}__utilities--MarginRight: 0;
+    --#{$text-input-group}__utilities--c-button--PaddingInlineEnd: var(--#{$menu-toggle}--m-typeahead--c-text-input-group__utilities--c-button--PaddingInlineEnd);
+    --#{$text-input-group}__utilities--MarginInlineEnd: 0;
 
     flex: 1;
   }
@@ -486,8 +486,8 @@
 .#{$menu-toggle}__button {
   align-self: var(--#{$menu-toggle}__button--AlignSelf);
   min-width: var(--#{$menu-toggle}__button--MinWidth);
-  padding-inline-start: var(--#{$menu-toggle}__button--PaddingLeft);
-  padding-inline-end: var(--#{$menu-toggle}__button--PaddingRight);
+  padding-inline-start: var(--#{$menu-toggle}__button--PaddingInlineStart);
+  padding-inline-end: var(--#{$menu-toggle}__button--PaddingInlineEnd);
   color: inherit;
   background-color: var(--#{$menu-toggle}__button--BackgroundColor);
   border: 0;

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -13,7 +13,7 @@
   --#{$modal-box}--MaxHeight: calc(100% - var(--pf-t--global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
   --#{$modal-box}--m-align-top--spacer: var(--pf-t--global--spacer--sm);
   --#{$modal-box}--m-align-top--xl--spacer: var(--pf-t--global--spacer--xl);
-  --#{$modal-box}--m-align-top--Top: var(--#{$modal-box}--m-align-top--spacer);
+  --#{$modal-box}--m-align-top--BlockStart: var(--#{$modal-box}--m-align-top--spacer);
   --#{$modal-box}--m-align-top--MaxHeight: calc(100% - min(var(--#{$modal-box}--m-align-top--spacer), var(--pf-t--global--spacer--2xl)) - var(--#{$modal-box}--m-align-top--spacer));
   --#{$modal-box}--m-align-top--MaxWidth: calc(100% - min(var(--#{$modal-box}--m-align-top--spacer) * 2, var(--pf-t--global--spacer--xl)));
 
@@ -29,9 +29,9 @@
   }
 
   // Header
-  --#{$modal-box}__header--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__header--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__header--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__header--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$modal-box}__header--Gap: var(--pf-t--global--spacer--md);
 
   // Header main
@@ -43,7 +43,7 @@
   --#{$modal-box}__title--FontSize: var(--pf-t--global--font--size--heading--md);
 
   // Title icon
-  --#{$modal-box}__title-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$modal-box}__title-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$modal-box}__title-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // Description
@@ -52,26 +52,26 @@
 
   // Body
   --#{$modal-box}__body--MinHeight: calc(var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)); // Allow for at least 1 line of content in the body
-  --#{$modal-box}__body--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__body--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__body--PaddingLeft: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__body--last-child--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__header--body--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$modal-box}__body--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__body--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__body--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__body--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__header--body--PaddingBlockStart: var(--pf-t--global--spacer--md);
 
   // Close
-  --#{$modal-box}__close--Top: var(--#{$modal-box}__header--PaddingTop);
-  --#{$modal-box}__close--Right: var(--#{$modal-box}__header--PaddingRight);
-  --#{$modal-box}__close--sibling--MarginRight: calc(var(--pf-t--global--spacer--xl) + var(--pf-t--global--spacer--sm));
+  --#{$modal-box}__close--BlockStart: var(--#{$modal-box}__header--PaddingBlockStart);
+  --#{$modal-box}__close--InlineEnd: var(--#{$modal-box}__header--PaddingInlineEnd);
+  --#{$modal-box}__close--sibling--MarginInlineEnd: calc(var(--pf-t--global--spacer--xl) + var(--pf-t--global--spacer--sm));
 
   // Footer
-  --#{$modal-box}__footer--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__footer--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__footer--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$modal-box}__footer--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$modal-box}__footer--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Footer buttons
-  --#{$modal-box}__footer--c-button--MarginRight: var(--pf-t--global--spacer--md); // Button spacer is used to manipulate margin-inline-start and/or margin-right values at various breakpoints, with a single value.
-  --#{$modal-box}__footer--c-button--sm--MarginRight: calc(var(--#{$modal-box}__footer--c-button--MarginRight) / 2);
+  --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--pf-t--global--spacer--md); // Button spacer is used to manipulate margin-inline-start and/or margin-right values at various breakpoints, with a single value.
+  --#{$modal-box}__footer--c-button--sm--MarginInlineEnd: calc(var(--#{$modal-box}__footer--c-button--MarginInlineEnd) / 2);
 }
 
 .#{$modal-box} {
@@ -100,7 +100,7 @@
   }
 
   &.pf-m-align-top {
-    inset-block-start: var(--#{$modal-box}--m-align-top--Top);
+    inset-block-start: var(--#{$modal-box}--m-align-top--BlockStart);
     align-self: flex-start;
     max-width: var(--#{$modal-box}--m-align-top--MaxWidth);
     max-height: var(--#{$modal-box}--m-align-top--MaxHeight);
@@ -145,11 +145,11 @@
 // Close button
 .#{$modal-box}__close {
   position: absolute;
- inset-block-start: var(--#{$modal-box}__close--Top);
- inset-inline-end: var(--#{$modal-box}__close--Right);
+ inset-block-start: var(--#{$modal-box}__close--BlockStart);
+ inset-inline-end: var(--#{$modal-box}__close--InlineEnd);
 
   + * {
-    margin-inline-end: var(--#{$modal-box}__close--sibling--MarginRight); // Create room for the close button
+    margin-inline-end: var(--#{$modal-box}__close--sibling--MarginInlineEnd); // Create room for the close button
   }
 }
 
@@ -158,9 +158,9 @@
   flex-direction: column;
   flex-shrink: 0;
   gap: var(--#{$modal-box}__header--Gap);
-  padding-block-start: var(--#{$modal-box}__header--PaddingTop);
-  padding-inline-start: var(--#{$modal-box}__header--PaddingLeft);
-  padding-inline-end: var(--#{$modal-box}__header--PaddingRight);
+  padding-block-start: var(--#{$modal-box}__header--PaddingBlockStart);
+  padding-inline-start: var(--#{$modal-box}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$modal-box}__header--PaddingInlineEnd);
 
   &.pf-m-help {
     display: flex;
@@ -168,7 +168,7 @@
   }
 
   + .#{$modal-box}__body {
-    --#{$modal-box}__body--PaddingTop: var(--#{$modal-box}__header--body--PaddingTop);
+    --#{$modal-box}__body--PaddingBlockStart: var(--#{$modal-box}__header--body--PaddingBlockStart);
   }
 }
 
@@ -197,12 +197,12 @@
 }
 
 .#{$modal-box}__title-icon {
-  margin-inline-end: var(--#{$modal-box}__title-icon--MarginRight);
+  margin-inline-end: var(--#{$modal-box}__title-icon--MarginInlineEnd);
   color: var(--#{$modal-box}__title-icon--Color);
 }
 
 .#{$modal-box}__description {
-  padding-block-start: var(--#{$modal-box}__description--PaddingTop);
+  padding-block-start: var(--#{$modal-box}__description--PaddingBlockStart);
   font-size: var(--#{$modal-box}__description--FontSize);
   color: var(--#{$modal-box}__description--Color);
 }
@@ -211,9 +211,9 @@
 .#{$modal-box}__body {
   flex: 1 1 auto;
   min-height: var(--#{$modal-box}__body--MinHeight);
-  padding-block-start: var(--#{$modal-box}__body--PaddingTop);
-  padding-inline-start: var(--#{$modal-box}__body--PaddingLeft);
-  padding-inline-end: var(--#{$modal-box}__body--PaddingRight);
+  padding-block-start: var(--#{$modal-box}__body--PaddingBlockStart);
+  padding-inline-start: var(--#{$modal-box}__body--PaddingInlineStart);
+  padding-inline-end: var(--#{$modal-box}__body--PaddingInlineEnd);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -221,7 +221,7 @@
   -webkit-overflow-scrolling: touch;
 
   &:last-child {
-    padding-block-end: var(--#{$modal-box}__body--last-child--PaddingBottom);
+    padding-block-end: var(--#{$modal-box}__body--last-child--PaddingBlockEnd);
   }
 }
 
@@ -230,17 +230,17 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  padding-block-start: var(--#{$modal-box}__footer--PaddingTop);
-  padding-block-end: var(--#{$modal-box}__footer--PaddingBottom);
-  padding-inline-start: var(--#{$modal-box}__footer--PaddingLeft);
-  padding-inline-end: var(--#{$modal-box}__footer--PaddingRight);
+  padding-block-start: var(--#{$modal-box}__footer--PaddingBlockStart);
+  padding-block-end: var(--#{$modal-box}__footer--PaddingBlockEnd);
+  padding-inline-start: var(--#{$modal-box}__footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$modal-box}__footer--PaddingInlineEnd);
 
   // Base margin left and right equal for buttons when wrapped
   > .#{$button}:not(:last-child) {
-    margin-inline-end: var(--#{$modal-box}__footer--c-button--MarginRight);
+    margin-inline-end: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
 
     @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-      --#{$modal-box}__footer--c-button--MarginRight: var(--#{$modal-box}__footer--c-button--sm--MarginRight);
+      --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--sm--MarginInlineEnd);
     }
   }
 }

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -13,7 +13,7 @@
   --#{$modal-box}--MaxHeight: calc(100% - var(--pf-t--global--spacer--2xl)); // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
   --#{$modal-box}--m-align-top--spacer: var(--pf-t--global--spacer--sm);
   --#{$modal-box}--m-align-top--xl--spacer: var(--pf-t--global--spacer--xl);
-  --#{$modal-box}--m-align-top--BlockStart: var(--#{$modal-box}--m-align-top--spacer);
+  --#{$modal-box}--m-align-top--InsetBlockStart: var(--#{$modal-box}--m-align-top--spacer);
   --#{$modal-box}--m-align-top--MaxHeight: calc(100% - min(var(--#{$modal-box}--m-align-top--spacer), var(--pf-t--global--spacer--2xl)) - var(--#{$modal-box}--m-align-top--spacer));
   --#{$modal-box}--m-align-top--MaxWidth: calc(100% - min(var(--#{$modal-box}--m-align-top--spacer) * 2, var(--pf-t--global--spacer--xl)));
 
@@ -59,8 +59,8 @@
   --#{$modal-box}__header--body--PaddingBlockStart: var(--pf-t--global--spacer--md);
 
   // Close
-  --#{$modal-box}__close--BlockStart: var(--#{$modal-box}__header--PaddingBlockStart);
-  --#{$modal-box}__close--InlineEnd: var(--#{$modal-box}__header--PaddingInlineEnd);
+  --#{$modal-box}__close--InsetBlockStart: var(--#{$modal-box}__header--PaddingBlockStart);
+  --#{$modal-box}__close--InsetInlineEnd: var(--#{$modal-box}__header--PaddingInlineEnd);
   --#{$modal-box}__close--sibling--MarginInlineEnd: calc(var(--pf-t--global--spacer--xl) + var(--pf-t--global--spacer--sm));
 
   // Footer
@@ -100,7 +100,7 @@
   }
 
   &.pf-m-align-top {
-    inset-block-start: var(--#{$modal-box}--m-align-top--BlockStart);
+    inset-block-start: var(--#{$modal-box}--m-align-top--InsetBlockStart);
     align-self: flex-start;
     max-width: var(--#{$modal-box}--m-align-top--MaxWidth);
     max-height: var(--#{$modal-box}--m-align-top--MaxHeight);
@@ -145,8 +145,8 @@
 // Close button
 .#{$modal-box}__close {
   position: absolute;
- inset-block-start: var(--#{$modal-box}__close--BlockStart);
- inset-inline-end: var(--#{$modal-box}__close--InlineEnd);
+ inset-block-start: var(--#{$modal-box}__close--InsetBlockStart);
+ inset-inline-end: var(--#{$modal-box}__close--InsetInlineEnd);
 
   + * {
     margin-inline-end: var(--#{$modal-box}__close--sibling--MarginInlineEnd); // Create room for the close button

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
@@ -12,10 +12,10 @@
     "title"
     "upload"
     "info";
-  --#{$multiple-file-upload}__main--PaddingTop: var(--pf-t--global--spacer--xl);
-  --#{$multiple-file-upload}__main--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$multiple-file-upload}__main--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$multiple-file-upload}__main--PaddingLeft: var(--pf-t--global--spacer--xl);
+  --#{$multiple-file-upload}__main--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$multiple-file-upload}__main--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$multiple-file-upload}__main--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$multiple-file-upload}__main--PaddingInlineStart: var(--pf-t--global--spacer--xl);
   --#{$multiple-file-upload}__main--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$multiple-file-upload}__main--BorderStyle: dashed;
   --#{$multiple-file-upload}__main--BorderColor: var(--pf-t--global--border--color--default);
@@ -38,8 +38,8 @@
 
   // title text separator
   --#{$multiple-file-upload}__title-text-separator--Display: block;
-  --#{$multiple-file-upload}__title-text-separator--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$multiple-file-upload}__title-text-separator--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$multiple-file-upload}__title-text-separator--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$multiple-file-upload}__title-text-separator--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$multiple-file-upload}__title-text-separator--Color: var(--pf-t--global--text--color--regular);
   --#{$multiple-file-upload}__title-text-separator--FontFamily: var(--pf-t--global--font--family--body);
   --#{$multiple-file-upload}__title-text-separator--FontSize: var(--pf-t--global--font--size--body--lg);
@@ -48,7 +48,7 @@
   // info
   --#{$multiple-file-upload}__info--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$multiple-file-upload}__info--Color: var(--pf-t--global--text--color--subtle);
-  --#{$multiple-file-upload}__info--MarginTop: var(--pf-t--global--spacer--lg);
+  --#{$multiple-file-upload}__info--MarginBlockStart: var(--pf-t--global--spacer--lg);
 
   // drag-over
   --#{$multiple-file-upload}--m-drag-over__main--BorderStyle: dashed;
@@ -62,7 +62,7 @@
     "title upload"
     "info upload";
   --#{$multiple-file-upload}--m-horizontal__main--Gap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg);
-  --#{$multiple-file-upload}--m-horizontal__main--PaddingBottom: var(--pf-t--global--spacer--lg);
+  --#{$multiple-file-upload}--m-horizontal__main--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$multiple-file-upload}--m-horizontal__title--GridTemplateColumns: auto 1fr;
   --#{$multiple-file-upload}--m-horizontal__title--Gap: var(--pf-t--global--spacer--sm);
 
@@ -70,17 +70,17 @@
   --#{$multiple-file-upload}--m-horizontal__title-icon--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$multiple-file-upload}--m-horizontal__title-text--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--Display: inline;
-  --#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginTop: 0;
+  --#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginBlockStart: 0;
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--FontWeight: var(--pf-t--global--font--weight--heading);
-  --#{$multiple-file-upload}--m-horizontal__info--MarginTop: 0;
+  --#{$multiple-file-upload}--m-horizontal__info--MarginBlockStart: 0;
 
   // status container
-  --#{$multiple-file-upload}__status--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$multiple-file-upload}__status--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$multiple-file-upload}__status--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$multiple-file-upload}__status--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$multiple-file-upload}__status--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$multiple-file-upload}__status--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$multiple-file-upload}__status--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$multiple-file-upload}__status--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   // status progress
   --#{$multiple-file-upload}__status-progress--GridTemplateColumns: auto 1fr;
@@ -90,8 +90,8 @@
   --#{$multiple-file-upload}__status-progress-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // status item
-  --#{$multiple-file-upload}__status-item--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$multiple-file-upload}__status-item--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$multiple-file-upload}__status-item--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$multiple-file-upload}__status-item--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$multiple-file-upload}__status-item--GridTemplateColumns: auto 1fr auto;
   --#{$multiple-file-upload}__status-item--Gap: var(--pf-t--global--spacer--sm);
   --#{$multiple-file-upload}__status-item--BorderWidth: var(--pf-t--global--border--width--regular);
@@ -122,17 +122,17 @@
     --#{$multiple-file-upload}__main--GridTemplateColumns: var(--#{$multiple-file-upload}--m-horizontal__main--GridTemplateColumns);
     --#{$multiple-file-upload}__main--GridTemplateAreas: var(--#{$multiple-file-upload}--m-horizontal__main--GridTemplateAreas);
     --#{$multiple-file-upload}__main--Gap: var(--#{$multiple-file-upload}--m-horizontal__main--Gap);
-    --#{$multiple-file-upload}__main--PaddingBottom: var(--#{$multiple-file-upload}--m-horizontal__main--PaddingBottom);
+    --#{$multiple-file-upload}__main--PaddingBlockEnd: var(--#{$multiple-file-upload}--m-horizontal__main--PaddingBlockEnd);
     --#{$multiple-file-upload}__title--GridTemplateColumns: var(--#{$multiple-file-upload}--m-horizontal__title--GridTemplateColumns);
     --#{$multiple-file-upload}__title--Gap: var(--#{$multiple-file-upload}--m-horizontal__title--Gap);
     --#{$multiple-file-upload}__title-icon--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-icon--FontSize);
     --#{$multiple-file-upload}__title-text--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-text--FontSize);
     --#{$multiple-file-upload}__title-text-separator--FontFamily: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontFamily);
     --#{$multiple-file-upload}__title-text-separator--Display: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--Display);
-    --#{$multiple-file-upload}__title-text-separator--MarginTop: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginTop);
+    --#{$multiple-file-upload}__title-text-separator--MarginBlockStart: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginBlockStart);
     --#{$multiple-file-upload}__title-text-separator--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontSize);
     --#{$multiple-file-upload}__title-text-separator--FontWeight: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontWeight);
-    --#{$multiple-file-upload}__info--MarginTop: var(--#{$multiple-file-upload}--m-horizontal__info--MarginTop);
+    --#{$multiple-file-upload}__info--MarginBlockStart: var(--#{$multiple-file-upload}--m-horizontal__info--MarginBlockStart);
   }
 
   &.pf-m-drag-over {
@@ -148,10 +148,10 @@
   grid-template-columns: var(--#{$multiple-file-upload}__main--GridTemplateColumns);
   gap: var(--#{$multiple-file-upload}__main--Gap);
   align-items: center;
-  padding-block-start: var(--#{$multiple-file-upload}__main--PaddingTop);
-  padding-block-end: var(--#{$multiple-file-upload}__main--PaddingBottom);
-  padding-inline-start: var(--#{$multiple-file-upload}__main--PaddingLeft);
-  padding-inline-end: var(--#{$multiple-file-upload}__main--PaddingRight);
+  padding-block-start: var(--#{$multiple-file-upload}__main--PaddingBlockStart);
+  padding-block-end: var(--#{$multiple-file-upload}__main--PaddingBlockEnd);
+  padding-inline-start: var(--#{$multiple-file-upload}__main--PaddingInlineStart);
+  padding-inline-end: var(--#{$multiple-file-upload}__main--PaddingInlineEnd);
   text-align: var(--#{$multiple-file-upload}__main--TextAlign);
   border: var(--#{$multiple-file-upload}__main--BorderWidth) var(--#{$multiple-file-upload}__main--BorderStyle) var(--#{$multiple-file-upload}__main--BorderColor);
   border-radius: var(--#{$multiple-file-upload}__main--BorderRadius);
@@ -178,8 +178,8 @@
 
 .#{$multiple-file-upload}__title-text-separator {
   display: var(--#{$multiple-file-upload}__title-text-separator--Display);
-  margin-block-start: var(--#{$multiple-file-upload}__title-text-separator--MarginTop);
-  margin-block-end: var(--#{$multiple-file-upload}__title-text-separator--MarginBottom);
+  margin-block-start: var(--#{$multiple-file-upload}__title-text-separator--MarginBlockStart);
+  margin-block-end: var(--#{$multiple-file-upload}__title-text-separator--MarginBlockEnd);
   font-family: var(--#{$multiple-file-upload}__title-text-separator--FontFamily);
   font-size: var(--#{$multiple-file-upload}__title-text-separator--FontSize);
   font-weight: var(--#{$multiple-file-upload}__title-text-separator--FontWeight);
@@ -192,16 +192,16 @@
 
 .#{$multiple-file-upload}__info {
   grid-area: info;
-  margin-block-start: var(--#{$multiple-file-upload}__info--MarginTop);
+  margin-block-start: var(--#{$multiple-file-upload}__info--MarginBlockStart);
   font-size: var(--#{$multiple-file-upload}__info--FontSize);
   color: var(--#{$multiple-file-upload}__info--Color);
 }
 
 .#{$multiple-file-upload}__status {
-  padding-block-start: var(--#{$multiple-file-upload}__status--PaddingTop);
-  padding-block-end: var(--#{$multiple-file-upload}__status--PaddingBottom);
-  padding-inline-start: var(--#{$multiple-file-upload}__status--PaddingLeft);
-  padding-inline-end: var(--#{$multiple-file-upload}__status--PaddingRight);
+  padding-block-start: var(--#{$multiple-file-upload}__status--PaddingBlockStart);
+  padding-block-end: var(--#{$multiple-file-upload}__status--PaddingBlockEnd);
+  padding-inline-start: var(--#{$multiple-file-upload}__status--PaddingInlineStart);
+  padding-inline-end: var(--#{$multiple-file-upload}__status--PaddingInlineEnd);
 }
 
 .#{$multiple-file-upload}__status,
@@ -223,8 +223,8 @@
   display: grid;
   grid-template-columns: var(--#{$multiple-file-upload}__status-item--GridTemplateColumns);
   gap: var(--#{$multiple-file-upload}__status-item--Gap);
-  padding-block-start: var(--#{$multiple-file-upload}__status-item--PaddingTop);
-  padding-block-end: var(--#{$multiple-file-upload}__status-item--PaddingBottom);
+  padding-block-start: var(--#{$multiple-file-upload}__status-item--PaddingBlockStart);
+  padding-block-end: var(--#{$multiple-file-upload}__status-item--PaddingBlockEnd);
   border-block-end: var(--#{$multiple-file-upload}__status-item--BorderWidth) solid var(--#{$multiple-file-upload}__status-item--BorderColor);
 }
 

--- a/src/patternfly/components/NotificationBadge/notification-badge.scss
+++ b/src/patternfly/components/NotificationBadge/notification-badge.scss
@@ -4,14 +4,14 @@
   --#{$notification-badge}--BackgroundColor: transparent;
   --#{$notification-badge}--MinWidth: 40px;
   --#{$notification-badge}--Gap: var(--pf-t--global--spacer--xs);
-  --#{$notification-badge}--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$notification-badge}--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$notification-badge}--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$notification-badge}--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$notification-badge}--MarginTop: calc(-1 * var(--pf-t--global--spacer--sm));
-  --#{$notification-badge}--MarginRight: calc(-1 * var(--pf-t--global--spacer--sm));
-  --#{$notification-badge}--MarginBottom: calc(-1 * var(--pf-t--global--spacer--sm));
-  --#{$notification-badge}--MarginLeft: calc(-1 * var(--pf-t--global--spacer--sm));
+  --#{$notification-badge}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$notification-badge}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$notification-badge}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$notification-badge}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$notification-badge}--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--sm));
+  --#{$notification-badge}--MarginInlineEnd: calc(-1 * var(--pf-t--global--spacer--sm));
+  --#{$notification-badge}--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--sm));
+  --#{$notification-badge}--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--sm));
 
   // ::before border treatment
   --#{$notification-badge}--before--BorderColor: transparent;
@@ -45,14 +45,14 @@
   gap: var(--#{$notification-badge}--Gap);
   align-items: center;
   justify-content: center;
-  padding-block-start: var(--#{$notification-badge}--PaddingTop);
-  padding-block-end: var(--#{$notification-badge}--PaddingBottom);
-  padding-inline-start: var(--#{$notification-badge}--PaddingLeft);
-  padding-inline-end: var(--#{$notification-badge}--PaddingRight);
-  margin-block-start: var(--#{$notification-badge}--MarginTop);
-  margin-block-end: var(--#{$notification-badge}--MarginBottom);
-  margin-inline-start: var(--#{$notification-badge}--MarginLeft);
-  margin-inline-end: var(--#{$notification-badge}--MarginRight);
+  padding-block-start: var(--#{$notification-badge}--PaddingBlockStart);
+  padding-block-end: var(--#{$notification-badge}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$notification-badge}--PaddingInlineStart);
+  padding-inline-end: var(--#{$notification-badge}--PaddingInlineEnd);
+  margin-block-start: var(--#{$notification-badge}--MarginBlockStart);
+  margin-block-end: var(--#{$notification-badge}--MarginBlockEnd);
+  margin-inline-start: var(--#{$notification-badge}--MarginInlineStart);
+  margin-inline-end: var(--#{$notification-badge}--MarginInlineEnd);
   background-color: var(--#{$notification-badge}--BackgroundColor);
   border-radius: var(--#{$notification-badge}--BorderRadius);
 

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -4,17 +4,17 @@
   --#{$notification-drawer}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // Header
-  --#{$notification-drawer}__header--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__header--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$notification-drawer}__header--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__header--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$notification-drawer}__header--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$notification-drawer}__header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$notification-drawer}__header--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$notification-drawer}__header--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$notification-drawer}__header-title--FontSize: var(--pf-t--global--font--size--heading--md);
   --#{$notification-drawer}__header-title--FontWeight: var(--pf-t--global--font--weight--heading--bold);
   --#{$notification-drawer}__header-title--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$notification-drawer}__header-title--FontFamily: var(--pf-t--global--font--family--heading);
-  --#{$notification-drawer}__header-status--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__header-status--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$notification-drawer}__header-status--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$notification-drawer}__header-status--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$notification-drawer}__header-status--Color: var(--pf-t--global--text--color--subtle);
@@ -30,10 +30,10 @@
   --#{$notification-drawer}__list--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
 
   // List item
-  --#{$notification-drawer}__list-item--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__list-item--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__list-item--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__list-item--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__list-item--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__list-item--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__list-item--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__list-item--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$notification-drawer}__list-item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$notification-drawer}__list-item--BorderWidth: var(--pf-t--global--border--width--box--status--default);
   --#{$notification-drawer}__list-item--BorderRadius: var(--pf-t--global--border--radius--medium);
@@ -55,11 +55,11 @@
   --#{$notification-drawer}__list-item--m-hoverable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
 
   // List item header
-  --#{$notification-drawer}__list-item-header--MarginBottom: var(--pf-t--global--spacer--xs);
+  --#{$notification-drawer}__list-item-header--MarginBlockEnd: var(--pf-t--global--spacer--xs);
 
   // List item header icon
   --#{$notification-drawer}__list-item-header-icon--Color: inherit;
-  --#{$notification-drawer}__list-item-header-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$notification-drawer}__list-item-header-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // List item header title
   --#{$notification-drawer}__list-item-header-title--FontFamily: var(--pf-t--global--font--family--heading);
@@ -69,37 +69,37 @@
   --#{$notification-drawer}__list-item-header-title--max-lines: 1;
 
   // List item description
-  --#{$notification-drawer}__list-item-description--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$notification-drawer}__list-item-description--MarginBlockEnd: var(--pf-t--global--spacer--sm);
 
   // List item timestamp
   --#{$notification-drawer}__list-item-timestamp--Color: var(--pf-t--global--text--color--subtle);
   --#{$notification-drawer}__list-item-timestamp--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Group
-  --#{$notification-drawer}__group--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$notification-drawer}__group--m-expanded--group--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$notification-drawer}__group--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$notification-drawer}__group--m-expanded--group--BorderBlockEndColor: var(--pf-t--global--border--color--default);
   --#{$notification-drawer}__group--m-expanded--MinHeight: 0; // remove at breaking change
   --#{$notification-drawer}__group--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
 
   // Group toggle
-  --#{$notification-drawer}__group-toggle--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__group-toggle--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$notification-drawer}__group-toggle--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$notification-drawer}__group-toggle--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$notification-drawer}__group-toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__group-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$notification-drawer}__group-toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__group-toggle--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$notification-drawer}__group-toggle--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$notification-drawer}__group-toggle--OutlineOffset: #{pf-size-prem(-4px)};
 
   // Group toggle title
-  --#{$notification-drawer}__group-toggle-title--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__group-toggle-title--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$notification-drawer}__group-toggle-title--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$notification-drawer}__group-toggle-title--max-lines: 1;
 
   // Group toggle count
-  --#{$notification-drawer}__group-toggle-count--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__group-toggle-count--MarginInlineEnd: var(--pf-t--global--spacer--md);
 
   // Group toggle icon
-  --#{$notification-drawer}__group-toggle-icon--MarginRight: var(--pf-t--global--spacer--md);
+  --#{$notification-drawer}__group-toggle-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$notification-drawer}__group-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$notification-drawer}__group-toggle-icon--Transition: .2s ease-in 0s;
   --#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate: 90deg;
@@ -118,10 +118,10 @@
   display: flex;
   flex-shrink: 0;
   align-items: baseline;
-  padding-block-start: var(--#{$notification-drawer}__header--PaddingTop);
-  padding-block-end: var(--#{$notification-drawer}__header--PaddingBottom);
-  padding-inline-start: var(--#{$notification-drawer}__header--PaddingLeft);
-  padding-inline-end: var(--#{$notification-drawer}__header--PaddingRight);
+  padding-block-start: var(--#{$notification-drawer}__header--PaddingBlockStart);
+  padding-block-end: var(--#{$notification-drawer}__header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$notification-drawer}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$notification-drawer}__header--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__header--BackgroundColor);
 }
 
@@ -133,7 +133,7 @@
 }
 
 .#{$notification-drawer}__header-status {
-  margin-inline-start: var(--#{$notification-drawer}__header-status--MarginLeft);
+  margin-inline-start: var(--#{$notification-drawer}__header-status--MarginInlineStart);
   font-size: var(--#{$notification-drawer}__header-status--FontSize);
   font-weight: var(--#{$notification-drawer}__header-status--FontWeight);
   color: var(--#{$notification-drawer}__header-status--Color);
@@ -164,10 +164,10 @@
   position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
-  padding-block-start: var(--#{$notification-drawer}__list-item--PaddingTop);
-  padding-block-end: var(--#{$notification-drawer}__list-item--PaddingBottom);
-  padding-inline-start: var(--#{$notification-drawer}__list-item--PaddingLeft);
-  padding-inline-end: var(--#{$notification-drawer}__list-item--PaddingRight);
+  padding-block-start: var(--#{$notification-drawer}__list-item--PaddingBlockStart);
+  padding-block-end: var(--#{$notification-drawer}__list-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$notification-drawer}__list-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$notification-drawer}__list-item--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__list-item--BackgroundColor);
   border: var(--#{$notification-drawer}__list-item--BorderWidth) solid var(--#{$notification-drawer}__list-item--BorderColor);
   border-radius: var(--#{$notification-drawer}__list-item--BorderRadius);
@@ -220,11 +220,11 @@
   grid-row: 1 / 2;
   grid-column: 1 / 2;
   align-items: baseline;
-  margin-block-end: var(--#{$notification-drawer}__list-item-header--MarginBottom);
+  margin-block-end: var(--#{$notification-drawer}__list-item-header--MarginBlockEnd);
 }
 
 .#{$notification-drawer}__list-item-header-icon {
-  margin-inline-end: var(--#{$notification-drawer}__list-item-header-icon--MarginRight);
+  margin-inline-end: var(--#{$notification-drawer}__list-item-header-icon--MarginInlineEnd);
   color: var(--#{$notification-drawer}__list-item-header-icon--Color);
 }
 
@@ -248,7 +248,7 @@
 .#{$notification-drawer}__list-item-description {
   grid-row: 2 / 3;
   grid-column: 1 / 2;
-  margin-block-end: var(--#{$notification-drawer}__list-item-description--MarginBottom);
+  margin-block-end: var(--#{$notification-drawer}__list-item-description--MarginBlockEnd);
   word-break: break-word;
 }
 
@@ -265,7 +265,7 @@
 }
 
 .#{$notification-drawer}__group {
-  border-block-end: var(--#{$notification-drawer}__group--BorderBottomWidth) solid var(--#{$notification-drawer}__group--m-expanded--group--BorderBottomColor);
+  border-block-end: var(--#{$notification-drawer}__group--BorderBlockEndWidth) solid var(--#{$notification-drawer}__group--m-expanded--group--BorderBlockEndColor);
 
   &.pf-m-expanded {
     min-height: var(--#{$notification-drawer}__group--m-expanded--MinHeight);
@@ -277,10 +277,10 @@
   display: flex;
   align-items: baseline;
   width: 100%;
-  padding-block-start: var(--#{$notification-drawer}__group-toggle--PaddingTop);
-  padding-block-end: var(--#{$notification-drawer}__group-toggle--PaddingBottom);
-  padding-inline-start: var(--#{$notification-drawer}__group-toggle--PaddingLeft);
-  padding-inline-end: var(--#{$notification-drawer}__group-toggle--PaddingRight);
+  padding-block-start: var(--#{$notification-drawer}__group-toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$notification-drawer}__group-toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$notification-drawer}__group-toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$notification-drawer}__group-toggle--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__group-toggle--BackgroundColor);
   border: none;
   outline-offset: var(--#{$notification-drawer}__group-toggle--OutlineOffset);
@@ -290,7 +290,7 @@
   @include pf-v6-line-clamp("var(--#{$notification-drawer}__group-toggle-title--max-lines)");
 
   flex: 1;
-  margin-inline-end: var(--#{$notification-drawer}__group-toggle-title--MarginRight);
+  margin-inline-end: var(--#{$notification-drawer}__group-toggle-title--MarginInlineEnd);
   font-size: var(--#{$notification-drawer}__group-toggle-title--FontSize);
   text-align: start;
   word-break: break-word;
@@ -298,13 +298,13 @@
 
 .#{$notification-drawer}__group-toggle-count {
   margin-inline-start: auto;
-  margin-inline-end: var(--#{$notification-drawer}__group-toggle-count--MarginRight);
+  margin-inline-end: var(--#{$notification-drawer}__group-toggle-count--MarginInlineEnd);
 }
 
 .#{$notification-drawer}__group-toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginRight);
+  margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginInlineEnd);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);
   transition: var(--#{$notification-drawer}__group-toggle-icon--Transition);
 

--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -2,7 +2,7 @@
 
 :where(:root, .#{$number-input}) {
   // unit
-  --#{$number-input}__unit--c-input-group--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$number-input}__unit--c-input-group--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // icon
   --#{$number-input}__icon--FontSize: var(--pf-t--global--font--size--xs);
@@ -36,7 +36,7 @@
 
 .#{$input-group} + .#{$number-input}__unit,
 .#{$number-input}__unit + .#{$input-group} {
-  margin-inline-start: var(--#{$number-input}__unit--c-input-group--MarginLeft);
+  margin-inline-start: var(--#{$number-input}__unit--c-input-group--MarginInlineStart);
 }
 
 .#{$number-input}__icon {

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -3,64 +3,64 @@
 .#{$options-menu} {
   // Toggle
   --#{$options-menu}__toggle--BackgroundColor: transparent;
-  --#{$options-menu}__toggle--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$options-menu}__toggle--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$options-menu}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$options-menu}__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$options-menu}__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$options-menu}__toggle--ColumnGap: var(--#{$pf-global}--spacer--sm);
   --#{$options-menu}__toggle--MinWidth: 0;
   --#{$options-menu}__toggle--BorderWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$options-menu}__toggle--BorderTopColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$options-menu}__toggle--BorderRightColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$options-menu}__toggle--BorderBottomColor: var(--#{$pf-global}--BorderColor--200);
-  --#{$options-menu}__toggle--BorderLeftColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$options-menu}__toggle--BorderBlockStartColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$options-menu}__toggle--BorderInlineEndColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$options-menu}__toggle--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--200);
+  --#{$options-menu}__toggle--BorderInlineStartColor: var(--#{$pf-global}--BorderColor--300);
   --#{$options-menu}__toggle--Color: var(--#{$pf-global}--Color--100);
-  --#{$options-menu}__toggle--hover--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$options-menu}__toggle--active--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$options-menu}__toggle--active--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$options-menu}__toggle--focus--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$options-menu}__toggle--focus--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$options-menu}__toggle--expanded--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$options-menu}__toggle--expanded--BorderBottomColor: var(--#{$pf-global}--active-color--100);
+  --#{$options-menu}__toggle--hover--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$options-menu}__toggle--active--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$options-menu}__toggle--active--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$options-menu}__toggle--focus--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$options-menu}__toggle--focus--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$options-menu}__toggle--expanded--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$options-menu}__toggle--expanded--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
   --#{$options-menu}__toggle--disabled--BackgroundColor: var(--#{$pf-global}--disabled-color--300);
   --#{$options-menu}__toggle--m-plain--Color: var(--#{$pf-global}--Color--200);
   --#{$options-menu}__toggle--m-plain--hover--Color: var(--#{$pf-global}--Color--100);
   --#{$options-menu}__toggle--m-plain--disabled--Color: var(--#{$pf-global}--disabled-color--200);
-  --#{$options-menu}__toggle--m-plain--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$options-menu}__toggle--m-plain--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$options-menu}__toggle--m-plain--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$options-menu}__toggle--m-plain--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
 
   // Toggle arrow
-  --#{$options-menu}__toggle-icon--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__toggle-icon--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle-icon--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$options-menu}--m-top--m-expanded__toggle-icon--Rotate: 180deg;
   --#{$options-menu}--m-plain__toggle-icon--Color: var(--#{$pf-global}--Color--200);
   --#{$options-menu}--m-plain--hover__toggle-icon--Color: var(--#{$pf-global}--Color--100);
 
   // Text toggle button
   --#{$options-menu}__toggle-button--BackgroundColor: transparent;
-  --#{$options-menu}__toggle-button--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$options-menu}__toggle-button--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__toggle-button--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$options-menu}__toggle-button--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle-button--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$options-menu}__toggle-button--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__toggle-button--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$options-menu}__toggle-button--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
 
   // Menu
   --#{$options-menu}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
   --#{$options-menu}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$options-menu}__menu--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__menu--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$options-menu}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$options-menu}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$options-menu}--m-top__menu--Top: 0;
+  --#{$options-menu}--m-top__menu--BlockStart: 0;
   --#{$options-menu}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu item
   --#{$options-menu}__menu-item--BackgroundColor: transparent;
   --#{$options-menu}__menu-item--Color: var(--#{$pf-global}--Color--100);
   --#{$options-menu}__menu-item--FontSize: var(--#{$pf-global}--FontSize--md);
-  --#{$options-menu}__menu-item--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__menu-item--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$options-menu}__menu-item--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__menu-item--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$options-menu}__menu-item--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__menu-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$options-menu}__menu-item--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__menu-item--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$options-menu}__menu-item--disabled--Color: var(--#{$pf-global}--Color--dark-200);
   --#{$options-menu}__menu-item--hover--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-300);
   --#{$options-menu}__menu-item--disabled--BackgroundColor: transparent;
@@ -68,33 +68,33 @@
   // Menu item icon
   --#{$options-menu}__menu-item-icon--Color: var(--#{$pf-global}--active-color--100);
   --#{$options-menu}__menu-item-icon--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$options-menu}__menu-item-icon--PaddingLeft: var(--#{$pf-global}--spacer--lg);
+  --#{$options-menu}__menu-item-icon--PaddingInlineStart: var(--#{$pf-global}--spacer--lg);
 
   // Groups
-  --#{$options-menu}__group--group--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__group-title--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__group-title--PaddingRight: var(--#{$options-menu}__menu-item--PaddingRight);
-  --#{$options-menu}__group-title--PaddingBottom: var(--#{$options-menu}__menu-item--PaddingBottom);
-  --#{$options-menu}__group-title--PaddingLeft: var(--#{$options-menu}__menu-item--PaddingLeft);
+  --#{$options-menu}__group--group--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__group-title--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}__group-title--PaddingInlineEnd: var(--#{$options-menu}__menu-item--PaddingInlineEnd);
+  --#{$options-menu}__group-title--PaddingBlockEnd: var(--#{$options-menu}__menu-item--PaddingBlockEnd);
+  --#{$options-menu}__group-title--PaddingInlineStart: var(--#{$options-menu}__menu-item--PaddingInlineStart);
   --#{$options-menu}__group-title--FontSize: var(--#{$pf-global}--FontSize--xs);
   --#{$options-menu}__group-title--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$options-menu}__group-title--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Divider
-  --#{$options-menu}--c-divider--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}--c-divider--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}--c-divider--MarginBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$options-menu}--c-divider--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   position: relative;
   display: inline-block;
   max-width: 100%;
 
   .#{$divider} {
-    margin-block-start: var(--#{$options-menu}--c-divider--MarginTop);
-    margin-block-end: var(--#{$options-menu}--c-divider--MarginBottom);
+    margin-block-start: var(--#{$options-menu}--c-divider--MarginBlockStart);
+    margin-block-end: var(--#{$options-menu}--c-divider--MarginBlockEnd);
 
     // Support divider as last item in group to separate groups
     &:last-child {
-      --#{$options-menu}--c-divider--MarginBottom: 0;
+      --#{$options-menu}--c-divider--MarginBlockEnd: 0;
     }
   }
 }
@@ -109,32 +109,32 @@
     inset-inline-end: 0;
     content: "";
     border: var(--#{$options-menu}__toggle--BorderWidth) solid;
-    border-block-start-color: var(--#{$options-menu}__toggle--BorderTopColor);
-    border-block-end-color: var(--#{$options-menu}__toggle--BorderBottomColor);
-    border-inline-start-color: var(--#{$options-menu}__toggle--BorderLeftColor);
-    border-inline-end-color: var(--#{$options-menu}__toggle--BorderRightColor);
+    border-block-start-color: var(--#{$options-menu}__toggle--BorderBlockStartColor);
+    border-block-end-color: var(--#{$options-menu}__toggle--BorderBlockEndColor);
+    border-inline-start-color: var(--#{$options-menu}__toggle--BorderInlineStartColor);
+    border-inline-end-color: var(--#{$options-menu}__toggle--BorderInlineEndColor);
   }
 
   &:hover {
     &::before {
-      --#{$options-menu}__toggle--BorderBottomColor: var(--#{$options-menu}__toggle--hover--BorderBottomColor);
+      --#{$options-menu}__toggle--BorderBlockEndColor: var(--#{$options-menu}__toggle--hover--BorderBlockEndColor);
     }
   }
 
   &:active,
   &.pf-m-active {
     &::before {
-      --#{$options-menu}__toggle--BorderBottomColor: var(--#{$options-menu}__toggle--active--BorderBottomColor);
+      --#{$options-menu}__toggle--BorderBlockEndColor: var(--#{$options-menu}__toggle--active--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$options-menu}__toggle--active--BorderBottomWidth);
+      border-block-end-width: var(--#{$options-menu}__toggle--active--BorderBlockEndWidth);
     }
   }
 
   &:focus {
     &::before {
-      --#{$options-menu}__toggle--BorderBottomColor: var(--#{$options-menu}__toggle--focus--BorderBottomColor);
+      --#{$options-menu}__toggle--BorderBlockEndColor: var(--#{$options-menu}__toggle--focus--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$options-menu}__toggle--focus--BorderBottomWidth);
+      border-block-end-width: var(--#{$options-menu}__toggle--focus--BorderBlockEndWidth);
     }
   }
 }
@@ -146,19 +146,19 @@
   align-items: center;
   min-width: var(--#{$options-menu}__toggle--MinWidth);
   max-width: 100%;
-  padding-block-start: var(--#{$options-menu}__toggle--PaddingTop);
-  padding-block-end: var(--#{$options-menu}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$options-menu}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$options-menu}__toggle--PaddingRight);
+  padding-block-start: var(--#{$options-menu}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$options-menu}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$options-menu}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$options-menu}__toggle--PaddingInlineEnd);
   color: var(--#{$options-menu}__toggle--Color);
   background-color: var(--#{$options-menu}__toggle--BackgroundColor);
   border: none;
 
   .#{$options-menu}.pf-m-expanded > & {
     &::before {
-      --#{$options-menu}__toggle--BorderBottomColor: var(--#{$options-menu}__toggle--expanded--BorderBottomColor);
+      --#{$options-menu}__toggle--BorderBlockEndColor: var(--#{$options-menu}__toggle--expanded--BorderBlockEndColor);
 
-      border-block-end-width: var(--#{$options-menu}__toggle--expanded--BorderBottomWidth);
+      border-block-end-width: var(--#{$options-menu}__toggle--expanded--BorderBlockEndWidth);
     }
   }
 
@@ -166,8 +166,8 @@
     --#{$options-menu}__toggle-icon--Color: var(--#{$options-menu}--m-plain__toggle-icon--Color);
 
     &:not(.pf-m-text) {
-      --#{$options-menu}__toggle--PaddingRight: var(--#{$options-menu}__toggle--m-plain--PaddingRight);
-      --#{$options-menu}__toggle--PaddingLeft: var(--#{$options-menu}__toggle--m-plain--PaddingLeft);
+      --#{$options-menu}__toggle--PaddingInlineEnd: var(--#{$options-menu}__toggle--m-plain--PaddingInlineEnd);
+      --#{$options-menu}__toggle--PaddingInlineStart: var(--#{$options-menu}__toggle--m-plain--PaddingInlineStart);
 
       display: inline-block;
       color: var(--#{$options-menu}__toggle--m-plain--Color);
@@ -208,10 +208,10 @@
 }
 
 .#{$options-menu}__toggle-button {
-  padding-block-start: var(--#{$options-menu}__toggle-button--PaddingTop);
-  padding-block-end: var(--#{$options-menu}__toggle-button--PaddingBottom);
-  padding-inline-start: var(--#{$options-menu}__toggle-button--PaddingLeft);
-  padding-inline-end: var(--#{$options-menu}__toggle-button--PaddingRight);
+  padding-block-start: var(--#{$options-menu}__toggle-button--PaddingBlockStart);
+  padding-block-end: var(--#{$options-menu}__toggle-button--PaddingBlockEnd);
+  padding-inline-start: var(--#{$options-menu}__toggle-button--PaddingInlineStart);
+  padding-inline-end: var(--#{$options-menu}__toggle-button--PaddingInlineEnd);
   background-color: var(--#{$options-menu}__toggle-button--BackgroundColor);
   border: 0;
 }
@@ -229,8 +229,8 @@
 }
 
 .#{$options-menu}__toggle-icon {
-  padding-inline-start: var(--#{$options-menu}__toggle-icon--PaddingLeft);
-  padding-inline-end: var(--#{$options-menu}__toggle-icon--PaddingRight);
+  padding-inline-start: var(--#{$options-menu}__toggle-icon--PaddingInlineStart);
+  padding-inline-end: var(--#{$options-menu}__toggle-icon--PaddingInlineEnd);
 
   .#{$options-menu}.pf-m-top.pf-m-expanded & {
     transform: rotate(var(--#{$options-menu}--m-top--m-expanded__toggle-icon--Rotate));
@@ -239,11 +239,11 @@
 
 .#{$options-menu}__menu {
   position: absolute;
- inset-block-start: var(--#{$options-menu}__menu--Top);
+ inset-block-start: var(--#{$options-menu}__menu--BlockStart);
   z-index: var(--#{$options-menu}__menu--ZIndex);
   min-width: 100%;
-  padding-block-start: var(--#{$options-menu}__menu--PaddingTop);
-  padding-block-end: var(--#{$options-menu}__menu--PaddingBottom);
+  padding-block-start: var(--#{$options-menu}__menu--PaddingBlockStart);
+  padding-block-end: var(--#{$options-menu}__menu--PaddingBlockEnd);
   background-color: var(--#{$options-menu}__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--#{$options-menu}__menu--BoxShadow);
@@ -253,7 +253,7 @@
   }
 
   .#{$options-menu}.pf-m-top & {
-    --#{$options-menu}__menu--Top: var(--#{$options-menu}--m-top__menu--Top);
+    --#{$options-menu}__menu--BlockStart: var(--#{$options-menu}--m-top__menu--BlockStart);
 
     transform: translateY(var(--#{$options-menu}--m-top__menu--TranslateY));
   }
@@ -275,10 +275,10 @@
   display: flex;
   align-items: baseline;
   width: 100%;
-  padding-block-start: var(--#{$options-menu}__menu-item--PaddingTop);
-  padding-block-end: var(--#{$options-menu}__menu-item--PaddingBottom);
-  padding-inline-start: var(--#{$options-menu}__menu-item--PaddingLeft);
-  padding-inline-end: var(--#{$options-menu}__menu-item--PaddingRight);
+  padding-block-start: var(--#{$options-menu}__menu-item--PaddingBlockStart);
+  padding-block-end: var(--#{$options-menu}__menu-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$options-menu}__menu-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$options-menu}__menu-item--PaddingInlineEnd);
   font-size: var(--#{$options-menu}__menu-item--FontSize);
   color: var(--#{$options-menu}__menu-item--Color);
   white-space: nowrap;
@@ -302,7 +302,7 @@
 .#{$options-menu}__menu-item-icon {
   align-self: center;
   width: auto; // this allows the padding to apply when this class is used with an svg element
-  padding-inline-start: var(--#{$options-menu}__menu-item-icon--PaddingLeft);
+  padding-inline-start: var(--#{$options-menu}__menu-item-icon--PaddingInlineStart);
   margin-inline-start: auto;
   font-size: var(--#{$options-menu}__menu-item-icon--FontSize);
   color: var(--#{$options-menu}__menu-item-icon--Color);
@@ -310,15 +310,15 @@
 
 .#{$options-menu}__group {
   & + & {
-    padding-block-start: var(--#{$options-menu}__group--group--PaddingTop);
+    padding-block-start: var(--#{$options-menu}__group--group--PaddingBlockStart);
   }
 }
 
 .#{$options-menu}__group-title {
-  padding-block-start: var(--#{$options-menu}__group-title--PaddingTop);
-  padding-block-end: var(--#{$options-menu}__group-title--PaddingBottom);
-  padding-inline-start: var(--#{$options-menu}__group-title--PaddingLeft);
-  padding-inline-end: var(--#{$options-menu}__group-title--PaddingRight);
+  padding-block-start: var(--#{$options-menu}__group-title--PaddingBlockStart);
+  padding-block-end: var(--#{$options-menu}__group-title--PaddingBlockEnd);
+  padding-inline-start: var(--#{$options-menu}__group-title--PaddingInlineStart);
+  padding-inline-end: var(--#{$options-menu}__group-title--PaddingInlineEnd);
   font-size: var(--#{$options-menu}__group-title--FontSize);
   font-weight: var(--#{$options-menu}__group-title--FontWeight);
   color: var(--#{$options-menu}__group-title--Color);

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -48,9 +48,9 @@
   --#{$options-menu}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$options-menu}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
   --#{$options-menu}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
-  --#{$options-menu}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
+  --#{$options-menu}__menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs));
   --#{$options-menu}__menu--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$options-menu}--m-top__menu--BlockStart: 0;
+  --#{$options-menu}--m-top__menu--InsetBlockStart: 0;
   --#{$options-menu}--m-top__menu--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu item
@@ -239,7 +239,7 @@
 
 .#{$options-menu}__menu {
   position: absolute;
- inset-block-start: var(--#{$options-menu}__menu--BlockStart);
+ inset-block-start: var(--#{$options-menu}__menu--InsetBlockStart);
   z-index: var(--#{$options-menu}__menu--ZIndex);
   min-width: 100%;
   padding-block-start: var(--#{$options-menu}__menu--PaddingBlockStart);
@@ -253,7 +253,7 @@
   }
 
   .#{$options-menu}.pf-m-top & {
-    --#{$options-menu}__menu--BlockStart: var(--#{$options-menu}--m-top__menu--BlockStart);
+    --#{$options-menu}__menu--InsetBlockStart: var(--#{$options-menu}--m-top__menu--InsetBlockStart);
 
     transform: translateY(var(--#{$options-menu}--m-top__menu--TranslateY));
   }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -392,7 +392,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       --#{$context-selector}__toggle--BorderInlineEndColor: transparent;
       --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$page}__sidebar-body--m-menu--c-context-selector--BorderBlockEndColor);
       --#{$context-selector}__toggle--BorderInlineStartColor: transparent;
-      --#{$context-selector}__menu--BlockStart: 100%;
+      --#{$context-selector}__menu--InsetBlockStart: 100%;
 
       width: 100%;
     }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -16,22 +16,22 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__header--MinHeight: #{pf-size-prem(76px)}; // fixed height for header to ensure consistency across screen sizes.
 
   // Header brand
-  --#{$page}__header-brand--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$page}__header-brand--xl--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$page}__header-brand--xl--PaddingLeft: var(--pf-t--global--spacer--xl);
+  --#{$page}__header-brand--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$page}__header-brand--xl--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$page}__header-brand--xl--PaddingInlineStart: var(--pf-t--global--spacer--xl);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$page}__header-brand--PaddingLeft: var(--#{$page}__header-brand--xl--PaddingLeft);
+    --#{$page}__header-brand--PaddingInlineStart: var(--#{$page}__header-brand--xl--PaddingInlineStart);
     --#{$page}--inset: var(--#{$page}--xl--inset);
   }
 
   // Toggle
-  --#{$page}__header-sidebar-toggle__c-button--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$page}__header-sidebar-toggle__c-button--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$page}__header-sidebar-toggle__c-button--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$page}__header-sidebar-toggle__c-button--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$page}__header-sidebar-toggle__c-button--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$page}__header-sidebar-toggle__c-button--MarginLeft: calc(var(--#{$page}__header-sidebar-toggle__c-button--PaddingLeft) * -1);
+  --#{$page}__header-sidebar-toggle__c-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$page}__header-sidebar-toggle__c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$page}__header-sidebar-toggle__c-button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$page}__header-sidebar-toggle__c-button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$page}__header-sidebar-toggle__c-button--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$page}__header-sidebar-toggle__c-button--MarginInlineStart: calc(var(--#{$page}__header-sidebar-toggle__c-button--PaddingInlineStart) * -1);
   --#{$page}__header-sidebar-toggle__c-button--FontSize: var(--pf-t--global--icon--size--lg);
 
   // Header brand link
@@ -40,20 +40,20 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   // Header nav
   --#{$page}__header-nav--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$page}__header-nav--xl--BackgroundColor: transparent;
-  --#{$page}__header-nav--xl--PaddingRight: var(--pf-t--global--spacer--xl);
-  --#{$page}__header-nav--xl--PaddingLeft: var(--pf-t--global--spacer--xl);
+  --#{$page}__header-nav--xl--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$page}__header-nav--xl--PaddingInlineStart: var(--pf-t--global--spacer--xl);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
     --#{$page}__header-nav--BackgroundColor: var(--#{$page}__header-nav--xl--BackgroundColor);
-    --#{$page}__header-nav--PaddingRight: var(--#{$page}__header-nav--xl--PaddingRight);
-    --#{$page}__header-nav--PaddingLeft: var(--#{$page}__header-nav--xl--PaddingLeft);
+    --#{$page}__header-nav--PaddingInlineEnd: var(--#{$page}__header-nav--xl--PaddingInlineEnd);
+    --#{$page}__header-nav--PaddingInlineStart: var(--#{$page}__header-nav--xl--PaddingInlineStart);
   }
 
   // Header tools
-  --#{$page}__header-tools--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$page}__header-tools--xl--MarginRight: var(--pf-t--global--spacer--lg);
-  --#{$page}__header-tools--c-avatar--MarginLeft: var(--pf-t--global--spacer--md);
-  --#{$page}__header-tools-group--MarginLeft: var(--pf-t--global--spacer--xl);
+  --#{$page}__header-tools--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$page}__header-tools--xl--MarginInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$page}__header-tools--c-avatar--MarginInlineStart: var(--pf-t--global--spacer--md);
+  --#{$page}__header-tools-group--MarginInlineStart: var(--pf-t--global--spacer--xl);
   --#{$page}__header-tools-group--Display: flex;
   --#{$page}__header-tools-item--Display: block;
 
@@ -62,7 +62,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__header-tools--c-button--m-selected--before--Height: auto;
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$page}__header-tools--MarginRight: var(--#{$page}__header-tools--xl--MarginRight);
+    --#{$page}__header-tools--MarginInlineEnd: var(--#{$page}__header-tools--xl--MarginInlineEnd);
   }
 
   // Sidebar
@@ -75,31 +75,31 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__sidebar--TranslateZ: 0;
   --#{$page}__sidebar--m-expanded--TranslateX: 0;
   --#{$page}__sidebar--xl--TranslateX: 0;
-  --#{$page}__sidebar--MarginRight: 0;
+  --#{$page}__sidebar--MarginInlineEnd: 0;
   --#{$page}__sidebar--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$page}__sidebar--PaddingInlineStart: 0;
 
 
   // Sidebar header
-  --#{$page}__sidebar-header--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$page}__sidebar-header--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$page}__sidebar-header--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$page}__sidebar-header--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$page}__sidebar-title--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$page}__sidebar-header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$page}__sidebar-header--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$page}__sidebar-header--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$page}__sidebar-header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$page}__sidebar-title--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$page}__sidebar-title--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$page}__sidebar-title--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$page}__sidebar-title--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$page}__sidebar-title--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // Sidebar body
-  --#{$page}__sidebar-body--PaddingRight: 0;
-  --#{$page}__sidebar-body--PaddingLeft: 0;
-  --#{$page}__sidebar-body--m-page-insets--PaddingRight: var(--#{$page}--inset);
-  --#{$page}__sidebar-body--m-page-insets--PaddingLeft: var(--#{$page}--inset);
+  --#{$page}__sidebar-body--PaddingInlineEnd: 0;
+  --#{$page}__sidebar-body--PaddingInlineStart: 0;
+  --#{$page}__sidebar-body--m-page-insets--PaddingInlineEnd: var(--#{$page}--inset);
+  --#{$page}__sidebar-body--m-page-insets--PaddingInlineStart: var(--#{$page}--inset);
   --#{$page}__sidebar-body--m-menu--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$page}__sidebar-body--m-menu--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$page}__sidebar-body--m-menu--BorderTopWidth: var(--pf-t--global--border--width--button--default);
-  --#{$page}__sidebar-body--m-menu--c-context-selector--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$page}__sidebar-body--m-menu--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$page}__sidebar-body--m-menu--BorderBlockStartWidth: var(--pf-t--global--border--width--button--default);
+  --#{$page}__sidebar-body--m-menu--c-context-selector--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
     --#{$page}__sidebar--TranslateX: var(--#{$page}__sidebar--xl--TranslateX);
@@ -116,16 +116,16 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-container--BorderColor: var(--#{$page}__main-container--BackgroundColor); // TODO Border should match the background to blend in - change to be a page outline token
 
   // Main section
-  --#{$page}__main-section--MarginTop: var(--pf-t--global--spacer--md);
-  --#{$page}__main-section--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$page}__main-section--PaddingRight: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section - TODO, see if we can remove the need for this calc(), or possibly move it down to the property definition so a user can theme this without a calc()
-  --#{$page}__main-section--PaddingBottom: 0;
-  --#{$page}__main-section--PaddingLeft: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
-  --#{$page}__main-breadcrumb--main-section--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$page}__main-section--MarginBlockStart: var(--pf-t--global--spacer--md);
+  --#{$page}__main-section--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$page}__main-section--PaddingInlineEnd: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section - TODO, see if we can remove the need for this calc(), or possibly move it down to the property definition so a user can theme this without a calc()
+  --#{$page}__main-section--PaddingBlockEnd: 0;
+  --#{$page}__main-section--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
+  --#{$page}__main-breadcrumb--main-section--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$page}__main-section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$page}__main-section--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$page}__main-breadcrumb--page__main-tabs--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$page}__main-nav--page__main-tabs--PaddingTop: var(--pf-t--global--spacer--md);
+  --#{$page}__main-breadcrumb--page__main-tabs--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$page}__main-nav--page__main-tabs--PaddingBlockStart: var(--pf-t--global--spacer--md);
 
   // Limit width
   --#{$page}--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--#{$page}__sidebar--Width));
@@ -144,12 +144,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Main section horizontal nav
   --#{$page}__main-nav--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$page}__main-nav--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$page}__main-nav--PaddingRight: 0;
-  --#{$page}__main-nav--PaddingLeft: 0;
-  --#{$page}__main-nav--m-sticky-top--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$page}__main-nav--xl--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$page}__main-nav--xl--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$page}__main-nav--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$page}__main-nav--PaddingInlineEnd: 0;
+  --#{$page}__main-nav--PaddingInlineStart: 0;
+  --#{$page}__main-nav--m-sticky-top--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$page}__main-nav--xl--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$page}__main-nav--xl--PaddingInlineStart: var(--pf-t--global--spacer--sm);
 
   // Main section horizontal subnav
   --#{$page}__main-subnav--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -159,22 +159,22 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-subnav--PaddingInlineEnd: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth));
 
   // Main section breadcrumb
-  --#{$page}__main-breadcrumb--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$page}__main-breadcrumb--PaddingRight: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
-  --#{$page}__main-breadcrumb--PaddingBottom: 0;
-  --#{$page}__main-breadcrumb--PaddingLeft: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
+  --#{$page}__main-breadcrumb--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$page}__main-breadcrumb--PaddingInlineEnd: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
+  --#{$page}__main-breadcrumb--PaddingBlockEnd: 0;
+  --#{$page}__main-breadcrumb--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
   --#{$page}__main-breadcrumb--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // Main section tabs
-  --#{$page}__main-tabs--PaddingTop: 0;
-  --#{$page}__main-tabs--PaddingRight: 0;
-  --#{$page}__main-tabs--PaddingBottom: 0;
+  --#{$page}__main-tabs--PaddingBlockStart: 0;
+  --#{$page}__main-tabs--PaddingInlineEnd: 0;
+  --#{$page}__main-tabs--PaddingBlockEnd: 0;
   --#{$page}__main-tabs--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // Wizard main section
   --#{$page}__main-wizard--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$page}__main-wizard--BorderTopColor: var(--pf-t--global--border--color--default);
-  --#{$page}__main-wizard--BorderTopWidth: var(--pf-t--global--border--width--button--default);
+  --#{$page}__main-wizard--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+  --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--button--default);
   }
 
 .#{$page} {
@@ -231,10 +231,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 // Brand
 .#{$page}__header-brand {
   grid-column: 1 / 2;
-  padding-inline-start: var(--#{$page}__header-brand--PaddingLeft);
+  padding-inline-start: var(--#{$page}__header-brand--PaddingInlineStart);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    padding-inline-end: var(--#{$page}__header-brand--xl--PaddingRight); // set padding right here to allow mobile view to accomodate tools
+    padding-inline-end: var(--#{$page}__header-brand--xl--PaddingInlineEnd); // set padding right here to allow mobile view to accomodate tools
   }
 }
 
@@ -252,12 +252,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 // Sidebar toggle
 .#{$page}__header-brand-toggle {
   .#{$button} {
-    padding-block-start: var(--#{$page}__header-sidebar-toggle__c-button--PaddingTop);
-    padding-block-end: var(--#{$page}__header-sidebar-toggle__c-button--PaddingBottom);
-    padding-inline-start: var(--#{$page}__header-sidebar-toggle__c-button--PaddingLeft);
-    padding-inline-end: var(--#{$page}__header-sidebar-toggle__c-button--PaddingRight);
-    margin-inline-start: var(--#{$page}__header-sidebar-toggle__c-button--MarginLeft);
-    margin-inline-end: var(--#{$page}__header-sidebar-toggle__c-button--MarginRight);
+    padding-block-start: var(--#{$page}__header-sidebar-toggle__c-button--PaddingBlockStart);
+    padding-block-end: var(--#{$page}__header-sidebar-toggle__c-button--PaddingBlockEnd);
+    padding-inline-start: var(--#{$page}__header-sidebar-toggle__c-button--PaddingInlineStart);
+    padding-inline-end: var(--#{$page}__header-sidebar-toggle__c-button--PaddingInlineEnd);
+    margin-inline-start: var(--#{$page}__header-sidebar-toggle__c-button--MarginInlineStart);
+    margin-inline-end: var(--#{$page}__header-sidebar-toggle__c-button--MarginInlineEnd);
     font-size: var(--#{$page}__header-sidebar-toggle__c-button--FontSize);
     line-height: 1;
   }
@@ -269,8 +269,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   grid-column: 1 / -1;
   align-self: stretch;
   min-width: 0;
-  padding-inline-start: var(--#{$page}__header-nav--PaddingLeft);
-  padding-inline-end: var(--#{$page}__header-nav--PaddingRight);
+  padding-inline-start: var(--#{$page}__header-nav--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__header-nav--PaddingInlineEnd);
   background-color: var(--#{$page}__header-nav--BackgroundColor);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
@@ -287,10 +287,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 .#{$page}__header-tools {
   grid-column: 2 / 3;
   margin-inline-start: auto; // to push it to the right
-  margin-inline-end: var(--#{$page}__header-tools--MarginRight);
+  margin-inline-end: var(--#{$page}__header-tools--MarginInlineEnd);
 
   .#{$avatar} {
-    margin-inline-start: var(--#{$page}__header-tools--c-avatar--MarginLeft);
+    margin-inline-start: var(--#{$page}__header-tools--c-avatar--MarginInlineStart);
   }
 
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
@@ -304,7 +304,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   align-items: center;
 
   & + & {
-    margin-inline-start: var(--#{$page}__header-tools-group--MarginLeft);
+    margin-inline-start: var(--#{$page}__header-tools-group--MarginInlineStart);
   }
 }
 
@@ -324,7 +324,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   padding-block-start: 0;
   padding-block-end: var(--#{$page}__sidebar--PaddingBlockEnd);
   padding-inline-start: var(--#{$page}__sidebar--PaddingInlineStart);
-  margin-inline-end: var(--#{$page}__sidebar--MarginRight);
+  margin-inline-end: var(--#{$page}__sidebar--MarginInlineEnd);
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
@@ -358,13 +358,13 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 }
 
 .#{$page}__sidebar-header {
-  padding-block-start: var(--#{$page}__sidebar-header--PaddingTop);
-  padding-block-end: var(--#{$page}__sidebar-header--PaddingBottom);
-  border-block-end: var(--#{$page}__sidebar-header--BorderBottomWidth) solid var(--#{$page}__sidebar-header--BorderBottomColor);
+  padding-block-start: var(--#{$page}__sidebar-header--PaddingBlockStart);
+  padding-block-end: var(--#{$page}__sidebar-header--PaddingBlockEnd);
+  border-block-end: var(--#{$page}__sidebar-header--BorderBlockEndWidth) solid var(--#{$page}__sidebar-header--BorderBlockEndColor);
 }
 
 .#{$page}__sidebar-title {
-  padding-inline-start: var(--#{$page}__sidebar-title--PaddingLeft);
+  padding-inline-start: var(--#{$page}__sidebar-title--PaddingInlineStart);
   font-family: var(--#{$page}__sidebar-title--FontFamily);
   font-size: var(--#{$page}__sidebar-title--FontSize);
   font-weight: var(--#{$page}__sidebar-title--FontWeight);
@@ -372,8 +372,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 }
 
 .#{$page}__sidebar-body {
-  padding-inline-start: var(--#{$page}__sidebar-body--PaddingLeft);
-  padding-inline-end: var(--#{$page}__sidebar-body--PaddingRight);
+  padding-inline-start: var(--#{$page}__sidebar-body--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__sidebar-body--PaddingInlineEnd);
 
   &:last-child {
     flex-grow: 1;
@@ -381,31 +381,31 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   &.pf-m-menu {
     background-color: var(--#{$page}__sidebar-body--m-menu--BackgroundColor);
-    border-block-start: var(--#{$page}__sidebar-body--m-menu--BorderTopWidth) solid var(--#{$page}__sidebar-body--m-menu--BorderTopColor);
+    border-block-start: var(--#{$page}__sidebar-body--m-menu--BorderBlockStartWidth) solid var(--#{$page}__sidebar-body--m-menu--BorderBlockStartColor);
 
     & + & {
-      --#{$page}__sidebar-body--m-menu--BorderTopWidth: 0;
+      --#{$page}__sidebar-body--m-menu--BorderBlockStartWidth: 0;
     }
 
     .#{$context-selector} {
-      --#{$context-selector}__toggle--BorderTopColor: transparent;
-      --#{$context-selector}__toggle--BorderRightColor: transparent;
-      --#{$context-selector}__toggle--BorderBottomColor: var(--#{$page}__sidebar-body--m-menu--c-context-selector--BorderBottomColor);
-      --#{$context-selector}__toggle--BorderLeftColor: transparent;
-      --#{$context-selector}__menu--Top: 100%;
+      --#{$context-selector}__toggle--BorderBlockStartColor: transparent;
+      --#{$context-selector}__toggle--BorderInlineEndColor: transparent;
+      --#{$context-selector}__toggle--BorderBlockEndColor: var(--#{$page}__sidebar-body--m-menu--c-context-selector--BorderBlockEndColor);
+      --#{$context-selector}__toggle--BorderInlineStartColor: transparent;
+      --#{$context-selector}__menu--BlockStart: 100%;
 
       width: 100%;
     }
   }
 
   &.pf-m-page-insets {
-    --#{$page}__sidebar-body--PaddingRight: var(--#{$page}__sidebar-body--m-page-insets--PaddingRight);
-    --#{$page}__sidebar-body--PaddingLeft: var(--#{$page}__sidebar-body--m-page-insets--PaddingLeft);
+    --#{$page}__sidebar-body--PaddingInlineEnd: var(--#{$page}__sidebar-body--m-page-insets--PaddingInlineEnd);
+    --#{$page}__sidebar-body--PaddingInlineStart: var(--#{$page}__sidebar-body--m-page-insets--PaddingInlineStart);
   }
 
   &.pf-m-inset-none {
-    --#{$page}__sidebar-body--PaddingRight: 0;
-    --#{$page}__sidebar-body--PaddingLeft: 0;
+    --#{$page}__sidebar-body--PaddingInlineEnd: 0;
+    --#{$page}__sidebar-body--PaddingInlineStart: 0;
   }
 
   &.pf-m-fill {
@@ -525,9 +525,9 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 }
 
 .#{$page}__main-nav {
-  padding-block-start: var(--#{$page}__main-nav--PaddingTop);
-  padding-inline-start: var(--#{$page}__main-nav--PaddingLeft);
-  padding-inline-end: var(--#{$page}__main-nav--PaddingRight);
+  padding-block-start: var(--#{$page}__main-nav--PaddingBlockStart);
+  padding-inline-start: var(--#{$page}__main-nav--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__main-nav--PaddingInlineEnd);
   background-color: var(--#{$page}__main-nav--BackgroundColor);
 
   // Responsive height modifiers for sticky top/bottom
@@ -537,7 +537,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     @include pf-v6-apply-height-breakpoint($breakpoint) {
       &.pf-m-sticky-top#{$breakpoint-name},
       .#{$page}__main-group.pf-m-sticky-top#{$breakpoint-name} &:last-child {
-        padding-block-end: var(--#{$page}__main-nav--m-sticky-top--PaddingBottom);
+        padding-block-end: var(--#{$page}__main-nav--m-sticky-top--PaddingBlockEnd);
       }
     }
   }
@@ -552,14 +552,14 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 }
 
 .#{$page}__main-breadcrumb {
-  padding-block-start: var(--#{$page}__main-breadcrumb--PaddingTop);
-  padding-block-end: var(--#{$page}__main-breadcrumb--PaddingBottom);
-  padding-inline-start: var(--#{$page}__main-breadcrumb--PaddingLeft);
-  padding-inline-end: var(--#{$page}__main-breadcrumb--PaddingRight);
+  padding-block-start: var(--#{$page}__main-breadcrumb--PaddingBlockStart);
+  padding-block-end: var(--#{$page}__main-breadcrumb--PaddingBlockEnd);
+  padding-inline-start: var(--#{$page}__main-breadcrumb--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__main-breadcrumb--PaddingInlineEnd);
   background-color: var(--#{$page}__main-breadcrumb--BackgroundColor);
 
   + .#{$page}__main-section {
-    --#{$page}__main-section--PaddingTop: var(--#{$page}__main-breadcrumb--main-section--PaddingTop);
+    --#{$page}__main-section--PaddingBlockStart: var(--#{$page}__main-breadcrumb--main-section--PaddingBlockStart);
   }
 
   // Responsive height modifiers for sticky top/bottom
@@ -569,25 +569,25 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     @include pf-v6-apply-height-breakpoint($breakpoint) {
       &.pf-m-sticky-top#{$breakpoint-name},
       .#{$page}__main-group.pf-m-sticky-top#{$breakpoint-name} &:last-child {
-        --#{$page}__main-breadcrumb--PaddingBottom: var(--#{$page}__main-breadcrumb--m-sticky-top--PaddingBottom);
+        --#{$page}__main-breadcrumb--PaddingBlockEnd: var(--#{$page}__main-breadcrumb--m-sticky-top--PaddingBlockEnd);
       }
     }
   }
 }
 
 .#{$page}__main-tabs {
-  padding-block-start: var(--#{$page}__main-tabs--PaddingTop);
-  padding-block-end: var(--#{$page}__main-tabs--PaddingBottom);
-  padding-inline-start: var(--#{$page}__main-tabs--PaddingLeft);
-  padding-inline-end: var(--#{$page}__main-tabs--PaddingRight);
+  padding-block-start: var(--#{$page}__main-tabs--PaddingBlockStart);
+  padding-block-end: var(--#{$page}__main-tabs--PaddingBlockEnd);
+  padding-inline-start: var(--#{$page}__main-tabs--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__main-tabs--PaddingInlineEnd);
   background-color: var(--#{$page}__main-tabs--BackgroundColor);
 
   .#{$page}__main-nav + & {
-    --#{$page}__main-tabs--PaddingTop: var(--#{$page}__main-nav--page__main-tabs--PaddingTop);
+    --#{$page}__main-tabs--PaddingBlockStart: var(--#{$page}__main-nav--page__main-tabs--PaddingBlockStart);
   }
 
   .#{$page}__main-breadcrumb + & {
-    --#{$page}__main-tabs--PaddingTop: var(--#{$page}__main-breadcrumb--page__main-tabs--PaddingTop);
+    --#{$page}__main-tabs--PaddingBlockStart: var(--#{$page}__main-breadcrumb--page__main-tabs--PaddingBlockStart);
   }
 }
 
@@ -606,10 +606,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 }
 
 .#{$page}__main-section {
-  padding-block-start: var(--#{$page}__main-section--PaddingTop);
-  padding-block-end: var(--#{$page}__main-section--PaddingBottom);
-  padding-inline-start: var(--#{$page}__main-section--PaddingLeft);
-  padding-inline-end: var(--#{$page}__main-section--PaddingRight);
+  padding-block-start: var(--#{$page}__main-section--PaddingBlockStart);
+  padding-block-end: var(--#{$page}__main-section--PaddingBlockEnd);
+  padding-inline-start: var(--#{$page}__main-section--PaddingInlineStart);
+  padding-inline-end: var(--#{$page}__main-section--PaddingInlineEnd);
   background-color: var(--#{$page}__main-section--BackgroundColor);
 
   &.pf-m-secondary {
@@ -622,19 +622,19 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     @include pf-v6-apply-breakpoint($breakpoint) {
       // stylelint-disable max-nesting-depth
       &.pf-m-padding#{$breakpoint-name} {
-        padding-block-start: var(--#{$page}__main-section--PaddingTop);
-        padding-block-end: var(--#{$page}__main-section--PaddingBottom);
-        padding-inline-start: var(--#{$page}__main-section--PaddingLeft);
-        padding-inline-end: var(--#{$page}__main-section--PaddingRight);
+        padding-block-start: var(--#{$page}__main-section--PaddingBlockStart);
+        padding-block-end: var(--#{$page}__main-section--PaddingBlockEnd);
+        padding-inline-start: var(--#{$page}__main-section--PaddingInlineStart);
+        padding-inline-end: var(--#{$page}__main-section--PaddingInlineEnd);
 
         &.pf-m-limit-width {
           padding: 0;
 
           .#{$page}__main-body {
-            padding-block-start: var(--#{$page}__main-section--PaddingTop);
-            padding-block-end: var(--#{$page}__main-section--PaddingBottom);
-            padding-inline-start: var(--#{$page}__main-section--PaddingLeft);
-            padding-inline-end: var(--#{$page}__main-section--PaddingRight);
+            padding-block-start: var(--#{$page}__main-section--PaddingBlockStart);
+            padding-block-end: var(--#{$page}__main-section--PaddingBlockEnd);
+            padding-inline-start: var(--#{$page}__main-section--PaddingInlineStart);
+            padding-inline-end: var(--#{$page}__main-section--PaddingInlineEnd);
           }
         }
       }
@@ -654,10 +654,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   flex: 1 1;
   min-height: 0;
   background-color: var(--#{$page}__main-wizard--BackgroundColor);
-  border-block-start: var(--#{$page}__main-wizard--BorderTopWidth) solid var(--#{$page}__main-wizard--BorderTopColor);
+  border-block-start: var(--#{$page}__main-wizard--BorderBlockStartWidth) solid var(--#{$page}__main-wizard--BorderBlockStartColor);
 
   &:first-child {
-    --#{$page}__main-wizard--BorderTopWidth: 0;
+    --#{$page}__main-wizard--BorderBlockStartWidth: 0;
   }
 }
 
@@ -671,30 +671,30 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
 .#{$page}__main-body {
   .#{$page}__main-nav & {
-    padding-block-start: var(--#{$page}__main-nav--PaddingTop);
-    padding-inline-start: var(--#{$page}__main-nav--PaddingLeft);
-    padding-inline-end: var(--#{$page}__main-nav--PaddingRight);
+    padding-block-start: var(--#{$page}__main-nav--PaddingBlockStart);
+    padding-inline-start: var(--#{$page}__main-nav--PaddingInlineStart);
+    padding-inline-end: var(--#{$page}__main-nav--PaddingInlineEnd);
   }
 
   .#{$page}__main-breadcrumb & {
-    padding-block-start: var(--#{$page}__main-breadcrumb--PaddingTop);
-    padding-block-end: var(--#{$page}__main-breadcrumb--PaddingBottom);
-    padding-inline-start: var(--#{$page}__main-breadcrumb--PaddingLeft);
-    padding-inline-end: var(--#{$page}__main-breadcrumb--PaddingRight);
+    padding-block-start: var(--#{$page}__main-breadcrumb--PaddingBlockStart);
+    padding-block-end: var(--#{$page}__main-breadcrumb--PaddingBlockEnd);
+    padding-inline-start: var(--#{$page}__main-breadcrumb--PaddingInlineStart);
+    padding-inline-end: var(--#{$page}__main-breadcrumb--PaddingInlineEnd);
   }
 
   .#{$page}__main-section & {
-    padding-block-start: var(--#{$page}__main-section--PaddingTop);
-    padding-block-end: var(--#{$page}__main-section--PaddingBottom);
-    padding-inline-start: var(--#{$page}__main-section--PaddingLeft);
-    padding-inline-end: var(--#{$page}__main-section--PaddingRight);
+    padding-block-start: var(--#{$page}__main-section--PaddingBlockStart);
+    padding-block-end: var(--#{$page}__main-section--PaddingBlockEnd);
+    padding-inline-start: var(--#{$page}__main-section--PaddingInlineStart);
+    padding-inline-end: var(--#{$page}__main-section--PaddingInlineEnd);
   }
 
   .#{$page}__main-tabs & {
-    padding-block-start: var(--#{$page}__main-tabs--PaddingTop);
-    padding-block-end: var(--#{$page}__main-tabs--PaddingBottom);
-    padding-inline-start: var(--#{$page}__main-tabs--PaddingLeft);
-    padding-inline-end: var(--#{$page}__main-tabs--PaddingRight);
+    padding-block-start: var(--#{$page}__main-tabs--PaddingBlockStart);
+    padding-block-end: var(--#{$page}__main-tabs--PaddingBlockEnd);
+    padding-inline-start: var(--#{$page}__main-tabs--PaddingInlineStart);
+    padding-inline-end: var(--#{$page}__main-tabs--PaddingInlineEnd);
   }
 }
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -19,7 +19,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   // nav page select
   --#{$pagination}__nav-page-select--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$pagination}__nav-page-select--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$pagination}__nav-page-select--c-form-control--width-base: calc((var(--#{$form-control}--PaddingRight) + var(--#{$form-control}--PaddingLeft)) + (var(--#{$form-control}--before--BorderWidth) * 2));
+  --#{$pagination}__nav-page-select--c-form-control--width-base: calc((var(--#{$form-control}--PaddingInlineEnd) + var(--#{$form-control}--PaddingInlineStart)) + (var(--#{$form-control}--before--BorderWidth) * 2));
   --#{$pagination}__nav-page-select--c-form-control--width-chars: 2;
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
 
@@ -31,19 +31,19 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   // top
   --#{$pagination}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$pagination}--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
-  --#{$pagination}--m-sticky--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$pagination}--m-sticky--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$pagination}--m-sticky--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$pagination}--m-sticky--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$pagination}--m-sticky--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$pagination}--m-sticky--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-sticky--ZIndex: 100; // TODO: replace with z-index token
-  --#{$pagination}--m-sticky--Top: 0;
+  --#{$pagination}--m-sticky--BlockStart: 0;
 
   // bottom
   --#{$pagination}--m-bottom--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$pagination}--m-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
-  --#{$pagination}--m-bottom--Bottom: 0;
-  --#{$pagination}--m-bottom--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$pagination}--m-bottom--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--m-bottom--BlockEnd: 0;
+  --#{$pagination}--m-bottom--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--m-bottom--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
 
   // options menu
@@ -78,19 +78,19 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   &.pf-m-bottom {
     --#{$pagination}--m-sticky--BoxShadow: var(--#{$pagination}--m-bottom--m-sticky--BoxShadow);
-    --#{$pagination}--m-sticky--Top: auto;
+    --#{$pagination}--m-sticky--BlockStart: auto;
 
     position: sticky;
-    inset-block-end: var(--#{$pagination}--m-bottom--Bottom);
+    inset-block-end: var(--#{$pagination}--m-bottom--BlockEnd);
     justify-content: center;
-    padding-inline-start: var(--#{$pagination}--m-bottom--PaddingLeft);
-    padding-inline-end: var(--#{$pagination}--m-bottom--PaddingRight);
+    padding-inline-start: var(--#{$pagination}--m-bottom--PaddingInlineStart);
+    padding-inline-end: var(--#{$pagination}--m-bottom--PaddingInlineEnd);
     background-color: var(--#{$pagination}--m-bottom--BackgroundColor);
     box-shadow: var(--#{$pagination}--m-bottom--BoxShadow);
 
     &.pf-m-static {
-      --#{$pagination}--m-bottom--MarginTop: 0;
-      --#{$pagination}--m-bottom--BorderTopWidth: 0;
+      --#{$pagination}--m-bottom--MarginBlockStart: 0;
+      --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
 
       position: relative;
       box-shadow: none;
@@ -114,9 +114,9 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     }
 
     @media screen and (min-width: $pf-v6-global--breakpoint--md) {
-      --#{$pagination}--m-bottom--BorderTopWidth: 0;
-      --#{$pagination}--m-bottom--MarginTop: 0;
-      --#{$pagination}--m-bottom--Bottom: auto;
+      --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
+      --#{$pagination}--m-bottom--MarginBlockStart: 0;
+      --#{$pagination}--m-bottom--BlockEnd: auto;
 
       position: relative;
       justify-content: flex-end;
@@ -143,15 +143,15 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   }
 
   &.pf-m-sticky {
-    --#{$pagination}--m-bottom--Bottom: 0;
+    --#{$pagination}--m-bottom--BlockEnd: 0;
 
     position: sticky;
-    inset-block-start: var(--#{$pagination}--m-sticky--Top);
+    inset-block-start: var(--#{$pagination}--m-sticky--BlockStart);
     z-index: var(--#{$pagination}--m-sticky--ZIndex);
-    padding-block-start: var(--#{$pagination}--m-sticky--PaddingTop);
-    padding-block-end: var(--#{$pagination}--m-sticky--PaddingBottom);
-    padding-inline-start: var(--#{$pagination}--m-sticky--PaddingLeft);
-    padding-inline-end: var(--#{$pagination}--m-sticky--PaddingRight);
+    padding-block-start: var(--#{$pagination}--m-sticky--PaddingBlockStart);
+    padding-block-end: var(--#{$pagination}--m-sticky--PaddingBlockEnd);
+    padding-inline-start: var(--#{$pagination}--m-sticky--PaddingInlineStart);
+    padding-inline-end: var(--#{$pagination}--m-sticky--PaddingInlineEnd);
     background-color: var(--#{$pagination}--m-sticky--BackgroundColor);
     box-shadow: var(--#{$pagination}--m-sticky--BoxShadow);
   }

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -36,12 +36,12 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$pagination}--m-sticky--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-sticky--ZIndex: 100; // TODO: replace with z-index token
-  --#{$pagination}--m-sticky--BlockStart: 0;
+  --#{$pagination}--m-sticky--InsetBlockStart: 0;
 
   // bottom
   --#{$pagination}--m-bottom--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$pagination}--m-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
-  --#{$pagination}--m-bottom--BlockEnd: 0;
+  --#{$pagination}--m-bottom--InsetBlockEnd: 0;
   --#{$pagination}--m-bottom--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
@@ -78,10 +78,10 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   &.pf-m-bottom {
     --#{$pagination}--m-sticky--BoxShadow: var(--#{$pagination}--m-bottom--m-sticky--BoxShadow);
-    --#{$pagination}--m-sticky--BlockStart: auto;
+    --#{$pagination}--m-sticky--InsetBlockStart: auto;
 
     position: sticky;
-    inset-block-end: var(--#{$pagination}--m-bottom--BlockEnd);
+    inset-block-end: var(--#{$pagination}--m-bottom--InsetBlockEnd);
     justify-content: center;
     padding-inline-start: var(--#{$pagination}--m-bottom--PaddingInlineStart);
     padding-inline-end: var(--#{$pagination}--m-bottom--PaddingInlineEnd);
@@ -116,7 +116,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     @media screen and (min-width: $pf-v6-global--breakpoint--md) {
       --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
       --#{$pagination}--m-bottom--MarginBlockStart: 0;
-      --#{$pagination}--m-bottom--BlockEnd: auto;
+      --#{$pagination}--m-bottom--InsetBlockEnd: auto;
 
       position: relative;
       justify-content: flex-end;
@@ -143,10 +143,10 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   }
 
   &.pf-m-sticky {
-    --#{$pagination}--m-bottom--BlockEnd: 0;
+    --#{$pagination}--m-bottom--InsetBlockEnd: 0;
 
     position: sticky;
-    inset-block-start: var(--#{$pagination}--m-sticky--BlockStart);
+    inset-block-start: var(--#{$pagination}--m-sticky--InsetBlockStart);
     z-index: var(--#{$pagination}--m-sticky--ZIndex);
     padding-block-start: var(--#{$pagination}--m-sticky--PaddingBlockStart);
     padding-block-end: var(--#{$pagination}--m-sticky--PaddingBlockEnd);

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -24,26 +24,26 @@
   --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // header
-  --#{$panel}__header--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$panel}__header--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$panel}__header--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$panel}__header--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // main
   --#{$panel}__main--MaxHeight: none;
   --#{$panel}__main--Overflow: visible;
 
   // body
-  --#{$panel}__main-body--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$panel}__main-body--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$panel}__main-body--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$panel}__main-body--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // footer
-  --#{$panel}__footer--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$panel}__footer--BoxShadow: none;
 
   // scrollable
@@ -91,10 +91,10 @@
 }
 
 .#{$panel}__header {
-  padding-block-start: var(--#{$panel}__header--PaddingTop);
-  padding-block-end: var(--#{$panel}__header--PaddingBottom);
-  padding-inline-start: var(--#{$panel}__header--PaddingLeft);
-  padding-inline-end: var(--#{$panel}__header--PaddingRight);
+  padding-block-start: var(--#{$panel}__header--PaddingBlockStart);
+  padding-block-end: var(--#{$panel}__header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$panel}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$panel}__header--PaddingInlineEnd);
 }
 
 .#{$panel}__main {
@@ -103,16 +103,16 @@
 }
 
 .#{$panel}__main-body {
-  padding-block-start: var(--#{$panel}__main-body--PaddingTop);
-  padding-block-end: var(--#{$panel}__main-body--PaddingBottom);
-  padding-inline-start: var(--#{$panel}__main-body--PaddingLeft);
-  padding-inline-end: var(--#{$panel}__main-body--PaddingRight);
+  padding-block-start: var(--#{$panel}__main-body--PaddingBlockStart);
+  padding-block-end: var(--#{$panel}__main-body--PaddingBlockEnd);
+  padding-inline-start: var(--#{$panel}__main-body--PaddingInlineStart);
+  padding-inline-end: var(--#{$panel}__main-body--PaddingInlineEnd);
 }
 
 .#{$panel}__footer {
-  padding-block-start: var(--#{$panel}__footer--PaddingTop);
-  padding-block-end: var(--#{$panel}__footer--PaddingBottom);
-  padding-inline-start: var(--#{$panel}__footer--PaddingLeft);
-  padding-inline-end: var(--#{$panel}__footer--PaddingRight);
+  padding-block-start: var(--#{$panel}__footer--PaddingBlockStart);
+  padding-block-end: var(--#{$panel}__footer--PaddingBlockEnd);
+  padding-inline-start: var(--#{$panel}__footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$panel}__footer--PaddingInlineEnd);
   box-shadow: var(--#{$panel}__footer--BoxShadow);
 }

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -3,8 +3,8 @@
 .#{$popover} {
   // Component
   --#{$popover}--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$popover}--MinWidth: calc(var(--#{$popover}__content--PaddingLeft) + var(--#{$popover}__content--PaddingRight) + #{pf-size-prem(300px)});
-  --#{$popover}--MaxWidth: calc(var(--#{$popover}__content--PaddingLeft) + var(--#{$popover}__content--PaddingRight) + #{pf-size-prem(300px)});
+  --#{$popover}--MinWidth: calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)});
+  --#{$popover}--MaxWidth: calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)});
   --#{$popover}--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$popover}--BorderRadius: var(--pf-t--global--border--radius--medium);
 
@@ -18,10 +18,10 @@
 
   // Content
   --#{$popover}__content--BackgroundColor: var(--pf-t--global--background--color--floating--default);
-  --#{$popover}__content--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$popover}__content--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$popover}__content--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$popover}__content--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$popover}__content--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$popover}__content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$popover}__content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$popover}__content--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$popover}__content--BorderRadius: var(--pf-t--global--border--radius--medium);
 
   // Arrow
@@ -41,18 +41,18 @@
   --#{$popover}__arrow--m-left--TranslateX: 50%;
   --#{$popover}__arrow--m-left--TranslateY: -50%;
   --#{$popover}__arrow--m-left--Rotate: 45deg;
-  --#{$popover}__arrow--m-inline-top--Top: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-inline-bottom--Bottom: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-block-left--Left: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-block-right--Right: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-inline-top--BlockStart: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-inline-bottom--BlockEnd: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-block-left--InlineStart: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-block-right--InlineEnd: var(--pf-t--global--border--radius--medium);
 
   // Close
-  --#{$popover}__close--Top: calc(var(--#{$popover}__content--PaddingTop) - (var(--pf-t--global--spacer--control--vertical--compact) * 1.5)); // align top of button with top of text
-  --#{$popover}__close--Right: var(--#{$popover}__content--PaddingRight); // align right of content
-  --#{$popover}__close--sibling--PaddingRight: var(--pf-t--global--spacer--2xl);
+  --#{$popover}__close--BlockStart: calc(var(--#{$popover}__content--PaddingBlockStart) - (var(--pf-t--global--spacer--control--vertical--compact) * 1.5)); // align top of button with top of text
+  --#{$popover}__close--InlineEnd: var(--#{$popover}__content--PaddingInlineEnd); // align right of content
+  --#{$popover}__close--sibling--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
 
   // Header
-  --#{$popover}__header--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$popover}__header--MarginBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Title text
   --#{$popover}__title-text--Color: var(--pf-t--global--text--color--regular);
@@ -61,12 +61,12 @@
   --#{$popover}__title-text--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // Title icon
-  --#{$popover}__title-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$popover}__title-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$popover}__title-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$popover}__title-icon--FontSize: var(--pf-t--global--font--size--heading--xs);
 
   // Footer
-  --#{$popover}__footer--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$popover}__footer--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   position: relative;
   min-width: var(--#{$popover}--MinWidth);
@@ -78,10 +78,10 @@
   &.pf-m-no-padding {
     // Use px values below so the min/max-width calc() doesn't break
     // stylelint-disable length-zero-no-unit
-    --#{$popover}__content--PaddingTop: 0px;
-    --#{$popover}__content--PaddingRight: 0px;
-    --#{$popover}__content--PaddingBottom: 0px;
-    --#{$popover}__content--PaddingLeft: 0px;
+    --#{$popover}__content--PaddingBlockStart: 0px;
+    --#{$popover}__content--PaddingInlineEnd: 0px;
+    --#{$popover}__content--PaddingBlockEnd: 0px;
+    --#{$popover}__content--PaddingInlineStart: 0px;
     // stylelint-enable
   }
 
@@ -95,8 +95,8 @@
     .pf-m-top-left,
     .pf-m-top-right
   ) {
-    --#{$popover}__arrow--Bottom: var(--#{$popover}--m-top--Bottom, 0);
-    --#{$popover}__arrow--Left: var(--#{$popover}--m-top--Left, 50%);
+    --#{$popover}__arrow--BlockEnd: var(--#{$popover}--m-top--BlockEnd, 0);
+    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-top--InlineStart, 50%);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-top--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-top--Rotate);
@@ -107,8 +107,8 @@
     .pf-m-bottom-left,
     .pf-m-bottom-right
   ) {
-    --#{$popover}__arrow--Top: var(--#{$popover}--m-bottom--Top, 0);
-    --#{$popover}__arrow--Left: var(--#{$popover}--m-bottom--Left, 50%);
+    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-bottom--BlockStart, 0);
+    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-bottom--InlineStart, 50%);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-bottom--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-bottom--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-bottom--Rotate);
@@ -119,8 +119,8 @@
     .pf-m-left-top,
     .pf-m-left-bottom
   ) {
-    --#{$popover}__arrow--Top: var(--#{$popover}--m-left--Top, 50%);
-    --#{$popover}__arrow--Right: var(--#{$popover}--m-left--Right, 0);
+    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-left--BlockStart, 50%);
+    --#{$popover}__arrow--InlineEnd: var(--#{$popover}--m-left--InlineEnd, 0);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-left--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-left--Rotate);
@@ -131,8 +131,8 @@
     .pf-m-right-top,
     .pf-m-right-bottom
   ) {
-    --#{$popover}__arrow--Top: var(--#{$popover}--m-right--Top, 50%);
-    --#{$popover}__arrow--Left: var(--#{$popover}--m-right--Left, 0);
+    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-right--BlockStart, 50%);
+    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-right--InlineStart, 0);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-right--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-right--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-right--Rotate);
@@ -142,7 +142,7 @@
     .pf-m-left-top,
     .pf-m-right-top
   ) {
-    --#{$popover}__arrow--Top: var(--#{$popover}__arrow--m-inline-top--Top);
+    --#{$popover}__arrow--BlockStart: var(--#{$popover}__arrow--m-inline-top--BlockStart);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
   }
 
@@ -150,15 +150,15 @@
     .pf-m-left-bottom,
     .pf-m-right-bottom
   ) {
-    --#{$popover}__arrow--Top: auto;
-    --#{$popover}__arrow--Bottom: var(--#{$popover}__arrow--m-inline-bottom--Bottom);
+    --#{$popover}__arrow--BlockStart: auto;
+    --#{$popover}__arrow--BlockEnd: var(--#{$popover}__arrow--m-inline-bottom--BlockEnd);
   }
 
   &:is(
     .pf-m-top-left,
     .pf-m-bottom-left
   ) {
-    --#{$popover}__arrow--Left: var(--#{$popover}__arrow--m-block-left--Left);
+    --#{$popover}__arrow--InlineStart: var(--#{$popover}__arrow--m-block-left--InlineStart);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
   }
 
@@ -166,8 +166,8 @@
     .pf-m-top-right,
     .pf-m-bottom-right
   ) {
-    --#{$popover}__arrow--Right: var(--#{$popover}__arrow--m-block-right--Right);
-    --#{$popover}__arrow--Left: auto;
+    --#{$popover}__arrow--InlineEnd: var(--#{$popover}__arrow--m-block-right--InlineEnd);
+    --#{$popover}__arrow--InlineStart: auto;
   }
 
   &.pf-m-danger {
@@ -193,10 +193,10 @@
 
 .#{$popover}__content {
   position: relative;
-  padding-block-start: var(--#{$popover}__content--PaddingTop);
-  padding-block-end: var(--#{$popover}__content--PaddingBottom);
-  padding-inline-start: var(--#{$popover}__content--PaddingLeft);
-  padding-inline-end: var(--#{$popover}__content--PaddingRight);
+  padding-block-start: var(--#{$popover}__content--PaddingBlockStart);
+  padding-block-end: var(--#{$popover}__content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$popover}__content--PaddingInlineStart);
+  padding-inline-end: var(--#{$popover}__content--PaddingInlineEnd);
   background-color: var(--#{$popover}__content--BackgroundColor);
   border-radius: var(--#{$popover}__content--BorderRadius);
 }
@@ -204,22 +204,22 @@
 // Close button
 .#{$popover}__close {
   position: absolute;
-  inset-block-start: var(--#{$popover}__close--Top);
-  inset-inline-end: var(--#{$popover}__close--Right);
+  inset-block-start: var(--#{$popover}__close--BlockStart);
+  inset-inline-end: var(--#{$popover}__close--InlineEnd);
 
   // Create room for the close button
   + * {
-    padding-inline-end: var(--#{$popover}__close--sibling--PaddingRight);
+    padding-inline-end: var(--#{$popover}__close--sibling--PaddingInlineEnd);
   }
 }
 
 .#{$popover}__arrow {
   position: absolute;
   // stylelint-disable liberty/use-logical-spec
-  top: var(--#{$popover}__arrow--Top, auto);
-  right: var(--#{$popover}__arrow--Right, auto);
-  bottom: var(--#{$popover}__arrow--Bottom, auto);
-  left: var(--#{$popover}__arrow--Left, auto);
+  top: var(--#{$popover}__arrow--BlockStart, auto);
+  right: var(--#{$popover}__arrow--InlineEnd, auto);
+  bottom: var(--#{$popover}__arrow--BlockEnd, auto);
+  left: var(--#{$popover}__arrow--InlineStart, auto);
   // stylelint-enable
   width: var(--#{$popover}__arrow--Width);
   height: var(--#{$popover}__arrow--Height);
@@ -230,7 +230,7 @@
 }
 
 .#{$popover}__header {
-  margin-block-end: var(--#{$popover}__header--MarginBottom);
+  margin-block-end: var(--#{$popover}__header--MarginBlockEnd);
 }
 
 .#{$popover}__title {
@@ -239,7 +239,7 @@
 }
 
 .#{$popover}__title-icon {
-  margin-inline-end: var(--#{$popover}__title-icon--MarginRight);
+  margin-inline-end: var(--#{$popover}__title-icon--MarginInlineEnd);
   font-size: var(--#{$popover}__title-icon--FontSize);
   color: var(--#{$popover}__title-icon--Color);
 }
@@ -257,5 +257,5 @@
 }
 
 .#{$popover}__footer {
-  margin-block-start: var(--#{$popover}__footer--MarginTop);
+  margin-block-start: var(--#{$popover}__footer--MarginBlockStart);
 }

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -41,14 +41,14 @@
   --#{$popover}__arrow--m-left--TranslateX: 50%;
   --#{$popover}__arrow--m-left--TranslateY: -50%;
   --#{$popover}__arrow--m-left--Rotate: 45deg;
-  --#{$popover}__arrow--m-inline-top--BlockStart: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-inline-bottom--BlockEnd: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-block-left--InlineStart: var(--pf-t--global--border--radius--medium);
-  --#{$popover}__arrow--m-block-right--InlineEnd: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-inline-top--InsetBlockStart: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-inline-bottom--InsetBlockEnd: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-block-left--InsetInlineStart: var(--pf-t--global--border--radius--medium);
+  --#{$popover}__arrow--m-block-right--InsetInlineEnd: var(--pf-t--global--border--radius--medium);
 
   // Close
-  --#{$popover}__close--BlockStart: calc(var(--#{$popover}__content--PaddingBlockStart) - (var(--pf-t--global--spacer--control--vertical--compact) * 1.5)); // align top of button with top of text
-  --#{$popover}__close--InlineEnd: var(--#{$popover}__content--PaddingInlineEnd); // align right of content
+  --#{$popover}__close--InsetBlockStart: calc(var(--#{$popover}__content--PaddingBlockStart) - (var(--pf-t--global--spacer--control--vertical--compact) * 1.5)); // align top of button with top of text
+  --#{$popover}__close--InsetInlineEnd: var(--#{$popover}__content--PaddingInlineEnd); // align right of content
   --#{$popover}__close--sibling--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
 
   // Header
@@ -95,8 +95,8 @@
     .pf-m-top-left,
     .pf-m-top-right
   ) {
-    --#{$popover}__arrow--BlockEnd: var(--#{$popover}--m-top--BlockEnd, 0);
-    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-top--InlineStart, 50%);
+    --#{$popover}__arrow--InsetBlockEnd: var(--#{$popover}--m-top--InsetBlockEnd, 0);
+    --#{$popover}__arrow--InsetInlineStart: var(--#{$popover}--m-top--InsetInlineStart, 50%);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-top--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-top--Rotate);
@@ -107,8 +107,8 @@
     .pf-m-bottom-left,
     .pf-m-bottom-right
   ) {
-    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-bottom--BlockStart, 0);
-    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-bottom--InlineStart, 50%);
+    --#{$popover}__arrow--InsetBlockStart: var(--#{$popover}--m-bottom--InsetBlockStart, 0);
+    --#{$popover}__arrow--InsetInlineStart: var(--#{$popover}--m-bottom--InsetInlineStart, 50%);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-bottom--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-bottom--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-bottom--Rotate);
@@ -119,8 +119,8 @@
     .pf-m-left-top,
     .pf-m-left-bottom
   ) {
-    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-left--BlockStart, 50%);
-    --#{$popover}__arrow--InlineEnd: var(--#{$popover}--m-left--InlineEnd, 0);
+    --#{$popover}__arrow--InsetBlockStart: var(--#{$popover}--m-left--InsetBlockStart, 50%);
+    --#{$popover}__arrow--InsetInlineEnd: var(--#{$popover}--m-left--InsetInlineEnd, 0);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-left--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-left--Rotate);
@@ -131,8 +131,8 @@
     .pf-m-right-top,
     .pf-m-right-bottom
   ) {
-    --#{$popover}__arrow--BlockStart: var(--#{$popover}--m-right--BlockStart, 50%);
-    --#{$popover}__arrow--InlineStart: var(--#{$popover}--m-right--InlineStart, 0);
+    --#{$popover}__arrow--InsetBlockStart: var(--#{$popover}--m-right--InsetBlockStart, 50%);
+    --#{$popover}__arrow--InsetInlineStart: var(--#{$popover}--m-right--InsetInlineStart, 0);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-right--TranslateX);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-right--TranslateY);
     --#{$popover}__arrow--Rotate: var(--#{$popover}__arrow--m-right--Rotate);
@@ -142,7 +142,7 @@
     .pf-m-left-top,
     .pf-m-right-top
   ) {
-    --#{$popover}__arrow--BlockStart: var(--#{$popover}__arrow--m-inline-top--BlockStart);
+    --#{$popover}__arrow--InsetBlockStart: var(--#{$popover}__arrow--m-inline-top--InsetBlockStart);
     --#{$popover}__arrow--TranslateY: var(--#{$popover}__arrow--m-top--TranslateY);
   }
 
@@ -150,15 +150,15 @@
     .pf-m-left-bottom,
     .pf-m-right-bottom
   ) {
-    --#{$popover}__arrow--BlockStart: auto;
-    --#{$popover}__arrow--BlockEnd: var(--#{$popover}__arrow--m-inline-bottom--BlockEnd);
+    --#{$popover}__arrow--InsetBlockStart: auto;
+    --#{$popover}__arrow--InsetBlockEnd: var(--#{$popover}__arrow--m-inline-bottom--InsetBlockEnd);
   }
 
   &:is(
     .pf-m-top-left,
     .pf-m-bottom-left
   ) {
-    --#{$popover}__arrow--InlineStart: var(--#{$popover}__arrow--m-block-left--InlineStart);
+    --#{$popover}__arrow--InsetInlineStart: var(--#{$popover}__arrow--m-block-left--InsetInlineStart);
     --#{$popover}__arrow--TranslateX: var(--#{$popover}__arrow--m-left--TranslateX);
   }
 
@@ -166,8 +166,8 @@
     .pf-m-top-right,
     .pf-m-bottom-right
   ) {
-    --#{$popover}__arrow--InlineEnd: var(--#{$popover}__arrow--m-block-right--InlineEnd);
-    --#{$popover}__arrow--InlineStart: auto;
+    --#{$popover}__arrow--InsetInlineEnd: var(--#{$popover}__arrow--m-block-right--InsetInlineEnd);
+    --#{$popover}__arrow--InsetInlineStart: auto;
   }
 
   &.pf-m-danger {
@@ -204,8 +204,8 @@
 // Close button
 .#{$popover}__close {
   position: absolute;
-  inset-block-start: var(--#{$popover}__close--BlockStart);
-  inset-inline-end: var(--#{$popover}__close--InlineEnd);
+  inset-block-start: var(--#{$popover}__close--InsetBlockStart);
+  inset-inline-end: var(--#{$popover}__close--InsetInlineEnd);
 
   // Create room for the close button
   + * {
@@ -216,10 +216,10 @@
 .#{$popover}__arrow {
   position: absolute;
   // stylelint-disable liberty/use-logical-spec
-  top: var(--#{$popover}__arrow--BlockStart, auto);
-  right: var(--#{$popover}__arrow--InlineEnd, auto);
-  bottom: var(--#{$popover}__arrow--BlockEnd, auto);
-  left: var(--#{$popover}__arrow--InlineStart, auto);
+  top: var(--#{$popover}__arrow--InsetBlockStart, auto);
+  right: var(--#{$popover}__arrow--InsetInlineEnd, auto);
+  bottom: var(--#{$popover}__arrow--InsetBlockEnd, auto);
+  left: var(--#{$popover}__arrow--InsetInlineStart, auto);
   // stylelint-enable
   width: var(--#{$popover}__arrow--Width);
   height: var(--#{$popover}__arrow--Height);

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -176,7 +176,7 @@
   // disable linter as the indicator element should always grow ltr
   // stylelint-disable liberty/use-logical-spec
   inset-block-start: 0;
-  inset-inline-end: 0;
+  inset-inline-start: 0;
   // stylelint-enable
 }
 

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -12,7 +12,7 @@
   --#{$progress}__status-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$progress}__indicator--Height: var(--#{$progress}__bar--Height);
   --#{$progress}__indicator--BackgroundColor: var(--pf-t--global--color--brand--default);
-  --#{$progress}__helper-text--MarginTop: calc(var(--pf-t--global--spacer--sm) - var(--#{$progress}--GridGap));
+  --#{$progress}__helper-text--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) - var(--#{$progress}--GridGap));
 
   // Modifier variables
   --#{$progress}--m-success__indicator--BackgroundColor: var(--pf-t--global--color--status--success--default);
@@ -201,5 +201,5 @@
 .#{$progress}__helper-text {
   grid-row: 3 / 4;
   grid-column: 1 / 3;
-  margin-block-start: var(--#{$progress}__helper-text--MarginTop);
+  margin-block-start: var(--#{$progress}__helper-text--MarginBlockStart);
 }

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -175,8 +175,8 @@
 .#{$progress}__indicator {
   // disable linter as the indicator element should always grow ltr
   // stylelint-disable liberty/use-logical-spec
-  top: 0;
-  left: 0;
+  inset-block-start: 0;
+  inset-inline-end: 0;
   // stylelint-enable
 }
 

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -6,8 +6,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 @mixin pf-v6-c-progress-stepper--m-vertical {
   --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-vertical--GridAutoFlow);
   --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-vertical--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--BlockStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--BlockStart);
-  --#{$progress-stepper}__step-connector--before--InlineStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InlineStart);
+  --#{$progress-stepper}__step-connector--before--InsetBlockStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InsetBlockStart);
+  --#{$progress-stepper}__step-connector--before--InsetInlineStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InsetInlineStart);
   --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-vertical__step-connector--before--Width);
   --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-vertical__step-connector--before--Height);
   --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth);
@@ -33,8 +33,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 @mixin pf-v6-c-progress-stepper--m-horizontal {
   --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-horizontal--GridAutoFlow);
   --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-horizontal--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--BlockStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BlockStart);
-  --#{$progress-stepper}__step-connector--before--InlineStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InlineStart);
+  --#{$progress-stepper}__step-connector--before--InsetBlockStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InsetBlockStart);
+  --#{$progress-stepper}__step-connector--before--InsetInlineStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InsetInlineStart);
   --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Width);
   --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Height);
   --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth);
@@ -62,8 +62,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Vertical - these are the default settings
   --#{$progress-stepper}--m-vertical--GridAutoFlow: row;
   --#{$progress-stepper}--m-vertical--GridTemplateColumns: auto 1fr;
-  --#{$progress-stepper}--m-vertical__step-connector--before--BlockStart: 0;
-  --#{$progress-stepper}--m-vertical__step-connector--before--InlineStart: calc(var(--#{$progress-stepper}__step-icon--Width) / 2);
+  --#{$progress-stepper}--m-vertical__step-connector--before--InsetBlockStart: 0;
+  --#{$progress-stepper}--m-vertical__step-connector--before--InsetInlineStart: calc(var(--#{$progress-stepper}__step-icon--Width) / 2);
   --#{$progress-stepper}--m-vertical__step-connector--before--Width: auto;
   --#{$progress-stepper}--m-vertical__step-connector--before--Height: 100%;
   --#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth: var(--pf-t--global--border--width--box--default);
@@ -91,8 +91,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Horizontal
   --#{$progress-stepper}--m-horizontal--GridAutoFlow: column;
   --#{$progress-stepper}--m-horizontal--GridTemplateColumns: initial;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BlockStart: calc(var(--#{$progress-stepper}__step-icon--Height) / 2);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--InlineStart: 0;
+  --#{$progress-stepper}--m-horizontal__step-connector--before--InsetBlockStart: calc(var(--#{$progress-stepper}__step-icon--Height) / 2);
+  --#{$progress-stepper}--m-horizontal__step-connector--before--InsetInlineStart: 0;
   --#{$progress-stepper}--m-horizontal__step-connector--before--Width: 100%;
   --#{$progress-stepper}--m-horizontal__step-connector--before--Height: auto;
   --#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth: 0;
@@ -123,7 +123,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginBlockStart: -3px;
 
   // Center
-  --#{$progress-stepper}--m-center__step-connector--before--InlineStart: 50%;
+  --#{$progress-stepper}--m-center__step-connector--before--InsetInlineStart: 50%;
   --#{$progress-stepper}--m-center--GridTemplateColumns: 1fr;
   --#{$progress-stepper}--m-center__step-connector--JustifyContent: center;
   --#{$progress-stepper}--m-center__step-main--MarginInlineEnd: var(--pf-t--global--spacer--xs);
@@ -222,7 +222,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
     }
 
     .#{$progress-stepper}__step:not(:last-of-type) > .#{$progress-stepper}__step-connector::before {
-     inset-inline-start: var(--#{$progress-stepper}--m-center__step-connector--before--InlineStart);
+     inset-inline-start: var(--#{$progress-stepper}--m-center__step-connector--before--InsetInlineStart);
     }
 
     // If not compact variant, swap borders from connector to main
@@ -333,8 +333,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 
   .#{$progress-stepper}__step:not(:last-of-type) > &::before {
     position: absolute;
-    inset-block-start: var(--#{$progress-stepper}__step-connector--before--BlockStart); // half the height
-    inset-inline-start: var(--#{$progress-stepper}__step-connector--before--InlineStart);
+    inset-block-start: var(--#{$progress-stepper}__step-connector--before--InsetBlockStart); // half the height
+    inset-inline-start: var(--#{$progress-stepper}__step-connector--before--InsetInlineStart);
     width: var(--#{$progress-stepper}__step-connector--before--Width);
     height: var(--#{$progress-stepper}__step-connector--before--Height);
     content: "";

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -6,24 +6,24 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 @mixin pf-v6-c-progress-stepper--m-vertical {
   --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-vertical--GridAutoFlow);
   --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-vertical--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--Top: var(--#{$progress-stepper}--m-vertical__step-connector--before--Top);
-  --#{$progress-stepper}__step-connector--before--Left: var(--#{$progress-stepper}--m-vertical__step-connector--before--Left);
+  --#{$progress-stepper}__step-connector--before--BlockStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--BlockStart);
+  --#{$progress-stepper}__step-connector--before--InlineStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InlineStart);
   --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-vertical__step-connector--before--Width);
   --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-vertical__step-connector--before--Height);
-  --#{$progress-stepper}__step-connector--before--BorderRightWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderRightWidth);
-  --#{$progress-stepper}__step-connector--before--BorderRightColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderRightColor);
-  --#{$progress-stepper}__step-connector--before--BorderBottomWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBottomWidth);
-  --#{$progress-stepper}__step-connector--before--BorderBottomColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBottomColor);
+  --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth);
+  --#{$progress-stepper}__step-connector--before--BorderInlineEndColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndColor);
+  --#{$progress-stepper}__step-connector--before--BorderBlockEndWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndWidth);
+  --#{$progress-stepper}__step-connector--before--BorderBlockEndColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndColor);
   --#{$progress-stepper}__step-connector--before--Transform: var(--#{$progress-stepper}--m-vertical__step-connector--before--Transform);
-  --#{$progress-stepper}__step-main--MarginTop: var(--#{$progress-stepper}--m-vertical__step-main--MarginTop);
-  --#{$progress-stepper}__step-main--MarginRight: var(--#{$progress-stepper}--m-vertical__step-main--MarginRight);
-  --#{$progress-stepper}__step-main--MarginBottom: var(--#{$progress-stepper}--m-vertical__step-main--MarginBottom);
-  --#{$progress-stepper}__step-main--MarginLeft: var(--#{$progress-stepper}--m-vertical__step-main--MarginLeft);
+  --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-vertical__step-main--MarginBlockStart);
+  --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd);
+  --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-vertical__step-main--MarginBlockEnd);
+  --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical__step-main--MarginInlineStart);
 
   // Compact vertical
   --#{$progress-stepper}--m-compact--GridTemplateColumns: var(--#{$progress-stepper}--m-vertical--m-compact--GridTemplateColumns);
   --#{$progress-stepper}--m-compact__step-connector--GridRow: var(--#{$progress-stepper}--m-vertical--m-compact__step-connector--GridRow);
-  --#{$progress-stepper}--m-compact__step-connector--PaddingBottom: var(--#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBottom);
+  --#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd: var(--#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBlockEnd);
 
   // Center
   --#{$progress-stepper}--m-center__step-connector--before--Content: none; // border swap
@@ -33,24 +33,24 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 @mixin pf-v6-c-progress-stepper--m-horizontal {
   --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-horizontal--GridAutoFlow);
   --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-horizontal--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--Top: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Top);
-  --#{$progress-stepper}__step-connector--before--Left: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Left);
+  --#{$progress-stepper}__step-connector--before--BlockStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BlockStart);
+  --#{$progress-stepper}__step-connector--before--InlineStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InlineStart);
   --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Width);
   --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Height);
-  --#{$progress-stepper}__step-connector--before--BorderRightWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderRightWidth);
-  --#{$progress-stepper}__step-connector--before--BorderRightColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderRightColor);
-  --#{$progress-stepper}__step-connector--before--BorderBottomWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBottomWidth);
-  --#{$progress-stepper}__step-connector--before--BorderBottomColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBottomColor);
+  --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth);
+  --#{$progress-stepper}__step-connector--before--BorderInlineEndColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndColor);
+  --#{$progress-stepper}__step-connector--before--BorderBlockEndWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndWidth);
+  --#{$progress-stepper}__step-connector--before--BorderBlockEndColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndColor);
   --#{$progress-stepper}__step-connector--before--Transform: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Transform);
-  --#{$progress-stepper}__step-main--MarginTop: var(--#{$progress-stepper}--m-horizontal__step-main--MarginTop);
-  --#{$progress-stepper}__step-main--MarginRight: var(--#{$progress-stepper}--m-horizontal__step-main--MarginRight);
-  --#{$progress-stepper}__step-main--MarginBottom: var(--#{$progress-stepper}--m-horizontal__step-main--MarginBottom);
-  --#{$progress-stepper}__step-main--MarginLeft: var(--#{$progress-stepper}--m-horizontal__step-main--MarginLeft);
+  --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-horizontal__step-main--MarginBlockStart);
+  --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-horizontal__step-main--MarginInlineEnd);
+  --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-horizontal__step-main--MarginBlockEnd);
+  --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-horizontal__step-main--MarginInlineStart);
 
   // Compact horizontal
   --#{$progress-stepper}--m-compact--GridTemplateColumns: var(--#{$progress-stepper}--m-horizontal--m-compact--GridTemplateColumns);
   --#{$progress-stepper}--m-compact__step-connector--GridRow: var(--#{$progress-stepper}--m-horizontal--m-compact__step-connector--GridRow);
-  --#{$progress-stepper}--m-compact__step-connector--PaddingBottom: var(--#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBottom);
+  --#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd: var(--#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBlockEnd);
 
   // Center
   --#{$progress-stepper}--m-center__step-connector--before--Content: ""; // border swap
@@ -62,75 +62,75 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Vertical - these are the default settings
   --#{$progress-stepper}--m-vertical--GridAutoFlow: row;
   --#{$progress-stepper}--m-vertical--GridTemplateColumns: auto 1fr;
-  --#{$progress-stepper}--m-vertical__step-connector--before--Top: 0;
-  --#{$progress-stepper}--m-vertical__step-connector--before--Left: calc(var(--#{$progress-stepper}__step-icon--Width) / 2);
+  --#{$progress-stepper}--m-vertical__step-connector--before--BlockStart: 0;
+  --#{$progress-stepper}--m-vertical__step-connector--before--InlineStart: calc(var(--#{$progress-stepper}__step-icon--Width) / 2);
   --#{$progress-stepper}--m-vertical__step-connector--before--Width: auto;
   --#{$progress-stepper}--m-vertical__step-connector--before--Height: 100%;
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderRightWidth: var(--pf-t--global--border--width--box--default);
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderRightColor: var(--pf-t--global--border--color--default);
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBottomWidth: 0;
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBottomColor: transparent;
+  --#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth: var(--pf-t--global--border--width--box--default);
+  --#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
+  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndWidth: 0;
+  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndColor: transparent;
   --#{$progress-stepper}--m-vertical__step-connector--before--Transform: translateX(-50%);
-  --#{$progress-stepper}--m-vertical__step-main--MarginTop: 0px; // needs px for calc
-  --#{$progress-stepper}--m-vertical__step-main--MarginRight: 0;
-  --#{$progress-stepper}--m-vertical__step-main--MarginBottom: var(--pf-t--global--spacer--xl);
-  --#{$progress-stepper}--m-vertical__step-main--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-vertical__step-main--MarginBlockStart: 0px; // needs px for calc
+  --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: 0;
+  --#{$progress-stepper}--m-vertical__step-main--MarginBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // Compact, vertical
   --#{$progress-stepper}--m-vertical--m-compact--GridTemplateColumns: 1fr;
-  --#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$progress-stepper}--m-vertical--m-compact__step-connector--GridRow: auto;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginTop: 0;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginRight: 0;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginLeft: 0;
+  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginBlockStart: 0;
+  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineEnd: 0;
+  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineStart: 0;
 
   // Center, vertical
-  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginRight: 0;
-  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginLeft: 0;
+  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineEnd: 0;
+  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineStart: 0;
 
   // Horizontal
   --#{$progress-stepper}--m-horizontal--GridAutoFlow: column;
   --#{$progress-stepper}--m-horizontal--GridTemplateColumns: initial;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--Top: calc(var(--#{$progress-stepper}__step-icon--Height) / 2);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--Left: 0;
+  --#{$progress-stepper}--m-horizontal__step-connector--before--BlockStart: calc(var(--#{$progress-stepper}__step-icon--Height) / 2);
+  --#{$progress-stepper}--m-horizontal__step-connector--before--InlineStart: 0;
   --#{$progress-stepper}--m-horizontal__step-connector--before--Width: 100%;
   --#{$progress-stepper}--m-horizontal__step-connector--before--Height: auto;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderRightWidth: 0;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderRightColor: unset;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth: 0;
+  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndColor: unset;
+  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndColor: var(--pf-t--global--border--color--default);
   --#{$progress-stepper}--m-horizontal__step-connector--before--Transform: translateY(-50%);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginTop: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginRight: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginBottom: 0;
-  --#{$progress-stepper}--m-horizontal__step-main--MarginLeft: 0;
+  --#{$progress-stepper}--m-horizontal__step-main--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-horizontal__step-main--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-horizontal__step-main--MarginBlockEnd: 0;
+  --#{$progress-stepper}--m-horizontal__step-main--MarginInlineStart: 0;
 
   // Compact, horizontal
   --#{$progress-stepper}--m-horizontal--m-compact--GridTemplateColumns: repeat(auto-fill, #{pf-size-prem(28px)});
-  --#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBottom: 0;
+  --#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBlockEnd: 0;
   --#{$progress-stepper}--m-horizontal--m-compact__step-connector--GridRow: 2;
 
   // Compact
   --#{$progress-stepper}--m-compact--GridAutoFlow: row;
-  --#{$progress-stepper}--m-compact__step-main--MarginTop: 0;
-  --#{$progress-stepper}--m-compact__step-main--MarginBottom: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-compact__step-main--MarginBlockStart: 0;
+  --#{$progress-stepper}--m-compact__step-main--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$progress-stepper}--m-compact__step-connector--MinWidth: #{pf-size-prem(28px)};
   --#{$progress-stepper}--m-compact__step-icon--Width: #{pf-size-prem(18px)};
   --#{$progress-stepper}--m-compact__step-icon--FontSize: var(--pf-t--global--icon--size--font--body--sm);
   --#{$progress-stepper}--m-compact__step-title--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$progress-stepper}--m-compact__step-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$progress-stepper}--m-compact__pficon--MarginTop: 2px;
-  --#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginTop: -3px;
+  --#{$progress-stepper}--m-compact__pficon--MarginBlockStart: 2px;
+  --#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginBlockStart: -3px;
 
   // Center
-  --#{$progress-stepper}--m-center__step-connector--before--Left: 50%;
+  --#{$progress-stepper}--m-center__step-connector--before--InlineStart: 50%;
   --#{$progress-stepper}--m-center--GridTemplateColumns: 1fr;
   --#{$progress-stepper}--m-center__step-connector--JustifyContent: center;
-  --#{$progress-stepper}--m-center__step-main--MarginRight: var(--pf-t--global--spacer--xs);
-  --#{$progress-stepper}--m-center__step-main--MarginLeft: var(--pf-t--global--spacer--xs);
+  --#{$progress-stepper}--m-center__step-main--MarginInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$progress-stepper}--m-center__step-main--MarginInlineStart: var(--pf-t--global--spacer--xs);
   --#{$progress-stepper}--m-center__step-main--TextAlign: center;
-  --#{$progress-stepper}--m-center__step-description--MarginRight: 0;
-  --#{$progress-stepper}--m-center__step-description--MarginLeft: 0;
+  --#{$progress-stepper}--m-center__step-description--MarginInlineEnd: 0;
+  --#{$progress-stepper}--m-center__step-description--MarginInlineStart: 0;
 
   // Stepper variables
   --#{$progress-stepper}--GridTemplateRows: auto 1fr;
@@ -155,8 +155,8 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}__step--m-custom__step-icon--Color: var(--pf-t--global--icon--color--status--custom--default);
 
   // Icon adjustments to fix differences in alignment
-  --#{$progress-stepper}__pficon--MarginTop: 3px;
-  --#{$progress-stepper}__fa-exclamation-triangle--MarginTop: -2px;
+  --#{$progress-stepper}__pficon--MarginBlockStart: 3px;
+  --#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart: -2px;
 
   // Step Title variables
   --#{$progress-stepper}__step-title--Color: var(--pf-t--global--text--color--regular);
@@ -180,7 +180,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}__step--m-danger__step-title--m-help-text--hover--Color: var(--pf-t--global--text--color--status--danger--hover);
 
   // Step Description variables
-  --#{$progress-stepper}__step-description--MarginTop: var(--pf-t--global--spacer--xs);
+  --#{$progress-stepper}__step-description--MarginBlockStart: var(--pf-t--global--spacer--xs);
   --#{$progress-stepper}__step-description--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$progress-stepper}__step-description--Color: var(--pf-t--global--text--color--subtle);
   --#{$progress-stepper}__step-description--TextAlign: start;
@@ -205,15 +205,15 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Progress stepper Modifiers
   &.pf-m-center {
     --#{$progress-stepper}__step-connector--JustifyContent: var(--#{$progress-stepper}--m-center__step-connector--JustifyContent);
-    --#{$progress-stepper}__step-main--MarginRight: var(--#{$progress-stepper}--m-center__step-main--MarginRight);
-    --#{$progress-stepper}__step-main--MarginLeft: var(--#{$progress-stepper}--m-center__step-main--MarginLeft);
+    --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-center__step-main--MarginInlineEnd);
+    --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-center__step-main--MarginInlineStart);
     --#{$progress-stepper}--step-main--TextAlign: var(--#{$progress-stepper}--m-center__step-main--TextAlign, auto);
     --#{$progress-stepper}__step-title--TextAlign: var(--#{$progress-stepper}--m-center__step-title--TextAlign, auto);
-    --#{$progress-stepper}__step-description--MarginRight: var(--#{$progress-stepper}--m-center__step-description--MarginRight);
-    --#{$progress-stepper}__step-description--MarginLeft: var(--#{$progress-stepper}--m-center__step-description--MarginLeft);
+    --#{$progress-stepper}__step-description--MarginInlineEnd: var(--#{$progress-stepper}--m-center__step-description--MarginInlineEnd);
+    --#{$progress-stepper}__step-description--MarginInlineStart: var(--#{$progress-stepper}--m-center__step-description--MarginInlineStart);
     --#{$progress-stepper}__step-description--TextAlign: var(--#{$progress-stepper}--m-center__step-description--TextAlign, auto);
-    --#{$progress-stepper}--m-vertical__step-main--MarginRight: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginRight);
-    --#{$progress-stepper}--m-vertical__step-main--MarginLeft: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginLeft);
+    --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineEnd);
+    --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineStart);
 
     grid-template-columns: var(--#{$progress-stepper}--m-center--GridTemplateColumns);
 
@@ -222,7 +222,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
     }
 
     .#{$progress-stepper}__step:not(:last-of-type) > .#{$progress-stepper}__step-connector::before {
-     inset-inline-start: var(--#{$progress-stepper}--m-center__step-connector--before--Left);
+     inset-inline-start: var(--#{$progress-stepper}--m-center__step-connector--before--InlineStart);
     }
 
     // If not compact variant, swap borders from connector to main
@@ -238,17 +238,17 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   }
 
   &.pf-m-compact {
-    --#{$progress-stepper}__step-main--MarginTop: var(--#{$progress-stepper}--m-compact__step-main--MarginTop);
-    --#{$progress-stepper}__step-main--MarginBottom: var(--#{$progress-stepper}--m-compact__step-main--MarginBottom);
+    --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockStart);
+    --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockEnd);
     --#{$progress-stepper}__step-icon--Width: var(--#{$progress-stepper}--m-compact__step-icon--Width);
     --#{$progress-stepper}__step-icon--FontSize: var(--#{$progress-stepper}--m-compact__step-icon--FontSize);
     --#{$progress-stepper}__step-title--FontSize: var(--#{$progress-stepper}--m-compact__step-title--FontSize);
     --#{$progress-stepper}__step--m-current__step-title--FontWeight: var(--#{$progress-stepper}--m-compact__step-title--FontWeight);
-    --#{$progress-stepper}__pficon--MarginTop: var(--#{$progress-stepper}--m-compact__pficon--MarginTop);
-    --#{$progress-stepper}__fa-exclamation-triangle--MarginTop: var(--#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginTop);
-    --#{$progress-stepper}--m-vertical__step-main--MarginTop: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginTop);
-    --#{$progress-stepper}--m-vertical__step-main--MarginRight: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginRight);
-    --#{$progress-stepper}--m-vertical__step-main--MarginLeft: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginLeft);
+    --#{$progress-stepper}__pficon--MarginBlockStart: var(--#{$progress-stepper}--m-compact__pficon--MarginBlockStart);
+    --#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart: var(--#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginBlockStart);
+    --#{$progress-stepper}--m-vertical__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginBlockStart);
+    --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineEnd);
+    --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineStart);
 
     display: inline-grid;
     grid-template-columns: var(--#{$progress-stepper}--m-compact--GridTemplateColumns);
@@ -257,11 +257,11 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
     .#{$progress-stepper}__step-connector {
       grid-row: var(--#{$progress-stepper}--m-compact__step-connector--GridRow);
       min-width: var(--#{$progress-stepper}--m-compact__step-connector--MinWidth);
-      padding-block-end: var(--#{$progress-stepper}--m-compact__step-connector--PaddingBottom);
+      padding-block-end: var(--#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd);
     }
 
     .#{$progress-stepper}__step-main {
-      margin-block-end: var(--#{$progress-stepper}--m-compact__step-main--MarginBottom);
+      margin-block-end: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockEnd);
     }
 
     .#{$progress-stepper}__step:not(.pf-m-current) .#{$progress-stepper}__step-main {
@@ -320,7 +320,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   }
 
   &:last-child {
-    --#{$progress-stepper}__step-main--MarginBottom: 0;
+    --#{$progress-stepper}__step-main--MarginBlockEnd: 0;
   }
 }
 
@@ -333,13 +333,13 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 
   .#{$progress-stepper}__step:not(:last-of-type) > &::before {
     position: absolute;
-    inset-block-start: var(--#{$progress-stepper}__step-connector--before--Top); // half the height
-    inset-inline-start: var(--#{$progress-stepper}__step-connector--before--Left);
+    inset-block-start: var(--#{$progress-stepper}__step-connector--before--BlockStart); // half the height
+    inset-inline-start: var(--#{$progress-stepper}__step-connector--before--InlineStart);
     width: var(--#{$progress-stepper}__step-connector--before--Width);
     height: var(--#{$progress-stepper}__step-connector--before--Height);
     content: "";
-    border-block-end: var(--#{$progress-stepper}__step-connector--before--BorderBottomWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderBottomColor);
-    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderRightWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderRightColor);
+    border-block-end: var(--#{$progress-stepper}__step-connector--before--BorderBlockEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderBlockEndColor);
+    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderInlineEndColor);
     transform: var(--#{$progress-stepper}__step-connector--before--Transform);
   }
 }
@@ -361,12 +361,12 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Align pficons with the font awesome icons
   // stylelint-disable
   .pf-v6-pficon {
-    margin-block-start: var(--#{$progress-stepper}__pficon--MarginTop);
+    margin-block-start: var(--#{$progress-stepper}__pficon--MarginBlockStart);
   }
 
   // Push the triangle up to fit inside the circle
   .fa-exclamation-triangle {
-    margin-block-start: var(--#{$progress-stepper}__fa-exclamation-triangle--MarginTop);
+    margin-block-start: var(--#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart);
   }
   // stylelint-enable
 }
@@ -374,21 +374,21 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 // Step main
 .#{$progress-stepper}__step-main {
   min-width: 0;
-  margin-block-start: var(--#{$progress-stepper}__step-main--MarginTop);
-  margin-block-end: var(--#{$progress-stepper}__step-main--MarginBottom);
-  margin-inline-start: var(--#{$progress-stepper}__step-main--MarginLeft);
-  margin-inline-end: var(--#{$progress-stepper}__step-main--MarginRight);
+  margin-block-start: var(--#{$progress-stepper}__step-main--MarginBlockStart);
+  margin-block-end: var(--#{$progress-stepper}__step-main--MarginBlockEnd);
+  margin-inline-start: var(--#{$progress-stepper}__step-main--MarginInlineStart);
+  margin-inline-end: var(--#{$progress-stepper}__step-main--MarginInlineEnd);
   text-align: var(--#{$progress-stepper}--step-main--TextAlign, auto);
   overflow-wrap: anywhere;
 
   // Draw a new border for vertical alignment using step main
   .#{$progress-stepper}__step:not(:last-of-type) > &::before {
     position: absolute;
-    inset-block-start: calc(100% + var(--#{$progress-stepper}__step-main--MarginTop));
-    inset-inline-start: calc(50% - calc(var(--#{$progress-stepper}__step-connector--before--BorderRightWidth) / 2));
+    inset-block-start: calc(100% + var(--#{$progress-stepper}__step-main--MarginBlockStart));
+    inset-inline-start: calc(50% - calc(var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) / 2));
     width: auto;
-    height: calc(var(--#{$progress-stepper}__step-main--MarginTop) + var(--#{$progress-stepper}__step-main--MarginBottom));
-    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderRightWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderRightColor);
+    height: calc(var(--#{$progress-stepper}__step-main--MarginBlockStart) + var(--#{$progress-stepper}__step-main--MarginBlockEnd));
+    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderInlineEndColor);
   }
 }
 
@@ -420,7 +420,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
 
 // Step description
 .#{$progress-stepper}__step-description {
-  margin-block-start: var(--#{$progress-stepper}__step-description--MarginTop);
+  margin-block-start: var(--#{$progress-stepper}__step-description--MarginBlockStart);
   font-size: var(--#{$progress-stepper}__step-description--FontSize);
   color: var(--#{$progress-stepper}__step-description--Color);
   text-align: var(--#{$progress-stepper}__step-description--TextAlign);

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -15,9 +15,9 @@
   --#{$radio}__description--Color: var(--pf-t--global--text--color--subtle);
 
   // * Radio input
-  --#{$radio}__input--first-child--MarginLeft: #{pf-size-prem(1px)};
-  --#{$radio}__input--last-child--MarginRight: #{pf-size-prem(1px)};
-  --#{$radio}__body--MarginTop: var(--pf-t--global--spacer--sm);
+  --#{$radio}__input--first-child--MarginInlineStart: #{pf-size-prem(1px)};
+  --#{$radio}__input--last-child--MarginInlineEnd: #{pf-size-prem(1px)};
+  --#{$radio}__body--MarginBlockStart: var(--pf-t--global--spacer--sm);
 
   // TODO: due to subpixel rendering and this value resolving to 21px, the checkbox vertical centering is off by 1px. Mozilla rounds subpixels up while chrome rounds down. This is a temporary fix until we can find a better solution.
   --#{$radio}__input--TranslateY: calc((var(--#{$radio}__label--LineHeight) * var(--#{$radio}__label--FontSize) / 2 ) - 50%); // find height of single label, divide by two, offset by 50% of own height
@@ -54,12 +54,12 @@
 
   // fixes a chrome issue where the left edge is cut off in a container with overflow hidden
   &:first-child {
-    margin-inline-start: var(--#{$radio}__input--first-child--MarginLeft);
+    margin-inline-start: var(--#{$radio}__input--first-child--MarginInlineStart);
   }
 
   // fixes a chrome issue where the right edge is cut off in a container with overflow hidden
   &:last-child {
-    margin-inline-end: var(--#{$radio}__input--last-child--MarginRight);
+    margin-inline-end: var(--#{$radio}__input--last-child--MarginInlineEnd);
   }
 }
 
@@ -78,7 +78,7 @@
 
 .#{$radio}__body {
   grid-column: 2;
-  margin-block-start: var(--#{$radio}__body--MarginTop);
+  margin-block-start: var(--#{$radio}__body--MarginBlockStart);
 }
 
 .#{$radio}__label,

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -2,74 +2,74 @@
 
 .#{$select} {
   // Toggle
-  --#{$select}__toggle--PaddingTop: var(--#{$pf-global}--spacer--form-element);
-  --#{$select}__toggle--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__toggle--PaddingBottom: var(--#{$pf-global}--spacer--form-element);
-  --#{$select}__toggle--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle--PaddingBlockStart: var(--#{$pf-global}--spacer--form-element);
+  --#{$select}__toggle--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle--PaddingBlockEnd: var(--#{$pf-global}--spacer--form-element);
+  --#{$select}__toggle--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$select}__toggle--MinWidth: var(--#{$pf-global}--target-size--MinWidth);
   --#{$select}__toggle--FontSize: var(--#{$pf-global}--FontSize--md);
   --#{$select}__toggle--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$select}__toggle--LineHeight: var(--#{$pf-global}--LineHeight--md);
   --#{$select}__toggle--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
-  --#{$select}__toggle--before--BorderTopWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$select}__toggle--before--BorderRightWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$select}__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--sm);
-  --#{$select}__toggle--before--BorderLeftWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$select}__toggle--before--BorderBlockStartWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$select}__toggle--before--BorderInlineEndWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--sm);
+  --#{$select}__toggle--before--BorderInlineStartWidth: var(--#{$pf-global}--BorderWidth--sm);
   --#{$select}__toggle--before--BorderWidth: initial; // remove at breaking change
-  --#{$select}__toggle--before--BorderTopColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$select}__toggle--before--BorderRightColor: var(--#{$pf-global}--BorderColor--300);
-  --#{$select}__toggle--before--BorderBottomColor: var(--#{$pf-global}--BorderColor--200);
-  --#{$select}__toggle--before--BorderLeftColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$select}__toggle--before--BorderBlockStartColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$select}__toggle--before--BorderInlineEndColor: var(--#{$pf-global}--BorderColor--300);
+  --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--BorderColor--200);
+  --#{$select}__toggle--before--BorderInlineStartColor: var(--#{$pf-global}--BorderColor--300);
   --#{$select}__toggle--Color: var(--#{$pf-global}--Color--100);
-  --#{$select}__toggle--hover--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$select}__toggle--focus--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$select}__toggle--focus--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$select}__toggle--active--before--BorderBottomColor: var(--#{$pf-global}--active-color--100);
-  --#{$select}__toggle--active--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$select}__toggle--m-expanded--before--BorderBottomColor: var(--#{$pf-global}--active-color--100); // rename to c-select--m-expanded at breaking change
-  --#{$select}__toggle--m-expanded--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md); // rename to c-select--m-expanded at breaking change
+  --#{$select}__toggle--hover--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$select}__toggle--focus--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$select}__toggle--focus--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$select}__toggle--active--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100);
+  --#{$select}__toggle--active--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$select}__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$pf-global}--active-color--100); // rename to c-select--m-expanded at breaking change
+  --#{$select}__toggle--m-expanded--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md); // rename to c-select--m-expanded at breaking change
   --#{$select}__toggle--disabled--BackgroundColor: var(--#{$pf-global}--disabled-color--300);
   --#{$select}__toggle--m-plain--before--BorderColor: transparent;
   --#{$select}__toggle--m-placeholder--Color: transparent;
-  --#{$select}--m-invalid__toggle--before--BorderBottomColor: var(--#{$pf-global}--danger-color--100);
-  --#{$select}--m-invalid__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$select}--m-invalid__toggle--hover--before--BorderBottomColor: var(--#{$pf-global}--danger-color--100);
-  --#{$select}--m-invalid__toggle--focus--before--BorderBottomColor: var(--#{$pf-global}--danger-color--100);
-  --#{$select}--m-invalid__toggle--active--before--BorderBottomColor: var(--#{$pf-global}--danger-color--100);
-  --#{$select}--m-invalid__toggle--m-expanded--before--BorderBottomColor: var(--#{$pf-global}--danger-color--100);
+  --#{$select}--m-invalid__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--danger-color--100);
+  --#{$select}--m-invalid__toggle--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$select}--m-invalid__toggle--hover--before--BorderBlockEndColor: var(--#{$pf-global}--danger-color--100);
+  --#{$select}--m-invalid__toggle--focus--before--BorderBlockEndColor: var(--#{$pf-global}--danger-color--100);
+  --#{$select}--m-invalid__toggle--active--before--BorderBlockEndColor: var(--#{$pf-global}--danger-color--100);
+  --#{$select}--m-invalid__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$pf-global}--danger-color--100);
   --#{$select}--m-invalid__toggle-status-icon--Color: var(--#{$pf-global}--danger-color--100);
-  --#{$select}--m-success__toggle--before--BorderBottomColor: var(--#{$pf-global}--success-color--100);
-  --#{$select}--m-success__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$select}--m-success__toggle--hover--before--BorderBottomColor: var(--#{$pf-global}--success-color--100);
-  --#{$select}--m-success__toggle--focus--before--BorderBottomColor: var(--#{$pf-global}--success-color--100);
-  --#{$select}--m-success__toggle--active--before--BorderBottomColor: var(--#{$pf-global}--success-color--100);
-  --#{$select}--m-success__toggle--m-expanded--before--BorderBottomColor: var(--#{$pf-global}--success-color--100);
+  --#{$select}--m-success__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--success-color--100);
+  --#{$select}--m-success__toggle--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$select}--m-success__toggle--hover--before--BorderBlockEndColor: var(--#{$pf-global}--success-color--100);
+  --#{$select}--m-success__toggle--focus--before--BorderBlockEndColor: var(--#{$pf-global}--success-color--100);
+  --#{$select}--m-success__toggle--active--before--BorderBlockEndColor: var(--#{$pf-global}--success-color--100);
+  --#{$select}--m-success__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$pf-global}--success-color--100);
   --#{$select}--m-success__toggle-status-icon--Color: var(--#{$pf-global}--success-color--100);
-  --#{$select}--m-warning__toggle--before--BorderBottomColor: var(--#{$pf-global}--warning-color--100);
-  --#{$select}--m-warning__toggle--before--BorderBottomWidth: var(--#{$pf-global}--BorderWidth--md);
-  --#{$select}--m-warning__toggle--hover--before--BorderBottomColor: var(--#{$pf-global}--warning-color--100);
-  --#{$select}--m-warning__toggle--focus--before--BorderBottomColor: var(--#{$pf-global}--warning-color--100);
-  --#{$select}--m-warning__toggle--active--before--BorderBottomColor: var(--#{$pf-global}--warning-color--100);
-  --#{$select}--m-warning__toggle--m-expanded--before--BorderBottomColor: var(--#{$pf-global}--warning-color--100);
+  --#{$select}--m-warning__toggle--before--BorderBlockEndColor: var(--#{$pf-global}--warning-color--100);
+  --#{$select}--m-warning__toggle--before--BorderBlockEndWidth: var(--#{$pf-global}--BorderWidth--md);
+  --#{$select}--m-warning__toggle--hover--before--BorderBlockEndColor: var(--#{$pf-global}--warning-color--100);
+  --#{$select}--m-warning__toggle--focus--before--BorderBlockEndColor: var(--#{$pf-global}--warning-color--100);
+  --#{$select}--m-warning__toggle--active--before--BorderBlockEndColor: var(--#{$pf-global}--warning-color--100);
+  --#{$select}--m-warning__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$pf-global}--warning-color--100);
   --#{$select}--m-warning__toggle-status-icon--Color: var(--#{$pf-global}--warning-color--100);
 
   // Space for the children of the toggle
-  --#{$select}__toggle-wrapper--not-last-child--MarginRight: var(--#{$pf-global}--spacer--xs);
+  --#{$select}__toggle-wrapper--not-last-child--MarginInlineEnd: var(--#{$pf-global}--spacer--xs);
 
   // Max-width is needed for ellipsing the text. This leaves enough space for the toggle caret.
   // However, for cases where the clear icon button or a badge are added, the correct width will need to be calculated in script
   --#{$select}__toggle-wrapper--MaxWidth: calc(100% - var(--#{$pf-global}--spacer--lg));
 
   // Chip group within a toggle-wrapper needs a margin-bottom in case it wraps
-  --#{$select}__toggle-wrapper--c-chip-group--MarginTop: #{pf-size-prem(5px)};
-  --#{$select}__toggle-wrapper--c-chip-group--MarginBottom: #{pf-size-prem(5px)};
+  --#{$select}__toggle-wrapper--c-chip-group--MarginBlockStart: #{pf-size-prem(5px)};
+  --#{$select}__toggle-wrapper--c-chip-group--MarginBlockEnd: #{pf-size-prem(5px)};
 
   // Select input for typeahead
   --#{$select}__toggle-typeahead--FlexBasis: 10em;
   --#{$select}__toggle-typeahead--BackgroundColor: transparent;
-  --#{$select}__toggle-typeahead--BorderTop: var(--#{$pf-global}--BorderWidth--sm) solid transparent;
-  --#{$select}__toggle-typeahead--BorderRight: none;
-  --#{$select}__toggle-typeahead--BorderLeft: none;
+  --#{$select}__toggle-typeahead--BorderBlockStart: var(--#{$pf-global}--BorderWidth--sm) solid transparent;
+  --#{$select}__toggle-typeahead--BorderInlineEnd: none;
+  --#{$select}__toggle-typeahead--BorderInlineStart: none;
 
   // Typeahead form
   --#{$select}__toggle-typeahead--MinWidth: #{pf-size-prem(120px)};
@@ -78,49 +78,49 @@
   --#{$select}__toggle--m-placeholder__toggle-text--Color: var(--#{$pf-global}--Color--dark-200);
 
   //  Select toggle icon + toggle text
-  --#{$select}__toggle-icon--toggle-text--MarginLeft: var(--#{$pf-global}--spacer--xs);
+  --#{$select}__toggle-icon--toggle-text--MarginInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Select toggle badge
-  --#{$select}__toggle-badge--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle-badge--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
 
   // Select toggle status icon
-  --#{$select}__toggle-status-icon--MarginLeft: var(--#{$pf-global}--spacer--xs);
+  --#{$select}__toggle-status-icon--MarginInlineStart: var(--#{$pf-global}--spacer--xs);
   --#{$select}__toggle-status-icon--Color: var(--#{$pf-global}--Color--100);
 
   // Toggle arrow
-  --#{$select}__toggle-arrow--MarginLeft: var(--#{$pf-global}--spacer--md);
-  --#{$select}__toggle-arrow--MarginRight: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__toggle-arrow--with-clear--MarginLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle-arrow--MarginInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$select}__toggle-arrow--MarginInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle-arrow--with-clear--MarginInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$select}__toggle-arrow--m-top--m-expanded__toggle-arrow--Rotate: 180deg;
   --#{$select}--m-plain__toggle-arrow--Color: var(--#{$pf-global}--Color--200);
   --#{$select}--m-plain--hover__toggle-arrow--Color: var(--#{$pf-global}--Color--100);
 
   // Toggle button
-  --#{$select}__toggle-clear--PaddingRight: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__toggle-clear--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$select}__toggle-clear--toggle-button--PaddingLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle-clear--PaddingInlineEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__toggle-clear--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$select}__toggle-clear--toggle-button--PaddingInlineStart: var(--#{$pf-global}--spacer--sm);
   --#{$select}__toggle-button--Color: var(--#{$pf-global}--Color--100);
 
   // Menu
   --#{$select}__menu--BackgroundColor: var(--#{$pf-global}--BackgroundColor--light-100);
   --#{$select}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
-  --#{$select}__menu--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu--Top: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$select}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$select}__menu--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$select}__menu--Width: auto;
   --#{$select}__menu--MinWidth: 100%;
   --#{$select}__menu--m-top--TranslateY: calc(-100% - var(--#{$pf-global}--spacer--xs)); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu list item
-  --#{$select}__list-item--m-loading--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__list-item--m-loading--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
 
   // Menu item
-  --#{$select}__menu-item--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu-item--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-item--m-selected--PaddingRight: var(--#{$pf-global}--spacer--2xl);
-  --#{$select}__menu-item--PaddingBottom: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu-item--PaddingLeft: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-item--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu-item--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-item--m-selected--PaddingInlineEnd: var(--#{$pf-global}--spacer--2xl);
+  --#{$select}__menu-item--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu-item--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$select}__menu-item--FontSize: var(--#{$pf-global}--FontSize--md);
   --#{$select}__menu-item--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$select}__menu-item--LineHeight: var(--#{$pf-global}--LineHeight--md);
@@ -153,8 +153,8 @@
   // Menu item icon
   --#{$select}__menu-item-icon--Color: var(--#{$pf-global}--active-color--100);
   --#{$select}__menu-item-icon--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$select}__menu-item-icon--Right: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-item-icon--Top: 50%;
+  --#{$select}__menu-item-icon--InlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-item-icon--BlockStart: 50%;
   --#{$select}__menu-item-icon--TranslateY: -50%;
 
   // Menu item action icon
@@ -164,27 +164,27 @@
   --#{$select}__menu-item--match--FontWeight: var(--#{$pf-global}--FontWeight--bold);
 
   // Menu group padding
-  --#{$select}__menu-search--PaddingTop: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu-search--PaddingRight: var(--#{$select}__menu-item--PaddingRight);
-  --#{$select}__menu-search--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-search--PaddingLeft: var(--#{$select}__menu-item--PaddingLeft);
+  --#{$select}__menu-search--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu-search--PaddingInlineEnd: var(--#{$select}__menu-item--PaddingInlineEnd);
+  --#{$select}__menu-search--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-search--PaddingInlineStart: var(--#{$select}__menu-item--PaddingInlineStart);
 
   // Menu group
   // add a little space if it's not the first group because the first one also has the menu padding
-  --#{$select}__menu-group--menu-group--PaddingTop: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu-group--menu-group--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
 
   // Menu section heading
   // Paddings are set to always line up with the other menu items
-  --#{$select}__menu-group-title--PaddingTop: var(--#{$select}__menu-item--PaddingTop);
-  --#{$select}__menu-group-title--PaddingRight: var(--#{$select}__menu-item--PaddingRight);
-  --#{$select}__menu-group-title--PaddingBottom: var(--#{$select}__menu-item--PaddingBottom);
-  --#{$select}__menu-group-title--PaddingLeft: var(--#{$select}__menu-item--PaddingLeft);
+  --#{$select}__menu-group-title--PaddingBlockStart: var(--#{$select}__menu-item--PaddingBlockStart);
+  --#{$select}__menu-group-title--PaddingInlineEnd: var(--#{$select}__menu-item--PaddingInlineEnd);
+  --#{$select}__menu-group-title--PaddingBlockEnd: var(--#{$select}__menu-item--PaddingBlockEnd);
+  --#{$select}__menu-group-title--PaddingInlineStart: var(--#{$select}__menu-item--PaddingInlineStart);
   --#{$select}__menu-group-title--FontSize: var(--#{$pf-global}--FontSize--xs);
   --#{$select}__menu-group-title--FontWeight: var(--#{$pf-global}--FontWeight--normal);
   --#{$select}__menu-group-title--Color: var(--#{$pf-global}--Color--dark-200);
 
   // Menu item count
-  --#{$select}__menu-item-count--MarginLeft: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-item-count--MarginInlineStart: var(--#{$pf-global}--spacer--md);
   --#{$select}__menu-item-count--FontSize: var(--#{$pf-global}--FontSize--sm);
   --#{$select}__menu-item-count--Color: var(--#{$pf-global}--Color--200);
   --#{$select}__menu-item--disabled__menu-item-count--Color: var(--#{$pf-global}--Color--dark-200);
@@ -192,72 +192,72 @@
   // Menu item description
   --#{$select}__menu-item-description--FontSize: var(--#{$pf-global}--FontSize--xs);
   --#{$select}__menu-item-description--Color: var(--#{$pf-global}--Color--200);
-  --#{$select}__menu-item-description--PaddingRight: var(--#{$select}__menu-item--PaddingRight);
+  --#{$select}__menu-item-description--PaddingInlineEnd: var(--#{$select}__menu-item--PaddingInlineEnd);
 
   // Menu item title
-  --#{$select}__menu-item-main--PaddingRight: var(--#{$select}__menu-item--PaddingRight);
-  --#{$select}__menu-item--m-selected__menu-item-main--PaddingRight: var(--#{$select}__menu-item--m-selected--PaddingRight);
+  --#{$select}__menu-item-main--PaddingInlineEnd: var(--#{$select}__menu-item--PaddingInlineEnd);
+  --#{$select}__menu-item--m-selected__menu-item-main--PaddingInlineEnd: var(--#{$select}__menu-item--m-selected--PaddingInlineEnd);
 
   // Menu footer
   --#{$select}__menu-footer--BoxShadow: var(--#{$pf-global}--BoxShadow--sm-top);
-  --#{$select}__menu-footer--PaddingTop: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-footer--PaddingRight: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-footer--PaddingBottom: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-footer--PaddingLeft: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-footer--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu-footer--MarginBottom: calc(var(--#{$pf-global}--spacer--sm) * -1);
+  --#{$select}__menu-footer--PaddingBlockStart: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-footer--PaddingInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-footer--PaddingBlockEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-footer--PaddingInlineStart: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-footer--MarginBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$select}__menu-footer--MarginBlockEnd: calc(var(--#{$pf-global}--spacer--sm) * -1);
 
   // Divider
-  --#{$select}-menu--c-divider--MarginTop: var(--#{$pf-global}--spacer--sm);
-  --#{$select}-menu--c-divider--MarginBottom: var(--#{$pf-global}--spacer--sm);
+  --#{$select}-menu--c-divider--MarginBlockStart: var(--#{$pf-global}--spacer--sm);
+  --#{$select}-menu--c-divider--MarginBlockEnd: var(--#{$pf-global}--spacer--sm);
 
   position: relative;
   display: inline-block;
   width: 100%;
 
   .#{$divider} {
-    margin-block-start: var(--#{$select}-menu--c-divider--MarginTop);
-    margin-block-end: var(--#{$select}-menu--c-divider--MarginBottom);
+    margin-block-start: var(--#{$select}-menu--c-divider--MarginBlockStart);
+    margin-block-end: var(--#{$select}-menu--c-divider--MarginBlockEnd);
 
     // Support divider as last item in group to separate groups
     &:last-child {
-      --#{$select}-menu--c-divider--MarginBottom: 0;
+      --#{$select}-menu--c-divider--MarginBlockEnd: 0;
     }
   }
 
   &.pf-m-invalid {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}--m-invalid__toggle--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}--m-invalid__toggle--before--BorderBottomWidth);
-    --#{$select}__toggle--hover--before--BorderBottomColor: var(--#{$select}--m-invalid__toggle--hover--before--BorderBottomColor);
-    --#{$select}__toggle--focus--before--BorderBottomColor: var(--#{$select}--m-invalid__toggle--focus--before--BorderBottomColor);
-    --#{$select}__toggle--active--before--BorderBottomColor: var(--#{$select}--m-invalid__toggle--active--before--BorderBottomColor);
-    --#{$select}__toggle--m-expanded--before--BorderBottomColor: var(--#{$select}--m-invalid__toggle--m-expanded--before--BorderBottomColor);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}--m-invalid__toggle--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}--m-invalid__toggle--before--BorderBlockEndWidth);
+    --#{$select}__toggle--hover--before--BorderBlockEndColor: var(--#{$select}--m-invalid__toggle--hover--before--BorderBlockEndColor);
+    --#{$select}__toggle--focus--before--BorderBlockEndColor: var(--#{$select}--m-invalid__toggle--focus--before--BorderBlockEndColor);
+    --#{$select}__toggle--active--before--BorderBlockEndColor: var(--#{$select}--m-invalid__toggle--active--before--BorderBlockEndColor);
+    --#{$select}__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$select}--m-invalid__toggle--m-expanded--before--BorderBlockEndColor);
     --#{$select}__toggle-status-icon--Color: var(--#{$select}--m-invalid__toggle-status-icon--Color);
   }
 
   &.pf-m-success {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}--m-success__toggle--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}--m-success__toggle--before--BorderBottomWidth);
-    --#{$select}__toggle--hover--before--BorderBottomColor: var(--#{$select}--m-success__toggle--hover--before--BorderBottomColor);
-    --#{$select}__toggle--focus--before--BorderBottomColor: var(--#{$select}--m-success__toggle--focus--before--BorderBottomColor);
-    --#{$select}__toggle--active--before--BorderBottomColor: var(--#{$select}--m-success__toggle--active--before--BorderBottomColor);
-    --#{$select}__toggle--m-expanded--before--BorderBottomColor: var(--#{$select}--m-success__toggle--m-expanded--before--BorderBottomColor);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}--m-success__toggle--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}--m-success__toggle--before--BorderBlockEndWidth);
+    --#{$select}__toggle--hover--before--BorderBlockEndColor: var(--#{$select}--m-success__toggle--hover--before--BorderBlockEndColor);
+    --#{$select}__toggle--focus--before--BorderBlockEndColor: var(--#{$select}--m-success__toggle--focus--before--BorderBlockEndColor);
+    --#{$select}__toggle--active--before--BorderBlockEndColor: var(--#{$select}--m-success__toggle--active--before--BorderBlockEndColor);
+    --#{$select}__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$select}--m-success__toggle--m-expanded--before--BorderBlockEndColor);
     --#{$select}__toggle-status-icon--Color: var(--#{$select}--m-success__toggle-status-icon--Color);
   }
 
   &.pf-m-warning {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}--m-warning__toggle--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}--m-warning__toggle--before--BorderBottomWidth);
-    --#{$select}__toggle--hover--before--BorderBottomColor: var(--#{$select}--m-warning__toggle--hover--before--BorderBottomColor);
-    --#{$select}__toggle--focus--before--BorderBottomColor: var(--#{$select}--m-warning__toggle--focus--before--BorderBottomColor);
-    --#{$select}__toggle--active--before--BorderBottomColor: var(--#{$select}--m-warning__toggle--active--before--BorderBottomColor);
-    --#{$select}__toggle--m-expanded--before--BorderBottomColor: var(--#{$select}--m-warning__toggle--m-expanded--before--BorderBottomColor);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}--m-warning__toggle--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}--m-warning__toggle--before--BorderBlockEndWidth);
+    --#{$select}__toggle--hover--before--BorderBlockEndColor: var(--#{$select}--m-warning__toggle--hover--before--BorderBlockEndColor);
+    --#{$select}__toggle--focus--before--BorderBlockEndColor: var(--#{$select}--m-warning__toggle--focus--before--BorderBlockEndColor);
+    --#{$select}__toggle--active--before--BorderBlockEndColor: var(--#{$select}--m-warning__toggle--active--before--BorderBlockEndColor);
+    --#{$select}__toggle--m-expanded--before--BorderBlockEndColor: var(--#{$select}--m-warning__toggle--m-expanded--before--BorderBlockEndColor);
     --#{$select}__toggle-status-icon--Color: var(--#{$select}--m-warning__toggle-status-icon--Color);
   }
 }
 
 .#{$select}__menu-search + .#{$divider} {
-  --#{$select}-menu--c-divider--MarginTop: 0;
+  --#{$select}-menu--c-divider--MarginBlockStart: 0;
 }
 
 .#{$select}__toggle {
@@ -267,10 +267,10 @@
   justify-content: space-between;
   width: 100%;
   min-width: var(--#{$select}__toggle--MinWidth);
-  padding-block-start: var(--#{$select}__toggle--PaddingTop);
-  padding-block-end: var(--#{$select}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$select}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$select}__toggle--PaddingRight);
+  padding-block-start: var(--#{$select}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$select}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$select}__toggle--PaddingInlineEnd);
   font-size: var(--#{$select}__toggle--FontSize);
   font-weight: var(--#{$select}__toggle--FontWeight);
   line-height: var(--#{$select}__toggle--LineHeight);
@@ -292,38 +292,38 @@
   }
 
   &::before {
-    --#{$select}__toggle--before--BorderWidth-base: var(--#{$select}__toggle--before--BorderTopWidth) var(--#{$select}__toggle--before--BorderRightWidth) var(--#{$select}__toggle--before--BorderBottomWidth) var(--#{$select}__toggle--before--BorderLeftWidth); // remove at breaking change
+    --#{$select}__toggle--before--BorderWidth-base: var(--#{$select}__toggle--before--BorderBlockStartWidth) var(--#{$select}__toggle--before--BorderInlineEndWidth) var(--#{$select}__toggle--before--BorderBlockEndWidth) var(--#{$select}__toggle--before--BorderInlineStartWidth); // remove at breaking change
 
     position: absolute;
     inset: 0;
     content: "";
     border-style: solid;
     border-width: var(--#{$select}__toggle--before--BorderWidth, var(--#{$select}__toggle--before--BorderWidth-base));
-    border-block-start-color: var(--#{$select}__toggle--before--BorderTopColor);
-    border-block-end-color: var(--#{$select}__toggle--before--BorderBottomColor);
-    border-inline-start-color: var(--#{$select}__toggle--before--BorderLeftColor);
-    border-inline-end-color: var(--#{$select}__toggle--before--BorderRightColor);
+    border-block-start-color: var(--#{$select}__toggle--before--BorderBlockStartColor);
+    border-block-end-color: var(--#{$select}__toggle--before--BorderBlockEndColor);
+    border-inline-start-color: var(--#{$select}__toggle--before--BorderInlineStartColor);
+    border-inline-end-color: var(--#{$select}__toggle--before--BorderInlineEndColor);
   }
 
   &:hover {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}__toggle--hover--before--BorderBottomColor);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}__toggle--hover--before--BorderBlockEndColor);
   }
 
   &:focus,
   &:focus-within {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}__toggle--focus--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}__toggle--focus--before--BorderBottomWidth);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}__toggle--focus--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}__toggle--focus--before--BorderBlockEndWidth);
   }
 
   &:active,
   &.pf-m-active {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}__toggle--active--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}__toggle--active--before--BorderBottomWidth);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}__toggle--active--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}__toggle--active--before--BorderBlockEndWidth);
   }
 
   .pf-m-expanded > & {
-    --#{$select}__toggle--before--BorderBottomColor: var(--#{$select}__toggle--m-expanded--before--BorderBottomColor);
-    --#{$select}__toggle--before--BorderBottomWidth: var(--#{$select}__toggle--m-expanded--before--BorderBottomWidth);
+    --#{$select}__toggle--before--BorderBlockEndColor: var(--#{$select}__toggle--m-expanded--before--BorderBlockEndColor);
+    --#{$select}__toggle--before--BorderBlockEndWidth: var(--#{$select}__toggle--m-expanded--before--BorderBlockEndWidth);
   }
 
   &.pf-m-plain {
@@ -343,9 +343,9 @@
   }
 
   &.pf-m-typeahead {
-    --#{$select}__toggle--PaddingTop: 0;
-    --#{$select}__toggle--PaddingRight: 0;
-    --#{$select}__toggle--PaddingBottom: 0;
+    --#{$select}__toggle--PaddingBlockStart: 0;
+    --#{$select}__toggle--PaddingInlineEnd: 0;
+    --#{$select}__toggle--PaddingBlockEnd: 0;
 
     .#{$form-control} {
       @include pf-v6-text-overflow;
@@ -357,8 +357,8 @@
   }
 
   .#{$select}__toggle-clear {
-    padding-inline-start: var(--#{$select}__toggle-clear--PaddingLeft);
-    padding-inline-end: var(--#{$select}__toggle-clear--PaddingRight);
+    padding-inline-start: var(--#{$select}__toggle-clear--PaddingInlineStart);
+    padding-inline-end: var(--#{$select}__toggle-clear--PaddingInlineEnd);
     margin-inline-start: auto;
   }
 
@@ -367,7 +367,7 @@
   }
 
   .#{$select}__toggle-clear + .#{$select}__toggle-button {
-    padding-inline-start: var(--#{$select}__toggle-clear--toggle-button--PaddingLeft);
+    padding-inline-start: var(--#{$select}__toggle-clear--toggle-button--PaddingInlineStart);
   }
 
   &.pf-m-placeholder {
@@ -379,8 +379,8 @@
   color: var(--#{$select}__toggle-arrow--Color, inherit);
 
   * + & {
-    margin-inline-start: var(--#{$select}__toggle-arrow--MarginLeft);
-    margin-inline-end: var(--#{$select}__toggle-arrow--MarginRight);
+    margin-inline-start: var(--#{$select}__toggle-arrow--MarginInlineStart);
+    margin-inline-end: var(--#{$select}__toggle-arrow--MarginInlineEnd);
   }
   // stylelint-disable-next-line
   .#{$select}.pf-m-top.pf-m-expanded & {
@@ -409,33 +409,33 @@
 
   // Add space between children
   > :not(:last-child) {
-    margin-inline-end: var(--#{$select}__toggle-wrapper--not-last-child--MarginRight);
+    margin-inline-end: var(--#{$select}__toggle-wrapper--not-last-child--MarginInlineEnd);
   }
 
   // a chip group needs a bottom margin to make some space between the chip group and typeahead input box if it wraps
   .#{$chip}-group {
-    margin-block-start: var(--#{$select}__toggle-wrapper--c-chip-group--MarginTop);
-    margin-block-end: var(--#{$select}__toggle-wrapper--c-chip-group--MarginBottom);
+    margin-block-start: var(--#{$select}__toggle-wrapper--c-chip-group--MarginBlockStart);
+    margin-block-end: var(--#{$select}__toggle-wrapper--c-chip-group--MarginBlockEnd);
   }
 
   // When the input is the first thing then use a negative left padding so it matches the toggle container
   > .#{$select}__toggle-typeahead:first-child {
-    margin-inline-start: calc(-1 * var(--#{$select}__toggle--PaddingLeft));
+    margin-inline-start: calc(-1 * var(--#{$select}__toggle--PaddingInlineStart));
   }
 }
 
 .#{$select}__toggle-icon + .#{$select}__toggle-text {
-  margin-inline-start: var(--#{$select}__toggle-icon--toggle-text--MarginLeft);
+  margin-inline-start: var(--#{$select}__toggle-icon--toggle-text--MarginInlineStart);
 }
 
 .#{$select}__toggle-status-icon {
-  margin-inline-start: var(--#{$select}__toggle-status-icon--MarginLeft);
+  margin-inline-start: var(--#{$select}__toggle-status-icon--MarginInlineStart);
   color: var(--#{$select}__toggle-status-icon--Color);
 }
 
 .#{$select}__toggle-badge {
   display: flex;
-  padding-inline-start: var(--#{$select}__toggle-badge--PaddingLeft);
+  padding-inline-start: var(--#{$select}__toggle-badge--PaddingInlineStart);
 }
 
 .#{$select}__toggle-typeahead {
@@ -456,12 +456,12 @@
 
 .#{$select}__menu {
   position: absolute;
- inset-block-start: var(--#{$select}__menu--Top);
+ inset-block-start: var(--#{$select}__menu--BlockStart);
   z-index: var(--#{$select}__menu--ZIndex);
   width: var(--#{$select}__menu--Width);
   min-width: var(--#{$select}__menu--MinWidth);
-  padding-block-start: var(--#{$select}__menu--PaddingTop);
-  padding-block-end: var(--#{$select}__menu--PaddingBottom);
+  padding-block-start: var(--#{$select}__menu--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__menu--PaddingBlockEnd);
   background-color: var(--#{$select}__menu--BackgroundColor);
   background-clip: padding-box;
   box-shadow: var(--#{$select}__menu--BoxShadow);
@@ -502,10 +502,10 @@
 .#{$select}__menu-item {
   position: relative;
   width: var(--#{$select}__menu-item--Width);
-  padding-block-start: var(--#{$select}__menu-item--PaddingTop);
-  padding-block-end: var(--#{$select}__menu-item--PaddingBottom);
-  padding-inline-start: var(--#{$select}__menu-item--PaddingLeft);
-  padding-inline-end: var(--#{$select}__menu-item--PaddingRight);
+  padding-block-start: var(--#{$select}__menu-item--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__menu-item--PaddingBlockEnd);
+  padding-inline-start: var(--#{$select}__menu-item--PaddingInlineStart);
+  padding-inline-end: var(--#{$select}__menu-item--PaddingInlineEnd);
   font-size: var(--#{$select}__menu-item--FontSize);
   font-weight: var(--#{$select}__menu-item--FontWeight);
   line-height: var(--#{$select}__menu-item--LineHeight);
@@ -539,9 +539,9 @@
   }
 
   &.pf-m-link {
-    --#{$select}__menu-item--PaddingRight: 0;
-    --#{$select}__menu-item-main--PaddingRight: 0;
-    --#{$select}__menu-item-description--PaddingRight: 0;
+    --#{$select}__menu-item--PaddingInlineEnd: 0;
+    --#{$select}__menu-item-main--PaddingInlineEnd: 0;
+    --#{$select}__menu-item-description--PaddingInlineEnd: 0;
     --#{$select}__menu-item--Width: var(--#{$select}__menu-item--m-link--Width);
     --#{$select}__menu-item--hover--BackgroundColor: var(--#{$select}__menu-item--m-link--hover--BackgroundColor);
     --#{$select}__menu-item--focus--BackgroundColor: var(--#{$select}__menu-item--m-link--focus--BackgroundColor);
@@ -579,13 +579,13 @@
   }
 
   &.pf-m-selected {
-    --#{$select}__menu-item--PaddingRight: var(--#{$select}__menu-item--m-selected--PaddingRight);
-    --#{$select}__menu-item-main--PaddingRight: var(--#{$select}__menu-item--m-selected__menu-item-main--PaddingRight);
+    --#{$select}__menu-item--PaddingInlineEnd: var(--#{$select}__menu-item--m-selected--PaddingInlineEnd);
+    --#{$select}__menu-item-main--PaddingInlineEnd: var(--#{$select}__menu-item--m-selected__menu-item-main--PaddingInlineEnd);
   }
 
   &.pf-m-description {
     &:not(.#{$check}) {
-      --#{$select}__menu-item--PaddingRight: 0;
+      --#{$select}__menu-item--PaddingInlineEnd: 0;
     }
 
     .#{$check}__label {
@@ -618,7 +618,7 @@
 
 .#{$select}__list-item {
   &.pf-m-loading {
-    padding-block-start: var(--#{$select}__list-item--m-loading--PaddingTop);
+    padding-block-start: var(--#{$select}__list-item--m-loading--PaddingBlockStart);
     text-align: center;
   }
 }
@@ -626,7 +626,7 @@
 .#{$select}__menu-item-main {
   position: relative;
   display: block;
-  padding-inline-end: var(--#{$select}__menu-item-main--PaddingRight);
+  padding-inline-end: var(--#{$select}__menu-item-main--PaddingInlineEnd);
   white-space: nowrap;
 }
 
@@ -640,22 +640,22 @@
 
 .#{$select}__menu-item-count {
   align-self: center;
-  margin-inline-start: var(--#{$select}__menu-item-count--MarginLeft);
+  margin-inline-start: var(--#{$select}__menu-item-count--MarginInlineStart);
   font-size: var(--#{$select}__menu-item-count--FontSize);
   color: var(--#{$select}__menu-item-count--Color);
 }
 
 .#{$select}__menu-item-description {
   display: block;
-  padding-inline-end: var(--#{$select}__menu-item-description--PaddingRight);
+  padding-inline-end: var(--#{$select}__menu-item-description--PaddingInlineEnd);
   font-size: var(--#{$select}__menu-item-description--FontSize);
   color: var(--#{$select}__menu-item-description--Color);
 }
 
 .#{$select}__menu-item-icon {
   position: absolute;
-  inset-block-start: var(--#{$select}__menu-item-icon--Top);
-  inset-inline-end: var(--#{$select}__menu-item-icon--Right);
+  inset-block-start: var(--#{$select}__menu-item-icon--BlockStart);
+  inset-inline-end: var(--#{$select}__menu-item-icon--InlineEnd);
   font-size: var(--#{$select}__menu-item-icon--FontSize);
   color: var(--#{$select}__menu-item-icon--Color);
   transform: translateY(var(--#{$select}__menu-item-icon--TranslateY));
@@ -673,32 +673,32 @@
 }
 
 .#{$select}__menu-group + .#{$select}__menu-group {
-  padding-block-start: var(--#{$select}__menu-group--menu-group--PaddingTop);
+  padding-block-start: var(--#{$select}__menu-group--menu-group--PaddingBlockStart);
 }
 
 .#{$select}__menu-search {
-  padding-block-start: var(--#{$select}__menu-search--PaddingTop);
-  padding-block-end: var(--#{$select}__menu-search--PaddingBottom);
-  padding-inline-start: var(--#{$select}__menu-search--PaddingLeft);
-  padding-inline-end: var(--#{$select}__menu-search--PaddingRight);
+  padding-block-start: var(--#{$select}__menu-search--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__menu-search--PaddingBlockEnd);
+  padding-inline-start: var(--#{$select}__menu-search--PaddingInlineStart);
+  padding-inline-end: var(--#{$select}__menu-search--PaddingInlineEnd);
 }
 
 .#{$select}__menu-group-title {
-  padding-block-start: var(--#{$select}__menu-group-title--PaddingTop);
-  padding-block-end: var(--#{$select}__menu-group-title--PaddingBottom);
-  padding-inline-start: var(--#{$select}__menu-group-title--PaddingLeft);
-  padding-inline-end: var(--#{$select}__menu-group-title--PaddingRight);
+  padding-block-start: var(--#{$select}__menu-group-title--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__menu-group-title--PaddingBlockEnd);
+  padding-inline-start: var(--#{$select}__menu-group-title--PaddingInlineStart);
+  padding-inline-end: var(--#{$select}__menu-group-title--PaddingInlineEnd);
   font-size: var(--#{$select}__menu-group-title--FontSize);
   font-weight: var(--#{$select}__menu-group-title--FontWeight);
   color: var(--#{$select}__menu-group-title--Color);
 }
 
 .#{$select}__menu-footer {
-  padding-block-start: var(--#{$select}__menu-footer--PaddingTop);
-  padding-block-end: var(--#{$select}__menu-footer--PaddingBottom);
-  padding-inline-start: var(--#{$select}__menu-footer--PaddingLeft);
-  padding-inline-end: var(--#{$select}__menu-footer--PaddingRight);
-  margin-block-start: var(--#{$select}__menu-footer--MarginTop);
-  margin-block-end: var(--#{$select}__menu-footer--MarginBottom);
+  padding-block-start: var(--#{$select}__menu-footer--PaddingBlockStart);
+  padding-block-end: var(--#{$select}__menu-footer--PaddingBlockEnd);
+  padding-inline-start: var(--#{$select}__menu-footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$select}__menu-footer--PaddingInlineEnd);
+  margin-block-start: var(--#{$select}__menu-footer--MarginBlockStart);
+  margin-block-end: var(--#{$select}__menu-footer--MarginBlockEnd);
   box-shadow: var(--#{$select}__menu-footer--BoxShadow);
 }

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -106,7 +106,7 @@
   --#{$select}__menu--BoxShadow: var(--#{$pf-global}--BoxShadow--md);
   --#{$select}__menu--PaddingBlockStart: var(--#{$pf-global}--spacer--sm);
   --#{$select}__menu--PaddingBlockEnd: var(--#{$pf-global}--spacer--sm);
-  --#{$select}__menu--BlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
+  --#{$select}__menu--InsetBlockStart: calc(100% + var(--#{$pf-global}--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
   --#{$select}__menu--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$select}__menu--Width: auto;
   --#{$select}__menu--MinWidth: 100%;
@@ -153,8 +153,8 @@
   // Menu item icon
   --#{$select}__menu-item-icon--Color: var(--#{$pf-global}--active-color--100);
   --#{$select}__menu-item-icon--FontSize: var(--#{$pf-global}--icon--FontSize--sm);
-  --#{$select}__menu-item-icon--InlineEnd: var(--#{$pf-global}--spacer--md);
-  --#{$select}__menu-item-icon--BlockStart: 50%;
+  --#{$select}__menu-item-icon--InsetInlineEnd: var(--#{$pf-global}--spacer--md);
+  --#{$select}__menu-item-icon--InsetBlockStart: 50%;
   --#{$select}__menu-item-icon--TranslateY: -50%;
 
   // Menu item action icon
@@ -456,7 +456,7 @@
 
 .#{$select}__menu {
   position: absolute;
- inset-block-start: var(--#{$select}__menu--BlockStart);
+ inset-block-start: var(--#{$select}__menu--InsetBlockStart);
   z-index: var(--#{$select}__menu--ZIndex);
   width: var(--#{$select}__menu--Width);
   min-width: var(--#{$select}__menu--MinWidth);
@@ -654,8 +654,8 @@
 
 .#{$select}__menu-item-icon {
   position: absolute;
-  inset-block-start: var(--#{$select}__menu-item-icon--BlockStart);
-  inset-inline-end: var(--#{$select}__menu-item-icon--InlineEnd);
+  inset-block-start: var(--#{$select}__menu-item-icon--InsetBlockStart);
+  inset-inline-end: var(--#{$select}__menu-item-icon--InsetInlineEnd);
   font-size: var(--#{$select}__menu-item-icon--FontSize);
   color: var(--#{$select}__menu-item-icon--Color);
   transform: translateY(var(--#{$select}__menu-item-icon--TranslateY));

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -11,37 +11,37 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--BorderColor--base: var(--pf-t--global--border--color--default);
 
   // Panel
-  --#{$sidebar}__panel--PaddingTop: 0;
-  --#{$sidebar}__panel--PaddingRight: 0;
-  --#{$sidebar}__panel--PaddingBottom: 0;
-  --#{$sidebar}__panel--PaddingLeft: 0;
+  --#{$sidebar}__panel--PaddingBlockStart: 0;
+  --#{$sidebar}__panel--PaddingInlineEnd: 0;
+  --#{$sidebar}__panel--PaddingBlockEnd: 0;
+  --#{$sidebar}__panel--PaddingInlineStart: 0;
   --#{$sidebar}__panel--Order: -1;
 
   // Panel padding
-  --#{$sidebar}__panel--m-padding--PaddingTop: var(--#{$sidebar}--inset);
-  --#{$sidebar}__panel--m-padding--PaddingRight: var(--#{$sidebar}--inset);
-  --#{$sidebar}__panel--m-padding--PaddingBottom: var(--#{$sidebar}--inset);
-  --#{$sidebar}__panel--m-padding--PaddingLeft: var(--#{$sidebar}--inset);
+  --#{$sidebar}__panel--m-padding--PaddingBlockStart: var(--#{$sidebar}--inset);
+  --#{$sidebar}__panel--m-padding--PaddingInlineEnd: var(--#{$sidebar}--inset);
+  --#{$sidebar}__panel--m-padding--PaddingBlockEnd: var(--#{$sidebar}--inset);
+  --#{$sidebar}__panel--m-padding--PaddingInlineStart: var(--#{$sidebar}--inset);
 
   // Content
-  --#{$sidebar}__content--PaddingTop: 0;
-  --#{$sidebar}__content--PaddingRight: 0;
-  --#{$sidebar}__content--PaddingBottom: 0;
-  --#{$sidebar}__content--PaddingLeft: 0;
+  --#{$sidebar}__content--PaddingBlockStart: 0;
+  --#{$sidebar}__content--PaddingInlineEnd: 0;
+  --#{$sidebar}__content--PaddingBlockEnd: 0;
+  --#{$sidebar}__content--PaddingInlineStart: 0;
   --#{$sidebar}__content--Order: 1;
 
   // Content padding
-  --#{$sidebar}__content--m-padding--PaddingTop: var(--#{$sidebar}--inset);
-  --#{$sidebar}__content--m-padding--PaddingRight: var(--#{$sidebar}--inset);
-  --#{$sidebar}__content--m-padding--PaddingBottom: var(--#{$sidebar}--inset);
-  --#{$sidebar}__content--m-padding--PaddingLeft: var(--#{$sidebar}--inset);
+  --#{$sidebar}__content--m-padding--PaddingBlockStart: var(--#{$sidebar}--inset);
+  --#{$sidebar}__content--m-padding--PaddingInlineEnd: var(--#{$sidebar}--inset);
+  --#{$sidebar}__content--m-padding--PaddingBlockEnd: var(--#{$sidebar}--inset);
+  --#{$sidebar}__content--m-padding--PaddingInlineStart: var(--#{$sidebar}--inset);
 
   // Main
   --#{$sidebar}__main--FlexDirection: column;
   --#{$sidebar}__main--md--FlexDirection: row;
   --#{$sidebar}__main--AlignItems: stretch;
   --#{$sidebar}__main--md--AlignItems: flex-start;
-  --#{$sidebar}__main--child--MarginTop: 0;
+  --#{$sidebar}__main--child--MarginBlockStart: 0;
 
   // Gutter
   --#{$sidebar}--m-gutter__main--Gap: var(--#{$sidebar}--inset);
@@ -61,7 +61,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-stack__main--FlexDirection: column;
   --#{$sidebar}--m-stack__main--AlignItems: stretch;
   --#{$sidebar}--m-stack__panel--Position: sticky;
-  --#{$sidebar}--m-stack__panel--Top: 0;
+  --#{$sidebar}--m-stack__panel--BlockStart: 0;
   --#{$sidebar}--m-stack__panel--BoxShadow: var(--#{$sidebar}__panel--BoxShadow--base);
   --#{$sidebar}--m-stack--m-panel-right__panel--Order: -1;
 
@@ -69,7 +69,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-split__main--AlignItems: flex-start;
   --#{$sidebar}--m-split__main--FlexDirection: row;
   --#{$sidebar}--m-split__panel--Position: static;
-  --#{$sidebar}--m-split__panel--Top: auto;
+  --#{$sidebar}--m-split__panel--BlockStart: auto;
   --#{$sidebar}--m-split--m-panel-right__panel--Order: 1;
   --#{$sidebar}--m-split__main--m-border--before--Display: block;
 
@@ -77,8 +77,8 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__panel--FlexBasis--base: auto;
   --#{$sidebar}__panel--BoxShadow--base: var(--pf-t--global--box-shadow--md--bottom);
   --#{$sidebar}__panel--BoxShadow: var(--#{$sidebar}__panel--BoxShadow--base);
-  --#{$sidebar}__panel--Top: 0;
-  --#{$sidebar}__panel--md--Top: auto;
+  --#{$sidebar}__panel--BlockStart: 0;
+  --#{$sidebar}__panel--md--BlockStart: auto;
   --#{$sidebar}__panel--Position: sticky;
   --#{$sidebar}__panel--md--Position: static;
   --#{$sidebar}__panel--FlexBasis-base: auto;
@@ -95,7 +95,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__content--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // Sticky
-  --#{$sidebar}__panel--m-sticky--Top: 0;
+  --#{$sidebar}__panel--m-sticky--BlockStart: 0;
   --#{$sidebar}__panel--m-sticky--Position: sticky;
 }
 
@@ -108,7 +108,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}__main--m-border--before--md--Display); // show border starting at md breakpoint
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--md--FlexBasis);
-    --#{$sidebar}__panel--Top: var(--#{$sidebar}__panel--md--Top);
+    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}__panel--md--BlockStart);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--md--Position);
   }
 
@@ -134,7 +134,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}--m-stack__main--FlexDirection);
     --#{$sidebar}__main--AlignItems: var(--#{$sidebar}--m-stack__main--AlignItems);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}--m-stack__panel--Position);
-    --#{$sidebar}__panel--Top: var(--#{$sidebar}--m-stack__panel--Top);
+    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}--m-stack__panel--BlockStart);
     --#{$sidebar}__panel--BoxShadow: var(--#{$sidebar}--m-stack__panel--BoxShadow);
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-stack--FlexBasis);
     --#{$sidebar}__main--m-border--before--Display: none;
@@ -145,7 +145,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}--m-split__main--FlexDirection);
     --#{$sidebar}__main--AlignItems: var(--#{$sidebar}--m-split__main--AlignItems);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}--m-split__panel--Position);
-    --#{$sidebar}__panel--Top: var(--#{$sidebar}--m-split__panel--Top);
+    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}--m-split__panel--BlockStart);
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-split--FlexBasis);
     --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}--m-split__main--m-border--before--Display);
@@ -169,33 +169,33 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
 .#{$sidebar}__panel {
   position: var(--#{$sidebar}__panel--Position);
-  inset-block-start: var(--#{$sidebar}__panel--Top);
+  inset-block-start: var(--#{$sidebar}__panel--BlockStart);
   z-index: var(--#{$sidebar}__panel--ZIndex);
   flex-basis: var(--#{$sidebar}__panel--FlexBasis);
   flex-shrink: 0;
   order: var(--#{$sidebar}__panel--Order);
-  padding-block-start: var(--#{$sidebar}__panel--PaddingTop);
-  padding-block-end: var(--#{$sidebar}__panel--PaddingBottom);
-  padding-inline-start: var(--#{$sidebar}__panel--PaddingLeft);
-  padding-inline-end: var(--#{$sidebar}__panel--PaddingRight);
+  padding-block-start: var(--#{$sidebar}__panel--PaddingBlockStart);
+  padding-block-end: var(--#{$sidebar}__panel--PaddingBlockEnd);
+  padding-inline-start: var(--#{$sidebar}__panel--PaddingInlineStart);
+  padding-inline-end: var(--#{$sidebar}__panel--PaddingInlineEnd);
   background-color: var(--#{$sidebar}__panel--BackgroundColor);
   box-shadow: var(--#{$sidebar}__panel--BoxShadow);
 
   &.pf-m-padding {
-    --#{$sidebar}__panel--PaddingTop: var(--#{$sidebar}__panel--m-padding--PaddingTop);
-    --#{$sidebar}__panel--PaddingRight: var(--#{$sidebar}__panel--m-padding--PaddingRight);
-    --#{$sidebar}__panel--PaddingBottom: var(--#{$sidebar}__panel--m-padding--PaddingBottom);
-    --#{$sidebar}__panel--PaddingLeft: var(--#{$sidebar}__panel--m-padding--PaddingLeft);
+    --#{$sidebar}__panel--PaddingBlockStart: var(--#{$sidebar}__panel--m-padding--PaddingBlockStart);
+    --#{$sidebar}__panel--PaddingInlineEnd: var(--#{$sidebar}__panel--m-padding--PaddingInlineEnd);
+    --#{$sidebar}__panel--PaddingBlockEnd: var(--#{$sidebar}__panel--m-padding--PaddingBlockEnd);
+    --#{$sidebar}__panel--PaddingInlineStart: var(--#{$sidebar}__panel--m-padding--PaddingInlineStart);
   }
 
   &.pf-m-sticky {
     --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--m-sticky--Position);
-    --#{$sidebar}__panel--Top: var(--#{$sidebar}__panel--m-sticky--Top);
+    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}__panel--m-sticky--BlockStart);
   }
 
   &.pf-m-static {
     --#{$sidebar}__panel--Position: static;
-    --#{$sidebar}__panel--Top: auto;
+    --#{$sidebar}__panel--BlockStart: auto;
   }
 
   &.pf-m-secondary {
@@ -206,17 +206,17 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 .#{$sidebar}__content {
   flex-grow: 1;
   order: var(--#{$sidebar}__content--Order);
-  padding-block-start: var(--#{$sidebar}__content--PaddingTop);
-  padding-block-end: var(--#{$sidebar}__content--PaddingBottom);
-  padding-inline-start: var(--#{$sidebar}__content--PaddingLeft);
-  padding-inline-end: var(--#{$sidebar}__content--PaddingRight);
+  padding-block-start: var(--#{$sidebar}__content--PaddingBlockStart);
+  padding-block-end: var(--#{$sidebar}__content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$sidebar}__content--PaddingInlineStart);
+  padding-inline-end: var(--#{$sidebar}__content--PaddingInlineEnd);
   background-color: var(--#{$sidebar}__content--BackgroundColor);
 
   &.pf-m-padding {
-    --#{$sidebar}__content--PaddingTop: var(--#{$sidebar}__content--m-padding--PaddingTop);
-    --#{$sidebar}__content--PaddingRight: var(--#{$sidebar}__content--m-padding--PaddingRight);
-    --#{$sidebar}__content--PaddingBottom: var(--#{$sidebar}__content--m-padding--PaddingBottom);
-    --#{$sidebar}__content--PaddingLeft: var(--#{$sidebar}__content--m-padding--PaddingTop);
+    --#{$sidebar}__content--PaddingBlockStart: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
+    --#{$sidebar}__content--PaddingInlineEnd: var(--#{$sidebar}__content--m-padding--PaddingInlineEnd);
+    --#{$sidebar}__content--PaddingBlockEnd: var(--#{$sidebar}__content--m-padding--PaddingBlockEnd);
+    --#{$sidebar}__content--PaddingInlineStart: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
   }
 
   &.pf-m-no-background {

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -61,7 +61,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-stack__main--FlexDirection: column;
   --#{$sidebar}--m-stack__main--AlignItems: stretch;
   --#{$sidebar}--m-stack__panel--Position: sticky;
-  --#{$sidebar}--m-stack__panel--BlockStart: 0;
+  --#{$sidebar}--m-stack__panel--InsetBlockStart: 0;
   --#{$sidebar}--m-stack__panel--BoxShadow: var(--#{$sidebar}__panel--BoxShadow--base);
   --#{$sidebar}--m-stack--m-panel-right__panel--Order: -1;
 
@@ -69,7 +69,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-split__main--AlignItems: flex-start;
   --#{$sidebar}--m-split__main--FlexDirection: row;
   --#{$sidebar}--m-split__panel--Position: static;
-  --#{$sidebar}--m-split__panel--BlockStart: auto;
+  --#{$sidebar}--m-split__panel--InsetBlockStart: auto;
   --#{$sidebar}--m-split--m-panel-right__panel--Order: 1;
   --#{$sidebar}--m-split__main--m-border--before--Display: block;
 
@@ -77,8 +77,8 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__panel--FlexBasis--base: auto;
   --#{$sidebar}__panel--BoxShadow--base: var(--pf-t--global--box-shadow--md--bottom);
   --#{$sidebar}__panel--BoxShadow: var(--#{$sidebar}__panel--BoxShadow--base);
-  --#{$sidebar}__panel--BlockStart: 0;
-  --#{$sidebar}__panel--md--BlockStart: auto;
+  --#{$sidebar}__panel--InsetBlockStart: 0;
+  --#{$sidebar}__panel--md--InsetBlockStart: auto;
   --#{$sidebar}__panel--Position: sticky;
   --#{$sidebar}__panel--md--Position: static;
   --#{$sidebar}__panel--FlexBasis-base: auto;
@@ -95,7 +95,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__content--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // Sticky
-  --#{$sidebar}__panel--m-sticky--BlockStart: 0;
+  --#{$sidebar}__panel--m-sticky--InsetBlockStart: 0;
   --#{$sidebar}__panel--m-sticky--Position: sticky;
 }
 
@@ -108,7 +108,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}__main--m-border--before--md--Display); // show border starting at md breakpoint
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--md--FlexBasis);
-    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}__panel--md--BlockStart);
+    --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}__panel--md--InsetBlockStart);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--md--Position);
   }
 
@@ -134,7 +134,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}--m-stack__main--FlexDirection);
     --#{$sidebar}__main--AlignItems: var(--#{$sidebar}--m-stack__main--AlignItems);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}--m-stack__panel--Position);
-    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}--m-stack__panel--BlockStart);
+    --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}--m-stack__panel--InsetBlockStart);
     --#{$sidebar}__panel--BoxShadow: var(--#{$sidebar}--m-stack__panel--BoxShadow);
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-stack--FlexBasis);
     --#{$sidebar}__main--m-border--before--Display: none;
@@ -145,7 +145,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}--m-split__main--FlexDirection);
     --#{$sidebar}__main--AlignItems: var(--#{$sidebar}--m-split__main--AlignItems);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}--m-split__panel--Position);
-    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}--m-split__panel--BlockStart);
+    --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}--m-split__panel--InsetBlockStart);
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-split--FlexBasis);
     --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}--m-split__main--m-border--before--Display);
@@ -169,7 +169,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
 .#{$sidebar}__panel {
   position: var(--#{$sidebar}__panel--Position);
-  inset-block-start: var(--#{$sidebar}__panel--BlockStart);
+  inset-block-start: var(--#{$sidebar}__panel--InsetBlockStart);
   z-index: var(--#{$sidebar}__panel--ZIndex);
   flex-basis: var(--#{$sidebar}__panel--FlexBasis);
   flex-shrink: 0;
@@ -190,12 +190,12 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   &.pf-m-sticky {
     --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--m-sticky--Position);
-    --#{$sidebar}__panel--BlockStart: var(--#{$sidebar}__panel--m-sticky--BlockStart);
+    --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}__panel--m-sticky--InsetBlockStart);
   }
 
   &.pf-m-static {
     --#{$sidebar}__panel--Position: static;
-    --#{$sidebar}__panel--BlockStart: auto;
+    --#{$sidebar}__panel--InsetBlockStart: auto;
   }
 
   &.pf-m-secondary {

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -2,10 +2,10 @@
 
 :where(:root, .#{$simple-list}) {
   // Simple list item link
-  --#{$simple-list}__item-link--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$simple-list}__item-link--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$simple-list}__item-link--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$simple-list}__item-link--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$simple-list}__item-link--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$simple-list}__item-link--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$simple-list}__item-link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$simple-list}__item-link--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$simple-list}__item-link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$simple-list}__item-link--Color: var(--pf-t--global--text--color--subtle);
   --#{$simple-list}__item-link--FontSize: var(--pf-t--global--font--size--body--default);
@@ -21,25 +21,25 @@
   --#{$simple-list}__item-link--m-link--hover--Color: var(--pf-t--global--text--color--link--hover);
 
   // Simple list title
-  --#{$simple-list}__title--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$simple-list}__title--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$simple-list}__title--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$simple-list}__title--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$simple-list}__title--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$simple-list}__title--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$simple-list}__title--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$simple-list}__title--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$simple-list}__title--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$simple-list}__title--Color: var(--pf-t--global--text--color--regular);
   --#{$simple-list}__title--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // Simple list section
-  --#{$simple-list}__section--section--MarginTop: var(--pf-t--global--spacer--sm);
+  --#{$simple-list}__section--section--MarginBlockStart: var(--pf-t--global--spacer--sm);
 }
 
 .#{$simple-list}__item-link {
   display: block;
   width: 100%;
-  padding-block-start: var(--#{$simple-list}__item-link--PaddingTop);
-  padding-block-end: var(--#{$simple-list}__item-link--PaddingBottom);
-  padding-inline-start: var(--#{$simple-list}__item-link--PaddingLeft);
-  padding-inline-end: var(--#{$simple-list}__item-link--PaddingRight);
+  padding-block-start: var(--#{$simple-list}__item-link--PaddingBlockStart);
+  padding-block-end: var(--#{$simple-list}__item-link--PaddingBlockEnd);
+  padding-inline-start: var(--#{$simple-list}__item-link--PaddingInlineStart);
+  padding-inline-end: var(--#{$simple-list}__item-link--PaddingInlineEnd);
   font-size: var(--#{$simple-list}__item-link--FontSize);
   color: var(--#{$simple-list}__item-link--Color);
   text-align: start;
@@ -69,15 +69,15 @@
 }
 
 .#{$simple-list}__title {
-  padding-block-start: var(--#{$simple-list}__title--PaddingTop);
-  padding-block-end: var(--#{$simple-list}__title--PaddingBottom);
-  padding-inline-start: var(--#{$simple-list}__title--PaddingLeft);
-  padding-inline-end: var(--#{$simple-list}__title--PaddingRight);
+  padding-block-start: var(--#{$simple-list}__title--PaddingBlockStart);
+  padding-block-end: var(--#{$simple-list}__title--PaddingBlockEnd);
+  padding-inline-start: var(--#{$simple-list}__title--PaddingInlineStart);
+  padding-inline-end: var(--#{$simple-list}__title--PaddingInlineEnd);
   font-size: var(--#{$simple-list}__title--FontSize);
   font-weight: var(--#{$simple-list}__title--FontWeight);
   color: var(--#{$simple-list}__title--Color);
 }
 
 .#{$simple-list}__section + .#{$simple-list}__section {
-  margin-block-start: var(--#{$simple-list}__section--section--MarginTop);
+  margin-block-start: var(--#{$simple-list}__section--section--MarginBlockStart);
 }

--- a/src/patternfly/components/Skeleton/skeleton.scss
+++ b/src/patternfly/components/Skeleton/skeleton.scss
@@ -7,7 +7,7 @@
   --#{$skeleton}--BorderRadius: var(--pf-t--global--spacer--sm);
 
   // Before
-  --#{$skeleton}--before--PaddingBottom: 0;
+  --#{$skeleton}--before--PaddingBlockEnd: 0;
   --#{$skeleton}--before--Height: auto;
   --#{$skeleton}--before--Content: "\00a0";
 
@@ -25,7 +25,7 @@
 
   // Circle
   --#{$skeleton}--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
-  --#{$skeleton}--m-circle--before--PaddingBottom: 100%;
+  --#{$skeleton}--m-circle--before--PaddingBlockEnd: 100%;
 
   // Text modifiers
   --#{$skeleton}--m-text-4xl--Height: calc(var(--pf-t--global--font--size--4xl) * var(--pf-t--global--font--line-height--heading));
@@ -70,7 +70,7 @@
   &::before {
     display: block;
     height: var(--#{$skeleton}--before--Height);
-    padding-block-end: var(--#{$skeleton}--before--PaddingBottom);
+    padding-block-end: var(--#{$skeleton}--before--PaddingBlockEnd);
     content: var(--#{$skeleton}--before--Content);
   }
 
@@ -94,7 +94,7 @@
   &.pf-m-square,
   &.pf-m-circle {
     --#{$skeleton}--before--Height: 0;
-    --#{$skeleton}--before--PaddingBottom: var(--#{$skeleton}--m-circle--before--PaddingBottom);
+    --#{$skeleton}--before--PaddingBlockEnd: var(--#{$skeleton}--m-circle--before--PaddingBlockEnd);
   }
 
   // Width

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,18 +1,18 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$skip-to-content}) {
-  --#{$skip-to-content}--BlockStart: var(--pf-t--global--spacer--md);
+  --#{$skip-to-content}--InsetBlockStart: var(--pf-t--global--spacer--md);
   --#{$skip-to-content}--ZIndex: var(--pf-t--global--z-index--2xl);
-  --#{$skip-to-content}--focus--InlineStart: var(--pf-t--global--spacer--md);
+  --#{$skip-to-content}--focus--InsetInlineStart: var(--pf-t--global--spacer--md);
 }
 
 .#{$skip-to-content} {
   position: absolute;
-  inset-block-start: var(--#{$skip-to-content}--BlockStart);
+  inset-block-start: var(--#{$skip-to-content}--InsetBlockStart);
   inset-inline-start: -300%; // moves off screen
   z-index: var(--#{$skip-to-content}--ZIndex);
 
   &:focus-within {
-    inset-inline-start: var(--#{$skip-to-content}--focus--InlineStart);
+    inset-inline-start: var(--#{$skip-to-content}--focus--InsetInlineStart);
   }
 }

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,18 +1,18 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$skip-to-content}) {
-  --#{$skip-to-content}--Top: var(--pf-t--global--spacer--md);
+  --#{$skip-to-content}--BlockStart: var(--pf-t--global--spacer--md);
   --#{$skip-to-content}--ZIndex: var(--pf-t--global--z-index--2xl);
-  --#{$skip-to-content}--focus--Left: var(--pf-t--global--spacer--md);
+  --#{$skip-to-content}--focus--InlineStart: var(--pf-t--global--spacer--md);
 }
 
 .#{$skip-to-content} {
   position: absolute;
-  inset-block-start: var(--#{$skip-to-content}--Top);
+  inset-block-start: var(--#{$skip-to-content}--BlockStart);
   inset-inline-start: -300%; // moves off screen
   z-index: var(--#{$skip-to-content}--ZIndex);
 
   &:focus-within {
-    inset-inline-start: var(--#{$skip-to-content}--focus--Left);
+    inset-inline-start: var(--#{$skip-to-content}--focus--InlineStart);
   }
 }

--- a/src/patternfly/components/Slider/examples/Slider.md
+++ b/src/patternfly/components/Slider/examples/Slider.md
@@ -16,15 +16,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--InlineStart="87.5%"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InsetInlineStart="87.5%"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -54,8 +54,8 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -73,15 +73,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--InlineStart="87.5%"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InsetInlineStart="87.5%"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -101,11 +101,11 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="25%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="75%"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="25%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="75%"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -266,15 +266,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--InlineStart="87.5%"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InsetInlineStart="87.5%"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -292,11 +292,11 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="25%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--InlineStart="75%"}}
-      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InsetInlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="25%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InsetInlineStart="75%"}}
+      {{> slider-step slider-step--InsetInlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}

--- a/src/patternfly/components/Slider/examples/Slider.md
+++ b/src/patternfly/components/Slider/examples/Slider.md
@@ -16,15 +16,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--Left="87.5%"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InlineStart="87.5%"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -54,8 +54,8 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -73,15 +73,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--Left="87.5%"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InlineStart="87.5%"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -101,11 +101,11 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="25%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="50%" slider-step--label="50%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="75%"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="25%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="75%"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -266,15 +266,15 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="12.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="25%" slider-step--label="2" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="37.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="50%" slider-step--label="4" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="62.5%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="75%" slider-step--label="6"}}
-      {{> slider-step slider-step--Left="87.5%"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="8"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="12.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="25%" slider-step--label="2" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="37.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="50%" slider-step--label="4" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="62.5%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="75%" slider-step--label="6"}}
+      {{> slider-step slider-step--InlineStart="87.5%"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="8"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}
@@ -292,11 +292,11 @@ cssPrefix: pf-v6-c-slider
   {{#> slider-main}}
     {{> slider-rail}}
     {{#> slider-steps}}
-      {{> slider-step slider-step--Left="0%" slider-step--label="0%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="25%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="50%" slider-step--label="50%" slider-step--IsActive="true"}}
-      {{> slider-step slider-step--Left="75%"}}
-      {{> slider-step slider-step--Left="100%" slider-step--label="100%"}}
+      {{> slider-step slider-step--InlineStart="0%" slider-step--label="0%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="25%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="50%" slider-step--label="50%" slider-step--IsActive="true"}}
+      {{> slider-step slider-step--InlineStart="75%"}}
+      {{> slider-step slider-step--InlineStart="100%" slider-step--label="100%"}}
     {{/slider-steps}}
     {{> slider-thumb}}
   {{/slider-main}}

--- a/src/patternfly/components/Slider/slider-step.hbs
+++ b/src/patternfly/components/Slider/slider-step.hbs
@@ -1,5 +1,5 @@
 <div class="{{pfv}}slider__step{{#if slider-step--IsActive}} pf-m-active{{/if}}{{#if slider-step--modifier}} {{slider-step--modifier}}{{/if}}"
-  style="--pf-v6-c-slider__step--Left: {{slider-step--Left}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
+  style="--pf-v6-c-slider__step--InlineStart: {{slider-step--InlineStart}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
   {{#if slider-step--attribute}}
     {{{slider-step--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Slider/slider-step.hbs
+++ b/src/patternfly/components/Slider/slider-step.hbs
@@ -1,5 +1,5 @@
 <div class="{{pfv}}slider__step{{#if slider-step--IsActive}} pf-m-active{{/if}}{{#if slider-step--modifier}} {{slider-step--modifier}}{{/if}}"
-  style="--pf-v6-c-slider__step--InlineStart: {{slider-step--InlineStart}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
+  style="--pf-v6-c-slider__step--InsetInlineStart: {{slider-step--InsetInlineStart}};{{#if slider-step--styles}} {{slider-step--styles}}{{/if}}"
   {{#if slider-step--attribute}}
     {{{slider-step--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -2,11 +2,11 @@
 
 :where(:root, .#{$slider}) {
   --#{$slider}--value: 0; // should always be set inline
-  --#{$slider}__step--Left: 0; // should always be set inline
+  --#{$slider}__step--InlineStart: 0; // should always be set inline
 
   // rail
-  --#{$slider}__rail--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$slider}__rail--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$slider}__rail--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$slider}__rail--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$slider}__rail-track--Height: #{pf-size-prem(4px)};
   --#{$slider}__rail-track--before--base--BackgroundColor: var(--pf-t--global--border--color--default);
   --#{$slider}__rail-track--before--fill--BackgroundColor: var(--pf-t--global--border--color--hover);
@@ -18,7 +18,7 @@
   --#{$slider}__steps--Height: var(--#{$slider}__steps--FontSize);
 
   // step tick
-  --#{$slider}__step-tick--Top: var(--pf-t--global--spacer--md);
+  --#{$slider}__step-tick--BlockStart: var(--pf-t--global--spacer--md);
   --#{$slider}__step-tick--Width: #{pf-size-prem(4px)};
   --#{$slider}__step-tick--Height: #{pf-size-prem(4px)};
   --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--subtle);
@@ -30,15 +30,15 @@
 
   // step label
   --#{$slider}__step-label--TranslateX: -50%;
-  --#{$slider}__step-label--Top: calc(var(--pf-t--global--spacer--xl) + var(--#{$slider}__rail-track--Height));
+  --#{$slider}__step-label--BlockStart: calc(var(--pf-t--global--spacer--xl) + var(--#{$slider}__rail-track--Height));
   --#{$slider}__step--first-child__step-label--TranslateX: 0;
   --#{$slider}__step--last-child__step-label--TranslateX: -100%;
 
   // thumb
-  --#{$slider}__thumb--Top: calc(var(--#{$slider}__rail-track--Height) / 2 + var(--pf-t--global--spacer--md));
+  --#{$slider}__thumb--BlockStart: calc(var(--#{$slider}__rail-track--Height) / 2 + var(--pf-t--global--spacer--md));
   --#{$slider}__thumb--Width: #{pf-size-prem(16px)};
   --#{$slider}__thumb--Height: #{pf-size-prem(16px)};
-  --#{$slider}__thumb--Left: var(--#{$slider}--value);
+  --#{$slider}__thumb--InlineStart: var(--#{$slider}--value);
   --#{$slider}__thumb--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$slider}__thumb--TranslateX: -50%;
   --#{$slider}__thumb--TranslateY: -50%;
@@ -58,18 +58,18 @@
   --#{$slider}__thumb--before--TranslateY: -50%;
 
   // value
-  --#{$slider}__value--MarginLeft: var(--pf-t--global--spacer--md);
-  --#{$slider}__value--c-form-control--width-base: calc(var(--#{$form-control}--PaddingLeft) + var(--#{$form-control}--PaddingRight) + #{pf-size-prem(20px)}); // form control base width + number input spinner width
+  --#{$slider}__value--MarginInlineStart: var(--pf-t--global--spacer--md);
+  --#{$slider}__value--c-form-control--width-base: calc(var(--#{$form-control}--PaddingInlineStart) + var(--#{$form-control}--PaddingInlineEnd) + #{pf-size-prem(20px)}); // form control base width + number input spinner width
   --#{$slider}__value--c-form-control--width-chars: 3;
   --#{$slider}__value--c-form-control--Width: calc(var(--#{$slider}__value--c-form-control--width-base) + var(--#{$slider}__value--c-form-control--width-chars) * 1ch);
   --#{$slider}__value--m-floating--TranslateX: -50%;
   --#{$slider}__value--m-floating--TranslateY: -100%;
-  --#{$slider}__value--m-floating--Left: var(--#{$slider}--value);
+  --#{$slider}__value--m-floating--InlineStart: var(--#{$slider}--value);
   --#{$slider}__value--m-floating--ZIndex: var(--pf-t--global--z-index--sm);
 
   // actions
-  --#{$slider}__actions--MarginRight: var(--pf-t--global--spacer--sm);
-  --#{$slider}__main--actions--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$slider}__actions--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$slider}__main--actions--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // disabled
   --#{$slider}--m-disabled__rail-track--before--fill--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
@@ -108,8 +108,8 @@
 }
 
 .#{$slider}__rail {
-  padding-block-start: var(--#{$slider}__rail--PaddingTop);
-  padding-block-end: var(--#{$slider}__rail--PaddingBottom);
+  padding-block-start: var(--#{$slider}__rail--PaddingBlockStart);
+  padding-block-end: var(--#{$slider}__rail--PaddingBlockEnd);
 }
 
 .#{$slider}__rail-track {
@@ -140,7 +140,7 @@
 .#{$slider}__step {
   position: absolute;
   inset-block-start: 0;
-  inset-inline-start: var(--#{$slider}__step--Left); // set programmatically as an inline style
+  inset-inline-start: var(--#{$slider}__step--InlineStart); // set programmatically as an inline style
   content: "";
 
   &.pf-m-active {
@@ -166,7 +166,7 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__step-tick--Top);
+  inset-block-start: var(--#{$slider}__step-tick--BlockStart);
   inset-inline-start: 0;
   width: var(--#{$slider}__step-tick--Width);
   height: var(--#{$slider}__step-tick--Height);
@@ -182,7 +182,7 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__step-label--Top);
+  inset-block-start: var(--#{$slider}__step-label--BlockStart);
   word-break: normal;
 }
 
@@ -194,8 +194,8 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__thumb--Top);
-  inset-inline-start: var(--#{$slider}__thumb--Left);
+  inset-block-start: var(--#{$slider}__thumb--BlockStart);
+  inset-inline-start: var(--#{$slider}__thumb--InlineStart);
   width: var(--#{$slider}__thumb--Width);
   height: var(--#{$slider}__thumb--Height);
   cursor: pointer;
@@ -235,7 +235,7 @@
 }
 
 .#{$slider}__value {
-  margin-inline-start: var(--#{$slider}__value--MarginLeft);
+  margin-inline-start: var(--#{$slider}__value--MarginInlineStart);
 
   &.pf-m-floating {
     @include pf-v6-bidirectional-style(
@@ -244,11 +244,11 @@
       $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$slider}__value--m-floating--TranslateX))}, var(--#{$slider}__value--m-floating--TranslateY)),
     );
 
-    --#{$slider}__value--MarginLeft: 0;
+    --#{$slider}__value--MarginInlineStart: 0;
 
     position: absolute;
     inset-block-start: 0;
-    inset-inline-start: var(--#{$slider}__value--m-floating--Left);
+    inset-inline-start: var(--#{$slider}__value--m-floating--InlineStart);
     z-index: var(--#{$slider}__value--m-floating--ZIndex);
   }
 
@@ -259,11 +259,11 @@
 
 .#{$slider}__actions {
   display: flex;
-  margin-inline-end: var(--#{$slider}__actions--MarginRight);
+  margin-inline-end: var(--#{$slider}__actions--MarginInlineEnd);
 
   .#{$slider}__main ~ & {
-    --#{$slider}__actions--MarginRight: 0;
+    --#{$slider}__actions--MarginInlineEnd: 0;
 
-    margin-inline-start: var(--#{$slider}__main--actions--MarginLeft);
+    margin-inline-start: var(--#{$slider}__main--actions--MarginInlineStart);
   }
 }

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -2,7 +2,7 @@
 
 :where(:root, .#{$slider}) {
   --#{$slider}--value: 0; // should always be set inline
-  --#{$slider}__step--InlineStart: 0; // should always be set inline
+  --#{$slider}__step--InsetInlineStart: 0; // should always be set inline
 
   // rail
   --#{$slider}__rail--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -18,7 +18,7 @@
   --#{$slider}__steps--Height: var(--#{$slider}__steps--FontSize);
 
   // step tick
-  --#{$slider}__step-tick--BlockStart: var(--pf-t--global--spacer--md);
+  --#{$slider}__step-tick--InsetBlockStart: var(--pf-t--global--spacer--md);
   --#{$slider}__step-tick--Width: #{pf-size-prem(4px)};
   --#{$slider}__step-tick--Height: #{pf-size-prem(4px)};
   --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--subtle);
@@ -30,15 +30,15 @@
 
   // step label
   --#{$slider}__step-label--TranslateX: -50%;
-  --#{$slider}__step-label--BlockStart: calc(var(--pf-t--global--spacer--xl) + var(--#{$slider}__rail-track--Height));
+  --#{$slider}__step-label--InsetBlockStart: calc(var(--pf-t--global--spacer--xl) + var(--#{$slider}__rail-track--Height));
   --#{$slider}__step--first-child__step-label--TranslateX: 0;
   --#{$slider}__step--last-child__step-label--TranslateX: -100%;
 
   // thumb
-  --#{$slider}__thumb--BlockStart: calc(var(--#{$slider}__rail-track--Height) / 2 + var(--pf-t--global--spacer--md));
+  --#{$slider}__thumb--InsetBlockStart: calc(var(--#{$slider}__rail-track--Height) / 2 + var(--pf-t--global--spacer--md));
   --#{$slider}__thumb--Width: #{pf-size-prem(16px)};
   --#{$slider}__thumb--Height: #{pf-size-prem(16px)};
-  --#{$slider}__thumb--InlineStart: var(--#{$slider}--value);
+  --#{$slider}__thumb--InsetInlineStart: var(--#{$slider}--value);
   --#{$slider}__thumb--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$slider}__thumb--TranslateX: -50%;
   --#{$slider}__thumb--TranslateY: -50%;
@@ -64,7 +64,7 @@
   --#{$slider}__value--c-form-control--Width: calc(var(--#{$slider}__value--c-form-control--width-base) + var(--#{$slider}__value--c-form-control--width-chars) * 1ch);
   --#{$slider}__value--m-floating--TranslateX: -50%;
   --#{$slider}__value--m-floating--TranslateY: -100%;
-  --#{$slider}__value--m-floating--InlineStart: var(--#{$slider}--value);
+  --#{$slider}__value--m-floating--InsetInlineStart: var(--#{$slider}--value);
   --#{$slider}__value--m-floating--ZIndex: var(--pf-t--global--z-index--sm);
 
   // actions
@@ -140,7 +140,7 @@
 .#{$slider}__step {
   position: absolute;
   inset-block-start: 0;
-  inset-inline-start: var(--#{$slider}__step--InlineStart); // set programmatically as an inline style
+  inset-inline-start: var(--#{$slider}__step--InsetInlineStart); // set programmatically as an inline style
   content: "";
 
   &.pf-m-active {
@@ -166,7 +166,7 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__step-tick--BlockStart);
+  inset-block-start: var(--#{$slider}__step-tick--InsetBlockStart);
   inset-inline-start: 0;
   width: var(--#{$slider}__step-tick--Width);
   height: var(--#{$slider}__step-tick--Height);
@@ -182,7 +182,7 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__step-label--BlockStart);
+  inset-block-start: var(--#{$slider}__step-label--InsetBlockStart);
   word-break: normal;
 }
 
@@ -194,8 +194,8 @@
   );
 
   position: absolute;
-  inset-block-start: var(--#{$slider}__thumb--BlockStart);
-  inset-inline-start: var(--#{$slider}__thumb--InlineStart);
+  inset-block-start: var(--#{$slider}__thumb--InsetBlockStart);
+  inset-inline-start: var(--#{$slider}__thumb--InsetInlineStart);
   width: var(--#{$slider}__thumb--Width);
   height: var(--#{$slider}__thumb--Height);
   cursor: pointer;
@@ -248,7 +248,7 @@
 
     position: absolute;
     inset-block-start: 0;
-    inset-inline-start: var(--#{$slider}__value--m-floating--InlineStart);
+    inset-inline-start: var(--#{$slider}__value--m-floating--InsetInlineStart);
     z-index: var(--#{$slider}__value--m-floating--ZIndex);
   }
 

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -8,7 +8,7 @@
   // Switch icon
   --#{$switch}__toggle-icon--FontSize: calc(var(--#{$switch}--FontSize) * .625); // We don't use an icon font-size here because this value allows the icon to scale relative to the switch's font-size.
   --#{$switch}__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--default);
-  --#{$switch}__toggle-icon--Left: calc(var(--#{$switch}--FontSize) * .4);
+  --#{$switch}__toggle-icon--InlineStart: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
   --#{$switch}__input--disabled__toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 
@@ -39,7 +39,7 @@
   --#{$switch}__toggle--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__toggle--before--Height: var(--#{$switch}__toggle--before--Width);
-  --#{$switch}__toggle--before--Left: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
+  --#{$switch}__toggle--before--InlineStart: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
   --#{$switch}__toggle--before--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$switch}__toggle--before--Transition: transform .25s ease 0s;
   --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon--Offset) + var(--#{$switch}__toggle--before--Width));
@@ -153,7 +153,7 @@
   &::before {
     position: absolute;
     inset-block-start: 50%;
-    inset-inline-start: var(--#{$switch}__toggle--before--Left);
+    inset-inline-start: var(--#{$switch}__toggle--before--InlineStart);
     display: block;
     width: var(--#{$switch}__toggle--before--Width);
     height: var(--#{$switch}__toggle--before--Height);
@@ -177,7 +177,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-block-end: 0;
-  inset-inline-start: var(--#{$switch}__toggle-icon--Left);
+  inset-inline-start: var(--#{$switch}__toggle-icon--InlineStart);
   display: flex;
   align-items: center;
   font-size: var(--#{$switch}__toggle-icon--FontSize);

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -8,7 +8,7 @@
   // Switch icon
   --#{$switch}__toggle-icon--FontSize: calc(var(--#{$switch}--FontSize) * .625); // We don't use an icon font-size here because this value allows the icon to scale relative to the switch's font-size.
   --#{$switch}__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--default);
-  --#{$switch}__toggle-icon--InlineStart: calc(var(--#{$switch}--FontSize) * .4);
+  --#{$switch}__toggle-icon--InsetInlineStart: calc(var(--#{$switch}--FontSize) * .4);
   --#{$switch}__toggle-icon--Offset: #{pf-size-prem(2px)}; // this value is created to handle sizing of the toggle and therefore the width of the toggle and its transform value.
   --#{$switch}__input--disabled__toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 
@@ -39,7 +39,7 @@
   --#{$switch}__toggle--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon--Offset));
   --#{$switch}__toggle--before--Height: var(--#{$switch}__toggle--before--Width);
-  --#{$switch}__toggle--before--InlineStart: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
+  --#{$switch}__toggle--before--InsetInlineStart: calc((var(--#{$switch}__toggle--Height) - var(--#{$switch}__toggle--before--Height)) / 2);
   --#{$switch}__toggle--before--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$switch}__toggle--before--Transition: transform .25s ease 0s;
   --#{$switch}__toggle--Width: calc(var(--#{$switch}__toggle--Height) + var(--#{$switch}__toggle-icon--Offset) + var(--#{$switch}__toggle--before--Width));
@@ -153,7 +153,7 @@
   &::before {
     position: absolute;
     inset-block-start: 50%;
-    inset-inline-start: var(--#{$switch}__toggle--before--InlineStart);
+    inset-inline-start: var(--#{$switch}__toggle--before--InsetInlineStart);
     display: block;
     width: var(--#{$switch}__toggle--before--Width);
     height: var(--#{$switch}__toggle--before--Height);
@@ -177,7 +177,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-block-end: 0;
-  inset-inline-start: var(--#{$switch}__toggle-icon--InlineStart);
+  inset-inline-start: var(--#{$switch}__toggle-icon--InsetInlineStart);
   display: flex;
   align-items: center;
   font-size: var(--#{$switch}__toggle-icon--FontSize);

--- a/src/patternfly/components/TabContent/tab-content.scss
+++ b/src/patternfly/components/TabContent/tab-content.scss
@@ -1,23 +1,23 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$tab-content}) {
-  --#{$tab-content}__body--PaddingTop: 0;
-  --#{$tab-content}__body--PaddingRight: 0;
-  --#{$tab-content}__body--PaddingBottom: 0;
-  --#{$tab-content}__body--PaddingLeft: 0;
+  --#{$tab-content}__body--PaddingBlockStart: 0;
+  --#{$tab-content}__body--PaddingInlineEnd: 0;
+  --#{$tab-content}__body--PaddingBlockEnd: 0;
+  --#{$tab-content}__body--PaddingInlineStart: 0;
   --#{$tab-content}--BackgroundColor: transparent;
 
   // Padding
-  --#{$tab-content}__body--m-padding--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$tab-content}__body--m-padding--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$tab-content}__body--m-padding--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$tab-content}__body--m-padding--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$tab-content}__body--m-padding--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$tab-content}__body--m-padding--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$tab-content}__body--m-padding--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$tab-content}__body--m-padding--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // Match page padding
-  --#{$tab-content}__body--m-padding--xl--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$tab-content}__body--m-padding--xl--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$tab-content}__body--m-padding--xl--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$tab-content}__body--m-padding--xl--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$tab-content}__body--m-padding--xl--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$tab-content}__body--m-padding--xl--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$tab-content}__body--m-padding--xl--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$tab-content}__body--m-padding--xl--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Secondary modifier
   --#{$tab-content}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
@@ -27,10 +27,10 @@
   background-color: var(--#{$tab-content}--BackgroundColor);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$tab-content}__body--m-padding--PaddingTop: var(--#{$tab-content}__body--m-padding--xl--PaddingTop);
-    --#{$tab-content}__body--m-padding--PaddingRight: var(--#{$tab-content}__body--m-padding--xl--PaddingRight);
-    --#{$tab-content}__body--m-padding--PaddingBottom: var(--#{$tab-content}__body--m-padding--xl--PaddingBottom);
-    --#{$tab-content}__body--m-padding--PaddingLeft: var(--#{$tab-content}__body--m-padding--xl--PaddingLeft);
+    --#{$tab-content}__body--m-padding--PaddingBlockStart: var(--#{$tab-content}__body--m-padding--xl--PaddingBlockStart);
+    --#{$tab-content}__body--m-padding--PaddingInlineEnd: var(--#{$tab-content}__body--m-padding--xl--PaddingInlineEnd);
+    --#{$tab-content}__body--m-padding--PaddingBlockEnd: var(--#{$tab-content}__body--m-padding--xl--PaddingBlockEnd);
+    --#{$tab-content}__body--m-padding--PaddingInlineStart: var(--#{$tab-content}__body--m-padding--xl--PaddingInlineStart);
   }
 
   &.pf-m-secondary {
@@ -40,15 +40,15 @@
 
 // Body
 .#{$tab-content}__body {
-  padding-block-start: var(--#{$tab-content}__body--PaddingTop);
-  padding-block-end: var(--#{$tab-content}__body--PaddingBottom);
-  padding-inline-start: var(--#{$tab-content}__body--PaddingLeft);
-  padding-inline-end: var(--#{$tab-content}__body--PaddingRight);
+  padding-block-start: var(--#{$tab-content}__body--PaddingBlockStart);
+  padding-block-end: var(--#{$tab-content}__body--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tab-content}__body--PaddingInlineStart);
+  padding-inline-end: var(--#{$tab-content}__body--PaddingInlineEnd);
 
   &.pf-m-padding {
-    --#{$tab-content}__body--PaddingTop: var(--#{$tab-content}__body--m-padding--PaddingTop);
-    --#{$tab-content}__body--PaddingRight: var(--#{$tab-content}__body--m-padding--PaddingRight);
-    --#{$tab-content}__body--PaddingBottom: var(--#{$tab-content}__body--m-padding--PaddingBottom);
-    --#{$tab-content}__body--PaddingLeft: var(--#{$tab-content}__body--m-padding--PaddingLeft);
+    --#{$tab-content}__body--PaddingBlockStart: var(--#{$tab-content}__body--m-padding--PaddingBlockStart);
+    --#{$tab-content}__body--PaddingInlineEnd: var(--#{$tab-content}__body--m-padding--PaddingInlineEnd);
+    --#{$tab-content}__body--PaddingBlockEnd: var(--#{$tab-content}__body--m-padding--PaddingBlockEnd);
+    --#{$tab-content}__body--PaddingInlineStart: var(--#{$tab-content}__body--m-padding--PaddingInlineStart);
   }
 }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -321,7 +321,7 @@
   .#{$table}__compound-expansion-toggle {
     --#{$table}__compound-expansion-toggle__button--before--BorderInlineEndWidth: 0;
     --#{$table}__compound-expansion-toggle__button--before--BorderInlineStartWidth: 0;
-    --#{$table}__compound-expansion-toggle__button--after--BlockStart: 100%;
+    --#{$table}__compound-expansion-toggle__button--after--InsetBlockStart: 100%;
   }
 
   // Compound expansion responsive

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -46,80 +46,80 @@
   // * Table body
   --#{$table}__tbody--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
   --#{$table}__tbody--after--border-width--base: var(--pf-t--global--border--width--extra-strong);
-  --#{$table}__tbody--after--BorderLeftWidth: 0;
+  --#{$table}__tbody--after--BorderInlineStartWidth: 0;
   --#{$table}__tbody--after--BorderColor: var(--pf-t--global--border--color--clicked);
 
   // * Table tr responsive
   --#{$table}__tr--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
-  --#{$table}__tr--responsive--last-child--BorderBottomWidth: var(--#{$table}__tbody--responsive--border-width--base);
+  --#{$table}__tr--responsive--last-child--BorderBlockEndWidth: var(--#{$table}__tbody--responsive--border-width--base);
   --#{$table}__tr--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
-  --#{$table}__tr--responsive--MarginTop: var(--#{$table}__tbody--responsive--border-width--base);
-  --#{$table}__tr--responsive--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}__tr--responsive--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$table}__tr--responsive--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$table}__tr--responsive--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$table}__tr--responsive--MarginBlockStart: var(--#{$table}__tbody--responsive--border-width--base);
+  --#{$table}__tr--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}__tr--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__tr--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__tr--responsive--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // * Table tr responsive nested table
-  --#{$table}__tr--responsive--nested-table--PaddingTop: var(--pf-t--global--spacer--xl);
-  --#{$table}__tr--responsive--nested-table--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$table}__tr--responsive--nested-table--PaddingBottom: var(--pf-t--global--spacer--xl);
-  --#{$table}__tr--responsive--nested-table--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$table}__tr--responsive--nested-table--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$table}__tr--responsive--nested-table--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__tr--responsive--nested-table--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$table}__tr--responsive--nested-table--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // * Table tbody
-  --#{$table}__tbody--after__tr--BorderLeftWidth: 0;
-  --#{$table}__tbody--after__tr--BorderLeftColor: transparent;
-  --#{$table}__tbody--m-expanded--after__tr--BorderLeftWidth: var(--#{$table}__expandable-row--after--border-width--base);
-  --#{$table}__tbody--m-expanded--after__tr--BorderLeftColor: var(--pf-t--global--border--color--clicked);
+  --#{$table}__tbody--after__tr--BorderInlineStartWidth: 0;
+  --#{$table}__tbody--after__tr--BorderInlineStartColor: transparent;
+  --#{$table}__tbody--m-expanded--after__tr--BorderInlineStartWidth: var(--#{$table}__expandable-row--after--border-width--base);
+  --#{$table}__tbody--m-expanded--after__tr--BorderInlineStartColor: var(--pf-t--global--border--color--clicked);
 
   // * Table tbody selected
-  --#{$table}__tbody--m-selected--after__tr--BorderLeftWidth: var(--#{$table}__expandable-row--after--border-width--base);
-  --#{$table}__tbody--m-selected--after__tr--BorderLeftColor: var(--pf-t--global--border--color--clicked);
+  --#{$table}__tbody--m-selected--after__tr--BorderInlineStartWidth: var(--#{$table}__expandable-row--after--border-width--base);
+  --#{$table}__tbody--m-selected--after__tr--BorderInlineStartColor: var(--pf-t--global--border--color--clicked);
 
   // * Table grid cell
   --#{$table}--m-grid--cell--hidden-visible--Display: grid;
 
   // * Table grid cell
-  --#{$table}--m-grid--cell--PaddingTop: 0;
-  --#{$table}--m-grid--cell--PaddingRight: 0;
-  --#{$table}--m-grid--cell--PaddingBottom: 0;
-  --#{$table}--m-grid--cell--PaddingLeft: 0;
+  --#{$table}--m-grid--cell--PaddingBlockStart: 0;
+  --#{$table}--m-grid--cell--PaddingInlineEnd: 0;
+  --#{$table}--m-grid--cell--PaddingBlockEnd: 0;
+  --#{$table}--m-grid--cell--PaddingInlineStart: 0;
 
   // * Table td responsive
   --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-child--responsive--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--responsive--PaddingRight: 0;
-  --#{$table}--cell--responsive--PaddingLeft: 0;
+  --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--responsive--PaddingInlineEnd: 0;
+  --#{$table}--cell--responsive--PaddingInlineStart: 0;
 
   // * Table grid compact table
-  --#{$table}--m-compact__tr--responsive--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact__tr--responsive--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact__tr__td--responsive--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__tr__td--responsive--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__check--responsive--MarginTop: #{pf-size-prem(7px)};
-  --#{$table}--m-compact__action--responsive--MarginTop: calc(var(--pf-t--global--spacer--xs) * -1);
-  --#{$table}--m-compact__action--responsive--MarginBottom: calc(var(--pf-t--global--spacer--xs) * -1);
-  --#{$table}--m-compact__toggle--c-button--responsive--MarginBottom: calc(#{pf-size-prem(6px)} * -1);
+  --#{$table}--m-compact__tr--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact__tr--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact__tr__td--responsive--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__tr__td--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__check--responsive--MarginBlockStart: #{pf-size-prem(7px)};
+  --#{$table}--m-compact__action--responsive--MarginBlockStart: calc(var(--pf-t--global--spacer--xs) * -1);
+  --#{$table}--m-compact__action--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
+  --#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd: calc(#{pf-size-prem(6px)} * -1);
 
   // * Table grid expandable row content
-  --#{$table}__expandable-row-content--responsive--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$table}__expandable-row-content--responsive--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__expandable-row-content--responsive--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$table}__expandable-row-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // * Table check
-  --#{$table}__check--responsive--MarginLeft: var(--#{$table}__tbody--responsive--border-width--base);
-  --#{$table}__check--responsive--MarginTop: #{pf-size-prem(14px)};
+  --#{$table}__check--responsive--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
+  --#{$table}__check--responsive--MarginBlockStart: #{pf-size-prem(14px)};
 
   // * Table grid favorite
-  --#{$table}--m-grid__favorite--MarginTop: #{pf-size-prem(8px)};
-  --#{$table}--m-grid__check--favorite--MarginLeft: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-grid__favorite--MarginBlockStart: #{pf-size-prem(8px)};
+  --#{$table}--m-grid__check--favorite--MarginInlineStart: var(--pf-t--global--spacer--xl);
 
   // * Table grid action
-  --#{$table}--m-grid__action--MarginTop: #{pf-size-prem(6px)};
-  --#{$table}__action--responsive--MarginLeft: var(--pf-t--global--spacer--xl);
-  --#{$table}--m-grid__favorite--action--MarginLeft: var(--pf-t--global--spacer--2xl);
-  --#{$table}--m-grid__check--favorite--action--MarginLeft: calc(var(--#{$table}--m-grid__check--favorite--MarginLeft) + var(--#{$table}--m-grid__favorite--action--MarginLeft));
+  --#{$table}--m-grid__action--MarginBlockStart: #{pf-size-prem(6px)};
+  --#{$table}__action--responsive--MarginInlineStart: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-grid__favorite--action--MarginInlineStart: var(--pf-t--global--spacer--2xl);
+  --#{$table}--m-grid__check--favorite--action--MarginInlineStart: calc(var(--#{$table}--m-grid__check--favorite--MarginInlineStart) + var(--#{$table}--m-grid__favorite--action--MarginInlineStart));
 
   // * Table grid toggle icon
   --#{$table}__toggle__icon--Transition: .2s ease-in 0s;
@@ -128,16 +128,16 @@
 
 // - Table mobile layout
 @include pf-mobile-layout {
-  --#{$table}--cell--PaddingTop: var(--#{$table}--m-grid--cell--PaddingTop);
-  --#{$table}--cell--PaddingRight: var(--#{$table}--m-grid--cell--PaddingRight);
-  --#{$table}--cell--PaddingBottom: var(--#{$table}--m-grid--cell--PaddingBottom);
-  --#{$table}--cell--PaddingLeft: var(--#{$table}--m-grid--cell--PaddingLeft);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-grid--cell--PaddingBlockStart);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--m-grid--cell--PaddingInlineEnd);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-grid--cell--PaddingBlockEnd);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}--m-grid--cell--PaddingInlineStart);
 
   // - Table favorite
-  --#{$table}__favorite--c-button--MarginTop: auto;
-  --#{$table}__favorite--c-button--MarginRight: auto;
-  --#{$table}__favorite--c-button--MarginBottom: auto;
-  --#{$table}__favorite--c-button--MarginLeft: auto;
+  --#{$table}__favorite--c-button--MarginBlockStart: auto;
+  --#{$table}__favorite--c-button--MarginInlineEnd: auto;
+  --#{$table}__favorite--c-button--MarginBlockEnd: auto;
+  --#{$table}__favorite--c-button--MarginInlineStart: auto;
 
   display: grid;
   border: none;
@@ -190,7 +190,7 @@
   // The last tr should always have a border width of 1px
   tr:where(.#{$table}__tr):last-child,
   tbody:where(.#{$table}__tbody):last-of-type:not(:only-of-type) > tr:where(.#{$table}__tr) {
-    border-block-end-width: var(--#{$table}__tr--responsive--last-child--BorderBottomWidth);
+    border-block-end-width: var(--#{$table}__tr--responsive--last-child--BorderBlockEndWidth);
   }
 
   // - Table grid tbody expanded
@@ -208,7 +208,7 @@
 
   // - Table grid tr selected
   tr:where(.#{$table}__tr).pf-m-selected {
-    --#{$table}__expandable-row--after--BorderLeftWidth: 0;
+    --#{$table}__expandable-row--after--BorderInlineStartWidth: 0;
     --#{$table}__expandable-row--after--BorderColor: transparent;
   }
 
@@ -225,41 +225,41 @@
     grid-column-gap: var(--#{$table}__tr--responsive--GridColumnGap);
 
     // set base variables to reset later
-    padding-block-start: var(--#{$table}__tr--responsive--PaddingTop);
-    padding-inline-end: var(--#{$table}__tr--responsive--PaddingRight);
-    padding-block-end: var(--#{$table}__tr--responsive--PaddingBottom);
-    padding-inline-start: var(--#{$table}__tr--responsive--PaddingLeft);
+    padding-block-start: var(--#{$table}__tr--responsive--PaddingBlockStart);
+    padding-inline-end: var(--#{$table}__tr--responsive--PaddingInlineEnd);
+    padding-block-end: var(--#{$table}__tr--responsive--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}__tr--responsive--PaddingInlineStart);
 
     // Reset td padding
     & > :where(th, td) {
-      padding-block-start: var(--#{$table}--cell--responsive--PaddingTop);
-      padding-inline-end: var(--#{$table}--cell--responsive--PaddingRight);
-      padding-block-end: var(--#{$table}--cell--responsive--PaddingBottom);
-      padding-inline-start: var(--#{$table}--cell--responsive--PaddingLeft);
+      padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
+      padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
+      padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
+      padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
 
       // remove padding from first child to align with kebab
       &:first-child {
-        --#{$table}--cell--responsive--PaddingTop: var(--#{$table}--cell--first-child--responsive--PaddingTop);
+        --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--cell--first-child--responsive--PaddingBlockStart);
       }
     }
   }
 
   // - Table grid compact
   &.pf-m-compact {
-    --#{$table}__tr--responsive--PaddingTop: var(--#{$table}--m-compact__tr--responsive--PaddingTop);
-    --#{$table}__tr--responsive--PaddingBottom: var(--#{$table}--m-compact__tr--responsive--PaddingBottom);
-    --#{$table}--cell--responsive--PaddingTop: var(--#{$table}--m-compact__tr__td--responsive--PaddingTop);
-    --#{$table}--cell--responsive--PaddingBottom: var(--#{$table}--m-compact__tr__td--responsive--PaddingBottom);
-    --#{$table}__check--responsive--MarginTop: var(--#{$table}--m-compact__check--responsive--MarginTop);
-    --#{$table}__check--input--MarginTop: 0;
+    --#{$table}__tr--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr--responsive--PaddingBlockStart);
+    --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr--responsive--PaddingBlockEnd);
+    --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockStart);
+    --#{$table}--cell--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockEnd);
+    --#{$table}__check--responsive--MarginBlockStart: var(--#{$table}--m-compact__check--responsive--MarginBlockStart);
+    --#{$table}__check--input--MarginBlockStart: 0;
 
     .#{$table}__action {
-      margin-block-start: var(--#{$table}--m-compact__action--responsive--MarginTop);
-      margin-block-end: var(--#{$table}--m-compact__action--responsive--MarginTop);
+      margin-block-start: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
+      margin-block-end: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
     }
 
     .#{$table}__toggle .#{$button} {
-      margin-block-end: var(--#{$table}--m-compact__toggle--c-button--responsive--MarginBottom);
+      margin-block-end: var(--#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd);
     }
   }
 
@@ -294,34 +294,34 @@
   tr:where(.#{$table}__tr) > :where(th, td) {
     // Remove first child padding left
     &:first-child {
-      --#{$table}--cell--PaddingLeft: 0;
+      --#{$table}--cell--PaddingInlineStart: 0;
     }
 
     // Remove last child padding right
     &:last-child {
-      --#{$table}--cell--PaddingRight: 0;
+      --#{$table}--cell--PaddingInlineEnd: 0;
     }
   }
 
   // - Table grid table
   .#{$table} {
-    --#{$table}__tr--responsive--PaddingTop: var(--#{$table}__tr--responsive--nested-table--PaddingTop);
-    --#{$table}__tr--responsive--PaddingRight: var(--#{$table}__tr--responsive--nested-table--PaddingRight);
-    --#{$table}__tr--responsive--PaddingBottom: var(--#{$table}__tr--responsive--nested-table--PaddingBottom);
-    --#{$table}__tr--responsive--PaddingLeft: var(--#{$table}__tr--responsive--nested-table--PaddingLeft);
+    --#{$table}__tr--responsive--PaddingBlockStart: var(--#{$table}__tr--responsive--nested-table--PaddingBlockStart);
+    --#{$table}__tr--responsive--PaddingInlineEnd: var(--#{$table}__tr--responsive--nested-table--PaddingInlineEnd);
+    --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}__tr--responsive--nested-table--PaddingBlockEnd);
+    --#{$table}__tr--responsive--PaddingInlineStart: var(--#{$table}__tr--responsive--nested-table--PaddingInlineStart);
 
     border: 0;
 
     tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) + tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) {
-      --#{$table}__tr--responsive--PaddingTop: 0;
+      --#{$table}__tr--responsive--PaddingBlockStart: 0;
     }
   }
 
   // - Table grid compound expansion toggle
   .#{$table}__compound-expansion-toggle {
-    --#{$table}__compound-expansion-toggle__button--before--BorderRightWidth: 0;
-    --#{$table}__compound-expansion-toggle__button--before--BorderLeftWidth: 0;
-    --#{$table}__compound-expansion-toggle__button--after--Top: 100%;
+    --#{$table}__compound-expansion-toggle__button--before--BorderInlineEndWidth: 0;
+    --#{$table}__compound-expansion-toggle__button--before--BorderInlineStartWidth: 0;
+    --#{$table}__compound-expansion-toggle__button--after--BlockStart: 100%;
   }
 
   // Compound expansion responsive
@@ -336,19 +336,19 @@
       inset-inline-start: 0;
       content: "";
       border: 0;
-      border-inline-start: var(--#{$table}__tbody--after--BorderLeftWidth) solid var(--#{$table}__tbody--after--BorderColor);
+      border-inline-start: var(--#{$table}__tbody--after--BorderInlineStartWidth) solid var(--#{$table}__tbody--after--BorderColor);
     }
 
     &.pf-m-expanded {
-      --#{$table}__tbody--after--BorderLeftWidth: var(--#{$table}__tbody--after--border-width--base);
+      --#{$table}__tbody--after--BorderInlineStartWidth: var(--#{$table}__tbody--after--border-width--base);
 
       & tbody:where(.#{$table}__tbody) {
-        --#{$table}__tbody--after--BorderLeftWidth: 0;
+        --#{$table}__tbody--after--BorderInlineStartWidth: 0;
       }
     }
 
     > tr:where(.#{$table}__tr) > :first-child:not(.#{$table}__check)::after {
-      --#{$table}__expandable-row--after--BorderLeftWidth: 0;
+      --#{$table}__expandable-row--after--BorderInlineStartWidth: 0;
 
       position: static;
       width: auto;
@@ -358,12 +358,12 @@
 
   // - Table grid expandable row
   .#{$table}__expandable-row {
-    --#{$table}--cell--responsive--PaddingTop: 0;
-    --#{$table}--cell--responsive--PaddingRight: 0;
-    --#{$table}--cell--responsive--PaddingBottom: 0;
-    --#{$table}--cell--responsive--PaddingLeft: 0;
-    --#{$table}--cell--PaddingRight: 0;
-    --#{$table}--cell--PaddingLeft: 0;
+    --#{$table}--cell--responsive--PaddingBlockStart: 0;
+    --#{$table}--cell--responsive--PaddingInlineEnd: 0;
+    --#{$table}--cell--responsive--PaddingBlockEnd: 0;
+    --#{$table}--cell--responsive--PaddingInlineStart: 0;
+    --#{$table}--cell--PaddingInlineEnd: 0;
+    --#{$table}--cell--PaddingInlineStart: 0;
 
     display: block;
     max-height: var(--#{$table}__expandable-row--MaxHeight);  // Overflow scroll should only happen on responsive
@@ -400,15 +400,15 @@
     }
 
     .#{$table}__expandable-row-content {
-      padding-inline-end: var(--#{$table}__expandable-row-content--responsive--PaddingRight);
-      padding-inline-start: var(--#{$table}__expandable-row-content--responsive--PaddingLeft);
+      padding-inline-end: var(--#{$table}__expandable-row-content--responsive--PaddingInlineEnd);
+      padding-inline-start: var(--#{$table}__expandable-row-content--responsive--PaddingInlineStart);
     }
   }
 
   // - Table grid tbody hoverable
   tbody:where(.#{$table}__tbody).pf-m-hoverable {
-    --#{$table}__tbody--after--BorderLeftWidth: 0;
-    --#{$table}__tbody--after--BorderLeftColor: transparent;
+    --#{$table}__tbody--after--BorderInlineStartWidth: 0;
+    --#{$table}__tbody--after--BorderInlineStartColor: transparent;
 
     &,
     > tr:where(.#{$table}__tr) {
@@ -421,18 +421,18 @@
       inset-block-start: 0;
       inset-block-end: 0;
       inset-inline-start: 0;
-      width: var(--#{$table}__tbody--after__tr--BorderLeftWidth);
-      background-color: var(--#{$table}__tbody--after__tr--BorderLeftColor);
+      width: var(--#{$table}__tbody--after__tr--BorderInlineStartWidth);
+      background-color: var(--#{$table}__tbody--after__tr--BorderInlineStartColor);
     }
 
     &.pf-m-expanded {
-      --#{$table}__tbody--after__tr--BorderLeftWidth: var(--#{$table}__tbody--m-expanded--after__tr--BorderLeftWidth);
-      --#{$table}__tbody--after__tr--BorderLeftColor: var(--#{$table}__tbody--m-expanded--after__tr--BorderLeftColor);
+      --#{$table}__tbody--after__tr--BorderInlineStartWidth: var(--#{$table}__tbody--m-expanded--after__tr--BorderInlineStartWidth);
+      --#{$table}__tbody--after__tr--BorderInlineStartColor: var(--#{$table}__tbody--m-expanded--after__tr--BorderInlineStartColor);
     }
 
     &.pf-m-selected {
-      --#{$table}__tbody--after__tr--BorderLeftWidth: var(--#{$table}__tbody--m-selected--after__tr--BorderLeftWidth);
-      --#{$table}__tbody--after__tr--BorderLeftColor: var(--#{$table}__tbody--m-selected--after__tr--BorderLeftColor);
+      --#{$table}__tbody--after__tr--BorderInlineStartWidth: var(--#{$table}__tbody--m-selected--after__tr--BorderInlineStartWidth);
+      --#{$table}__tbody--after__tr--BorderInlineStartColor: var(--#{$table}__tbody--m-selected--after__tr--BorderInlineStartColor);
     }
   }
 
@@ -445,8 +445,8 @@
       inset-block-start: 0;
       inset-block-end: 0;
       inset-inline-start: 0;
-      width: var(--#{$table}__tr--m-selected--after--BorderLeftWidth);
-      background-color: var(--#{$table}__tr--m-selected--after--BorderLeftColor);
+      width: var(--#{$table}__tr--m-selected--after--BorderInlineStartWidth);
+      background-color: var(--#{$table}__tr--m-selected--after--BorderInlineStartColor);
     }
   }
 
@@ -475,10 +475,10 @@
 
   // - Table grid button
   .#{$table}__button {
-    --#{$table}--cell--PaddingTop: var(--#{$table}--m-grid--cell--PaddingTop);
-    --#{$table}--cell--PaddingRight: var(--#{$table}--m-grid--cell--PaddingRight);
-    --#{$table}--cell--PaddingBottom: var(--#{$table}--m-grid--cell--PaddingBottom);
-    --#{$table}--cell--PaddingLeft: var(--#{$table}--m-grid--cell--PaddingLeft);
+    --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-grid--cell--PaddingBlockStart);
+    --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--m-grid--cell--PaddingInlineEnd);
+    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-grid--cell--PaddingBlockEnd);
+    --#{$table}--cell--PaddingInlineStart: var(--#{$table}--m-grid--cell--PaddingInlineStart);
   }
 
   // - Table grid check - Table grid favorite - Table grid action
@@ -491,20 +491,20 @@
 
   // - Table grid check
   .#{$table}__check {
-    margin-block-start: var(--#{$table}__check--responsive--MarginTop);
-    margin-inline-start: var(--#{$table}__check--responsive--MarginLeft);
+    margin-block-start: var(--#{$table}__check--responsive--MarginBlockStart);
+    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
     line-height: 1;
 
     ~ .#{$table}__favorite {
-      margin-inline-start: var(--#{$table}--m-grid__check--favorite--MarginLeft);
+      margin-inline-start: var(--#{$table}--m-grid__check--favorite--MarginInlineStart);
 
       ~ .#{$table}__action {
-        margin-inline-start: var(--#{$table}--m-grid__check--favorite--action--MarginLeft);
+        margin-inline-start: var(--#{$table}--m-grid__check--favorite--action--MarginInlineStart);
       }
     }
 
     ~ .#{$table}__action {
-      margin-inline-start: var(--#{$table}__action--responsive--MarginLeft);
+      margin-inline-start: var(--#{$table}__action--responsive--MarginInlineStart);
     }
 
     label {
@@ -515,16 +515,16 @@
 
   // - Table grid favorite
   .#{$table}__favorite {
-    margin-block-start: var(--#{$table}--m-grid__favorite--MarginTop);
+    margin-block-start: var(--#{$table}--m-grid__favorite--MarginBlockStart);
 
     ~ .#{$table}__action {
-      margin-inline-start: var(--#{$table}--m-grid__favorite--action--MarginLeft);
+      margin-inline-start: var(--#{$table}--m-grid__favorite--action--MarginInlineStart);
     }
   }
 
   // - Table grid action
   .#{$table}__action {
-    margin-block-start: var(--#{$table}--m-grid__action--MarginTop);
+    margin-block-start: var(--#{$table}--m-grid__action--MarginBlockStart);
     text-align: end;
 
     // @smallest breakpoint

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -5,23 +5,23 @@
   --#{$table}__sticky-cell--MinWidth--base: #{pf-size-prem(140px)};
   --#{$table}__sticky-cell--MinWidth: var(--#{$table}__sticky-cell--MinWidth--base);
   --#{$table}__sticky-cell--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$table}__sticky-cell--InlineEnd: auto;
-  --#{$table}__sticky-cell--InlineStart: auto;
+  --#{$table}__sticky-cell--InsetInlineEnd: auto;
+  --#{$table}__sticky-cell--InsetInlineStart: auto;
   --#{$table}__sticky-cell--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
   --#{$table}__sticky-cell--m-border-left--before--BorderInlineStartWidth: var(--pf-t--global--border--width--divider--default);
   --#{$table}__sticky-cell--m-border-left--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
-  --#{$table}__sticky-cell--m-right--InlineEnd: 0;
-  --#{$table}__sticky-cell--m-left--InlineStart: 0;
+  --#{$table}__sticky-cell--m-right--InsetInlineEnd: 0;
+  --#{$table}__sticky-cell--m-left--InsetInlineStart: 0;
   --#{$table}--m-sticky-header__sticky-cell--ZIndex: calc(var(--#{$table}__sticky-cell--ZIndex) + 1);
 }
 
 // - Table sticky cell
 .#{$table} .#{$table}__sticky-cell {
   position: sticky;
-  inset-inline-start: var(--#{$table}__sticky-cell--InlineStart);
-  inset-inline-end: var(--#{$table}__sticky-cell--InlineEnd);
+  inset-inline-start: var(--#{$table}__sticky-cell--InsetInlineStart);
+  inset-inline-end: var(--#{$table}__sticky-cell--InsetInlineEnd);
   z-index: var(--#{$table}__sticky-cell--ZIndex);
   min-width: var(--#{$table}__sticky-cell--MinWidth);
 }
@@ -45,12 +45,12 @@
 
   &.pf-m-right,
   &.pf-m-inline-end {
-    --#{$table}__sticky-cell--InlineEnd: var(--#{$table}__sticky-cell--m-right--InlineEnd);
+    --#{$table}__sticky-cell--InsetInlineEnd: var(--#{$table}__sticky-cell--m-right--InsetInlineEnd);
   }
 
   &.pf-m-left,
   &.pf-m-inline-start {
-    --#{$table}__sticky-cell--InlineStart: var(--#{$table}__sticky-cell--m-left--InlineStart);
+    --#{$table}__sticky-cell--InsetInlineStart: var(--#{$table}__sticky-cell--m-left--InsetInlineStart);
   }
 }
 

--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -5,23 +5,23 @@
   --#{$table}__sticky-cell--MinWidth--base: #{pf-size-prem(140px)};
   --#{$table}__sticky-cell--MinWidth: var(--#{$table}__sticky-cell--MinWidth--base);
   --#{$table}__sticky-cell--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$table}__sticky-cell--Right: auto;
-  --#{$table}__sticky-cell--Left: auto;
+  --#{$table}__sticky-cell--InlineEnd: auto;
+  --#{$table}__sticky-cell--InlineStart: auto;
   --#{$table}__sticky-cell--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$table}__sticky-cell--m-border-right--before--BorderRightWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}__sticky-cell--m-border-right--before--BorderRightColor: var(--pf-t--global--border--color--default);
-  --#{$table}__sticky-cell--m-border-left--before--BorderLeftWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}__sticky-cell--m-border-left--before--BorderLeftColor: var(--pf-t--global--border--color--default);
-  --#{$table}__sticky-cell--m-right--Right: 0;
-  --#{$table}__sticky-cell--m-left--Left: 0;
+  --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
+  --#{$table}__sticky-cell--m-border-left--before--BorderInlineStartWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}__sticky-cell--m-border-left--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
+  --#{$table}__sticky-cell--m-right--InlineEnd: 0;
+  --#{$table}__sticky-cell--m-left--InlineStart: 0;
   --#{$table}--m-sticky-header__sticky-cell--ZIndex: calc(var(--#{$table}__sticky-cell--ZIndex) + 1);
 }
 
 // - Table sticky cell
 .#{$table} .#{$table}__sticky-cell {
   position: sticky;
-  inset-inline-start: var(--#{$table}__sticky-cell--Left);
-  inset-inline-end: var(--#{$table}__sticky-cell--Right);
+  inset-inline-start: var(--#{$table}__sticky-cell--InlineStart);
+  inset-inline-end: var(--#{$table}__sticky-cell--InlineEnd);
   z-index: var(--#{$table}__sticky-cell--ZIndex);
   min-width: var(--#{$table}__sticky-cell--MinWidth);
 }
@@ -34,23 +34,23 @@
   background-clip: padding-box;
 
   &.pf-m-border-right::before {
-    --#{$table}--cell--m-border-right--before--BorderRightWidth: var(--#{$table}__sticky-cell--m-border-right--before--BorderRightWidth);
-    --#{$table}--cell--m-border-right--before--BorderRightColor: var(--#{$table}__sticky-cell--m-border-right--before--BorderRightColor);
+    --#{$table}--cell--m-border-right--before--BorderInlineEndWidth: var(--#{$table}__sticky-cell--m-border-right--before--BorderInlineEndWidth);
+    --#{$table}--cell--m-border-right--before--BorderInlineEndColor: var(--#{$table}__sticky-cell--m-border-right--before--BorderInlineEndColor);
   }
 
   &.pf-m-border-left::before {
-    --#{$table}--cell--m-border-left--before--BorderLeftWidth: var(--#{$table}__sticky-cell--m-border-left--before--BorderLeftWidth);
-    --#{$table}--cell--m-border-left--before--BorderLeftColor: var(--#{$table}__sticky-cell--m-border-left--before--BorderLeftColor);
+    --#{$table}--cell--m-border-left--before--BorderInlineStartWidth: var(--#{$table}__sticky-cell--m-border-left--before--BorderInlineStartWidth);
+    --#{$table}--cell--m-border-left--before--BorderInlineStartColor: var(--#{$table}__sticky-cell--m-border-left--before--BorderInlineStartColor);
   }
 
   &.pf-m-right,
   &.pf-m-inline-end {
-    --#{$table}__sticky-cell--Right: var(--#{$table}__sticky-cell--m-right--Right);
+    --#{$table}__sticky-cell--InlineEnd: var(--#{$table}__sticky-cell--m-right--InlineEnd);
   }
 
   &.pf-m-left,
   &.pf-m-inline-start {
-    --#{$table}__sticky-cell--Left: var(--#{$table}__sticky-cell--m-left--Left);
+    --#{$table}__sticky-cell--InlineStart: var(--#{$table}__sticky-cell--m-left--InlineStart);
   }
 }
 

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -24,7 +24,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
   // * Table tree view toggle
   --#{$table}--m-tree-view__toggle--Position: absolute;
-  --#{$table}--m-tree-view__toggle--InlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
+  --#{$table}--m-tree-view__toggle--InsetInlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
   --#{$table}--m-tree-view__toggle--TranslateX: -100%;
 
   // * Table tree view toggle toggle icon
@@ -38,7 +38,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 // - Table tree view
 .#{$table}.pf-m-tree-view {
   > tbody > tr {
-    --#{$table}--m-tree-view__toggle--InlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
+    --#{$table}--m-tree-view__toggle--InsetInlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
 
     &.pf-m-no-inset {
       --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}--m-no-inset__tree-view-main--PaddingInlineStart);
@@ -77,7 +77,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     );
 
     position: var(--#{$table}--m-tree-view__toggle--Position);
-    inset-inline-start: var(--#{$table}--m-tree-view__toggle--InlineStart);
+    inset-inline-start: var(--#{$table}--m-tree-view__toggle--InsetInlineStart);
 
     .#{$table}__toggle-icon {
       min-width: var(--#{$table}--m-tree-view__toggle__toggle-icon--MinWidth);

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -8,52 +8,52 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}__tree-view-main--nested-indent--base: calc(var(--#{$table}__tree-view-main--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it
 
   // * Table tree view main button
-  --#{$table}__tree-view-main--c-button--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__tree-view-main--c-button--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table tree view main
-  --#{$table}__tree-view-main--PaddingLeft: var(--#{$table}__tree-view-main--indent--base);
-  --#{$table}__tree-view-main--MarginLeft: calc(var(--#{$table}--cell--PaddingLeft) * -1);
+  --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}__tree-view-main--indent--base);
+  --#{$table}__tree-view-main--MarginInlineStart: calc(var(--#{$table}--cell--PaddingInlineStart) * -1);
 
   // * Table tree view check
-  --#{$table}__tree-view-main--c-table__check--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$table}__tree-view-main--c-table__check--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__tree-view-main--c-table__check--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__tree-view-main--c-table__check--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table tree view icon
   --#{$table}__tree-view-icon--MinWidth: var(--pf-t--global--spacer--md);
-  --#{$table}__tree-view-icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__tree-view-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table tree view toggle
   --#{$table}--m-tree-view__toggle--Position: absolute;
-  --#{$table}--m-tree-view__toggle--Left: var(--#{$table}__tree-view-main--PaddingLeft);
+  --#{$table}--m-tree-view__toggle--InlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
   --#{$table}--m-tree-view__toggle--TranslateX: -100%;
 
   // * Table tree view toggle toggle icon
   --#{$table}--m-tree-view__toggle__toggle-icon--MinWidth: var(--pf-t--global--spacer--md);
 
   // * Table tree view no inset tree view main
-  --#{$table}--m-no-inset__tree-view-main--PaddingLeft: 0;
-  --#{$table}--m-no-inset__tree-view-main--MarginLeft: 0;
+  --#{$table}--m-no-inset__tree-view-main--PaddingInlineStart: 0;
+  --#{$table}--m-no-inset__tree-view-main--MarginInlineStart: 0;
 }
 
 // - Table tree view
 .#{$table}.pf-m-tree-view {
   > tbody > tr {
-    --#{$table}--m-tree-view__toggle--Left: var(--#{$table}__tree-view-main--PaddingLeft);
+    --#{$table}--m-tree-view__toggle--InlineStart: var(--#{$table}__tree-view-main--PaddingInlineStart);
 
     &.pf-m-no-inset {
-      --#{$table}__tree-view-main--PaddingLeft: var(--#{$table}--m-no-inset__tree-view-main--PaddingLeft);
-      --#{$table}__tree-view-main--MarginLeft: var(--#{$table}--m-no-inset__tree-view-main--MarginLeft);
+      --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}--m-no-inset__tree-view-main--PaddingInlineStart);
+      --#{$table}__tree-view-main--MarginInlineStart: var(--#{$table}--m-no-inset__tree-view-main--MarginInlineStart);
     }
   }
 
   &.pf-m-no-inset {
-    --#{$table}__tree-view-main--PaddingLeft: var(--#{$table}--m-no-inset__tree-view-main--PaddingLeft);
-    --#{$table}__tree-view-main--MarginLeft: var(--#{$table}--m-no-inset__tree-view-main--MarginLeft);
+    --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}--m-no-inset__tree-view-main--PaddingInlineStart);
+    --#{$table}__tree-view-main--MarginInlineStart: var(--#{$table}--m-no-inset__tree-view-main--MarginInlineStart);
   }
 
   @for $i from 2 through $pf-v6-c-tree-view--MaxDepth {
     tr:where(.#{$table}__tr)[aria-level="#{$i}"] {
-      --#{$table}__tree-view-main--PaddingLeft: calc(var(--#{$table}__tree-view-main--nested-indent--base) * #{$i - 1} + var(--#{$table}__tree-view-main--indent--base));
+      --#{$table}__tree-view-main--PaddingInlineStart: calc(var(--#{$table}__tree-view-main--nested-indent--base) * #{$i - 1} + var(--#{$table}__tree-view-main--indent--base));
     }
   }
 }
@@ -64,8 +64,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   display: flex;
   align-items: baseline;
   min-width: 0;
-  padding-inline-start: var(--#{$table}__tree-view-main--PaddingLeft);
-  margin-inline-start: var(--#{$table}__tree-view-main--MarginLeft);
+  padding-inline-start: var(--#{$table}__tree-view-main--PaddingInlineStart);
+  margin-inline-start: var(--#{$table}__tree-view-main--MarginInlineStart);
   text-align: start;
   cursor: pointer;
 
@@ -77,7 +77,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     );
 
     position: var(--#{$table}--m-tree-view__toggle--Position);
-    inset-inline-start: var(--#{$table}--m-tree-view__toggle--Left);
+    inset-inline-start: var(--#{$table}--m-tree-view__toggle--InlineStart);
 
     .#{$table}__toggle-icon {
       min-width: var(--#{$table}--m-tree-view__toggle__toggle-icon--MinWidth);
@@ -85,21 +85,21 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     .#{$button} {
       margin-block-start: -50%;
-      margin-inline-end: var(--#{$table}__tree-view-main--c-button--MarginRight);
+      margin-inline-end: var(--#{$table}__tree-view-main--c-button--MarginInlineEnd);
     }
   }
 
 
   > .#{$table}__check {
-    margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginRight);
+    margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
   }
 
   > .#{$table}__check label {
-    padding-inline-end: var(--#{$table}__tree-view-main--c-table__check--PaddingRight);
+    padding-inline-end: var(--#{$table}__tree-view-main--c-table__check--PaddingInlineEnd);
     margin-block-start: 0;
     margin-block-end: 0;
     margin-inline-start: 0;
-    margin-inline-end: calc(var(--#{$table}__tree-view-main--c-table__check--MarginRight) * -1);
+    margin-inline-end: calc(var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd) * -1);
   }
 }
 
@@ -111,7 +111,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 // - Table tree view icon
 .#{$table}__tree-view-icon {
   min-width: var(--#{$table}__tree-view-icon--MinWidth);
-  margin-inline-end: var(--#{$table}__tree-view-icon--MarginRight);
+  margin-inline-end: var(--#{$table}__tree-view-icon--MarginInlineEnd);
 }
 
 // - Table tree view details toggle
@@ -154,44 +154,44 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}--m-tree-view-grid--tr--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
   // tbody cells
-  --#{$table}--m-tree-view-grid__tbody--cell--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}--m-tree-view-grid__tbody--cell--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$table}--m-tree-view-grid__tbody--cell--PaddingLeft: var(--#{$table}__tree-view-main--indent--base);
+  --#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: var(--#{$table}__tree-view-main--indent--base);
   --#{$table}--m-tree-view-grid__tbody--cell--GridColumnGap: var(--pf-t--global--spacer--sm);
 
   // action
-  --#{$table}--m-tree-view-grid--c-table__action--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}--m-tree-view-grid--c-table__action--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$table}--m-tree-view-grid--c-table__action--PaddingLeft: 0;
-  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingTop: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-tree-view-grid--c-table__action--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--m-tree-view-grid--c-table__action--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}--m-tree-view-grid--c-table__action--PaddingInlineStart: 0;
+  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart: var(--pf-t--global--spacer--xl);
 
   // details
-  --#{$table}--m-tree-view-grid--m-tree-view-details-expanded--PaddingBottom: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-tree-view-grid--m-tree-view-details-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
 
   // node cells
-  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingTop: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingBlockStart: var(--pf-t--global--spacer--xl);
   --#{$table}--m-tree-view-grid__td--data-label--GridTemplateColumns: repeat(auto-fit, minmax(150px, 1fr)); // use minmax func to contain possible text modifier width
-  --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBottom: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // main
-  --#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--MarginRight: 0;
+  --#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--MarginInlineEnd: 0;
   --#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--Order: 4;
 
   // text
-  --#{$table}__tree-view-text--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__tree-view-text--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // tbody cells
-  --#{$table}__tbody--cell--PaddingTop: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingTop);
-  --#{$table}__tbody--cell--PaddingBottom: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingBottom);
+  --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockStart);
+  --#{$table}__tbody--cell--PaddingBlockEnd: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockEnd);
 
   // toggle
-  --#{$table}__tree-view-details-toggle--MarginTop: calc(#{pf-size-prem(6px)} * -1);
-  --#{$table}__tree-view-details-toggle--MarginBottom: calc(#{pf-size-prem(6px)} * -1);
+  --#{$table}__tree-view-details-toggle--MarginBlockStart: calc(#{pf-size-prem(6px)} * -1);
+  --#{$table}__tree-view-details-toggle--MarginBlockEnd: calc(#{pf-size-prem(6px)} * -1);
 
   // toggle
-  --#{$table}--m-tree-view-grid--c-dropdown--MarginTop: calc(#{pf-size-prem(6px)} * -1);
-  --#{$table}--m-tree-view-grid--c-dropdown--MarginBottom: calc(#{pf-size-prem(6px)} * -1);
+  --#{$table}--m-tree-view-grid--c-dropdown--MarginBlockStart: calc(#{pf-size-prem(6px)} * -1);
+  --#{$table}--m-tree-view-grid--c-dropdown--MarginBlockEnd: calc(#{pf-size-prem(6px)} * -1);
 
   tbody:where(.#{$table}__tbody) tr:where(.#{$table}__tr) {
     position: relative;
@@ -202,7 +202,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
       position: absolute;
       inset-block-start: 0;
       inset-block-end: 0;
-      inset-inline-start: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingLeft);
+      inset-inline-start: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart);
       inset-inline-end: 0;
       content: '';
       border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
@@ -217,23 +217,23 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   // target node rows
   tr:where(.#{$table}__tr)[aria-expanded] {
     .#{$table}__tree-view-title-cell {
-      --#{$table}--cell--PaddingTop: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingTop);
+      --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingBlockStart);
     }
 
     .#{$table}__tree-view-title-cell ~ .#{$table}__action {
-      --#{$table}--cell--PaddingTop: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingTop);
+      --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart);
     }
   }
 
   td:where(.#{$table}__td):not(.#{$table}__tree-view-title-cell) {
-    --#{$table}--cell--PaddingTop: var(--#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingTop);
-    --#{$table}--cell--PaddingBottom: var(--#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBottom);
+    --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockStart);
+    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockEnd);
 
-    padding-inline-start: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingLeft);
+    padding-inline-start: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart);
   }
 
   .#{$table}__tree-view-text {
-    padding-inline-end: var(--#{$table}__tree-view-text--PaddingRight);
+    padding-inline-end: var(--#{$table}__tree-view-text--PaddingInlineEnd);
   }
 
   thead:where(.#{$table}__thead) th:where(.#{$table}__th) {
@@ -265,7 +265,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
   // - Table tree view tr tree view details expanded
   tr:where(.#{$table}__tr).pf-m-tree-view-details-expanded {
-    padding-block-end: var(--#{$table}--m-tree-view-grid--m-tree-view-details-expanded--PaddingBottom);
+    padding-block-end: var(--#{$table}--m-tree-view-grid--m-tree-view-details-expanded--PaddingBlockEnd);
 
     td:where(.#{$table}__td)[data-label] {
       display: grid;
@@ -286,16 +286,16 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   // - Table tree view action
   .#{$table}__action {
     --#{$table}--cell--Width: auto;
-    --#{$table}--m-tree-view-grid__tbody--cell--PaddingLeft: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingLeft);
-    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingTop: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingTop);
-    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBottom: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingBottom);
+    --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingInlineStart);
+    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingBlockStart);
+    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockEnd: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingBlockEnd);
 
     grid-row: 1;
     grid-column: 2;
 
     > .#{$dropdown} {
-      margin-block-start: var(--#{$table}--m-tree-view-grid--c-dropdown--MarginTop);
-      margin-block-end: var(--#{$table}--m-tree-view-grid--c-dropdown--MarginBottom);
+      margin-block-start: var(--#{$table}--m-tree-view-grid--c-dropdown--MarginBlockStart);
+      margin-block-end: var(--#{$table}--m-tree-view-grid--c-dropdown--MarginBlockEnd);
     }
   }
 
@@ -303,18 +303,18 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   .#{$table}__tree-view-main > .#{$table}__check {
     order: var(--#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--Order);
     margin-inline-start: auto;
-    margin-inline-end: var(--#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--MarginRight);
+    margin-inline-end: var(--#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--MarginInlineEnd);
   }
 
   // - Table tree view details toggle
   .#{$table}__tree-view-details-toggle {
-    margin-block-start: var(--#{$table}__tree-view-details-toggle--MarginTop);
-    margin-block-end: var(--#{$table}__tree-view-details-toggle--MarginBottom);
+    margin-block-start: var(--#{$table}__tree-view-details-toggle--MarginBlockStart);
+    margin-block-end: var(--#{$table}__tree-view-details-toggle--MarginBlockEnd);
   }
 
   @for $i from 2 through $pf-v6-c-tree-view--MaxDepth {
     tr:where(.#{$table}__tr)[aria-level="#{$i}"] {
-      --#{$table}--m-tree-view-grid__tbody--cell--PaddingLeft: calc(var(--#{$table}__tree-view-main--nested-indent--base) * #{$i - 1} + var(--#{$table}__tree-view-main--indent--base)); // indent, plus indent level, plus
+      --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: calc(var(--#{$table}__tree-view-main--nested-indent--base) * #{$i - 1} + var(--#{$table}__tree-view-main--indent--base)); // indent, plus indent level, plus
     }
   }
 }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -935,7 +935,7 @@
   // stylelint-disable
   > td,
   > th {
-    padding-top: 0;
+    padding-block-start: 0;
   }
 
   td:where(.#{$table}__td),

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -11,41 +11,41 @@
   // * Table caption
   --#{$table}__caption--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__caption--Color: var(--pf-t--global--text--color--subtle);
-  --#{$table}__caption--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$table}__caption--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$table}__caption--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // * Table thead cell
   --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // * Table thead toggle
-  --#{$table}__thead__toggle--PaddingBottom: var(--pf-t--global--spacer--xs);
+  --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // * Table body cell
-  --#{$table}__tbody--cell--PaddingTop: var(--#{$table}--cell--Padding--base);
-  --#{$table}__tbody--cell--PaddingBottom: var(--#{$table}--cell--Padding--base);
+  --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
+  --#{$table}__tbody--cell--PaddingBlockEnd: var(--#{$table}--cell--Padding--base);
   --#{$table}__tbody--cell--FontSize: var(--pf-t--global--font--size--body--default); // set this explicitly for input heights to calc properly
 
   // * Table tr
-  --#{$table}__tr--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}__tr--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$table}__tr--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}__tr--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   // TODO: update these in order of appearance in scss declarations
 
   // * Table cell
   --#{$table}--cell--Padding--base: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--PaddingTop: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingRight: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingBottom: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingLeft: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
   --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$table}--cell--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
   --#{$table}--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--sm);
-  --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingLeft: var(--#{$table}--cell--Padding--base);
+  --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
 
   // * Table cell - default variables
   --#{$table}--cell--MinWidth: 0;
@@ -57,17 +57,17 @@
   --#{$table}--cell--WordBreak: normal;
 
   // * Table cell border right
-  --#{$table}--cell--m-border-right--before--BorderRightWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}--cell--m-border-right--before--BorderRightColor: var(--pf-t--global--border--color--default);
-  --#{$table}--cell--m-border-left--before--BorderLeftWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}--cell--m-border-left--before--BorderLeftColor: var(--pf-t--global--border--color--default);
+  --#{$table}--cell--m-border-right--before--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}--cell--m-border-right--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
+  --#{$table}--cell--m-border-left--before--BorderInlineStartWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}--cell--m-border-left--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
 
   // * Table help
   --#{$table}--cell--m-help--MinWidth: 11ch;
 
   // * Table truncate
   --#{$table}--m-truncate--cell--MaxWidth: 1px;
-  --#{$table}--m-truncate--cell--MinWidth: calc(5ch + var(--#{$table}--cell--PaddingRight) + var(--#{$table}--cell--PaddingLeft));
+  --#{$table}--m-truncate--cell--MinWidth: calc(5ch + var(--#{$table}--cell--PaddingInlineEnd) + var(--#{$table}--cell--PaddingInlineStart));
 
   // * Table truncate
   --#{$table}--m-truncate__text--MinWidth: 5ch;
@@ -76,19 +76,19 @@
   --#{$table}--cell--hidden-visible--Display: table-cell;
 
   // * Table toggle
-  --#{$table}__toggle--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
   --#{$table}__toggle--c-button__toggle-icon--Transition: .2s ease-in 0s;
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
   // * Table button
-  --#{$table}__button--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}__button--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$table}__button--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$table}__button--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$table}__button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__button--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$table}__button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$table}__button--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$table}__button--OutlineOffset: calc(var(--pf-t--global--border--width--strong) * -1);
@@ -97,8 +97,8 @@
   --#{$table}__button--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
 
   // * Table check
-  --#{$table}__check--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$table}__check--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__check--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__check--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table favorite
   --#{$table}__favorite--c-button--FontSize: var(--pf-t--global--font--size--body--default);
@@ -110,31 +110,31 @@
   --#{$table}__tr--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // * Table action
-  --#{$table}__action--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__action--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table expandable row
   --#{$table}__expandable-row--Transition: var(--pf-t--global--transition);
 
   // * Table expandable row content
-  --#{$table}__expandable-row-content--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$table}__expandable-row-content--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$table}__expandable-row-content--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$table}__expandable-row-content--PaddingRight: var(--pf-t--global--spacer--md);
+  --#{$table}__expandable-row-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}__expandable-row-content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__expandable-row-content--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$table}__expandable-row-content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$table}__expandable-row-content--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // * Table control row
   --#{$table}__control-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$table}__control-row--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$table}__control-row__tbody--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$table}__control-row--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$table}__control-row__tbody--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   // * Table icon inline
-  --#{$table}__icon-inline--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$table}__icon-inline--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table sort cell
-  --#{$table}__sort--MinWidth: calc(6ch + var(--#{$table}--cell--PaddingRight) + var(--#{$table}--cell--PaddingLeft) + var(--#{$table}__sort-indicator--MarginLeft));
+  --#{$table}__sort--MinWidth: calc(6ch + var(--#{$table}--cell--PaddingInlineEnd) + var(--#{$table}--cell--PaddingInlineStart) + var(--#{$table}__sort-indicator--MarginInlineStart));
   --#{$table}__sort--m-selected__button--Color: var(--pf-t--global--color--brand--clicked);
   --#{$table}__sort--m-help--MinWidth: 15ch;
 
@@ -144,7 +144,7 @@
 
   // * Table sort indicator
   --#{$table}__sort-indicator--Color: var(--pf-t--global--icon--color--subtle);
-  --#{$table}__sort-indicator--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$table}__sort-indicator--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$table}__sort--m-selected__sort-indicator--Color: var(--pf-t--global--color--brand--clicked);
   --#{$table}__sort__button--hover__sort-indicator--Color: var(--pf-t--global--text--color--regular);
 
@@ -152,7 +152,7 @@
   --#{$table}__th--m-help--MinWidth: 11ch;
 
   // * Table header popover
-  --#{$table}__column-help--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$table}__column-help--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // * Table compound expansion toggle button
   --#{$table}__compound-expansion-toggle__button--Color: var(--pf-t--global--icon--color--brand--default);
@@ -163,27 +163,27 @@
 
   // * Table compound expansion toggle button after
   --#{$table}__compound-expansion-toggle__button--after--BorderColor: var(--pf-t--global--border--color--clicked);
-  --#{$table}__compound-expansion-toggle__button--after--BorderTopWidth: 0;
-  --#{$table}__compound-expansion-toggle__button--hover--after--BorderTopWidth: var(--pf-t--global--border--width--strong);
-  --#{$table}__compound-expansion-toggle--m-expanded__button--after--BorderTopWidth: var(--pf-t--global--border--width--strong);
+  --#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth: 0;
+  --#{$table}__compound-expansion-toggle__button--hover--after--BorderBlockStartWidth: var(--pf-t--global--border--width--strong);
+  --#{$table}__compound-expansion-toggle--m-expanded__button--after--BorderBlockStartWidth: var(--pf-t--global--border--width--strong);
 
   // * Compound expandable
   --#{$table}--compound-expansion--m-expanded--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
 
   // * Table compact th
-  --#{$table}--m-compact__th--PaddingTop: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
-  --#{$table}--m-compact__th--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact__th--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
+  --#{$table}--m-compact__th--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table compact cell
-  --#{$table}--m-compact--cell--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact--cell--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table compact action
-  --#{$table}--m-compact__action--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__action--PaddingBottom: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // * Table expandable row expanded
-  --#{$table}__expandable-row--m-expanded--BorderBottomColor: var(--pf-t--global--border--color--default);
+  --#{$table}__expandable-row--m-expanded--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
   // * Table tr clickable
   --#{$table}__tr--m-clickable--BackgroundColor: transparent;
@@ -206,15 +206,15 @@
 
   // * Table nested column header
   --#{$table}__thead--m-nested-column-header--button--OutlineOffset: #{pf-size-prem(-3px)};
-  --#{$table}__thead--m-nested-column-header__tr--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$table}__thead--m-nested-column-header__tr--PaddingBottom: var(--pf-t--global--spacer--md);
+  --#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
   // * Table subhead
   --#{$table}__subhead--Color: var(--pf-t--global--text--color--subtle);
 
   // * Table subhead button
-  --#{$table}__nested-column-header__button--PaddingLeft: calc(var(--#{$table}__button--PaddingLeft) - var(--pf-t--global--spacer--sm));
-  --#{$table}__nested-column-header__button--PaddingRight: calc(var(--#{$table}__button--PaddingRight) - var(--pf-t--global--spacer--xs));
+  --#{$table}__nested-column-header__button--PaddingInlineStart: calc(var(--#{$table}__button--PaddingInlineStart) - var(--pf-t--global--spacer--sm));
+  --#{$table}__nested-column-header__button--PaddingInlineEnd: calc(var(--#{$table}__button--PaddingInlineEnd) - var(--pf-t--global--spacer--xs));
 
   // * Table striped
   --#{$table}--m-striped__tr--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
@@ -283,7 +283,7 @@
       th:where(.#{$table}__th),
       td:where(.#{$table}__td) {
         &:not([rowspan]) {
-          --#{$table}--cell--PaddingBottom: var(--#{$table}__thead--m-nested-column-header__tr--PaddingBottom);
+          --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd);
         }
       }
       // stylelint-enable
@@ -321,10 +321,10 @@
     width: var(--#{$table}--cell--Width);
     min-width: var(--#{$table}--cell--MinWidth);
     max-width: var(--#{$table}--cell--MaxWidth);
-    padding-block-start: var(--#{$table}--cell--PaddingTop);
-    padding-block-end: var(--#{$table}--cell--PaddingBottom);
-    padding-inline-start: var(--#{$table}--cell--PaddingLeft);
-    padding-inline-end: var(--#{$table}--cell--PaddingRight);
+    padding-block-start: var(--#{$table}--cell--PaddingBlockStart);
+    padding-block-end: var(--#{$table}--cell--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}--cell--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}--cell--PaddingInlineEnd);
 
     // default settings
     overflow: var(--#{$table}--cell--Overflow);
@@ -338,12 +338,12 @@
 
     // First child padding left
     &:first-child {
-      padding-inline-start: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingLeft));
+      padding-inline-start: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingInlineStart));
     }
 
     // Last child padding right
     &:last-child {
-      padding-inline-end: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingRight));
+      padding-inline-end: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingInlineEnd));
     }
 
     &.pf-m-center {
@@ -376,19 +376,19 @@
     }
 
     &.pf-m-border-right::before {
-      border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderRightWidth) solid var(--#{$table}--cell--m-border-right--before--BorderRightColor);
+      border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderInlineEndWidth) solid var(--#{$table}--cell--m-border-right--before--BorderInlineEndColor);
     }
 
     &.pf-m-border-left::before {
-      border-inline-start: var(--#{$table}--cell--m-border-left--before--BorderLeftWidth) solid var(--#{$table}--cell--m-border-left--before--BorderLeftColor);
+      border-inline-start: var(--#{$table}--cell--m-border-left--before--BorderInlineStartWidth) solid var(--#{$table}--cell--m-border-left--before--BorderInlineStartColor);
     }
   }
 
   // - Table caption
   caption:where(.#{$table}__caption) {
-    padding-block-start: var(--#{$table}__caption--PaddingTop);
-    padding-block-end: var(--#{$table}__caption--PaddingBottom);
-    padding-inline-start: var(--#{$table}__caption--PaddingLeft);
+    padding-block-start: var(--#{$table}__caption--PaddingBlockStart);
+    padding-block-end: var(--#{$table}__caption--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}__caption--PaddingInlineStart);
     font-size: var(--#{$table}__caption--FontSize);
     color: var(--#{$table}__caption--Color);
     text-align: start;
@@ -410,7 +410,7 @@
         th:where(.#{$table}__th),
         td:where(.#{$table}__td) {
           &:not([rowspan]) {
-            --#{$table}--cell--PaddingTop: var(--#{$table}__thead--m-nested-column-header__tr--PaddingTop);
+            --#{$table}--cell--PaddingBlockStart: var(--#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart);
           }
         }
       }
@@ -428,8 +428,8 @@
   // - Table tbody
   // stylelint-disable
   tbody:where(.#{$table}__tbody) {
-    --#{$table}--cell--PaddingTop: var(--#{$table}__tbody--cell--PaddingTop);
-    --#{$table}--cell--PaddingBottom: var(--#{$table}__tbody--cell--PaddingBottom);
+    --#{$table}--cell--PaddingBlockStart: var(--#{$table}__tbody--cell--PaddingBlockStart);
+    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__tbody--cell--PaddingBlockEnd);
     --#{$table}--cell--FontSize: var(--#{$table}__tbody--cell--FontSize);
 
     > tr:where(.#{$table}__tr) > :where(th, td) {
@@ -509,10 +509,10 @@
 
   // stylelint-disable selector-no-qualifying-type, selector-max-compound-selectors
   &.pf-m-no-border-rows > tbody:where(.#{$table}__tbody) {
-    --#{$table}__tr--BorderBottomWidth: 0;
-    --#{$table}__tbody--BorderBottomWidth: 0;
-    --#{$table}--m-expandable__tbody--BorderBottomWidth: 0;
-    --#{$table}__control-row--BorderBottomWidth: 0;
+    --#{$table}__tr--BorderBlockEndWidth: 0;
+    --#{$table}__tbody--BorderBlockEndWidth: 0;
+    --#{$table}--m-expandable__tbody--BorderBlockEndWidth: 0;
+    --#{$table}__control-row--BorderBlockEndWidth: 0;
 
     > tr:where(.#{$table}__tr) {
       border-block-end: 0;
@@ -547,7 +547,7 @@
     }
 
     &.pf-m-first-cell-offset-reset > :first-child {
-      padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingLeft);
+      padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart);
     }
   }
 
@@ -621,12 +621,12 @@
 // - Table button
 .#{$table}__button {
   width: auto;
-  padding-block-start: var(--#{$table}__button--PaddingTop);
-  padding-block-end: var(--#{$table}__button--PaddingBottom);
-  padding-inline-start: var(--#{$table}__button--PaddingLeft);
-  padding-inline-end: var(--#{$table}__button--PaddingRight);
-  margin-block-end: calc(var(--#{$table}__button--PaddingBottom) * -1);
-  margin-inline-start: calc(var(--#{$table}__button--PaddingLeft) * -1);
+  padding-block-start: var(--#{$table}__button--PaddingBlockStart);
+  padding-block-end: var(--#{$table}__button--PaddingBlockEnd);
+  padding-inline-start: var(--#{$table}__button--PaddingInlineStart);
+  padding-inline-end: var(--#{$table}__button--PaddingInlineEnd);
+  margin-block-end: calc(var(--#{$table}__button--PaddingBlockEnd) * -1);
+  margin-inline-start: calc(var(--#{$table}__button--PaddingInlineStart) * -1);
   font-size: inherit;
   font-weight: inherit;
   color: var(--#{$table}__button--Color);
@@ -712,10 +712,10 @@
 
 // - Table toggle
 .#{$table}__toggle {
-  --#{$table}--cell--PaddingTop: var(--#{$table}__toggle--PaddingTop);
-  --#{$table}--cell--PaddingBottom: var(--#{$table}__toggle--PaddingBottom);
-  --#{$table}--cell--PaddingLeft: var(--#{$table}__toggle--PaddingLeft);
-  --#{$table}--cell--PaddingRight: var(--#{$table}__toggle--PaddingRight);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}__toggle--PaddingBlockStart);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__toggle--PaddingBlockEnd);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__toggle--PaddingInlineStart);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__toggle--PaddingInlineEnd);
 
   .#{$button} {
     &.pf-m-expanded .#{$table}__toggle-icon {
@@ -738,8 +738,8 @@
 
 // - Table check
 .#{$table}__check {
-  --#{$table}--cell--PaddingLeft: var(--#{$table}__check--PaddingLeft);
-  --#{$table}--cell--PaddingRight: var(--#{$table}__check--PaddingRight);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__check--PaddingInlineStart);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__check--PaddingInlineEnd);
 
   vertical-align: top;
 
@@ -799,10 +799,10 @@
 .#{$table}__favorite,
 .#{$table}__inline-edit-action,
 .#{$table}__draggable {
-  --#{$table}--cell--PaddingTop: var(--#{$table}__action--PaddingTop);
-  --#{$table}--cell--PaddingBottom: var(--#{$table}__action--PaddingBottom);
-  --#{$table}--cell--PaddingLeft: var(--#{$table}__action--PaddingLeft);
-  --#{$table}--cell--PaddingRight: var(--#{$table}__action--PaddingRight);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}__action--PaddingBlockStart);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__action--PaddingBlockEnd);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__action--PaddingInlineStart);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__action--PaddingInlineEnd);
 }
 
 // - Table action - Table inline edit action
@@ -846,18 +846,18 @@
     inset: 0;
     content: '';
     border: 0;
-    border-block-start: var(--#{$table}__compound-expansion-toggle__button--after--BorderTopWidth) solid var(--#{$table}__compound-expansion-toggle__button--after--BorderColor);
+    border-block-start: var(--#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth) solid var(--#{$table}__compound-expansion-toggle__button--after--BorderColor);
   }
 
   &:hover,
   &:focus-within {
     --#{$table}__compound-expansion-toggle__button--BackgroundColor: var(--#{$table}__compound-expansion-toggle__button--hover--BackgroundColor);
-    --#{$table}__compound-expansion-toggle__button--after--BorderTopWidth: var(--#{$table}__compound-expansion-toggle__button--hover--after--BorderTopWidth);
+    --#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth: var(--#{$table}__compound-expansion-toggle__button--hover--after--BorderBlockStartWidth);
   }
 
   &.pf-m-expanded {
     --#{$table}__compound-expansion-toggle__button--BackgroundColor: var(--#{$table}__compound-expansion-toggle__button--expanded--BackgroundColor);
-    --#{$table}__compound-expansion-toggle__button--after--BorderTopWidth: var(--#{$table}__compound-expansion-toggle--m-expanded__button--after--BorderTopWidth);
+    --#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth: var(--#{$table}__compound-expansion-toggle--m-expanded__button--after--BorderBlockStartWidth);
   }
 
   &:focus-within {
@@ -874,7 +874,7 @@
 
 // - Table column help action
 .#{$table}__column-help-action {
-  margin-inline-start: var(--#{$table}__column-help--MarginLeft);
+  margin-inline-start: var(--#{$table}__column-help--MarginInlineStart);
 }
 
 // - Table sort
@@ -917,7 +917,7 @@
 .#{$table}__sort-indicator {
   grid-column: 2;
   align-self: end;
-  margin-inline-start: var(--#{$table}__sort-indicator--MarginLeft); // TODO: update this to gap
+  margin-inline-start: var(--#{$table}__sort-indicator--MarginInlineStart); // TODO: update this to gap
   color: var(--#{$table}__sort-indicator--Color);
   pointer-events: none;
 }
@@ -955,16 +955,16 @@
 
   // - Table expandable row content
   .#{$table}__expandable-row-content {
-    padding-block-start: var(--#{$table}__expandable-row-content--PaddingTop);
-    padding-block-end: var(--#{$table}__expandable-row-content--PaddingBottom);
-    padding-inline-start: var(--#{$table}__expandable-row-content--PaddingLeft);
-    padding-inline-end: var(--#{$table}__expandable-row-content--PaddingRight);
+    padding-block-start: var(--#{$table}__expandable-row-content--PaddingBlockStart);
+    padding-block-end: var(--#{$table}__expandable-row-content--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}__expandable-row-content--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}__expandable-row-content--PaddingInlineEnd);
     border-radius: var(--#{$table}__expandable-row-content--BorderRadius);
   }
 
   // - Table expandable row content expanded
   &.pf-m-expanded {
-    border-block-end-color: var(--#{$table}__expandable-row--m-expanded--BorderBottomColor);
+    border-block-end-color: var(--#{$table}__expandable-row--m-expanded--BorderBlockEndColor);
     border-block-end-width: var(--#{$table}--border-width--base);
   }
 
@@ -980,14 +980,14 @@
 
 // - Table compact
 .#{$table}.pf-m-compact {
-  --#{$table}--cell--PaddingTop: var(--#{$table}--m-compact--cell--PaddingTop);
-  --#{$table}--cell--PaddingBottom: var(--#{$table}--m-compact--cell--PaddingBottom);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact--cell--PaddingBlockStart);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact--cell--PaddingBlockEnd);
 
   // - Table compact table tr
   tr:where(.#{$table}__tr) {
     &:not(.#{$table}__expandable-row) {
-      --#{$table}--cell--PaddingTop: var(--#{$table}--m-compact--cell--PaddingTop);
-      --#{$table}--cell--PaddingBottom: var(--#{$table}--m-compact--cell--PaddingBottom);
+      --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact--cell--PaddingBlockStart);
+      --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact--cell--PaddingBlockEnd);
     }
   }
 
@@ -995,8 +995,8 @@
   thead:where(.#{$table}__thead) {
     th:where(.#{$table}__th),
     .#{$table}__toggle {
-      --#{$table}--cell--PaddingTop: var(--#{$table}--m-compact__th--PaddingTop);
-      --#{$table}--cell--PaddingBottom: var(--#{$table}--m-compact__th--PaddingBottom);
+      --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__th--PaddingBlockStart);
+      --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__th--PaddingBlockEnd);
     }
   }
 
@@ -1004,8 +1004,8 @@
   .#{$table}__favorite,
   .#{$table}__toggle,
   .#{$table}__draggable {
-    --#{$table}--cell--PaddingTop: var(--#{$table}--m-compact__action--PaddingTop);
-    --#{$table}--cell--PaddingBottom: var(--#{$table}--m-compact__action--PaddingBottom);
+    --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
+    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
   }
 
   .#{$table}__icon {
@@ -1017,19 +1017,19 @@
 
 // - Table thead
 .#{$table}__thead {
-  --#{$table}__tr--BorderBottomWidth: 0;
-  --#{$table}__toggle--PaddingBottom: var(--#{$table}__thead__toggle--PaddingBottom);
+  --#{$table}__tr--BorderBlockEndWidth: 0;
+  --#{$table}__toggle--PaddingBlockEnd: var(--#{$table}__thead__toggle--PaddingBlockEnd);
 
   vertical-align: bottom;
 
   // - Table nested column header button
   &.pf-m-nested-column-header {
     .#{$table}__button {
-      --#{$table}__button--PaddingLeft: var(--#{$table}__nested-column-header__button--PaddingLeft);
-      --#{$table}__button--PaddingRight: var(--#{$table}__nested-column-header__button--PaddingRight);
+      --#{$table}__button--PaddingInlineStart: var(--#{$table}__nested-column-header__button--PaddingInlineStart);
+      --#{$table}__button--PaddingInlineEnd: var(--#{$table}__nested-column-header__button--PaddingInlineEnd);
 
       // margin to align with thead padding
-      margin-inline-end: calc(var(--#{$table}__button--PaddingLeft) * -1);
+      margin-inline-end: calc(var(--#{$table}__button--PaddingInlineStart) * -1);
     }
   }
 }
@@ -1052,24 +1052,24 @@
 
   // - Table tbody
   .#{$table}__tbody {
-    border-block-end: var(--#{$table}__tr--BorderBottomWidth) solid var(--#{$table}__tr--BorderBottomColor);
+    border-block-end: var(--#{$table}__tr--BorderBlockEndWidth) solid var(--#{$table}__tr--BorderBlockEndColor);
   }
 
   // - Table tbody - Table tr
   .#{$table}__tbody.pf-m-expanded {
-    border-block-end: var(--#{$table}__tr--BorderBottomWidth) solid var(--#{$table}__tr--BorderBottomColor);
+    border-block-end: var(--#{$table}__tr--BorderBlockEndWidth) solid var(--#{$table}__tr--BorderBlockEndColor);
 
     // - Table tbody table control row
     .#{$table}__control-row {
       background-color: var(--#{$table}__control-row--BackgroundColor);
-      border-block-end: var(--#{$table}__control-row--BorderBottomWidth) solid var(--#{$table}__control-row__tbody--BorderBottomColor);
+      border-block-end: var(--#{$table}__control-row--BorderBlockEndWidth) solid var(--#{$table}__control-row__tbody--BorderBlockEndColor);
     }
   }
 }
 
 // - Table tr
 .#{$table}__tr {
-  border-block-end: var(--#{$table}__tr--BorderBottomWidth) solid var(--#{$table}__tr--BorderBottomColor);
+  border-block-end: var(--#{$table}__tr--BorderBlockEndWidth) solid var(--#{$table}__tr--BorderBlockEndColor);
 
   .#{$table}__thead & {
     border-block-end: 0;
@@ -1086,7 +1086,7 @@
   align-items: center;
 
   > :not(:last-child) {
-    margin-inline-end: var(--#{$table}__icon-inline--MarginRight);
+    margin-inline-end: var(--#{$table}__icon-inline--MarginInlineEnd);
   }
 }
 

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -13,7 +13,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier
         table--scrollable--th--content=cell-2--content
         table-th--IsStickyLeft=true
-        table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 80px; --pf-v6-c-table__sticky-cell--InlineStart: 100px;"'}}
+        table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 80px; --pf-v6-c-table__sticky-cell--InsetInlineStart: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -13,7 +13,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier
         table--scrollable--th--content=cell-2--content
         table-th--IsStickyLeft=true
-        table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 80px; --pf-v6-c-table__sticky-cell--Left: 100px;"'}}
+        table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 80px; --pf-v6-c-table__sticky-cell--InlineStart: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -10,7 +10,7 @@
     {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--IsSortable=true}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--Left: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--InlineStart: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--IsSortable=true}}
   {{/if}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -10,7 +10,7 @@
     {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--IsSortable=true}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--InlineStart: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--InsetInlineStart: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--IsSortable=true}}
   {{/if}}

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -8,10 +8,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--Width: auto;
   --#{$tabs}--before--BorderColor: var(--pf-t--global--border--color--default);
   --#{$tabs}--before--border-width--base: var(--pf-t--global--border--width--regular);
-  --#{$tabs}--before--BorderTopWidth: 0;
-  --#{$tabs}--before--BorderRightWidth: 0;
-  --#{$tabs}--before--BorderBottomWidth: var(--#{$tabs}--before--border-width--base);
-  --#{$tabs}--before--BorderLeftWidth: 0;
+  --#{$tabs}--before--BorderBlockStartWidth: 0;
+  --#{$tabs}--before--BorderInlineEndWidth: 0;
+  --#{$tabs}--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
+  --#{$tabs}--before--BorderInlineStartWidth: 0;
   --#{$tabs}--m-vertical--inset: var(--pf-t--global--spacer--sm);
 
   // Tabs, Page insets modifier
@@ -22,14 +22,14 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical--MaxWidth: #{pf-size-prem(250px)};
   --#{$tabs}--m-vertical--m-box--inset: var(--pf-t--global--spacer--md);
   --#{$tabs}--m-vertical__list--before--BorderColor: var(--#{$tabs}--before--BorderColor);
-  --#{$tabs}--m-vertical__list--before--BorderTopWidth: 0;
-  --#{$tabs}--m-vertical__list--before--BorderRightWidth: 0;
-  --#{$tabs}--m-vertical__list--before--BorderBottomWidth: 0;
-  --#{$tabs}--m-vertical__list--before--BorderLeftWidth: var(--#{$tabs}--before--border-width--base);
+  --#{$tabs}--m-vertical__list--before--BorderBlockStartWidth: 0;
+  --#{$tabs}--m-vertical__list--before--BorderInlineEndWidth: 0;
+  --#{$tabs}--m-vertical__list--before--BorderBlockEndWidth: 0;
+  --#{$tabs}--m-vertical__list--before--BorderInlineStartWidth: var(--#{$tabs}--before--border-width--base);
 
   // Tabs, Box modifier
-  --#{$tabs}--m-box__item--m-current--first-child__link--before--BorderLeftWidth: var(--#{$tabs}__link--before--border-width--base);
-  --#{$tabs}--m-box__item--m-current--last-child__link--before--BorderRightWidth: var(--#{$tabs}--before--border-width--base);
+  --#{$tabs}--m-box__item--m-current--first-child__link--before--BorderInlineStartWidth: var(--#{$tabs}__link--before--border-width--base);
+  --#{$tabs}--m-box__item--m-current--last-child__link--before--BorderInlineEndWidth: var(--#{$tabs}--before--border-width--base);
 
   // Tabs List
   --#{$tabs}__list--Display: flex;
@@ -55,18 +55,18 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}__link--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$tabs}__link--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$tabs}__link--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$tabs}__link--PaddingBottom: var(--pf-t--global--spacer--xs);
-  --#{$tabs}__link--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$tabs}__link--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$tabs}__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$tabs}__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$tabs}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$tabs}__link--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$tabs}__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}__item--m-current__link--Color: var(--pf-t--global--text--color--regular);
   --#{$tabs}__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}--m-vertical__link--PaddingLeft: var(--pf-t--global--spacer--sm);
-  --#{$tabs}--m-vertical__link--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$tabs}--m-vertical__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$tabs}--m-vertical__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tabs}--m-box__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box__link--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$tabs}--m-box__link--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
@@ -82,28 +82,28 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   // Link before
   --#{$tabs}__link--before--border-color--base: var(--pf-t--global--border--color--default);
   --#{$tabs}__link--before--border-width--base: var(--pf-t--global--border--width--regular);
-  --#{$tabs}__link--before--BorderTopColor: var(--#{$tabs}__link--before--border-color--base);
-  --#{$tabs}__link--before--BorderRightColor: var(--#{$tabs}__link--before--border-color--base);
-  --#{$tabs}__link--before--BorderBottomColor: var(--#{$tabs}__link--before--border-color--base);
-  --#{$tabs}__link--before--BorderLeftColor: var(--#{$tabs}__link--before--border-color--base);
-  --#{$tabs}__link--before--BorderTopWidth: 0;
-  --#{$tabs}__link--before--BorderRightWidth: 0;
-  --#{$tabs}__link--before--BorderBottomWidth: 0;
-  --#{$tabs}__link--before--BorderLeftWidth: 0;
-  --#{$tabs}__link--before--Left: calc(var(--#{$tabs}__link--before--border-width--base) * -1);
-  --#{$tabs}__link--disabled--before--BorderRightWidth: 0;
-  --#{$tabs}__link--disabled--before--BorderBottomWidth: var(--#{$tabs}--before--border-width--base);
-  --#{$tabs}__link--disabled--before--BorderLeftWidth: 0;
+  --#{$tabs}__link--before--BorderBlockStartColor: var(--#{$tabs}__link--before--border-color--base);
+  --#{$tabs}__link--before--BorderInlineEndColor: var(--#{$tabs}__link--before--border-color--base);
+  --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}__link--before--border-color--base);
+  --#{$tabs}__link--before--BorderInlineStartColor: var(--#{$tabs}__link--before--border-color--base);
+  --#{$tabs}__link--before--BorderBlockStartWidth: 0;
+  --#{$tabs}__link--before--BorderInlineEndWidth: 0;
+  --#{$tabs}__link--before--BorderBlockEndWidth: 0;
+  --#{$tabs}__link--before--BorderInlineStartWidth: 0;
+  --#{$tabs}__link--before--InlineStart: calc(var(--#{$tabs}__link--before--border-width--base) * -1);
+  --#{$tabs}__link--disabled--before--BorderInlineEndWidth: 0;
+  --#{$tabs}__link--disabled--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
+  --#{$tabs}__link--disabled--before--BorderInlineStartWidth: 0;
 
   // Link after
-  --#{$tabs}__link--after--Top: auto;
-  --#{$tabs}__link--after--Right: 0;
-  --#{$tabs}__link--after--Bottom: 0;
+  --#{$tabs}__link--after--BlockStart: auto;
+  --#{$tabs}__link--after--InlineEnd: 0;
+  --#{$tabs}__link--after--BlockEnd: 0;
   --#{$tabs}__link--after--BorderColor: var(--pf-t--global--border--color--default);
   --#{$tabs}__link--after--BorderWidth: 0;
-  --#{$tabs}__link--after--BorderTopWidth: 0;
-  --#{$tabs}__link--after--BorderRightWidth: 0;
-  --#{$tabs}__link--after--BorderLeftWidth: 0;
+  --#{$tabs}__link--after--BorderBlockStartWidth: 0;
+  --#{$tabs}__link--after--BorderInlineEndWidth: 0;
+  --#{$tabs}__link--after--BorderInlineStartWidth: 0;
   --#{$tabs}__item--m-current__link--after--BorderColor: var(--pf-t--global--border--color--clicked);
   --#{$tabs}__item--m-current__link--after--BorderWidth: var(--pf-t--global--border--width--extra-strong);
 
@@ -120,9 +120,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   // Scroll buttons before
   --#{$tabs}__scroll-button--before--BorderColor: var(--#{$tabs}--before--BorderColor);
   --#{$tabs}__scroll-button--before--border-width--base: var(--pf-t--global--border--width--regular);
-  --#{$tabs}__scroll-button--before--BorderRightWidth: 0;
-  --#{$tabs}__scroll-button--before--BorderBottomWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
-  --#{$tabs}__scroll-button--before--BorderLeftWidth: 0;
+  --#{$tabs}__scroll-button--before--BorderInlineEndWidth: 0;
+  --#{$tabs}__scroll-button--before--BorderBlockEndWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
+  --#{$tabs}__scroll-button--before--BorderInlineStartWidth: 0;
 
   // Scroll snap
   --#{$tabs}__list--ScrollSnapTypeAxis: x;
@@ -136,8 +136,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__toggle-icon--Color: currentcolor;
   --#{$tabs}__toggle-icon--Transition: all 250ms cubic-bezier(.42, 0, .58, 1);
   --#{$tabs}__toggle-icon--Rotate: 0;
-  --#{$tabs}__toggle-text--MarginLeft: 0;
-  --#{$tabs}__toggle-button__toggle-text--MarginLeft: var(--pf-t--global--spacer--md);
+  --#{$tabs}__toggle-text--MarginInlineStart: 0;
+  --#{$tabs}__toggle-button__toggle-text--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$tabs}__toggle-button__toggle-text--Color: var(--pf-t--global--text--color--regular);
   --#{$tabs}--m-expanded__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$tabs}--m-expanded__toggle-icon--Rotate: 90deg;
@@ -150,11 +150,11 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   // Item action
   --#{$tabs}__item-action--c-button--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}--m-subtab__item-action--c-button--FontSize: var(--pf-t--global--font--size--xs);
-  --#{$tabs}__item-action-icon--MarginTop: #{pf-size-prem(2px)};
+  --#{$tabs}__item-action-icon--MarginBlockStart: #{pf-size-prem(2px)};
 
   // Add button
   --#{$tabs}__add--before--BorderColor: var(--#{$tabs}__link--before--border-color--base);
-  --#{$tabs}__add--before--BorderLeftWidth: var(--#{$tabs}__link--before--border-width--base);
+  --#{$tabs}__add--before--BorderInlineStartWidth: var(--#{$tabs}__link--before--border-width--base);
   --#{$tabs}__add--c-button--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}--m-subtab__add--c-button--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}__add--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -184,10 +184,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     inset-inline-start: 0;
     inset-inline-end: 0;
     border: solid var(--#{$tabs}--before--BorderColor);
-    border-block-start-width: var(--#{$tabs}--before--BorderTopWidth);
-    border-block-end-width: var(--#{$tabs}--before--BorderBottomWidth);
-    border-inline-start-width: var(--#{$tabs}--before--BorderLeftWidth);
-    border-inline-end-width: var(--#{$tabs}--before--BorderRightWidth);
+    border-block-start-width: var(--#{$tabs}--before--BorderBlockStartWidth);
+    border-block-end-width: var(--#{$tabs}--before--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$tabs}--before--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$tabs}--before--BorderInlineEndWidth);
   }
 
   // Filled style
@@ -200,11 +200,11 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
       flex-grow: 1;
 
       &:first-child {
-        --#{$tabs}--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+        --#{$tabs}--m-box__item--m-current--first-child__link--before--BorderInlineStartWidth: 0;
       }
 
       &:last-child {
-        --#{$tabs}--m-box__item--m-current--last-child__link--before--BorderRightWidth: 0;
+        --#{$tabs}--m-box__item--m-current--last-child__link--before--BorderInlineEndWidth: 0;
       }
     }
 
@@ -233,15 +233,15 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 
   &.pf-m-no-border-bottom {
-    --#{$tabs}--before--BorderBottomWidth: 0;
-    --#{$tabs}__link--disabled--before--BorderBottomWidth: 0;
+    --#{$tabs}--before--BorderBlockEndWidth: 0;
+    --#{$tabs}__link--disabled--before--BorderBlockEndWidth: 0;
   }
 
   // Remove bottom border for variants
   &.pf-m-box,
   &.pf-m-vertical {
     .#{$tabs}__link {
-      --#{$tabs}__link--after--BorderBottomWidth: 0;
+      --#{$tabs}__link--after--BorderBlockEndWidth: 0;
     }
   }
 
@@ -254,33 +254,33 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__link--disabled--BackgroundColor: var(--#{$tabs}--m-box__link--disabled--BackgroundColor);
     --#{$tabs}__link--hover--BackgroundColor: var(--#{$tabs}--m-box__link--hover--BackgroundColor);
     --#{$tabs}__item--m-current__link--BackgroundColor: var(--#{$tabs}--m-box__item--m-current__link--BackgroundColor);
-    --#{$tabs}__link--before--BorderBottomWidth: var(--#{$tabs}__link--before--border-width--base);
-    --#{$tabs}__link--after--Top: 0;
-    --#{$tabs}__link--after--Bottom: auto;
+    --#{$tabs}__link--before--BorderBlockEndWidth: var(--#{$tabs}__link--before--border-width--base);
+    --#{$tabs}__link--after--BlockStart: 0;
+    --#{$tabs}__link--after--BlockEnd: auto;
 
     .#{$tabs}__link {
-      --#{$tabs}__link--after--BorderTopWidth: var(--#{$tabs}__link--after--BorderWidth);
+      --#{$tabs}__link--after--BorderBlockStartWidth: var(--#{$tabs}__link--after--BorderWidth);
     }
 
     // Remove border from last-child
     .#{$tabs}__item:last-child {
-      --#{$tabs}__link--before--BorderRightWidth: 0;
+      --#{$tabs}__link--before--BorderInlineEndWidth: 0;
     }
 
     .#{$tabs}__item.pf-m-current {
       --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__item--m-current__link--BackgroundColor);
-      --#{$tabs}__link--before--BorderBottomColor: var(--#{$tabs}__link--BackgroundColor);
+      --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}__link--BackgroundColor);
     }
 
     // stylelint-disable
     // Add border to first-child
     .#{$tabs}__item.pf-m-current:first-child .#{$tabs}__link::before {
-      border-inline-start-width: var(--#{$tabs}--m-box__item--m-current--first-child__link--before--BorderLeftWidth);
+      border-inline-start-width: var(--#{$tabs}--m-box__item--m-current--first-child__link--before--BorderInlineStartWidth);
     }
 
     // Add border to last-child
     .#{$tabs}__item.pf-m-current:last-child .#{$tabs}__link::before {
-      border-inline-end-width: var(--#{$tabs}--m-box__item--m-current--last-child__link--before--BorderRightWidth);
+      border-inline-end-width: var(--#{$tabs}--m-box__item--m-current--last-child__link--before--BorderInlineEndWidth);
     }
 
     // Collapse left border into scroll button when expanded
@@ -297,7 +297,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     // stylelint-disable selector-max-class
     // Remove offset from current adjacent item
     .#{$tabs}__item.pf-m-current + .#{$tabs}__item {
-      --#{$tabs}__link--before--Left: 0;
+      --#{$tabs}__link--before--InlineStart: 0;
     }
     // stylelint-enable
 
@@ -316,17 +316,17 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   &.pf-m-vertical {
     --#{$tabs}--Width: var(--#{$tabs}--m-vertical--Width);
     --#{$tabs}--inset: var(--#{$tabs}--m-vertical--inset);
-    --#{$tabs}--before--BorderBottomWidth: 0;
+    --#{$tabs}--before--BorderBlockEndWidth: 0;
     --#{$tabs}__item--PaddingInlineStart: var(--#{$tabs}--m-vertical__item--PaddingInlineStart);
     --#{$tabs}__item--PaddingInlineEnd: var(--#{$tabs}--m-vertical__item--PaddingInlineEnd);
-    --#{$tabs}__link--PaddingLeft: var(--#{$tabs}--m-vertical__link--PaddingLeft);
-    --#{$tabs}__link--PaddingRight: var(--#{$tabs}--m-vertical__link--PaddingRight);
-    --#{$tabs}__link--before--Left: 0;
-    --#{$tabs}__link--disabled--before--BorderBottomWidth: 0;
-    --#{$tabs}__link--disabled--before--BorderLeftWidth: var(--#{$tabs}--before--border-width--base);
-    --#{$tabs}__link--after--Top: 0;
-    --#{$tabs}__link--after--Bottom: 0;
-    --#{$tabs}__link--after--Right: auto;
+    --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-vertical__link--PaddingInlineStart);
+    --#{$tabs}__link--PaddingInlineEnd: var(--#{$tabs}--m-vertical__link--PaddingInlineEnd);
+    --#{$tabs}__link--before--InlineStart: 0;
+    --#{$tabs}__link--disabled--before--BorderBlockEndWidth: 0;
+    --#{$tabs}__link--disabled--before--BorderInlineStartWidth: var(--#{$tabs}--before--border-width--base);
+    --#{$tabs}__link--after--BlockStart: 0;
+    --#{$tabs}__link--after--BlockEnd: 0;
+    --#{$tabs}__link--after--InlineEnd: auto;
     --#{$tabs}__list--ScrollSnapTypeAxis: var(--#{$tabs}--m-vertical__list--ScrollSnapTypeAxis);
 
     display: inline-flex;
@@ -345,10 +345,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
         position: absolute;
         inset-inline-end: auto;
         border: solid var(--#{$tabs}--m-vertical__list--before--BorderColor);
-        border-block-start-width: var(--#{$tabs}--m-vertical__list--before--BorderTopWidth);
-        border-block-end-width: var(--#{$tabs}--m-vertical__list--before--BorderBottomWidth);
-        border-inline-start-width: var(--#{$tabs}--m-vertical__list--before--BorderLeftWidth);
-        border-inline-end-width: var(--#{$tabs}--m-vertical__list--before--BorderRightWidth);
+        border-block-start-width: var(--#{$tabs}--m-vertical__list--before--BorderBlockStartWidth);
+        border-block-end-width: var(--#{$tabs}--m-vertical__list--before--BorderBlockEndWidth);
+        border-inline-start-width: var(--#{$tabs}--m-vertical__list--before--BorderInlineStartWidth);
+        border-inline-end-width: var(--#{$tabs}--m-vertical__list--before--BorderInlineEndWidth);
       }
     }
 
@@ -362,8 +362,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
 
     .#{$tabs}__link {
-      --#{$tabs}__link--after--BorderTopWidth: 0;
-      --#{$tabs}__link--after--BorderLeftWidth: var(--#{$tabs}__link--after--BorderWidth);
+      --#{$tabs}__link--after--BorderBlockStartWidth: 0;
+      --#{$tabs}__link--after--BorderInlineStartWidth: var(--#{$tabs}__link--after--BorderWidth);
 
       max-width: 100%;
       text-align: start;
@@ -410,12 +410,12 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   // Box, vertical
   &.pf-m-box.pf-m-vertical {
     --#{$tabs}--inset: var(--#{$tabs}--m-vertical--m-box--inset);
-    --#{$tabs}--m-vertical__list--before--BorderLeftWidth: 0;
-    --#{$tabs}--m-vertical__list--before--BorderRightWidth: var(--#{$tabs}--before--border-width--base);
-    --#{$tabs}__link--before--BorderRightWidth: var(--#{$tabs}__link--before--border-width--base);
-    --#{$tabs}__link--disabled--before--BorderRightWidth: var(--#{$tabs}--before--border-width--base);
-    --#{$tabs}__link--disabled--before--BorderBottomWidth: var(--#{$tabs}--before--border-width--base);
-    --#{$tabs}__link--disabled--before--BorderLeftWidth: 0;
+    --#{$tabs}--m-vertical__list--before--BorderInlineStartWidth: 0;
+    --#{$tabs}--m-vertical__list--before--BorderInlineEndWidth: var(--#{$tabs}--before--border-width--base);
+    --#{$tabs}__link--before--BorderInlineEndWidth: var(--#{$tabs}__link--before--border-width--base);
+    --#{$tabs}__link--disabled--before--BorderInlineEndWidth: var(--#{$tabs}--before--border-width--base);
+    --#{$tabs}__link--disabled--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
+    --#{$tabs}__link--disabled--before--BorderInlineStartWidth: 0;
 
     .#{$tabs}__list::before {
       inset-inline-start: auto;
@@ -424,21 +424,21 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
     // stylelint-disable selector-max-class
     .#{$tabs}__item:last-child {
-      --#{$tabs}__link--before--BorderRightWidth: var(--#{$tabs}__link--before--border-width--base);
+      --#{$tabs}__link--before--BorderInlineEndWidth: var(--#{$tabs}__link--before--border-width--base);
     }
     .#{$tabs}__item:first-child {
-      --#{$tabs}__link--before--BorderTopWidth: var(--#{$tabs}__link--before--border-width--base);
+      --#{$tabs}__link--before--BorderBlockStartWidth: var(--#{$tabs}__link--before--border-width--base);
     }
 
     // Add border right color and weight
     .#{$tabs}__item.pf-m-current {
-      --#{$tabs}__link--before--BorderRightColor: var(--#{$tabs}__item--m-current__link--BackgroundColor);
-      --#{$tabs}__link--before--BorderBottomColor: var(--#{$tabs}__link--before--border-color--base);
+      --#{$tabs}__link--before--BorderInlineEndColor: var(--#{$tabs}__item--m-current__link--BackgroundColor);
+      --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}__link--before--border-color--base);
     }
 
     // Add border right color and weight
     .#{$tabs}__item:first-child.pf-m-current {
-      --#{$tabs}__link--before--BorderTopWidth: var(--#{$tabs}__link--before--border-width--base);
+      --#{$tabs}__link--before--BorderBlockStartWidth: var(--#{$tabs}__link--before--border-width--base);
     }
 
     // Offset vertical border to overlap horizontal border
@@ -479,7 +479,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 }
 
 .#{$tabs}__toggle-button {
-  --#{$tabs}__toggle-text--MarginLeft: var(--#{$tabs}__toggle-button__toggle-text--MarginLeft);
+  --#{$tabs}__toggle-text--MarginInlineStart: var(--#{$tabs}__toggle-button__toggle-text--MarginInlineStart);
   --#{$tabs}__toggle-text--Color: var(--#{$tabs}__toggle-button__toggle-text--Color);
 
   .#{$button} {
@@ -499,7 +499,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 }
 
 .#{$tabs}__toggle-text {
-  margin-inline-start: var(--#{$tabs}__toggle-text--MarginLeft);
+  margin-inline-start: var(--#{$tabs}__toggle-text--MarginInlineStart);
   color: var(--#{$tabs}__toggle-text--Color, inherit);
 }
 
@@ -590,17 +590,17 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 .#{$tabs}__link {
   @at-root .#{$tabs}__item.pf-m-action,
   & {
-    --#{$tabs}__link--after--BorderBottomWidth: var(--#{$tabs}__link--after--BorderWidth); // Set default border target
+    --#{$tabs}__link--after--BorderBlockEndWidth: var(--#{$tabs}__link--after--BorderWidth); // Set default border target
   }
 
   display: flex;
   flex: 1;
   column-gap: var(--#{$tabs}__link--ColumnGap);
   align-items: center;
-  padding-block-start: var(--#{$tabs}__link--PaddingTop);
-  padding-block-end: var(--#{$tabs}__link--PaddingBottom);
-  padding-inline-start: var(--#{$tabs}__link--PaddingLeft);
-  padding-inline-end: var(--#{$tabs}__link--PaddingRight);
+  padding-block-start: var(--#{$tabs}__link--PaddingBlockStart);
+  padding-block-end: var(--#{$tabs}__link--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tabs}__link--PaddingInlineStart);
+  padding-inline-end: var(--#{$tabs}__link--PaddingInlineEnd);
   font-size: var(--#{$tabs}__link--FontSize);
   color: var(--#{$tabs}__link--Color);
   text-decoration: none;
@@ -611,29 +611,29 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   & {
     &::before {
       pointer-events: none;
-      border-block-start-color: var(--#{$tabs}__link--before--BorderTopColor);
-      border-block-start-width: var(--#{$tabs}__link--before--BorderTopWidth);
-      border-block-end-color: var(--#{$tabs}__link--before--BorderBottomColor);
-      border-block-end-width: var(--#{$tabs}__link--before--BorderBottomWidth);
-      border-inline-start-color: var(--#{$tabs}__link--before--BorderLeftColor);
-      border-inline-start-width: var(--#{$tabs}__link--before--BorderLeftWidth);
-      border-inline-end-color: var(--#{$tabs}__link--before--BorderRightColor);
-      border-inline-end-width: var(--#{$tabs}__link--before--BorderRightWidth);
+      border-block-start-color: var(--#{$tabs}__link--before--BorderBlockStartColor);
+      border-block-start-width: var(--#{$tabs}__link--before--BorderBlockStartWidth);
+      border-block-end-color: var(--#{$tabs}__link--before--BorderBlockEndColor);
+      border-block-end-width: var(--#{$tabs}__link--before--BorderBlockEndWidth);
+      border-inline-start-color: var(--#{$tabs}__link--before--BorderInlineStartColor);
+      border-inline-start-width: var(--#{$tabs}__link--before--BorderInlineStartWidth);
+      border-inline-end-color: var(--#{$tabs}__link--before--BorderInlineEndColor);
+      border-inline-end-width: var(--#{$tabs}__link--before--BorderInlineEndWidth);
     }
   }
 
   @at-root .#{$tabs}__item.pf-m-action,
   & {
     &::after {
-      inset-block-start: var(--#{$tabs}__link--after--Top);
-      inset-block-end: var(--#{$tabs}__link--after--Bottom);
-      inset-inline-start: var(--#{$tabs}__link--before--Left); // use the ::before Left value to offset the top border / overlap left border
-      inset-inline-end: var(--#{$tabs}__link--after--Right);
+      inset-block-start: var(--#{$tabs}__link--after--BlockStart);
+      inset-block-end: var(--#{$tabs}__link--after--BlockEnd);
+      inset-inline-start: var(--#{$tabs}__link--before--InlineStart); // use the ::before Left value to offset the top border / overlap left border
+      inset-inline-end: var(--#{$tabs}__link--after--InlineEnd);
       border-color: var(--#{$tabs}__link--after--BorderColor);
-      border-block-start-width: var(--#{$tabs}__link--after--BorderTopWidth);
-      border-block-end-width: var(--#{$tabs}__link--after--BorderBottomWidth);
-      border-inline-start-width: var(--#{$tabs}__link--after--BorderLeftWidth);
-      border-inline-end-width: var(--#{$tabs}__link--after--BorderRightWidth);
+      border-block-start-width: var(--#{$tabs}__link--after--BorderBlockStartWidth);
+      border-block-end-width: var(--#{$tabs}__link--after--BorderBlockEndWidth);
+      border-inline-start-width: var(--#{$tabs}__link--after--BorderInlineStartWidth);
+      border-inline-end-width: var(--#{$tabs}__link--after--BorderInlineEndWidth);
     }
   }
 
@@ -651,9 +651,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   &.pf-m-disabled,
   &.pf-m-aria-disabled {
     --#{$tabs}__link--Color: var(--#{$tabs}__link--disabled--Color);
-    --#{$tabs}__link--before--BorderRightWidth: var(--#{$tabs}__link--disabled--before--BorderRightWidth);
-    --#{$tabs}__link--before--BorderBottomWidth: var(--#{$tabs}__link--disabled--before--BorderBottomWidth);
-    --#{$tabs}__link--before--BorderLeftWidth: var(--#{$tabs}__link--disabled--before--BorderLeftWidth);
+    --#{$tabs}__link--before--BorderInlineEndWidth: var(--#{$tabs}__link--disabled--before--BorderInlineEndWidth);
+    --#{$tabs}__link--before--BorderBlockEndWidth: var(--#{$tabs}__link--disabled--before--BorderBlockEndWidth);
+    --#{$tabs}__link--before--BorderInlineStartWidth: var(--#{$tabs}__link--disabled--before--BorderInlineStartWidth);
     --#{$tabs}__link--after--BorderWidth: 0;
   }
 
@@ -696,7 +696,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
 .#{$tabs}__item-action-icon {
   display: inline-block;
-  margin-block-start: var(--#{$tabs}__item-action-icon--MarginTop);
+  margin-block-start: var(--#{$tabs}__item-action-icon--MarginBlockStart);
 }
 
 // Scroll buttons
@@ -711,20 +711,20 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     &::before {
     border-color: var(--#{$tabs}__scroll-button--before--BorderColor);
     border-block-start-width: 0;
-    border-block-end-width: var(--#{$tabs}__scroll-button--before--BorderBottomWidth);
-    border-inline-start-width: var(--#{$tabs}__scroll-button--before--BorderLeftWidth);
-    border-inline-end-width: var(--#{$tabs}__scroll-button--before--BorderRightWidth);
+    border-block-end-width: var(--#{$tabs}__scroll-button--before--BorderBlockEndWidth);
+    border-inline-start-width: var(--#{$tabs}__scroll-button--before--BorderInlineStartWidth);
+    border-inline-end-width: var(--#{$tabs}__scroll-button--before--BorderInlineEndWidth);
   }
 
   &:nth-of-type(1) {
-    --#{$tabs}__scroll-button--before--BorderRightWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
+    --#{$tabs}__scroll-button--before--BorderInlineEndWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
 
     margin-inline-end: calc(var(--#{$tabs}__scroll-button--Width) * -1);
     transform: translateX(-100%);
   }
 
   &:nth-of-type(2) {
-    --#{$tabs}__scroll-button--before--BorderLeftWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
+    --#{$tabs}__scroll-button--before--BorderInlineStartWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
 
     margin-inline-start: calc(var(--#{$tabs}__scroll-button--Width) * -1);
     transform: translateX(100%);
@@ -740,7 +740,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   padding-inline-end: var(--#{$tabs}__add--PaddingInlineEnd);
 
   &::before {
-    border-inline-start: var(--#{$tabs}__add--before--BorderLeftWidth) solid var(--#{$tabs}__add--before--BorderColor);
+    border-inline-start: var(--#{$tabs}__add--before--BorderInlineStartWidth) solid var(--#{$tabs}__add--before--BorderColor);
   }
 
   .#{$button} {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -90,15 +90,15 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--before--BorderInlineEndWidth: 0;
   --#{$tabs}__link--before--BorderBlockEndWidth: 0;
   --#{$tabs}__link--before--BorderInlineStartWidth: 0;
-  --#{$tabs}__link--before--InlineStart: calc(var(--#{$tabs}__link--before--border-width--base) * -1);
+  --#{$tabs}__link--before--InsetInlineStart: calc(var(--#{$tabs}__link--before--border-width--base) * -1);
   --#{$tabs}__link--disabled--before--BorderInlineEndWidth: 0;
   --#{$tabs}__link--disabled--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
   --#{$tabs}__link--disabled--before--BorderInlineStartWidth: 0;
 
   // Link after
-  --#{$tabs}__link--after--BlockStart: auto;
-  --#{$tabs}__link--after--InlineEnd: 0;
-  --#{$tabs}__link--after--BlockEnd: 0;
+  --#{$tabs}__link--after--InsetBlockStart: auto;
+  --#{$tabs}__link--after--InsetInlineEnd: 0;
+  --#{$tabs}__link--after--InsetBlockEnd: 0;
   --#{$tabs}__link--after--BorderColor: var(--pf-t--global--border--color--default);
   --#{$tabs}__link--after--BorderWidth: 0;
   --#{$tabs}__link--after--BorderBlockStartWidth: 0;
@@ -255,8 +255,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__link--hover--BackgroundColor: var(--#{$tabs}--m-box__link--hover--BackgroundColor);
     --#{$tabs}__item--m-current__link--BackgroundColor: var(--#{$tabs}--m-box__item--m-current__link--BackgroundColor);
     --#{$tabs}__link--before--BorderBlockEndWidth: var(--#{$tabs}__link--before--border-width--base);
-    --#{$tabs}__link--after--BlockStart: 0;
-    --#{$tabs}__link--after--BlockEnd: auto;
+    --#{$tabs}__link--after--InsetBlockStart: 0;
+    --#{$tabs}__link--after--InsetBlockEnd: auto;
 
     .#{$tabs}__link {
       --#{$tabs}__link--after--BorderBlockStartWidth: var(--#{$tabs}__link--after--BorderWidth);
@@ -297,7 +297,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     // stylelint-disable selector-max-class
     // Remove offset from current adjacent item
     .#{$tabs}__item.pf-m-current + .#{$tabs}__item {
-      --#{$tabs}__link--before--InlineStart: 0;
+      --#{$tabs}__link--before--InsetInlineStart: 0;
     }
     // stylelint-enable
 
@@ -321,12 +321,12 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__item--PaddingInlineEnd: var(--#{$tabs}--m-vertical__item--PaddingInlineEnd);
     --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-vertical__link--PaddingInlineStart);
     --#{$tabs}__link--PaddingInlineEnd: var(--#{$tabs}--m-vertical__link--PaddingInlineEnd);
-    --#{$tabs}__link--before--InlineStart: 0;
+    --#{$tabs}__link--before--InsetInlineStart: 0;
     --#{$tabs}__link--disabled--before--BorderBlockEndWidth: 0;
     --#{$tabs}__link--disabled--before--BorderInlineStartWidth: var(--#{$tabs}--before--border-width--base);
-    --#{$tabs}__link--after--BlockStart: 0;
-    --#{$tabs}__link--after--BlockEnd: 0;
-    --#{$tabs}__link--after--InlineEnd: auto;
+    --#{$tabs}__link--after--InsetBlockStart: 0;
+    --#{$tabs}__link--after--InsetBlockEnd: 0;
+    --#{$tabs}__link--after--InsetInlineEnd: auto;
     --#{$tabs}__list--ScrollSnapTypeAxis: var(--#{$tabs}--m-vertical__list--ScrollSnapTypeAxis);
 
     display: inline-flex;
@@ -625,10 +625,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   @at-root .#{$tabs}__item.pf-m-action,
   & {
     &::after {
-      inset-block-start: var(--#{$tabs}__link--after--BlockStart);
-      inset-block-end: var(--#{$tabs}__link--after--BlockEnd);
-      inset-inline-start: var(--#{$tabs}__link--before--InlineStart); // use the ::before Left value to offset the top border / overlap left border
-      inset-inline-end: var(--#{$tabs}__link--after--InlineEnd);
+      inset-block-start: var(--#{$tabs}__link--after--InsetBlockStart);
+      inset-block-end: var(--#{$tabs}__link--after--InsetBlockEnd);
+      inset-inline-start: var(--#{$tabs}__link--before--InsetInlineStart); // use the ::before Left value to offset the top border / overlap left border
+      inset-inline-end: var(--#{$tabs}__link--after--InsetInlineEnd);
       border-color: var(--#{$tabs}__link--after--BorderColor);
       border-block-start-width: var(--#{$tabs}__link--after--BorderBlockStartWidth);
       border-block-end-width: var(--#{$tabs}__link--after--BorderBlockEndWidth);

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -32,7 +32,7 @@
   --#{$text-input-group}__text-input--OutlineOffset: -6px;
 
   // Icon
-  --#{$text-input-group}__icon--InlineStart: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__icon--InsetInlineStart: var(--pf-t--global--spacer--sm);
   --#{$text-input-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$text-input-group}__icon--TranslateY: -50%;
 
@@ -127,7 +127,7 @@
 .#{$text-input-group}__icon {
   position: absolute;
   inset-block-start: 50%;
-  inset-inline-start: var(--#{$text-input-group}__icon--InlineStart);
+  inset-inline-start: var(--#{$text-input-group}__icon--InsetInlineStart);
   color: var(--#{$text-input-group}__icon--Color);
   transform: translateY(var(--#{$text-input-group}__icon--TranslateY));
 }

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -10,21 +10,21 @@
   --#{$text-input-group}--m-hover--BorderColor: var(--pf-t--global--border--color--hover);
 
   // Main
-  --#{$text-input-group}__main--first-child--not--text-input--MarginLeft: var(--pf-t--global--spacer--xs);
-  --#{$text-input-group}__main--m-icon__text-input--PaddingLeft: var(--pf-t--global--spacer--xl);
+  --#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart: var(--pf-t--global--spacer--xl);
   --#{$text-input-group}__main--RowGap: var(--pf-t--global--spacer--xs);
   --#{$text-input-group}__main--ColumnGap: var(--pf-t--global--spacer--xs);
 
   // Chip group
-  --#{$text-input-group}--c-chip-group__main--PaddingTop: var(--pf-t--global--spacer--xs);
-  --#{$text-input-group}--c-chip-group__main--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$text-input-group}--c-chip-group__main--PaddingBottom: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}--c-chip-group__main--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}--c-chip-group__main--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}--c-chip-group__main--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // Text input
-  --#{$text-input-group}__text-input--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$text-input-group}__text-input--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$text-input-group}__text-input--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$text-input-group}__text-input--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__text-input--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__text-input--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__text-input--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__text-input--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$text-input-group}__text-input--MinWidth: 12ch;
   --#{$text-input-group}__text-input--m-hint--Color: var(--pf-t--global--text--color--placeholder);
   --#{$text-input-group}__text-input--placeholder--Color: var(--pf-t--global--text--color--placeholder);
@@ -32,14 +32,14 @@
   --#{$text-input-group}__text-input--OutlineOffset: -6px;
 
   // Icon
-  --#{$text-input-group}__icon--Left: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__icon--InlineStart: var(--pf-t--global--spacer--sm);
   --#{$text-input-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$text-input-group}__icon--TranslateY: -50%;
 
   // Utilities
-  --#{$text-input-group}__utilities--child--MarginLeft: var(--pf-t--global--spacer--xs);
-  --#{$text-input-group}__utilities--c-button--PaddingRight: var(--pf-t--global--spacer--xs);
-  --#{$text-input-group}__utilities--c-button--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}__utilities--child--MarginInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}__utilities--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$text-input-group}__utilities--c-button--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // input disabled style
   --#{$text-input-group}--m-disabled--Color: var(--pf-t--global--text--color--on-disabled);
@@ -95,17 +95,17 @@
   min-width: 0;
 
   &.pf-m-icon {
-    --#{$text-input-group}__text-input--PaddingLeft: var(--#{$text-input-group}__main--m-icon__text-input--PaddingLeft);
+    --#{$text-input-group}__text-input--PaddingInlineStart: var(--#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart);
   }
 
   > :first-child:not(.#{$text-input-group}__text) {
-    margin-inline-start: var(--#{$text-input-group}__main--first-child--not--text-input--MarginLeft);
+    margin-inline-start: var(--#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart);
   }
 
   .#{$chip-group}__main {
-    padding-block-start: var(--#{$text-input-group}--c-chip-group__main--PaddingTop);
-    padding-block-end: var(--#{$text-input-group}--c-chip-group__main--PaddingBottom);
-    padding-inline-end: var(--#{$text-input-group}--c-chip-group__main--PaddingRight);
+    padding-block-start: var(--#{$text-input-group}--c-chip-group__main--PaddingBlockStart);
+    padding-block-end: var(--#{$text-input-group}--c-chip-group__main--PaddingBlockEnd);
+    padding-inline-end: var(--#{$text-input-group}--c-chip-group__main--PaddingInlineEnd);
   }
 }
 
@@ -127,7 +127,7 @@
 .#{$text-input-group}__icon {
   position: absolute;
   inset-block-start: 50%;
-  inset-inline-start: var(--#{$text-input-group}__icon--Left);
+  inset-inline-start: var(--#{$text-input-group}__icon--InlineStart);
   color: var(--#{$text-input-group}__icon--Color);
   transform: translateY(var(--#{$text-input-group}__icon--TranslateY));
 }
@@ -138,10 +138,10 @@
   position: relative;
   width: 100%;
   min-width: var(--#{$text-input-group}__text-input--MinWidth);
-  padding-block-start: var(--#{$text-input-group}__text-input--PaddingTop);
-  padding-block-end: var(--#{$text-input-group}__text-input--PaddingBottom);
-  padding-inline-start: var(--#{$text-input-group}__text-input--PaddingLeft);
-  padding-inline-end: var(--#{$text-input-group}__text-input--PaddingRight);
+  padding-block-start: var(--#{$text-input-group}__text-input--PaddingBlockStart);
+  padding-block-end: var(--#{$text-input-group}__text-input--PaddingBlockEnd);
+  padding-inline-start: var(--#{$text-input-group}__text-input--PaddingInlineStart);
+  padding-inline-end: var(--#{$text-input-group}__text-input--PaddingInlineEnd);
   background-color: var(--#{$text-input-group}__text-input--BackgroundColor);
   border: 0;
   outline-offset: var(--#{$text-input-group}__text-input--OutlineOffset);
@@ -164,11 +164,11 @@
 .#{$text-input-group}__utilities {
   display: flex;
   align-items: center;
-  margin-inline-start: var(--#{$text-input-group}__utilities--MarginLeft);
-  margin-inline-end: var(--#{$text-input-group}__utilities--MarginRight);
+  margin-inline-start: var(--#{$text-input-group}__utilities--MarginInlineStart);
+  margin-inline-end: var(--#{$text-input-group}__utilities--MarginInlineEnd);
 
   > * + * {
-    margin-inline-start: var(--#{$text-input-group}__utilities--child--MarginLeft);
+    margin-inline-start: var(--#{$text-input-group}__utilities--child--MarginInlineStart);
   }
 }
 

--- a/src/patternfly/components/Tile/tile.scss
+++ b/src/patternfly/components/Tile/tile.scss
@@ -1,10 +1,10 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$tile}) {
-  --#{$tile}--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$tile}--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$tile}--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$tile}--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$tile}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$tile}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$tile}--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$tile}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$tile}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$tile}--BorderRadius: var(--pf-t--global--border--radius--medium);
 
@@ -15,7 +15,7 @@
   --#{$tile}--after--BackgroundColor: transparent;
 
   // icon
-  --#{$tile}__icon--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$tile}__icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tile}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
   --#{$tile}__icon--Color: var(--pf-t--global--icon--color--regular);
 
@@ -41,7 +41,7 @@
   --#{$tile}--m-disabled__body--Color: var(--pf-t--global--text--color--on-disabled);
 
   // Stacked variatiion
-  --#{$tile}__header--m-stacked__icon--MarginBottom: var(--pf-t--global--spacer--md);
+  --#{$tile}__header--m-stacked__icon--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$tile}__header--m-stacked__icon--FontSize: var(--pf-t--global--icon--size--xl);
 
   // large variation
@@ -52,10 +52,10 @@
   position: relative;
   display: inline-grid;
   grid-template-rows: min-content;
-  padding-block-start: var(--#{$tile}--PaddingTop);
-  padding-block-end: var(--#{$tile}--PaddingBottom);
-  padding-inline-start: var(--#{$tile}--PaddingLeft);
-  padding-inline-end: var(--#{$tile}--PaddingRight);
+  padding-block-start: var(--#{$tile}--PaddingBlockStart);
+  padding-block-end: var(--#{$tile}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tile}--PaddingInlineStart);
+  padding-inline-end: var(--#{$tile}--PaddingInlineEnd);
   cursor: pointer;
   background-color: var(--#{$tile}--BackgroundColor);
   border-radius: var(--#{$tile}--BorderRadius);
@@ -104,7 +104,7 @@
   align-items: center;
 
   &.pf-m-stacked {
-    --#{$tile}__icon--MarginRight: 0;
+    --#{$tile}__icon--MarginInlineEnd: 0;
     --#{$tile}__icon--FontSize: var(--#{$tile}__header--m-stacked__icon--FontSize);
 
     flex-direction: column;
@@ -113,7 +113,7 @@
     .#{$tile}__icon {
       display: flex;
       align-items: center;
-      margin-block-end: var(--#{$tile}__header--m-stacked__icon--MarginBottom);
+      margin-block-end: var(--#{$tile}__header--m-stacked__icon--MarginBlockEnd);
     }
   }
 }
@@ -129,7 +129,7 @@
 }
 
 .#{$tile}__icon {
-  margin-inline-end: var(--#{$tile}__icon--MarginRight);
+  margin-inline-end: var(--#{$tile}__icon--MarginInlineEnd);
   font-size: var(--#{$tile}__icon--FontSize);
   color: var(--#{$tile}__icon--Color);
 }

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -2,10 +2,10 @@
 
 :where(:root, .#{$toggle-group}) {
   // button
-  --#{$toggle-group}__button--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$toggle-group}__button--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$toggle-group}__button--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$toggle-group}__button--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$toggle-group}__button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}__button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$toggle-group}__button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}__button--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$toggle-group}__button--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$toggle-group}__button--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$toggle-group}__button--Color: var(--pf-t--global--text--color--regular);
@@ -18,14 +18,14 @@
   --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--default);
 
   // item
-  --#{$toggle-group}__item--item--MarginLeft: calc(-1 * var(--pf-t--global--border--width--control--default));
-  --#{$toggle-group}__item--first-child__button--BorderTopLeftRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--first-child__button--BorderBottomLeftRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--last-child__button--BorderTopRightRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--last-child__button--BorderBottomRightRadius: var(--pf-t--global--border--radius--tiny);
+  --#{$toggle-group}__item--item--MarginInlineStart: calc(-1 * var(--pf-t--global--border--width--control--default));
+  --#{$toggle-group}__item--first-child__button--BorderStartStartRadius: var(--pf-t--global--border--radius--tiny);
+  --#{$toggle-group}__item--first-child__button--BorderEndStartRadius: var(--pf-t--global--border--radius--tiny);
+  --#{$toggle-group}__item--last-child__button--BorderStartEndRadius: var(--pf-t--global--border--radius--tiny);
+  --#{$toggle-group}__item--last-child__button--BorderEndEndRadius: var(--pf-t--global--border--radius--tiny);
 
   // icon
-  --#{$toggle-group}__icon--text--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}__icon--text--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // Selected
   --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--default);
@@ -42,10 +42,10 @@
   --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Compact
-  --#{$toggle-group}--m-compact__button--PaddingTop: 0;
-  --#{$toggle-group}--m-compact__button--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$toggle-group}--m-compact__button--PaddingBottom: 0;
-  --#{$toggle-group}--m-compact__button--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}--m-compact__button--PaddingBlockStart: 0;
+  --#{$toggle-group}--m-compact__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}--m-compact__button--PaddingBlockEnd: 0;
+  --#{$toggle-group}--m-compact__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$toggle-group}--m-compact__button--FontSize: var(--pf-t--global--font--size--body--default);
 }
 
@@ -53,25 +53,25 @@
   display: flex;
 
   &.pf-m-compact {
-    --#{$toggle-group}__button--PaddingTop: var(--#{$toggle-group}--m-compact__button--PaddingTop);
-    --#{$toggle-group}__button--PaddingRight: var(--#{$toggle-group}--m-compact__button--PaddingRight);
-    --#{$toggle-group}__button--PaddingBottom: var(--#{$toggle-group}--m-compact__button--PaddingBottom);
-    --#{$toggle-group}__button--PaddingLeft: var(--#{$toggle-group}--m-compact__button--PaddingLeft);
+    --#{$toggle-group}__button--PaddingBlockStart: var(--#{$toggle-group}--m-compact__button--PaddingBlockStart);
+    --#{$toggle-group}__button--PaddingInlineEnd: var(--#{$toggle-group}--m-compact__button--PaddingInlineEnd);
+    --#{$toggle-group}__button--PaddingBlockEnd: var(--#{$toggle-group}--m-compact__button--PaddingBlockEnd);
+    --#{$toggle-group}__button--PaddingInlineStart: var(--#{$toggle-group}--m-compact__button--PaddingInlineStart);
     --#{$toggle-group}__button--FontSize: var(--#{$toggle-group}--m-compact__button--FontSize);
   }
 }
 
 .#{$toggle-group}__item {
   & + & {
-    margin-inline-start: var(--#{$toggle-group}__item--item--MarginLeft);
+    margin-inline-start: var(--#{$toggle-group}__item--item--MarginInlineStart);
   }
 
   &:first-child {
     .#{$toggle-group}__button {
       &,
       &::before {
-        border-start-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderTopLeftRadius);
-        border-end-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderBottomLeftRadius);
+        border-start-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderStartStartRadius);
+        border-end-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderEndStartRadius);
       }
     }
   }
@@ -80,8 +80,8 @@
     .#{$toggle-group}__button {
       &,
       &::before {
-        border-start-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderTopRightRadius);
-        border-end-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderBottomRightRadius);
+        border-start-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderStartEndRadius);
+        border-end-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderEndEndRadius);
       }
     }
   }
@@ -91,10 +91,10 @@
   position: relative;
   z-index: var(--#{$toggle-group}__button--ZIndex);
   display: inline-flex;
-  padding-block-start: var(--#{$toggle-group}__button--PaddingTop);
-  padding-block-end: var(--#{$toggle-group}__button--PaddingBottom);
-  padding-inline-start: var(--#{$toggle-group}__button--PaddingLeft);
-  padding-inline-end: var(--#{$toggle-group}__button--PaddingRight);
+  padding-block-start: var(--#{$toggle-group}__button--PaddingBlockStart);
+  padding-block-end: var(--#{$toggle-group}__button--PaddingBlockEnd);
+  padding-inline-start: var(--#{$toggle-group}__button--PaddingInlineStart);
+  padding-inline-end: var(--#{$toggle-group}__button--PaddingInlineEnd);
   font-size: var(--#{$toggle-group}__button--FontSize);
   line-height: var(--#{$toggle-group}__button--LineHeight);
   color: var(--#{$toggle-group}__button--Color);
@@ -156,6 +156,6 @@
 
 .#{$toggle-group}__icon + .#{$toggle-group}__text,
 .#{$toggle-group}__text + .#{$toggle-group}__icon {
-  margin-inline-start: var(--#{$toggle-group}__icon--text--MarginLeft);
+  margin-inline-start: var(--#{$toggle-group}__icon--text--MarginInlineStart);
 }
 

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -6,10 +6,10 @@
   --#{$tooltip}--BoxShadow: var(--pf-t--global--box-shadow--md);
 
   // Content variables
-  --#{$tooltip}__content--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$tooltip}__content--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$tooltip}__content--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$tooltip}__content--PaddingLeft: var(--pf-t--global--spacer--md);
+  --#{$tooltip}__content--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$tooltip}__content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$tooltip}__content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$tooltip}__content--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$tooltip}__content--Color: var(--pf-t--global--text--color--inverse);
   --#{$tooltip}__content--BackgroundColor: var(--pf-t--global--background--color--inverse--default);
   --#{$tooltip}__content--FontSize: var(--pf-t--global--font--size--body--sm);
@@ -44,8 +44,8 @@
     .pf-m-top-left,
     .pf-m-top-right
   ) {
-    --#{$tooltip}__arrow--Bottom: var(--#{$tooltip}--m-top--Bottom, 0);
-    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-top--Left, 50%);
+    --#{$tooltip}__arrow--BlockEnd: var(--#{$tooltip}--m-top--BlockEnd, 0);
+    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-top--InlineStart, 50%);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-top--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-top--Rotate);
@@ -56,8 +56,8 @@
     .pf-m-bottom-left,
     .pf-m-bottom-right
     ) {
-    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-bottom--Top, 0);
-    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-bottom--Left, 50%);
+    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-bottom--BlockStart, 0);
+    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-bottom--InlineStart, 50%);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-bottom--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-bottom--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-bottom--Rotate);
@@ -68,8 +68,8 @@
     .pf-m-left-top,
     .pf-m-left-bottom
   ) {
-    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-left--Top, 50%);
-    --#{$tooltip}__arrow--Right: var(--#{$tooltip}--m-left--Right, 0);
+    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-left--BlockStart, 50%);
+    --#{$tooltip}__arrow--InlineEnd: var(--#{$tooltip}--m-left--InlineEnd, 0);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-left--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-left--Rotate);
@@ -80,8 +80,8 @@
     .pf-m-right-top,
     .pf-m-right-bottom
   ) {
-    --#{$tooltip}__arrow--Top: var(--#{$tooltip}--m-right--Top, 50%);
-    --#{$tooltip}__arrow--Left: var(--#{$tooltip}--m-right--Left, 0);
+    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-right--BlockStart, 50%);
+    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-right--InlineStart, 0);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-right--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-right--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-right--Rotate);
@@ -91,7 +91,7 @@
     .pf-m-left-top,
     .pf-m-right-top
   ) {
-    --#{$tooltip}__arrow--Top: 0;
+    --#{$tooltip}__arrow--BlockStart: 0;
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
   }
 
@@ -99,15 +99,15 @@
     .pf-m-left-bottom,
     .pf-m-right-bottom
   ) {
-    --#{$tooltip}__arrow--Top: auto;
-    --#{$tooltip}__arrow--Bottom: 0;
+    --#{$tooltip}__arrow--BlockStart: auto;
+    --#{$tooltip}__arrow--BlockEnd: 0;
   }
 
   &:is(
     .pf-m-top-left,
     .pf-m-bottom-left
   ) {
-    --#{$tooltip}__arrow--Left: 0;
+    --#{$tooltip}__arrow--InlineStart: 0;
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
   }
 
@@ -115,17 +115,17 @@
     .pf-m-top-right,
     .pf-m-bottom-right
   ) {
-    --#{$tooltip}__arrow--Right: 0;
-    --#{$tooltip}__arrow--Left: auto;
+    --#{$tooltip}__arrow--InlineEnd: 0;
+    --#{$tooltip}__arrow--InlineStart: auto;
   }
 }
 
 .#{$tooltip}__content {
   position: relative;
-  padding-block-start: var(--#{$tooltip}__content--PaddingTop);
-  padding-block-end: var(--#{$tooltip}__content--PaddingBottom);
-  padding-inline-start: var(--#{$tooltip}__content--PaddingLeft);
-  padding-inline-end: var(--#{$tooltip}__content--PaddingRight);
+  padding-block-start: var(--#{$tooltip}__content--PaddingBlockStart);
+  padding-block-end: var(--#{$tooltip}__content--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tooltip}__content--PaddingInlineStart);
+  padding-inline-end: var(--#{$tooltip}__content--PaddingInlineEnd);
   font-size: var(--#{$tooltip}__content--FontSize);
   color: var(--#{$tooltip}__content--Color);
   text-align: center;
@@ -141,10 +141,10 @@
 .#{$tooltip}__arrow {
   position: absolute;
   // stylelint-disable liberty/use-logical-spec
-  top: var(--#{$tooltip}__arrow--Top, auto);
-  right: var(--#{$tooltip}__arrow--Right, auto);
-  bottom: var(--#{$tooltip}__arrow--Bottom, auto);
-  left: var(--#{$tooltip}__arrow--Left, auto);
+  top: var(--#{$tooltip}__arrow--BlockStart, auto);
+  right: var(--#{$tooltip}__arrow--InlineEnd, auto);
+  bottom: var(--#{$tooltip}__arrow--BlockEnd, auto);
+  left: var(--#{$tooltip}__arrow--InlineStart, auto);
   // stylelint-enable
   width: var(--#{$tooltip}__arrow--Width);
   height: var(--#{$tooltip}__arrow--Height);

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -44,8 +44,8 @@
     .pf-m-top-left,
     .pf-m-top-right
   ) {
-    --#{$tooltip}__arrow--BlockEnd: var(--#{$tooltip}--m-top--BlockEnd, 0);
-    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-top--InlineStart, 50%);
+    --#{$tooltip}__arrow--InsetBlockEnd: var(--#{$tooltip}--m-top--InsetBlockEnd, 0);
+    --#{$tooltip}__arrow--InsetInlineStart: var(--#{$tooltip}--m-top--InsetInlineStart, 50%);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-top--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-top--Rotate);
@@ -56,8 +56,8 @@
     .pf-m-bottom-left,
     .pf-m-bottom-right
     ) {
-    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-bottom--BlockStart, 0);
-    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-bottom--InlineStart, 50%);
+    --#{$tooltip}__arrow--InsetBlockStart: var(--#{$tooltip}--m-bottom--InsetBlockStart, 0);
+    --#{$tooltip}__arrow--InsetInlineStart: var(--#{$tooltip}--m-bottom--InsetInlineStart, 50%);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-bottom--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-bottom--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-bottom--Rotate);
@@ -68,8 +68,8 @@
     .pf-m-left-top,
     .pf-m-left-bottom
   ) {
-    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-left--BlockStart, 50%);
-    --#{$tooltip}__arrow--InlineEnd: var(--#{$tooltip}--m-left--InlineEnd, 0);
+    --#{$tooltip}__arrow--InsetBlockStart: var(--#{$tooltip}--m-left--InsetBlockStart, 50%);
+    --#{$tooltip}__arrow--InsetInlineEnd: var(--#{$tooltip}--m-left--InsetInlineEnd, 0);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-left--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-left--Rotate);
@@ -80,8 +80,8 @@
     .pf-m-right-top,
     .pf-m-right-bottom
   ) {
-    --#{$tooltip}__arrow--BlockStart: var(--#{$tooltip}--m-right--BlockStart, 50%);
-    --#{$tooltip}__arrow--InlineStart: var(--#{$tooltip}--m-right--InlineStart, 0);
+    --#{$tooltip}__arrow--InsetBlockStart: var(--#{$tooltip}--m-right--InsetBlockStart, 50%);
+    --#{$tooltip}__arrow--InsetInlineStart: var(--#{$tooltip}--m-right--InsetInlineStart, 0);
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-right--TranslateX);
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-right--TranslateY);
     --#{$tooltip}__arrow--Rotate: var(--#{$tooltip}__arrow--m-right--Rotate);
@@ -91,7 +91,7 @@
     .pf-m-left-top,
     .pf-m-right-top
   ) {
-    --#{$tooltip}__arrow--BlockStart: 0;
+    --#{$tooltip}__arrow--InsetBlockStart: 0;
     --#{$tooltip}__arrow--TranslateY: var(--#{$tooltip}__arrow--m-top--TranslateY);
   }
 
@@ -99,15 +99,15 @@
     .pf-m-left-bottom,
     .pf-m-right-bottom
   ) {
-    --#{$tooltip}__arrow--BlockStart: auto;
-    --#{$tooltip}__arrow--BlockEnd: 0;
+    --#{$tooltip}__arrow--InsetBlockStart: auto;
+    --#{$tooltip}__arrow--InsetBlockEnd: 0;
   }
 
   &:is(
     .pf-m-top-left,
     .pf-m-bottom-left
   ) {
-    --#{$tooltip}__arrow--InlineStart: 0;
+    --#{$tooltip}__arrow--InsetInlineStart: 0;
     --#{$tooltip}__arrow--TranslateX: var(--#{$tooltip}__arrow--m-left--TranslateX);
   }
 
@@ -115,8 +115,8 @@
     .pf-m-top-right,
     .pf-m-bottom-right
   ) {
-    --#{$tooltip}__arrow--InlineEnd: 0;
-    --#{$tooltip}__arrow--InlineStart: auto;
+    --#{$tooltip}__arrow--InsetInlineEnd: 0;
+    --#{$tooltip}__arrow--InsetInlineStart: auto;
   }
 }
 
@@ -141,10 +141,10 @@
 .#{$tooltip}__arrow {
   position: absolute;
   // stylelint-disable liberty/use-logical-spec
-  top: var(--#{$tooltip}__arrow--BlockStart, auto);
-  right: var(--#{$tooltip}__arrow--InlineEnd, auto);
-  bottom: var(--#{$tooltip}__arrow--BlockEnd, auto);
-  left: var(--#{$tooltip}__arrow--InlineStart, auto);
+  top: var(--#{$tooltip}__arrow--InsetBlockStart, auto);
+  right: var(--#{$tooltip}__arrow--InsetInlineEnd, auto);
+  bottom: var(--#{$tooltip}__arrow--InsetBlockEnd, auto);
+  left: var(--#{$tooltip}__arrow--InsetInlineStart, auto);
   // stylelint-enable
   width: var(--#{$tooltip}__arrow--Width);
   height: var(--#{$tooltip}__arrow--Height);

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -11,10 +11,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__content--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // Node
-  --#{$tree-view}__node--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__node--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__node--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__node--PaddingLeft: var(--#{$tree-view}__node--indent--base);
+  --#{$tree-view}__node--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}__node--indent--base);
   --#{$tree-view}__node--Color: var(--pf-t--global--text--color--subtle);
   --#{$tree-view}__node--BackgroundColor: transparent;
   --#{$tree-view}__node--m-current--Color: var(--pf-t--global--text--color--regular);
@@ -29,8 +29,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node-content--Overflow: visible;
 
   // Nested toggle
-  --#{$tree-view}__list-item__list-item__node-toggle--Top: var(--#{$tree-view}__node--PaddingTop);
-  --#{$tree-view}__list-item__list-item__node-toggle--Left: var(--#{$tree-view}__node--PaddingLeft);
+  --#{$tree-view}__list-item__list-item__node-toggle--BlockStart: var(--#{$tree-view}__node--PaddingBlockStart);
+  --#{$tree-view}__list-item__list-item__node-toggle--InlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
   --#{$tree-view}__list-item__list-item__node-toggle--TranslateX: -100%;
 
   // Toggle
@@ -42,27 +42,27 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Toggle icon
   --#{$tree-view}__node-toggle-icon--MinWidth: var(--pf-t--global--icon--size--font--body--default);
-  --#{$tree-view}__node-toggle--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__node-toggle--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$tree-view}__node-toggle--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__node-toggle--PaddingLeft: var(--pf-t--global--spacer--md);
-  --#{$tree-view}__node-toggle--MarginTop: calc(var(--#{$tree-view}__node-toggle--PaddingTop) * -1);
-  --#{$tree-view}__node-toggle--MarginBottom: calc(var(--#{$tree-view}__node-toggle--PaddingTop) * -1);
+  --#{$tree-view}__node-toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$tree-view}__node-toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node-toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$tree-view}__node-toggle--MarginBlockStart: calc(var(--#{$tree-view}__node-toggle--PaddingBlockStart) * -1);
+  --#{$tree-view}__node-toggle--MarginBlockEnd: calc(var(--#{$tree-view}__node-toggle--PaddingBlockStart) * -1);
 
   // Check
-  --#{$tree-view}__node-check--MarginRight: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node-check--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Badge
-  --#{$tree-view}__node-count--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node-count--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
   // Search
-  --#{$tree-view}__search--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__search--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__search--PaddingBottom: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}__search--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__search--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__search--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__search--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__search--PaddingInlineStart: var(--pf-t--global--spacer--sm);
 
   // Icon
-  --#{$tree-view}__node-icon--PaddingRight: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}__node-icon--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tree-view}__node-icon--Color: var(--pf-t--global--icon--color--subtle);
   --#{$tree-view}__node-toggle-icon--base--Rotate: 0;
   --#{$tree-view}__node-toggle-icon--Rotate: var(--#{$tree-view}__node-toggle-icon--base--Rotate);
@@ -79,93 +79,93 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Guides
   // ================================================================== //
-  --#{$tree-view}--m-guides--guide--Left: var(--#{$tree-view}--m-guides--guide-left--base); // starting value, this gets updated for each nesting level
+  --#{$tree-view}--m-guides--guide--InlineStart: var(--#{$tree-view}--m-guides--guide-left--base); // starting value, this gets updated for each nesting level
 
   // Base
   --#{$tree-view}--m-guides--guide-color--base: var(--pf-t--global--border--color--default);
   --#{$tree-view}--m-guides--guide-width--base: var(--pf-t--global--border--width--divider--default);
-  --#{$tree-view}--m-guides--guide-left--base: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-guides__list-node--guide-width--base));
-  --#{$tree-view}--m-guides--guide-left--base--offset: calc(var(--#{$tree-view}__list-item__list-item__node-toggle--Left) + var(--#{$tree-view}__node-toggle-icon--MinWidth) / 2); // based on toggle positioning
+  --#{$tree-view}--m-guides--guide-left--base: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-guides__list-node--guide-width--base));
+  --#{$tree-view}--m-guides--guide-left--base--offset: calc(var(--#{$tree-view}__list-item__list-item__node-toggle--InlineStart) + var(--#{$tree-view}__node-toggle-icon--MinWidth) / 2); // based on toggle positioning
   --#{$tree-view}--m-guides__list-node--guide-width--base: var(--pf-t--global--spacer--lg);
 
   // List item
-  --#{$tree-view}--m-guides__list-item--before--Top: 0;
+  --#{$tree-view}--m-guides__list-item--before--BlockStart: 0;
   --#{$tree-view}--m-guides__list-item--before--Width: var(--#{$tree-view}--m-guides--guide-width--base);
   --#{$tree-view}--m-guides__list-item--before--Height: 100%;
   --#{$tree-view}--m-guides__list-item--before--BackgroundColor: var(--#{$tree-view}--m-guides--guide-color--base);
-  --#{$tree-view}--m-guides__list-item--last-child--before--Top: var(--#{$tree-view}--m-guides__node--before--Top);
-  --#{$tree-view}--m-guides__list-item--last-child--before--Height: var(--#{$tree-view}--m-guides__list-item--last-child--before--Top);
+  --#{$tree-view}--m-guides__list-item--last-child--before--BlockStart: var(--#{$tree-view}--m-guides__node--before--BlockStart);
+  --#{$tree-view}--m-guides__list-item--last-child--before--Height: var(--#{$tree-view}--m-guides__list-item--last-child--before--BlockStart);
   --#{$tree-view}--m-guides__list-item--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Node
   --#{$tree-view}--m-guides__node--before--Width: #{pf-size-prem(16px)};
   --#{$tree-view}--m-guides__node--before--Height: var(--#{$tree-view}--m-guides--guide-width--base);
-  --#{$tree-view}--m-guides__node--before--Top: #{pf-size-prem(18px)};
+  --#{$tree-view}--m-guides__node--before--BlockStart: #{pf-size-prem(18px)};
   --#{$tree-view}--m-guides__node--before--BackgroundColor: var(--#{$tree-view}--m-guides--guide-color--base);
 
   // Compact
   // ================================================================== //
   // Base
-  --#{$tree-view}--m-compact--base-border--Left--offset: var(--pf-t--global--spacer--md);
-  --#{$tree-view}--m-compact--base-border--Left: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-compact--base-border--Left--offset));
+  --#{$tree-view}--m-compact--base-border--InlineStart--offset: var(--pf-t--global--spacer--md);
+  --#{$tree-view}--m-compact--base-border--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InlineStart--offset));
   --#{$tree-view}--m-compact__node--indent--base: var(--#{$tree-view}__node--indent--base); // based off of the expected width of the toggle button
   --#{$tree-view}--m-compact__node--nested-indent--base: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact--border--Left: var(--#{$tree-view}--m-compact--base-border--Left);
+  --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--base-border--InlineStart);
 
   // Node
   --#{$tree-view}--m-compact__node--Color: var(--pf-t--global--text--color--regular);
-  --#{$tree-view}--m-compact__node--PaddingTop: 0;
-  --#{$tree-view}--m-compact__node--PaddingBottom: 0;
-  --#{$tree-view}--m-compact__node--nested--PaddingTop: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}--m-compact__node--nested--PaddingBottom: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}--m-compact__node--PaddingBlockStart: 0;
+  --#{$tree-view}--m-compact__node--PaddingBlockEnd: 0;
+  --#{$tree-view}--m-compact__node--nested--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}--m-compact__node--nested--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Node toggle
-  --#{$tree-view}--m-compact__list-item__list-item__node-toggle--Top: calc(var(--#{$tree-view}--m-compact__node-container--PaddingTop));
+  --#{$tree-view}--m-compact__list-item__list-item__node-toggle--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart));
 
   // List item
-  --#{$tree-view}--m-compact__list-item--BorderBottomWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$tree-view}--m-compact__list-item--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$tree-view}--m-compact__list-item--before--Top: 0;
-  --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__node--before--Top);
-  --#{$tree-view}--m-compact__list-item--nested--before--Top: calc(var(--#{$tree-view}--m-compact__node--nested--PaddingTop) * -1);
-  --#{$tree-view}--m-compact__list-item--nested--last-child--before--Height: calc(var(--#{$tree-view}--m-compact__node--before--Top) + var(--#{$tree-view}--m-compact__node--nested--PaddingTop));
+  --#{$tree-view}--m-compact__list-item--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$tree-view}--m-compact__list-item--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$tree-view}--m-compact__list-item--before--BlockStart: 0;
+  --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__node--before--BlockStart);
+  --#{$tree-view}--m-compact__list-item--nested--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) * -1);
+  --#{$tree-view}--m-compact__list-item--nested--last-child--before--Height: calc(var(--#{$tree-view}--m-compact__node--before--BlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart));
 
   // Node
-  --#{$tree-view}--m-compact__node--PaddingLeft: var(--#{$tree-view}--m-compact__node--indent--base);
-  --#{$tree-view}--m-compact__node--before--Top: calc(var(--#{$tree-view}--m-compact__node-container--PaddingTop) + var(--#{$tree-view}--m-compact__node--nested--PaddingTop) + #{pf-size-prem(4px)});
-  --#{$tree-view}--m-compact__node--level-2--PaddingLeft: var(--#{$tree-view}--m-compact__node--indent--base);
+  --#{$tree-view}--m-compact__node--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--indent--base);
+  --#{$tree-view}--m-compact__node--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
+  --#{$tree-view}--m-compact__node--level-2--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--indent--base);
 
   // Node toggle
-  --#{$tree-view}--m-compact__node-toggle--nested--MarginRight: calc(var(--#{$tree-view}__node-toggle--PaddingLeft) * -.5);
-  --#{$tree-view}--m-compact__node-toggle--nested--MarginLeft: calc(var(--#{$tree-view}__node-toggle--PaddingLeft) * -1.5);
+  --#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd: calc(var(--#{$tree-view}__node-toggle--PaddingInlineStart) * -.5);
+  --#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart: calc(var(--#{$tree-view}__node-toggle--PaddingInlineStart) * -1.5);
 
   // Node container
   --#{$tree-view}--m-compact__node-container--Display: flex;
-  --#{$tree-view}--m-compact__node-container--PaddingBottom--base: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact__node-container--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact__node-container--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact__node-container--PaddingBottom: var(--#{$tree-view}--m-compact__node-container--PaddingBottom--base);
-  --#{$tree-view}--m-compact__node-container--PaddingLeft: var(--pf-t--global--spacer--xs);
+  --#{$tree-view}--m-compact__node-container--PaddingBlockEnd--base: var(--pf-t--global--spacer--lg);
+  --#{$tree-view}--m-compact__node-container--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$tree-view}--m-compact__node-container--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$tree-view}--m-compact__node-container--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node-container--PaddingBlockEnd--base);
+  --#{$tree-view}--m-compact__node-container--PaddingInlineStart: var(--pf-t--global--spacer--xs);
   --#{$tree-view}--m-compact__node-container--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$tree-view}--m-compact__node-container--nested--PaddingTop: var(--pf-t--global--spacer--md);
-  --#{$tree-view}--m-compact__node-container--nested--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact__node-container--nested--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$tree-view}--m-compact__node-container--nested--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$tree-view}--m-compact__node-container--nested--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$tree-view}--m-compact__node-container--nested--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBottom: 0;
+  --#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBlockEnd: 0;
 
   // Background transparent
   --#{$tree-view}--m-no-background__node-container--BackgroundColor: transparent;
 
   // Compact, no background
   // ================================================================== //
-  --#{$tree-view}--m-compact--m-no-background--base-border--Left--offset: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}--m-compact--m-no-background--base-border--Left: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-compact--m-no-background--base-border--Left--offset));
+  --#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}--m-compact--m-no-background--base-border--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset));
   --#{$tree-view}--m-compact--m-no-background__node--indent--base: var(--#{$tree-view}__node--indent--base); // based off of the expected width of the toggle button
   --#{$tree-view}--m-compact--m-no-background__node--nested-indent--base: var(--pf-t--global--spacer--2xl);
-  --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingTop: 0;
-  --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBottom: 0;
-  --#{$tree-view}--m-compact--m-no-background__node--before--Top: calc(var(--#{$tree-view}--m-compact__node-container--nested--PaddingTop) + var(--#{$tree-view}--m-compact__node--nested--PaddingTop) + #{pf-size-prem(4px)});
+  --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockStart: 0;
+  --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockEnd: 0;
+  --#{$tree-view}--m-compact--m-no-background__node--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
 }
 
 .#{$tree-view} {
@@ -179,13 +179,13 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         &::before,
         .#{$tree-view}__node::before {
           position: absolute;
-         inset-inline-start: var(--#{$tree-view}--m-guides--guide--Left);
+         inset-inline-start: var(--#{$tree-view}--m-guides--guide--InlineStart);
           content: "";
         }
 
         // vertical border
         &::before {
-         inset-block-start: var(--#{$tree-view}--m-guides__list-item--before--Top);
+         inset-block-start: var(--#{$tree-view}--m-guides__list-item--before--BlockStart);
           z-index: var(--#{$tree-view}--m-guides__list-item--ZIndex);
           width: var(--#{$tree-view}--m-guides__list-item--before--Width);
           height: var(--#{$tree-view}--m-guides__list-item--before--Height);
@@ -194,7 +194,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
         // horizontal border
         .#{$tree-view}__node::before {
-         inset-block-start: var(--#{$tree-view}--m-guides__node--before--Top);
+         inset-block-start: var(--#{$tree-view}--m-guides__node--before--BlockStart);
           width: var(--#{$tree-view}--m-guides__node--before--Width);
           height: var(--#{$tree-view}--m-guides__node--before--Height);
           background-color: var(--#{$tree-view}--m-guides__node--before--BackgroundColor);
@@ -205,55 +205,55 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         }
 
         .#{$tree-view}__list-item {
-          --#{$tree-view}--m-guides--guide--Left: var(--#{$tree-view}--m-guides--border--nested--Left); // swap with nested value
+          --#{$tree-view}--m-guides--guide--InlineStart: var(--#{$tree-view}--m-guides--border--nested--InlineStart); // swap with nested value
         }
         // stylelint-enable
       }
 
       &:last-child {
-        --#{$tree-view}--m-compact__list-item--BorderBottomWidth: 0; // hide nested list item bottom borders
+        --#{$tree-view}--m-compact__list-item--BorderBlockEndWidth: 0; // hide nested list item bottom borders
       }
     }
   }
 
   &.pf-m-compact {
     --#{$tree-view}__node--Color: var(--#{$tree-view}--m-compact__node--Color);
-    --#{$tree-view}__node--PaddingTop: var(--#{$tree-view}--m-compact__node--PaddingTop);
-    --#{$tree-view}__node--PaddingBottom: var(--#{$tree-view}--m-compact__node--PaddingBottom);
+    --#{$tree-view}__node--PaddingBlockStart: var(--#{$tree-view}--m-compact__node--PaddingBlockStart);
+    --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--PaddingBlockEnd);
     --#{$tree-view}__node-container--Display: var(--#{$tree-view}--m-compact__node-container--Display);
     --#{$tree-view}__node--hover--BackgroundColor: transparent;
-    --#{$tree-view}__list-item__list-item__node-toggle--Top: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--Top);
+    --#{$tree-view}__list-item__list-item__node-toggle--BlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--BlockStart);
 
     // Level 1
     .#{$tree-view}__list-item {
-      border-block-end: var(--#{$tree-view}--m-compact__list-item--BorderBottomWidth) solid var(--#{$tree-view}--m-compact__list-item--BorderBottomColor);
+      border-block-end: var(--#{$tree-view}--m-compact__list-item--BorderBlockEndWidth) solid var(--#{$tree-view}--m-compact__list-item--BorderBlockEndColor);
 
       &.pf-m-expanded {
-        --#{$tree-view}--m-compact__node-container--PaddingBottom: var(--#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBottom);
+        --#{$tree-view}--m-compact__node-container--PaddingBlockEnd: var(--#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBlockEnd);
       }
 
       // Level 2
       .#{$tree-view}__list-item {
-        --#{$tree-view}__node--PaddingTop: var(--#{$tree-view}--m-compact__node--nested--PaddingTop);
-        --#{$tree-view}__node--PaddingBottom: var(--#{$tree-view}--m-compact__node--nested--PaddingBottom);
+        --#{$tree-view}__node--PaddingBlockStart: var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart);
+        --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--nested--PaddingBlockEnd);
         --#{$tree-view}__node-toggle--Position: static;
-        --#{$tree-view}__node--PaddingLeft: var(--#{$tree-view}--m-compact__node--level-2--PaddingLeft); // second+ nested child padding left
+        --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--level-2--PaddingInlineStart); // second+ nested child padding left
         --#{$tree-view}__list-item__list-item__node-toggle--TranslateX: 0;
-        --#{$tree-view}--m-compact__list-item--BorderBottomWidth: 0; // hide nested list item bottom borders
-        --#{$tree-view}--m-compact__node-container--PaddingBottom: var(--#{$tree-view}--m-compact__node-container--PaddingBottom--base); // reset expanded node container padding
+        --#{$tree-view}--m-compact__list-item--BorderBlockEndWidth: 0; // hide nested list item bottom borders
+        --#{$tree-view}--m-compact__node-container--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node-container--PaddingBlockEnd--base); // reset expanded node container padding
 
         // stylelint-disable max-nesting-depth, selector-max-class
         &::before,
         .#{$tree-view}__node::before {
-         inset-inline-start: var(--#{$tree-view}--m-compact--border--Left);
+         inset-inline-start: var(--#{$tree-view}--m-compact--border--InlineStart);
         }
 
         &::before {
-         inset-block-start: var(--#{$tree-view}--m-compact__list-item--before--Top);
+         inset-block-start: var(--#{$tree-view}--m-compact__list-item--before--BlockStart);
         }
 
         .#{$tree-view}__node::before {
-         inset-block-start: var(--#{$tree-view}--m-compact__node--before--Top);
+         inset-block-start: var(--#{$tree-view}--m-compact__node--before--BlockStart);
         }
 
         &:last-child::before {
@@ -262,34 +262,34 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
         // Level 3
         .#{$tree-view}__list-item {
-          --#{$tree-view}__node--PaddingLeft: var(--#{$tree-view}--m-compact__node--PaddingLeft); // second+ nested child padding left
-          --#{$tree-view}--m-compact--border--Left: var(--#{$tree-view}--m-compact--border--nested--Left);
-          --#{$tree-view}--m-compact__list-item--before--Top: var(--#{$tree-view}--m-compact__list-item--nested--before--Top);
+          --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--PaddingInlineStart); // second+ nested child padding left
+          --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--border--nested--InlineStart);
+          --#{$tree-view}--m-compact__list-item--before--BlockStart: var(--#{$tree-view}--m-compact__list-item--nested--before--BlockStart);
           --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__list-item--nested--last-child--before--Height);
         }
 
         .#{$tree-view}__node-container {
-          padding-block-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingTop);
-          padding-block-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingBottom);
-          padding-inline-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingLeft);
-          padding-inline-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingRight);
+          padding-block-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart);
+          padding-block-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockEnd);
+          padding-inline-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart);
+          padding-inline-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineEnd);
           background-color: var(--#{$tree-view}--m-compact__node-container--nested--BackgroundColor);
         }
 
         // add margins to align item text flush left and offset gap between toggle and text
         .#{$tree-view}__node-toggle {
-          margin-inline-start: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginLeft);
-          margin-inline-end: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginRight);
+          margin-inline-start: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart);
+          margin-inline-end: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd);
         }
         // stylelint-enable
       }
     }
 
     .#{$tree-view}__node-container {
-      padding-block-start: var(--#{$tree-view}--m-compact__node-container--PaddingTop);
-      padding-block-end: var(--#{$tree-view}--m-compact__node-container--PaddingBottom);
-      padding-inline-start: var(--#{$tree-view}--m-compact__node-container--PaddingLeft);
-      padding-inline-end: var(--#{$tree-view}--m-compact__node-container--PaddingRight);
+      padding-block-start: var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart);
+      padding-block-end: var(--#{$tree-view}--m-compact__node-container--PaddingBlockEnd);
+      padding-inline-start: var(--#{$tree-view}--m-compact__node-container--PaddingInlineStart);
+      padding-inline-end: var(--#{$tree-view}--m-compact__node-container--PaddingInlineEnd);
     }
 
     // stylelint-disable selector-max-class, selector-max-compound-selectors
@@ -302,18 +302,18 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     // stylelint-enable
 
     &.pf-m-no-background {
-      --#{$tree-view}--m-compact__node--before--Top: var(--#{$tree-view}--m-compact--m-no-background__node--before--Top);
+      --#{$tree-view}--m-compact__node--before--BlockStart: var(--#{$tree-view}--m-compact--m-no-background__node--before--BlockStart);
 
       // stylelint-disable max-nesting-depth, selector-max-class
       .#{$tree-view}__list-item .#{$tree-view}__list-item {
-        --#{$tree-view}__node--PaddingTop: var(--#{$tree-view}--m-compact--m-no-background__node--nested--PaddingTop);
-        --#{$tree-view}__node--PaddingBottom: var(--#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBottom);
+        --#{$tree-view}__node--PaddingBlockStart: var(--#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockStart);
+        --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockEnd);
       }
 
       // level 3
       .#{$tree-view}__list-item .#{$tree-view}__list-item .#{$tree-view}__list-item {
-        --#{$tree-view}--m-compact--border--Left: var(--#{$tree-view}--m-compact--m-no-background--border--nested--Left);
-        --#{$tree-view}__node--PaddingLeft: var(--#{$tree-view}--m-compact--m-no-background__node--PaddingLeft); // third+ nested child padding left
+        --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--m-no-background--border--nested--InlineStart);
+        --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}--m-compact--m-no-background__node--PaddingInlineStart); // third+ nested child padding left
       }
       // stylelint-enable
     }
@@ -360,10 +360,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 .#{$tree-view}__node {
   position: relative;
   display: flex;
-  padding-block-start: var(--#{$tree-view}__node--PaddingTop);
-  padding-block-end: var(--#{$tree-view}__node--PaddingBottom);
-  padding-inline-start: var(--#{$tree-view}__node--PaddingLeft);
-  padding-inline-end: var(--#{$tree-view}__node--PaddingRight);
+  padding-block-start: var(--#{$tree-view}__node--PaddingBlockStart);
+  padding-block-end: var(--#{$tree-view}__node--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tree-view}__node--PaddingInlineStart);
+  padding-inline-end: var(--#{$tree-view}__node--PaddingInlineEnd);
   color: var(--#{$tree-view}__node--Color);
   background-color: var(--#{$tree-view}__node--BackgroundColor);
 
@@ -372,7 +372,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   }
 
   .#{$tree-view}__node-count {
-    margin-inline-start: var(--#{$tree-view}__node-count--MarginLeft);
+    margin-inline-start: var(--#{$tree-view}__node-count--MarginInlineStart);
   }
 }
 
@@ -394,23 +394,23 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 }
 
 .#{$tree-view}__node-check {
-  margin-inline-end: var(--#{$tree-view}__node-check--MarginRight);
+  margin-inline-end: var(--#{$tree-view}__node-check--MarginInlineEnd);
 }
 
 // TODO - should this use the button component? It isn't always a <button> element, but should have the same layout whether it's a button or not
 .#{$tree-view}__node-toggle {
   position: var(--#{$tree-view}__node-toggle--Position);
-  inset-block-start: var(--#{$tree-view}__list-item__list-item__node-toggle--Top);
-  inset-inline-start: var(--#{$tree-view}__list-item__list-item__node-toggle--Left);
+  inset-block-start: var(--#{$tree-view}__list-item__list-item__node-toggle--BlockStart);
+  inset-inline-start: var(--#{$tree-view}__list-item__list-item__node-toggle--InlineStart);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding-block-start: var(--#{$tree-view}__node-toggle--PaddingTop);
-  padding-block-end: var(--#{$tree-view}__node-toggle--PaddingBottom);
-  padding-inline-start: var(--#{$tree-view}__node-toggle--PaddingLeft);
-  padding-inline-end: var(--#{$tree-view}__node-toggle--PaddingRight);
-  margin-block-start: var(--#{$tree-view}__node-toggle--MarginTop);
-  margin-block-end: var(--#{$tree-view}__node-toggle--MarginBottom);
+  padding-block-start: var(--#{$tree-view}__node-toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$tree-view}__node-toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tree-view}__node-toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$tree-view}__node-toggle--PaddingInlineEnd);
+  margin-block-start: var(--#{$tree-view}__node-toggle--MarginBlockStart);
+  margin-block-end: var(--#{$tree-view}__node-toggle--MarginBlockEnd);
   color: var(--#{$tree-view}__node-toggle--Color);
   background-color: var(--#{$tree-view}__node-toggle--BackgroundColor);
   border: 0;
@@ -454,14 +454,14 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 }
 
 .#{$tree-view}__search {
-  padding-block-start: var(--#{$tree-view}__search--PaddingTop);
-  padding-block-end: var(--#{$tree-view}__search--PaddingBottom);
-  padding-inline-start: var(--#{$tree-view}__search--PaddingLeft);
-  padding-inline-end: var(--#{$tree-view}__search--PaddingRight);
+  padding-block-start: var(--#{$tree-view}__search--PaddingBlockStart);
+  padding-block-end: var(--#{$tree-view}__search--PaddingBlockEnd);
+  padding-inline-start: var(--#{$tree-view}__search--PaddingInlineStart);
+  padding-inline-end: var(--#{$tree-view}__search--PaddingInlineEnd);
 }
 
 .#{$tree-view}__node-icon {
-  padding-inline-end: var(--#{$tree-view}__node-icon--PaddingRight);
+  padding-inline-end: var(--#{$tree-view}__node-icon--PaddingInlineEnd);
   color: var(--#{$tree-view}__node-icon--Color);
 }
 
@@ -493,15 +493,15 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   @for $i from 1 through $pf-v6-c-tree-view--MaxNesting {
     #{$nested-item} {
-      --#{$tree-view}__list-item__list-item__node-toggle--Left: var(--#{$tree-view}__node--PaddingLeft);
-      --#{$tree-view}__node--PaddingLeft: calc(var(--#{$tree-view}__node--nested-indent--base) * #{$i} + var(--#{$tree-view}__node--indent--base));
-      --#{$tree-view}--m-guides--border--nested--Left: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-guides--guide-left--base--offset));
+      --#{$tree-view}__list-item__list-item__node-toggle--InlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
+      --#{$tree-view}__node--PaddingInlineStart: calc(var(--#{$tree-view}__node--nested-indent--base) * #{$i} + var(--#{$tree-view}__node--indent--base));
+      --#{$tree-view}--m-guides--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-guides--guide-left--base--offset));
 
       @if $i > 1 {
-        --#{$tree-view}--m-compact__node--PaddingLeft: calc(var(--#{$tree-view}--m-compact__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact__node--indent--base));
-        --#{$tree-view}--m-compact--border--nested--Left: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-compact--base-border--Left--offset));
-        --#{$tree-view}--m-compact--m-no-background__node--PaddingLeft: calc(var(--#{$tree-view}--m-compact--m-no-background__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact--m-no-background__node--indent--base));
-        --#{$tree-view}--m-compact--m-no-background--border--nested--Left: calc(var(--#{$tree-view}__node--PaddingLeft) - var(--#{$tree-view}--m-compact--m-no-background--base-border--Left--offset));
+        --#{$tree-view}--m-compact__node--PaddingInlineStart: calc(var(--#{$tree-view}--m-compact__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact__node--indent--base));
+        --#{$tree-view}--m-compact--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InlineStart--offset));
+        --#{$tree-view}--m-compact--m-no-background__node--PaddingInlineStart: calc(var(--#{$tree-view}--m-compact--m-no-background__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact--m-no-background__node--indent--base));
+        --#{$tree-view}--m-compact--m-no-background--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset));
       }
     }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -29,8 +29,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node-content--Overflow: visible;
 
   // Nested toggle
-  --#{$tree-view}__list-item__list-item__node-toggle--BlockStart: var(--#{$tree-view}__node--PaddingBlockStart);
-  --#{$tree-view}__list-item__list-item__node-toggle--InlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
+  --#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart: var(--#{$tree-view}__node--PaddingBlockStart);
+  --#{$tree-view}__list-item__list-item__node-toggle--InsetInlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
   --#{$tree-view}__list-item__list-item__node-toggle--TranslateX: -100%;
 
   // Toggle
@@ -79,38 +79,38 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Guides
   // ================================================================== //
-  --#{$tree-view}--m-guides--guide--InlineStart: var(--#{$tree-view}--m-guides--guide-left--base); // starting value, this gets updated for each nesting level
+  --#{$tree-view}--m-guides--guide--InsetInlineStart: var(--#{$tree-view}--m-guides--guide-left--base); // starting value, this gets updated for each nesting level
 
   // Base
   --#{$tree-view}--m-guides--guide-color--base: var(--pf-t--global--border--color--default);
   --#{$tree-view}--m-guides--guide-width--base: var(--pf-t--global--border--width--divider--default);
   --#{$tree-view}--m-guides--guide-left--base: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-guides__list-node--guide-width--base));
-  --#{$tree-view}--m-guides--guide-left--base--offset: calc(var(--#{$tree-view}__list-item__list-item__node-toggle--InlineStart) + var(--#{$tree-view}__node-toggle-icon--MinWidth) / 2); // based on toggle positioning
+  --#{$tree-view}--m-guides--guide-left--base--offset: calc(var(--#{$tree-view}__list-item__list-item__node-toggle--InsetInlineStart) + var(--#{$tree-view}__node-toggle-icon--MinWidth) / 2); // based on toggle positioning
   --#{$tree-view}--m-guides__list-node--guide-width--base: var(--pf-t--global--spacer--lg);
 
   // List item
-  --#{$tree-view}--m-guides__list-item--before--BlockStart: 0;
+  --#{$tree-view}--m-guides__list-item--before--InsetBlockStart: 0;
   --#{$tree-view}--m-guides__list-item--before--Width: var(--#{$tree-view}--m-guides--guide-width--base);
   --#{$tree-view}--m-guides__list-item--before--Height: 100%;
   --#{$tree-view}--m-guides__list-item--before--BackgroundColor: var(--#{$tree-view}--m-guides--guide-color--base);
-  --#{$tree-view}--m-guides__list-item--last-child--before--BlockStart: var(--#{$tree-view}--m-guides__node--before--BlockStart);
-  --#{$tree-view}--m-guides__list-item--last-child--before--Height: var(--#{$tree-view}--m-guides__list-item--last-child--before--BlockStart);
+  --#{$tree-view}--m-guides__list-item--last-child--before--InsetBlockStart: var(--#{$tree-view}--m-guides__node--before--InsetBlockStart);
+  --#{$tree-view}--m-guides__list-item--last-child--before--Height: var(--#{$tree-view}--m-guides__list-item--last-child--before--InsetBlockStart);
   --#{$tree-view}--m-guides__list-item--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Node
   --#{$tree-view}--m-guides__node--before--Width: #{pf-size-prem(16px)};
   --#{$tree-view}--m-guides__node--before--Height: var(--#{$tree-view}--m-guides--guide-width--base);
-  --#{$tree-view}--m-guides__node--before--BlockStart: #{pf-size-prem(18px)};
+  --#{$tree-view}--m-guides__node--before--InsetBlockStart: #{pf-size-prem(18px)};
   --#{$tree-view}--m-guides__node--before--BackgroundColor: var(--#{$tree-view}--m-guides--guide-color--base);
 
   // Compact
   // ================================================================== //
   // Base
-  --#{$tree-view}--m-compact--base-border--InlineStart--offset: var(--pf-t--global--spacer--md);
-  --#{$tree-view}--m-compact--base-border--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InlineStart--offset));
+  --#{$tree-view}--m-compact--base-border--InsetInlineStart--offset: var(--pf-t--global--spacer--md);
+  --#{$tree-view}--m-compact--base-border--InsetInlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InsetInlineStart--offset));
   --#{$tree-view}--m-compact__node--indent--base: var(--#{$tree-view}__node--indent--base); // based off of the expected width of the toggle button
   --#{$tree-view}--m-compact__node--nested-indent--base: var(--pf-t--global--spacer--lg);
-  --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--base-border--InlineStart);
+  --#{$tree-view}--m-compact--border--InsetInlineStart: var(--#{$tree-view}--m-compact--base-border--InsetInlineStart);
 
   // Node
   --#{$tree-view}--m-compact__node--Color: var(--pf-t--global--text--color--regular);
@@ -120,19 +120,19 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact__node--nested--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // Node toggle
-  --#{$tree-view}--m-compact__list-item__list-item__node-toggle--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart));
+  --#{$tree-view}--m-compact__list-item__list-item__node-toggle--InsetBlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart));
 
   // List item
   --#{$tree-view}--m-compact__list-item--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$tree-view}--m-compact__list-item--BorderBlockEndColor: var(--pf-t--global--border--color--default);
-  --#{$tree-view}--m-compact__list-item--before--BlockStart: 0;
-  --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__node--before--BlockStart);
-  --#{$tree-view}--m-compact__list-item--nested--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) * -1);
-  --#{$tree-view}--m-compact__list-item--nested--last-child--before--Height: calc(var(--#{$tree-view}--m-compact__node--before--BlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart));
+  --#{$tree-view}--m-compact__list-item--before--InsetBlockStart: 0;
+  --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__node--before--InsetBlockStart);
+  --#{$tree-view}--m-compact__list-item--nested--before--InsetBlockStart: calc(var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) * -1);
+  --#{$tree-view}--m-compact__list-item--nested--last-child--before--Height: calc(var(--#{$tree-view}--m-compact__node--before--InsetBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart));
 
   // Node
   --#{$tree-view}--m-compact__node--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--indent--base);
-  --#{$tree-view}--m-compact__node--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
+  --#{$tree-view}--m-compact__node--before--InsetBlockStart: calc(var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
   --#{$tree-view}--m-compact__node--level-2--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--indent--base);
 
   // Node toggle
@@ -159,13 +159,13 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Compact, no background
   // ================================================================== //
-  --#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset: var(--pf-t--global--spacer--sm);
-  --#{$tree-view}--m-compact--m-no-background--base-border--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset));
+  --#{$tree-view}--m-compact--m-no-background--base-border--InsetInlineStart--offset: var(--pf-t--global--spacer--sm);
+  --#{$tree-view}--m-compact--m-no-background--base-border--InsetInlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InsetInlineStart--offset));
   --#{$tree-view}--m-compact--m-no-background__node--indent--base: var(--#{$tree-view}__node--indent--base); // based off of the expected width of the toggle button
   --#{$tree-view}--m-compact--m-no-background__node--nested-indent--base: var(--pf-t--global--spacer--2xl);
   --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockStart: 0;
   --#{$tree-view}--m-compact--m-no-background__node--nested--PaddingBlockEnd: 0;
-  --#{$tree-view}--m-compact--m-no-background__node--before--BlockStart: calc(var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
+  --#{$tree-view}--m-compact--m-no-background__node--before--InsetBlockStart: calc(var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
 }
 
 .#{$tree-view} {
@@ -179,13 +179,13 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         &::before,
         .#{$tree-view}__node::before {
           position: absolute;
-         inset-inline-start: var(--#{$tree-view}--m-guides--guide--InlineStart);
+         inset-inline-start: var(--#{$tree-view}--m-guides--guide--InsetInlineStart);
           content: "";
         }
 
         // vertical border
         &::before {
-         inset-block-start: var(--#{$tree-view}--m-guides__list-item--before--BlockStart);
+         inset-block-start: var(--#{$tree-view}--m-guides__list-item--before--InsetBlockStart);
           z-index: var(--#{$tree-view}--m-guides__list-item--ZIndex);
           width: var(--#{$tree-view}--m-guides__list-item--before--Width);
           height: var(--#{$tree-view}--m-guides__list-item--before--Height);
@@ -194,7 +194,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
         // horizontal border
         .#{$tree-view}__node::before {
-         inset-block-start: var(--#{$tree-view}--m-guides__node--before--BlockStart);
+         inset-block-start: var(--#{$tree-view}--m-guides__node--before--InsetBlockStart);
           width: var(--#{$tree-view}--m-guides__node--before--Width);
           height: var(--#{$tree-view}--m-guides__node--before--Height);
           background-color: var(--#{$tree-view}--m-guides__node--before--BackgroundColor);
@@ -205,7 +205,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         }
 
         .#{$tree-view}__list-item {
-          --#{$tree-view}--m-guides--guide--InlineStart: var(--#{$tree-view}--m-guides--border--nested--InlineStart); // swap with nested value
+          --#{$tree-view}--m-guides--guide--InsetInlineStart: var(--#{$tree-view}--m-guides--border--nested--InsetInlineStart); // swap with nested value
         }
         // stylelint-enable
       }
@@ -222,7 +222,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--PaddingBlockEnd);
     --#{$tree-view}__node-container--Display: var(--#{$tree-view}--m-compact__node-container--Display);
     --#{$tree-view}__node--hover--BackgroundColor: transparent;
-    --#{$tree-view}__list-item__list-item__node-toggle--BlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--BlockStart);
+    --#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--InsetBlockStart);
 
     // Level 1
     .#{$tree-view}__list-item {
@@ -245,15 +245,15 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         // stylelint-disable max-nesting-depth, selector-max-class
         &::before,
         .#{$tree-view}__node::before {
-         inset-inline-start: var(--#{$tree-view}--m-compact--border--InlineStart);
+         inset-inline-start: var(--#{$tree-view}--m-compact--border--InsetInlineStart);
         }
 
         &::before {
-         inset-block-start: var(--#{$tree-view}--m-compact__list-item--before--BlockStart);
+         inset-block-start: var(--#{$tree-view}--m-compact__list-item--before--InsetBlockStart);
         }
 
         .#{$tree-view}__node::before {
-         inset-block-start: var(--#{$tree-view}--m-compact__node--before--BlockStart);
+         inset-block-start: var(--#{$tree-view}--m-compact__node--before--InsetBlockStart);
         }
 
         &:last-child::before {
@@ -263,8 +263,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         // Level 3
         .#{$tree-view}__list-item {
           --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}--m-compact__node--PaddingInlineStart); // second+ nested child padding left
-          --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--border--nested--InlineStart);
-          --#{$tree-view}--m-compact__list-item--before--BlockStart: var(--#{$tree-view}--m-compact__list-item--nested--before--BlockStart);
+          --#{$tree-view}--m-compact--border--InsetInlineStart: var(--#{$tree-view}--m-compact--border--nested--InsetInlineStart);
+          --#{$tree-view}--m-compact__list-item--before--InsetBlockStart: var(--#{$tree-view}--m-compact__list-item--nested--before--InsetBlockStart);
           --#{$tree-view}--m-compact__list-item--last-child--before--Height: var(--#{$tree-view}--m-compact__list-item--nested--last-child--before--Height);
         }
 
@@ -302,7 +302,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     // stylelint-enable
 
     &.pf-m-no-background {
-      --#{$tree-view}--m-compact__node--before--BlockStart: var(--#{$tree-view}--m-compact--m-no-background__node--before--BlockStart);
+      --#{$tree-view}--m-compact__node--before--InsetBlockStart: var(--#{$tree-view}--m-compact--m-no-background__node--before--InsetBlockStart);
 
       // stylelint-disable max-nesting-depth, selector-max-class
       .#{$tree-view}__list-item .#{$tree-view}__list-item {
@@ -312,7 +312,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
       // level 3
       .#{$tree-view}__list-item .#{$tree-view}__list-item .#{$tree-view}__list-item {
-        --#{$tree-view}--m-compact--border--InlineStart: var(--#{$tree-view}--m-compact--m-no-background--border--nested--InlineStart);
+        --#{$tree-view}--m-compact--border--InsetInlineStart: var(--#{$tree-view}--m-compact--m-no-background--border--nested--InsetInlineStart);
         --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}--m-compact--m-no-background__node--PaddingInlineStart); // third+ nested child padding left
       }
       // stylelint-enable
@@ -400,8 +400,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 // TODO - should this use the button component? It isn't always a <button> element, but should have the same layout whether it's a button or not
 .#{$tree-view}__node-toggle {
   position: var(--#{$tree-view}__node-toggle--Position);
-  inset-block-start: var(--#{$tree-view}__list-item__list-item__node-toggle--BlockStart);
-  inset-inline-start: var(--#{$tree-view}__list-item__list-item__node-toggle--InlineStart);
+  inset-block-start: var(--#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart);
+  inset-inline-start: var(--#{$tree-view}__list-item__list-item__node-toggle--InsetInlineStart);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -493,15 +493,15 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   @for $i from 1 through $pf-v6-c-tree-view--MaxNesting {
     #{$nested-item} {
-      --#{$tree-view}__list-item__list-item__node-toggle--InlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
+      --#{$tree-view}__list-item__list-item__node-toggle--InsetInlineStart: var(--#{$tree-view}__node--PaddingInlineStart);
       --#{$tree-view}__node--PaddingInlineStart: calc(var(--#{$tree-view}__node--nested-indent--base) * #{$i} + var(--#{$tree-view}__node--indent--base));
-      --#{$tree-view}--m-guides--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-guides--guide-left--base--offset));
+      --#{$tree-view}--m-guides--border--nested--InsetInlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-guides--guide-left--base--offset));
 
       @if $i > 1 {
         --#{$tree-view}--m-compact__node--PaddingInlineStart: calc(var(--#{$tree-view}--m-compact__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact__node--indent--base));
-        --#{$tree-view}--m-compact--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InlineStart--offset));
+        --#{$tree-view}--m-compact--border--nested--InsetInlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--base-border--InsetInlineStart--offset));
         --#{$tree-view}--m-compact--m-no-background__node--PaddingInlineStart: calc(var(--#{$tree-view}--m-compact--m-no-background__node--nested-indent--base) * #{$i - 1} + var(--#{$tree-view}--m-compact--m-no-background__node--indent--base));
-        --#{$tree-view}--m-compact--m-no-background--border--nested--InlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InlineStart--offset));
+        --#{$tree-view}--m-compact--m-no-background--border--nested--InsetInlineStart: calc(var(--#{$tree-view}__node--PaddingInlineStart) - var(--#{$tree-view}--m-compact--m-no-background--base-border--InsetInlineStart--offset));
       }
     }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -13,8 +13,8 @@
   --#{$wizard}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Close
-  --#{$wizard}__close--BlockStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$button}--m-plain--PaddingBlockStart));
-  --#{$wizard}__close--InlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__close--InsetBlockStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$button}--m-plain--PaddingBlockStart));
+  --#{$wizard}__close--InsetInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__close--FontSize: var(--pf-t--global--font--size--xl);
 
   // Title
@@ -58,7 +58,7 @@
   // Nav link number
   --#{$wizard}__nav-link--before--Width: 1.5rem;
   --#{$wizard}__nav-link--before--Height: 1.5rem;
-  --#{$wizard}__nav-link--before--BlockStart: calc(calc(var(--#{$wizard}__nav-link--PaddingBlockStart) + var(--#{$wizard}__nav-link--PaddingBlockEnd) + 1em * var(--pf-t--global--font--line-height--body)) / 2); // half of the link button it's beside
+  --#{$wizard}__nav-link--before--InsetBlockStart: calc(calc(var(--#{$wizard}__nav-link--PaddingBlockStart) + var(--#{$wizard}__nav-link--PaddingBlockEnd) + 1em * var(--pf-t--global--font--line-height--body)) / 2); // half of the link button it's beside
   --#{$wizard}__nav-link--before--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$wizard}__nav-link--before--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$wizard}__nav-link--before--Color: var(--pf-t--global--text--color--regular);
@@ -82,7 +82,7 @@
   --#{$wizard}--m-in-page__toggle--xl--PaddingInlineStart: calc(var(--pf-t--global--spacer--xl) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
 
   // Toggle number
-  --#{$wizard}__toggle-num--before--BlockStart: #{pf-size-prem(-2px)}; // TODO this should probably be calculated
+  --#{$wizard}__toggle-num--before--InsetBlockStart: #{pf-size-prem(-2px)}; // TODO this should probably be calculated
 
   // Toggle list item
   --#{$wizard}__toggle-list-item--not-last-child--MarginInlineEnd: var(--pf-t--global--spacer--sm);
@@ -194,8 +194,8 @@
   // Nested selector to match button component color specificity
   .#{$wizard}__close {
     position: absolute;
-   inset-block-start: var(--#{$wizard}__close--BlockStart);
-   inset-inline-end: var(--#{$wizard}__close--InlineEnd);
+   inset-block-start: var(--#{$wizard}__close--InsetBlockStart);
+   inset-inline-end: var(--#{$wizard}__close--InsetInlineEnd);
 
     button {
       font-size: var(--#{$wizard}__close--FontSize);
@@ -275,7 +275,7 @@
 
 .#{$wizard}__toggle-num {
   --#{$wizard}__nav-link--before--TranslateY: 0;
-  --#{$wizard}__nav-link--before--BlockStart: var(--#{$wizard}__toggle-num--before--BlockStart);
+  --#{$wizard}__nav-link--before--InsetBlockStart: var(--#{$wizard}__toggle-num--before--InsetBlockStart);
 }
 
 .#{$wizard}__toggle-separator {
@@ -422,7 +422,7 @@
     );
 
     position: absolute;
-    inset-block-start: var(--#{$wizard}__nav-link--before--BlockStart);
+    inset-block-start: var(--#{$wizard}__nav-link--before--InsetBlockStart);
     inset-inline-start: 0;
     display: inline-flex;
     align-items: center;

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -7,18 +7,18 @@
   // Header
   --#{$wizard}__header--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$wizard}__header--ZIndex: auto;
-  --#{$wizard}__header--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__header--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__header--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__header--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__header--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__header--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Close
-  --#{$wizard}__close--Top: calc(var(--pf-t--global--spacer--lg) - var(--#{$button}--m-plain--PaddingTop));
-  --#{$wizard}__close--Right: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__close--BlockStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$button}--m-plain--PaddingBlockStart));
+  --#{$wizard}__close--InlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__close--FontSize: var(--pf-t--global--font--size--xl);
 
   // Title
-  --#{$wizard}__title--PaddingRight: var(--pf-t--global--spacer--2xl);
+  --#{$wizard}__title--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
 
   // Title text
   --#{$wizard}__title-text--FontSize: var(--pf-t--global--font--size--3xl);
@@ -28,7 +28,7 @@
   --#{$wizard}__title-text--Color: var(--pf-t--global--text--color--regular);
 
   // Description
-  --#{$wizard}__description--PaddingTop: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__description--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__description--Color: var(--pf-t--global--text--color--subtle);
 
   // Nav link
@@ -48,8 +48,8 @@
   --#{$wizard}__nav-link--m-disabled--BackgroundColor: transparent;
 
   // Nav link toggle icon
-  --#{$wizard}__nav-link-toggle--PaddingRight: var(--pf-t--global--spacer--sm);
-  --#{$wizard}__nav-link-toggle--PaddingLeft: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__nav-link-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__nav-link-toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-toggle--Color: var(--pf-t--global--icon--color--regular);
   --#{$wizard}__nav-link-toggle-icon--Transition: var(--pf-t--global--transition);
   --#{$wizard}__nav-link-toggle-icon--Rotate: 0;
@@ -58,7 +58,7 @@
   // Nav link number
   --#{$wizard}__nav-link--before--Width: 1.5rem;
   --#{$wizard}__nav-link--before--Height: 1.5rem;
-  --#{$wizard}__nav-link--before--Top: calc(calc(var(--#{$wizard}__nav-link--PaddingBlockStart) + var(--#{$wizard}__nav-link--PaddingBlockEnd) + 1em * var(--pf-t--global--font--line-height--body)) / 2); // half of the link button it's beside
+  --#{$wizard}__nav-link--before--BlockStart: calc(calc(var(--#{$wizard}__nav-link--PaddingBlockStart) + var(--#{$wizard}__nav-link--PaddingBlockEnd) + 1em * var(--pf-t--global--font--line-height--body)) / 2); // half of the link button it's beside
   --#{$wizard}__nav-link--before--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$wizard}__nav-link--before--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$wizard}__nav-link--before--Color: var(--pf-t--global--text--color--regular);
@@ -73,27 +73,27 @@
   // Toggle
   --#{$wizard}__toggle--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$wizard}__toggle--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__toggle--PaddingRight: var(--pf-t--global--spacer--md);
-  --#{$wizard}__toggle--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__toggle--PaddingLeft: calc(var(--pf-t--global--spacer--lg) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
-  --#{$wizard}__toggle--BorderBottomWidth: var(--pf-t--global--border--width--regular);
-  --#{$wizard}__toggle--BorderBottomColor: var(--pf-t--global--border--color--default);
-  --#{$wizard}--m-in-page__toggle--xl--PaddingLeft: calc(var(--pf-t--global--spacer--xl) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
+  --#{$wizard}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$wizard}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__toggle--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
+  --#{$wizard}__toggle--BorderBlockEndWidth: var(--pf-t--global--border--width--regular);
+  --#{$wizard}__toggle--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  --#{$wizard}--m-in-page__toggle--xl--PaddingInlineStart: calc(var(--pf-t--global--spacer--xl) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
 
   // Toggle number
-  --#{$wizard}__toggle-num--before--Top: #{pf-size-prem(-2px)}; // TODO this should probably be calculated
+  --#{$wizard}__toggle-num--before--BlockStart: #{pf-size-prem(-2px)}; // TODO this should probably be calculated
 
   // Toggle list item
-  --#{$wizard}__toggle-list-item--not-last-child--MarginRight: var(--pf-t--global--spacer--sm);
-  --#{$wizard}__toggle-list-item--MarginBottom: var(--pf-t--global--spacer--xs);
+  --#{$wizard}__toggle-list-item--not-last-child--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__toggle-list-item--MarginBlockEnd: var(--pf-t--global--spacer--xs);
 
   // Toggle list
-  --#{$wizard}__toggle-list--MarginRight: var(--pf-t--global--spacer--sm);
-  --#{$wizard}__toggle-list--MarginBottom: calc(var(--#{$wizard}__toggle-list-item--MarginBottom) * -1);
+  --#{$wizard}__toggle-list--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__toggle-list--MarginBlockEnd: calc(var(--#{$wizard}__toggle-list-item--MarginBlockEnd) * -1);
 
   // Toggle separator
-  --#{$wizard}__toggle-separator--MarginLeft: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__toggle-separator--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__toggle-separator--Color: var(--pf-t--global--border--color--default);
 
   // Toggle icon
@@ -106,8 +106,8 @@
   --#{$wizard}__nav--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
   --#{$wizard}__nav--Width: 100%;
   --#{$wizard}__nav--lg--Width: #{pf-size-prem(250px)};
-  --#{$wizard}__nav--lg--BorderRightWidth: var(--pf-t--global--border--width--regular);
-  --#{$wizard}__nav--lg--BorderRightColor: var(--pf-t--global--border--color--default);
+  --#{$wizard}__nav--lg--BorderInlineEndWidth: var(--pf-t--global--border--width--regular);
+  --#{$wizard}__nav--lg--BorderInlineEndColor: var(--pf-t--global--border--color--default);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
     --#{$wizard}__nav--Width: var(--#{$wizard}__nav--lg--Width);
@@ -115,42 +115,42 @@
   }
 
   // Nav list (nested)
-  --#{$wizard}__nav-list--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__nav-list--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__nav-list--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__nav-list--PaddingLeft: calc(var(--pf-t--global--spacer--lg) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
-  --#{$wizard}__nav-list--nested--MarginLeft: var(--pf-t--global--spacer--md);
-  --#{$wizard}__nav-list--nested--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$wizard}__nav-list--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__nav-list--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__nav-list--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__nav-list--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) + var(--#{$wizard}__nav-link--before--Width) + var(--pf-t--global--spacer--sm));
+  --#{$wizard}__nav-list--nested--MarginInlineStart: var(--pf-t--global--spacer--md);
+  --#{$wizard}__nav-list--nested--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Nav item
-  --#{$wizard}__nav-item--MarginTop: var(--pf-t--global--spacer--md);
+  --#{$wizard}__nav-item--MarginBlockStart: var(--pf-t--global--spacer--md);
 
   // Outer wrap
   --#{$wizard}__outer-wrap--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__outer-wrap--lg--PaddingLeft: var(--#{$wizard}__nav--Width);
+  --#{$wizard}__outer-wrap--lg--PaddingInlineStart: var(--#{$wizard}__nav--Width);
   --#{$wizard}__outer-wrap--MinHeight: #{pf-size-prem(250px)};
 
   // Main
   --#{$wizard}__main--ZIndex: auto;
 
   // Body
-  --#{$wizard}__main-body--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__main-body--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__main-body--PaddingBottom: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__main-body--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__main-body--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__main-body--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__main-body--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__main-body--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Footer
   --#{$wizard}__footer--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$wizard}__footer--PaddingTop: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__footer--PaddingRight: var(--pf-t--global--spacer--lg);
-  --#{$wizard}__footer--PaddingBottom: var(--pf-t--global--spacer--md);
-  --#{$wizard}__footer--PaddingLeft: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$wizard}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$wizard}__footer--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--BorderWidth: var(--pf-t--global--border--width--divider--default);
   --#{$wizard}__footer--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$wizard}__footer--child--MarginRight: var(--pf-t--global--spacer--md);
-  --#{$wizard}__footer--child--MarginBottom: var(--pf-t--global--spacer--sm);
-  --#{$wizard}__footer-cancel--MarginLeft: calc(var(--pf-t--global--spacer--2xl) - var(--#{$wizard}__footer--child--MarginRight));
+  --#{$wizard}__footer--child--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$wizard}__footer--child--MarginBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$wizard}__footer-cancel--MarginInlineStart: calc(var(--pf-t--global--spacer--2xl) - var(--#{$wizard}__footer--child--MarginInlineEnd));
 }
 
 .#{$wizard} {
@@ -172,7 +172,7 @@
   }
 
   &.pf-m-finished {
-    --#{$wizard}__outer-wrap--lg--PaddingLeft: 0;
+    --#{$wizard}__outer-wrap--lg--PaddingInlineStart: 0;
 
     .#{$wizard}__nav,
     .#{$wizard}__footer,
@@ -185,17 +185,17 @@
 .#{$wizard}__header {
   position: relative;
   z-index: var(--#{$wizard}__header--ZIndex);
-  padding-block-start: var(--#{$wizard}__header--PaddingTop);
-  padding-block-end: var(--#{$wizard}__header--PaddingBottom);
-  padding-inline-start: var(--#{$wizard}__header--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__header--PaddingRight);
+  padding-block-start: var(--#{$wizard}__header--PaddingBlockStart);
+  padding-block-end: var(--#{$wizard}__header--PaddingBlockEnd);
+  padding-inline-start: var(--#{$wizard}__header--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__header--PaddingInlineEnd);
   background-color: var(--#{$wizard}__header--BackgroundColor);
 
   // Nested selector to match button component color specificity
   .#{$wizard}__close {
     position: absolute;
-   inset-block-start: var(--#{$wizard}__close--Top);
-   inset-inline-end: var(--#{$wizard}__close--Right);
+   inset-block-start: var(--#{$wizard}__close--BlockStart);
+   inset-inline-end: var(--#{$wizard}__close--InlineEnd);
 
     button {
       font-size: var(--#{$wizard}__close--FontSize);
@@ -204,7 +204,7 @@
 }
 
 .#{$wizard}__title {
-  padding-inline-end: var(--#{$wizard}__title--PaddingRight);
+  padding-inline-end: var(--#{$wizard}__title--PaddingInlineEnd);
   word-wrap: break-word;
 }
 
@@ -218,7 +218,7 @@
 
 .#{$wizard}__description {
   display: none;
-  padding-block-start: var(--#{$wizard}__description--PaddingTop);
+  padding-block-start: var(--#{$wizard}__description--PaddingBlockStart);
   color: var(--#{$wizard}__description--Color);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
@@ -232,13 +232,13 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
-  padding-block-start: var(--#{$wizard}__toggle--PaddingTop);
-  padding-block-end: var(--#{$wizard}__toggle--PaddingBottom);
-  padding-inline-start: var(--#{$wizard}__toggle--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__toggle--PaddingRight);
+  padding-block-start: var(--#{$wizard}__toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$wizard}__toggle--PaddingBlockEnd);
+  padding-inline-start: var(--#{$wizard}__toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__toggle--PaddingInlineEnd);
   background-color: var(--#{$wizard}__toggle--BackgroundColor);
   border-block-start: 0;
-  border-block-end: var(--#{$wizard}__toggle--BorderBottomWidth) solid var(--#{$wizard}__toggle--BorderBottomColor);
+  border-block-end: var(--#{$wizard}__toggle--BorderBlockEndWidth) solid var(--#{$wizard}__toggle--BorderBlockEndColor);
   border-inline-start: 0;
   border-inline-end: 0;
 
@@ -258,30 +258,30 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  margin-block-end: var(--#{$wizard}__toggle-list--MarginBottom);
-  margin-inline-end: var(--#{$wizard}__toggle-list--MarginRight);
+  margin-block-end: var(--#{$wizard}__toggle-list--MarginBlockEnd);
+  margin-inline-end: var(--#{$wizard}__toggle-list--MarginInlineEnd);
   list-style: none;
 }
 
 .#{$wizard}__toggle-list-item {
-  margin-block-end: var(--#{$wizard}__toggle-list-item--MarginBottom);
+  margin-block-end: var(--#{$wizard}__toggle-list-item--MarginBlockEnd);
   text-align: start;
   word-break: break-word;
 
   &:not(:last-child) {
-    margin-inline-end: var(--#{$wizard}__toggle-list-item--not-last-child--MarginRight);
+    margin-inline-end: var(--#{$wizard}__toggle-list-item--not-last-child--MarginInlineEnd);
   }
 }
 
 .#{$wizard}__toggle-num {
   --#{$wizard}__nav-link--before--TranslateY: 0;
-  --#{$wizard}__nav-link--before--Top: var(--#{$wizard}__toggle-num--before--Top);
+  --#{$wizard}__nav-link--before--BlockStart: var(--#{$wizard}__toggle-num--before--BlockStart);
 }
 
 .#{$wizard}__toggle-separator {
   @include pf-v6-mirror-inline-on-rtl;
 
-  margin-inline-start: var(--#{$wizard}__toggle-separator--MarginLeft);
+  margin-inline-start: var(--#{$wizard}__toggle-separator--MarginInlineStart);
   color: var(--#{$wizard}__toggle-separator--Color);
 }
 
@@ -298,7 +298,7 @@
   background-color: var(--#{$wizard}__outer-wrap--BackgroundColor);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
-    padding-inline-start: var(--#{$wizard}__outer-wrap--lg--PaddingLeft);
+    padding-inline-start: var(--#{$wizard}__outer-wrap--lg--PaddingInlineStart);
   }
 }
 
@@ -334,23 +334,23 @@
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
     display: block;
     height: 100%;
-    border-inline-end: var(--#{$wizard}__nav--lg--BorderRightWidth) solid var(--#{$wizard}__nav--lg--BorderRightColor);
+    border-inline-end: var(--#{$wizard}__nav--lg--BorderInlineEndWidth) solid var(--#{$wizard}__nav--lg--BorderInlineEndColor);
   }
 }
 
 .#{$wizard}__nav-list {
-  padding-block-start: var(--#{$wizard}__nav-list--PaddingTop);
-  padding-block-end: var(--#{$wizard}__nav-list--PaddingBottom);
-  padding-inline-start: var(--#{$wizard}__nav-list--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__nav-list--PaddingRight);
+  padding-block-start: var(--#{$wizard}__nav-list--PaddingBlockStart);
+  padding-block-end: var(--#{$wizard}__nav-list--PaddingBlockEnd);
+  padding-inline-start: var(--#{$wizard}__nav-list--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__nav-list--PaddingInlineEnd);
   list-style: none;
   counter-reset: wizard-nav-count;
 
   // Nested sub menus
   & & {
     padding: 0;
-    margin-block-start: var(--#{$wizard}__nav-list--nested--MarginTop);
-    margin-inline-start: var(--#{$wizard}__nav-list--nested--MarginLeft);
+    margin-block-start: var(--#{$wizard}__nav-list--nested--MarginBlockStart);
+    margin-inline-start: var(--#{$wizard}__nav-list--nested--MarginInlineStart);
 
     // Reset styles for nested nav links
     .#{$wizard}__nav-link {
@@ -367,7 +367,7 @@
 
 .#{$wizard}__nav-item {
   & + & {
-    margin-block-start: var(--#{$wizard}__nav-item--MarginTop);
+    margin-block-start: var(--#{$wizard}__nav-item--MarginBlockStart);
   }
 
   &.pf-m-expandable {
@@ -422,7 +422,7 @@
     );
 
     position: absolute;
-    inset-block-start: var(--#{$wizard}__nav-link--before--Top);
+    inset-block-start: var(--#{$wizard}__nav-link--before--BlockStart);
     inset-inline-start: 0;
     display: inline-flex;
     align-items: center;
@@ -478,8 +478,8 @@
 }
 
 .#{$wizard}__nav-link-toggle {
-  padding-inline-start: var(--#{$wizard}__nav-link-toggle--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__nav-link-toggle--PaddingRight);
+  padding-inline-start: var(--#{$wizard}__nav-link-toggle--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__nav-link-toggle--PaddingInlineEnd);
   color: var(--#{$wizard}__nav-link-toggle--Color);
 }
 
@@ -500,10 +500,10 @@
 }
 
 .#{$wizard}__main-body {
-  padding-block-start: var(--#{$wizard}__main-body--PaddingTop);
-  padding-block-end: var(--#{$wizard}__main-body--PaddingBottom);
-  padding-inline-start: var(--#{$wizard}__main-body--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__main-body--PaddingRight);
+  padding-block-start: var(--#{$wizard}__main-body--PaddingBlockStart);
+  padding-block-end: var(--#{$wizard}__main-body--PaddingBlockEnd);
+  padding-inline-start: var(--#{$wizard}__main-body--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__main-body--PaddingInlineEnd);
 
   &.pf-m-no-padding {
     padding: 0;
@@ -516,24 +516,24 @@
   display: flex;
   flex-shrink: 0;
   flex-wrap: wrap;
-  padding-block-start: var(--#{$wizard}__footer--PaddingTop);
-  padding-block-end: var(--#{$wizard}__footer--PaddingBottom);
-  padding-inline-start: var(--#{$wizard}__footer--PaddingLeft);
-  padding-inline-end: var(--#{$wizard}__footer--PaddingRight);
+  padding-block-start: var(--#{$wizard}__footer--PaddingBlockStart);
+  padding-block-end: var(--#{$wizard}__footer--PaddingBlockEnd);
+  padding-inline-start: var(--#{$wizard}__footer--PaddingInlineStart);
+  padding-inline-end: var(--#{$wizard}__footer--PaddingInlineEnd);
   background-color: var(--#{$wizard}__footer--BackgroundColor);
   border-block-start: var(--#{$wizard}__footer--BorderWidth) solid var(--#{$wizard}__footer--BorderColor);
 
   > * {
-    margin-block-end: var(--#{$wizard}__footer--child--MarginBottom);
+    margin-block-end: var(--#{$wizard}__footer--child--MarginBlockEnd);
 
     &:not(:last-child) {
-      margin-inline-end: var(--#{$wizard}__footer--child--MarginRight);
+      margin-inline-end: var(--#{$wizard}__footer--child--MarginInlineEnd);
     }
   }
 }
 
 .#{$wizard}__footer-cancel {
-  margin-inline-start: var(--#{$wizard}__footer-cancel--MarginLeft);
+  margin-inline-start: var(--#{$wizard}__footer-cancel--MarginInlineStart);
 }
 
 // stylelint-disable no-invalid-position-at-import-rule

--- a/src/patternfly/demos/Card/examples/Card.css
+++ b/src/patternfly/demos/Card/examples/Card.css
@@ -16,9 +16,9 @@
 }
 
 #ws-html-demos-c-card-status-card-expanded-with-popover .pf-v6-c-table {
-  --pf-v6-c-table__expandable-row--after--BorderLeftWidth: 0;
+  --pf-v6-c-table__expandable-row--after--BorderInlineStartWidth: 0;
   --pf-v6-c-table__expandable-row--after--BorderColor: transparent;
-  --pf-v6-c-table--m-compact--cell--first-last-child--PaddingLeft: var(--pf-v6-global--spacer--sm);
+  --pf-v6-c-table--m-compact--cell--first-last-child--PaddingInlineStart: var(--pf-v6-global--spacer--sm);
 }
 
 .ws-chart {


### PR DESCRIPTION
Fixes #6389

This renames variables with top/right/bottom/left in the name and have been repurposed to apply to inline/block start/end properties (supporting RTL)

Visual regression in https://drive.google.com/drive/u/0/folders/1Wb2OAB7rO_e-17jxLSGLuTtAm7g-WJUA
Note: I reverted all log viewer changes as @coker is going to do that in the log-viewer PR to avoid lots of conflicts.
Remaining visual regression failures are disabled button with a badge (fixed since the baseline screens), text formatting (also fixed since the baseline screens), and a leftover dropdown toggle.