### PR TITLE
feat(MenuToggle): split action toggle button modifier

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -234,7 +234,7 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 ```
 
-### Split button (checkbox with toggle text)
+### Split button (checkbox with label)
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check check-label--text="10 selected" check--IsDisabled=true}}
@@ -261,6 +261,23 @@ import './MenuToggle.css'
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check check-label--text="10 selected"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+```
+
+### Split button (checkbox with toggle button text)
+```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsSplitActionToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
     {{/menu-toggle-controls}}

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -272,9 +272,37 @@ import './MenuToggle.css'
 
 ### Split button (checkbox with toggle button text)
 ```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsSplitActionToggle="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+
+&nbsp;
+
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
       Toggle button text
     {{/menu-toggle-text}}
@@ -618,6 +646,7 @@ import './MenuToggle.css'
 | `.pf-v5-c-menu-toggle__button` | `<button>` | Initiates the menu toggle button. |
 | `.pf-m-split-button` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the split button variation. |
 | `.pf-m-action` | `.pf-v5-c-menu-toggle.pf-m-split-button` | Modifies the menu toggle component for the action, split button variation. |
+| `.pf-m-text` | `.pf-v5-c-menu-toggle-button` | Modifies the menu toggle component split button variation with text. |
 | `.pf-m-disabled` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the disabled variation. |
 | `.pf-m-primary` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the primary variation. |
 | `.pf-m-secondary` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -272,7 +272,7 @@ import './MenuToggle.css'
 
 ### Split button (checkbox with toggle button text)
 ```hbs
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
@@ -300,7 +300,7 @@ import './MenuToggle.css'
 
 &nbsp;
 
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
@@ -646,7 +646,7 @@ import './MenuToggle.css'
 | `.pf-v5-c-menu-toggle__button` | `<button>` | Initiates the menu toggle button. |
 | `.pf-m-split-button` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the split button variation. |
 | `.pf-m-action` | `.pf-v5-c-menu-toggle.pf-m-split-button` | Modifies the menu toggle component for the action, split button variation. |
-| `.pf-m-text` | `.pf-v5-c-menu-toggle-button` | Modifies the menu toggle component split button variation with text. |
+| `.pf-m-text` | `.pf-v5-c-menu-toggle__button` | Modifies the menu toggle component split button variation with text. |
 | `.pf-m-disabled` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the disabled variation. |
 | `.pf-m-primary` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the primary variation. |
 | `.pf-m-secondary` | `.pf-v5-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |

--- a/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
@@ -8,8 +8,6 @@
       {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input"')}}
       {{#if menu-toggle--check--text}}
         {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}{{menu-toggle--check--text}}{{/check-label}}
-      {{else}}
-        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}Label{{/check-label}}
       {{/if}}
     {{/check}}
   {{/if}}

--- a/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
@@ -7,7 +7,7 @@
     {{#> check check--type="label" check--attribute=(concat 'for="' menu-toggle--check--id '-input"') check--IsDisabled=menu-toggle--IsDisabled}}
       {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input"')}}
       {{#if menu-toggle--check--text}}
-        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}{{menu-toggle--check--text}}{{/check-label}}
+        {{#> check-label check-label--type="span" check-label--IsDisabled=menu-toggle--IsDisabled}}{{menu-toggle--check--text}}{{/check-label}}
       {{/if}}
     {{/check}}
   {{/if}}

--- a/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
@@ -1,4 +1,4 @@
-<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}}"
+<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}} {{#if menu-toggle-button--IsSplitActionToggle}}pf-m-split-toggle-button{{/if}}"
   type="button"
   {{#if menu-toggle-button--IsToggle}}
     aria-expanded="{{#if menu-toggle--IsExpanded}}true{{else}}false{{/if}}"

--- a/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
@@ -1,4 +1,4 @@
-<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}} {{#if menu-toggle-button--IsSplitActionToggle}}pf-m-split-toggle-button{{/if}}"
+<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}} {{#if menu-toggle-button--IsTextToggle}}pf-m-text{{/if}}"
   type="button"
   {{#if menu-toggle-button--IsToggle}}
     aria-expanded="{{#if menu-toggle--IsExpanded}}true{{else}}false{{/if}}"

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -158,7 +158,7 @@
   --#{$menu-toggle}__button--PaddingRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginLeft: var(--#{$pf-global}--spacer--sm);
-  --#{$menu-toggle}__button--m--text--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
+  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Typeahead
   --#{$menu-toggle}--m-typeahead__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
@@ -565,8 +565,6 @@
   --#{$menu-toggle}__controls--MarginRight: var(--#{$menu-toggle}__button__controls--MarginRight);
   --#{$menu-toggle}__controls--MarginLeft: var(--#{$menu-toggle}__button__controls--MarginLeft);
 
-  display: inline-flex;
-  align-items: baseline;
   align-self: var(--#{$menu-toggle}__button--AlignSelf);
   padding-inline-start: var(--#{$menu-toggle}__button--PaddingLeft);
   padding-inline-end: var(--#{$menu-toggle}__button--PaddingRight);
@@ -575,7 +573,11 @@
   border: 0;
 
   &.pf-m-text {
-    padding-inline-start: var(--#{$menu-toggle}__button--m--text--PaddingInlineStart);
+    --#{$menu-toggle}--m-split-button--last-child--PaddingLeft: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);
+
+    display: inline-flex;
+    align-items: baseline;
+    padding-inline-start: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);
   }
 }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -118,6 +118,7 @@
 
   // Split button
   --#{$menu-toggle}--m-split-button--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
+  --#{$menu-toggle}--m-split-button--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Split button, child
   --#{$menu-toggle}--m-split-button--child--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
@@ -410,6 +411,11 @@
 
         align-self: center;
       }
+    }
+
+    .pf-m-split-toggle-button {
+      display: flex;
+      padding-inline-start: var(--#{$menu-toggle}--m-split-button--PaddingInlineStart);
     }
 
     // Split button, active

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -118,7 +118,6 @@
 
   // Split button
   --#{$menu-toggle}--m-split-button--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
-  --#{$menu-toggle}--m-split-button--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Split button, child
   --#{$menu-toggle}--m-split-button--child--BackgroundColor: var(--#{$pf-global}--BackgroundColor--100);
@@ -159,6 +158,7 @@
   --#{$menu-toggle}__button--PaddingRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
   --#{$menu-toggle}__button__controls--MarginLeft: var(--#{$pf-global}--spacer--sm);
+  --#{$menu-toggle}__button--m--text--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Typeahead
   --#{$menu-toggle}--m-typeahead__controls--MarginRight: var(--#{$pf-global}--spacer--sm);
@@ -413,11 +413,6 @@
       }
     }
 
-    .pf-m-split-toggle-button {
-      display: flex;
-      padding-inline-start: var(--#{$menu-toggle}--m-split-button--PaddingInlineStart);
-    }
-
     // Split button, active
     &.pf-m-action {
       // stylelint-disable max-nesting-depth
@@ -570,12 +565,18 @@
   --#{$menu-toggle}__controls--MarginRight: var(--#{$menu-toggle}__button__controls--MarginRight);
   --#{$menu-toggle}__controls--MarginLeft: var(--#{$menu-toggle}__button__controls--MarginLeft);
 
+  display: inline-flex;
+  align-items: baseline;
   align-self: var(--#{$menu-toggle}__button--AlignSelf);
   padding-inline-start: var(--#{$menu-toggle}__button--PaddingLeft);
   padding-inline-end: var(--#{$menu-toggle}__button--PaddingRight);
   color: inherit;
   background-color: var(--#{$menu-toggle}__button--BackgroundColor);
   border: 0;
+
+  &.pf-m-text {
+    padding-inline-start: var(--#{$menu-toggle}__button--m--text--PaddingInlineStart);
+  }
 }
 
 .#{$menu-toggle}__icon {


### PR DESCRIPTION
Closes #6534.

Adds `pf-m-split-toggle-button` modifier, for use when a split action checkbox toggle has toggle text (not a checkbox label).