### PR TITLE
chore(multiple file upload): progress color

### DIFF
--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
@@ -88,7 +88,7 @@
   --#{$multiple-file-upload}__status-progress--Gap: var(--pf-t--global--spacer--sm);
 
   // status progress icon
-  --#{$multiple-file-upload}__status-progress-icon--Color: var(--pf-t--global--icon--color--regular);
+  --#{$multiple-file-upload}__status-progress-icon--Color: var(--pf-t--global--icon--color--brand--default);
 
   // status item
   --#{$multiple-file-upload}__status-item--PaddingTop: var(--pf-t--global--spacer--md);


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/6247

Single line change to update the color of the spinner icon on Multiple file upload.