### PR TITLE
fix(charts): update dark label color token

### DIFF
--- a/src/patternfly/base/tokens/tokens-charts-dark.scss
+++ b/src/patternfly/base/tokens/tokens-charts-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 May 2024 15:08:07 GMT
+// Generated on Wed, 22 May 2024 20:26:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--stroke-line-join: round;
@@ -22,7 +22,7 @@
   --pf-t--chart--global--BorderWidth--lg: 8;
   --pf-t--chart--global--BorderWidth--sm: 2;
   --pf-t--chart--global--BorderWidth--xs: 1;
-  --pf-t--chart--global--label--fill: var(--pf-t--color--gray--90);
+  --pf-t--chart--global--label--fill: var(--pf-t--color--white);
   --pf-t--chart--global--danger--color--100: var(--pf-t--color--red-orange--50);
   --pf-t--chart--global--success--color--100: var(--pf-t--color--blue--30);
   --pf-t--chart--global--warning--color--200: var(--pf-t--color--yellow--30);

--- a/src/patternfly/base/tokens/tokens-charts.scss
+++ b/src/patternfly/base/tokens/tokens-charts.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 May 2024 15:08:07 GMT
+// Generated on Wed, 22 May 2024 20:26:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--stroke-line-join: round;

--- a/src/patternfly/base/tokens/tokens-dark.scss
+++ b/src/patternfly/base/tokens/tokens-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 May 2024 15:08:07 GMT
+// Generated on Wed, 22 May 2024 20:26:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);

--- a/src/patternfly/base/tokens/tokens-default.scss
+++ b/src/patternfly/base/tokens/tokens-default.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 May 2024 15:08:07 GMT
+// Generated on Wed, 22 May 2024 20:26:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--timing-function--300: cubic-bezier(0, 0, .2, 1);

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -5,7 +5,7 @@
 @mixin pf-v6-tokens {
   --pf-t--color--red--70: #5f0000;
   --pf-t--color--red--60: #a60000;
-  --pf-t--color--red--50: #ee0000;
+  --pf-t--color--red--50: #e00;
   --pf-t--color--red--40: #f56e6e;
   --pf-t--color--red--30: #f9a8a8;
   --pf-t--color--red--20: #fbc5c5;
@@ -52,14 +52,14 @@
   --pf-t--color--teal--30: #9ad8d8;
   --pf-t--color--teal--20: #b9e5e5;
   --pf-t--color--teal--10: #daf2f2;
-  --pf-t--color--blue--70: #003366;
+  --pf-t--color--blue--70: #036;
   --pf-t--color--blue--60: #004d99;
-  --pf-t--color--blue--50: #0066cc;
+  --pf-t--color--blue--50: #06c;
   --pf-t--color--blue--40: #4394e5;
   --pf-t--color--blue--30: #92c5f9;
   --pf-t--color--blue--20: #b9dafc;
   --pf-t--color--blue--10: #e0f0ff;
-  --pf-t--color--black: #000000;
+  --pf-t--color--black: #000;
   --pf-t--color--gray--95: #151515;
   --pf-t--color--gray--90: #1f1f1f;
   --pf-t--color--gray--80: #292929;
@@ -70,5 +70,5 @@
   --pf-t--color--gray--30: #c7c7c7;
   --pf-t--color--gray--20: #e0e0e0;
   --pf-t--color--gray--10: #f2f2f2;
-  --pf-t--color--white: #ffffff;
+  --pf-t--color--white: #fff;
 }

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 May 2024 15:08:07 GMT
+// Generated on Wed, 22 May 2024 20:26:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--color--red--70: #5f0000;

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -5,7 +5,7 @@
 @mixin pf-v6-tokens {
   --pf-t--color--red--70: #5f0000;
   --pf-t--color--red--60: #a60000;
-  --pf-t--color--red--50: #e00;
+  --pf-t--color--red--50: #ee0000;
   --pf-t--color--red--40: #f56e6e;
   --pf-t--color--red--30: #f9a8a8;
   --pf-t--color--red--20: #fbc5c5;
@@ -52,14 +52,14 @@
   --pf-t--color--teal--30: #9ad8d8;
   --pf-t--color--teal--20: #b9e5e5;
   --pf-t--color--teal--10: #daf2f2;
-  --pf-t--color--blue--70: #036;
+  --pf-t--color--blue--70: #003366;
   --pf-t--color--blue--60: #004d99;
-  --pf-t--color--blue--50: #06c;
+  --pf-t--color--blue--50: #0066cc;
   --pf-t--color--blue--40: #4394e5;
   --pf-t--color--blue--30: #92c5f9;
   --pf-t--color--blue--20: #b9dafc;
   --pf-t--color--blue--10: #e0f0ff;
-  --pf-t--color--black: #000;
+  --pf-t--color--black: #000000;
   --pf-t--color--gray--95: #151515;
   --pf-t--color--gray--90: #1f1f1f;
   --pf-t--color--gray--80: #292929;
@@ -70,5 +70,5 @@
   --pf-t--color--gray--30: #c7c7c7;
   --pf-t--color--gray--20: #e0e0e0;
   --pf-t--color--gray--10: #f2f2f2;
-  --pf-t--color--white: #fff;
+  --pf-t--color--white: #ffffff;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6685

~~@lboehling just want to make sure the changes to the hex values in the palette token file are intentional? Looks to just change a handful of shorter hex values to the long/full value (eg `#06c` to `#0066cc`)~~ nevermind, core has a linter rule that complains about long hex values that can be shorter. Let the linter fix it for now, we may consider aligning on that format in the future