### PR TITLE
fix(hint): top-align hint actions

### DIFF
--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -55,6 +55,7 @@
   grid-row: 1;
   grid-column: 2;
   grid-auto-flow: column;
+  align-self: start;
   margin-inline-start: var(--#{$hint}__actions--MarginInlineStart);
   text-align: end;
 


### PR DESCRIPTION
closes #6570 

This PR adds `align-self: start` to the hint actions to keep them from filling available space.