### PR TITLE
fix(page): adjust spacing and brand size

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -56,7 +56,7 @@
   --#{$about-modal-box}__close--c-button--FontSize: var(--pf-t--global--icon--size--lg);
 
   // Brand img
-  --#{$about-modal-box}__brand-image--Height: #{pf-size-prem(40px)};
+  --#{$about-modal-box}__brand-image--Height: #{pf-size-prem(37px)};
 
   // Header
   --#{$about-modal-box}__header--PaddingInlineEnd: var(--pf-t--global--spacer--xl);

--- a/src/patternfly/components/Brand/examples/Brand.md
+++ b/src/patternfly/components/Brand/examples/Brand.md
@@ -25,7 +25,7 @@ import './Brand.css'
 ```hbs
 <div class="show-light">
 {{> brand
-  brand--attribute='style="--pf-v6-c-brand--Width: 40px; --pf-v6-c-brand--Width-on-md: 220px;"'
+  brand--attribute='style="--pf-v6-c-brand--Width: 37px; --pf-v6-c-brand--Width-on-md: 220px;"'
   brand--IsPicture="true"
   brand--img-url='/assets/images/PF-IconLogo-color.svg'
   brand--img-url-on-md='/assets/images/PF-HorizontalLogo-Color.svg'
@@ -35,7 +35,7 @@ import './Brand.css'
 <div class="show-dark">
 {{> brand
   brand--IsDark="true"
-  brand--attribute='style="--pf-v6-c-brand--Width: 40px; --pf-v6-c-brand--Width-on-md: 220px;"'
+  brand--attribute='style="--pf-v6-c-brand--Width: 37px; --pf-v6-c-brand--Width-on-md: 220px;"'
   brand--IsPicture="true"
   brand--img-url='/assets/images/PF-IconLogo-Reverse.svg'
   brand--img-url-on-md='/assets/images/PF-HorizontalLogo-Reverse.svg'

--- a/src/patternfly/components/Masthead/masthead-logo.hbs
+++ b/src/patternfly/components/Masthead/masthead-logo.hbs
@@ -1,5 +1,5 @@
 
-<svg height="40px" viewBox="0 0 679 158">
+<svg height="37px" viewBox="0 0 679 158">
     <title>PF-HorizontalLogo-Color </title>
     <defs>
         <linearGradient x1="68%" y1="2.25860997e-13%" x2="32%" y2="100%" id="linearGradient-{{masthead--id}}">

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -111,6 +111,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-container--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$page}__main-container--MarginInlineStart: var(--pf-t--global--spacer--lg);
   --#{$page}__main-container--MarginInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$page}__main-container--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$page}__main-container--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$page}__main-container--BorderWidth: var(--pf-t--global--spacer--sm); // TODO Change to be a page outline token
   --#{$page}__main-container--BorderColor: var(--#{$page}__main-container--BackgroundColor); // TODO Border should match the background to blend in - change to be a page outline token
@@ -494,6 +495,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 .#{$page}__main-container {
   align-self: start;
   max-height: var(--#{$page}__main-container--MaxHeight);
+  padding-block-end: var(--#{$page}__main-container--PaddingBlockEnd);
   margin-block-start: 0;
   margin-inline-start: var(--#{$page}__main-container--MarginInlineStart);
   margin-inline-end: var(--#{$page}__main-container--MarginInlineEnd);


### PR DESCRIPTION
Adjusts bottom spacing of the page main container to avoid the border radius.
Adjusts brand size from 40px to 37px to match Figma designs.

Fixes #6300 