### PR TITLE
fix(table): updated thead td to th

### DIFF
--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -1,5 +1,7 @@
 import { patternflyNamespace, patternflyVersion } from './init.mjs';
 
+// TODO: TODO: update ternary to not escape chars
+
 /** Ignore the object appended by handlebars. */
 export const concat = (...params) => {
   if (typeof params[params.length - 1] === 'object') {

--- a/src/patternfly/components/Check/check-input.hbs
+++ b/src/patternfly/components/Check/check-input.hbs
@@ -4,12 +4,12 @@
     aria-describedby="{{check--id}}-description"
   {{/if}}
   {{#if check--id}}
-    id="{{check--id}}-input"
-    name="{{check--id}}-input"
+    id="{{dasherize check--id 'input'}}"
+    name="{{dasherize check--id 'input'}}"
   {{/if}}
-  {{#if check--IsStandalone}}
-    aria-label="{{#if check--standalone--label}}{{check--standalone--label}}{{else}}Standalone check{{/if}}"
-  {{/if}}
+  {{#ifAny check--aria-label check--IsStandalone}}
+    aria-label="{{ternary check--aria-label check--aria-label 'Standalone check'}}"
+  {{/ifAny}}
   {{#if check-input--IsChecked}}
     checked
   {{/if}}

--- a/src/patternfly/components/Check/check.hbs
+++ b/src/patternfly/components/Check/check.hbs
@@ -5,9 +5,6 @@
   {{#if check--modifier}}
     {{check--modifier}}
   {{/if}}"
-  {{#if check--id}}
-    id="{{check--id}}"
-  {{/if}}
   {{#if check--IsLabelWrapped}}
     for="{{check--id}}-input"
   {{/if}}

--- a/src/patternfly/components/DataList/data-list-check.hbs
+++ b/src/patternfly/components/DataList/data-list-check.hbs
@@ -2,5 +2,8 @@
   {{#if data-list-check--attribute}}
     {{{data-list-check--attribute}}}
   {{/if}}>
-  {{> check check--IsStandalone=true check--IsLabelWrapped=true check--id=(dasherize data-list--id data-list-item--id)}}
+  {{> check
+      check--IsStandalone=true
+      check--IsLabelWrapped=true
+      check--id=(concat data-list--id '-' data-list-item--id '"' data-list-check-checkbox--attribute)}}
 </div>

--- a/src/patternfly/components/DataList/data-list-check.hbs
+++ b/src/patternfly/components/DataList/data-list-check.hbs
@@ -2,8 +2,5 @@
   {{#if data-list-check--attribute}}
     {{{data-list-check--attribute}}}
   {{/if}}>
-  {{> check
-      check--IsStandalone=true
-      check--IsLabelWrapped=true
-      check--id=(concat data-list--id '-' data-list-item--id '"' data-list-check-checkbox--attribute)}}
+  {{> check check--IsStandalone=true check--IsLabelWrapped=true check--id=(dasherize data-list--id data-list-item--id)}}
 </div>

--- a/src/patternfly/components/Menu/menu-item.hbs
+++ b/src/patternfly/components/Menu/menu-item.hbs
@@ -37,7 +37,7 @@
     {{#> menu-item-main}}
       {{#> menu-item-check}}
         {{#> check
-          check--id=(concat menu--id '-check-' menu-list-item--id)
+          check--id=(dasherize menu--id 'check' menu-list-item--id)
           check--IsStandalone=true
           check--IsDisabled=menu-list-item--IsDisabled
           check-input--IsChecked=(ternary menu-item--IsChecked true menu-list-item--IsChecked)}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -78,9 +78,9 @@
         check--IsStandalone=true
       }}
   {{/if}}
-  {{!-- {{#if menu-toggle--icon}}
+  {{#if menu-toggle--icon}}
     {{> menu-toggle-icon}}
-  {{/if}} --}}
+  {{/if}}
   {{#if menu-toggle--text}}
     {{> menu-toggle-text}}
   {{/if}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -73,14 +73,14 @@
   {{/if}}>
   {{#if menu-toggle--IsCheck}}
     {{> check
-        check--id=(concat menu-toggle--id '-check')
+        check--id=(dasherize menu-toggle--id 'check')
         check--IsLabelWrapped=true
         check--IsStandalone=true
       }}
   {{/if}}
-  {{#if menu-toggle--icon}}
+  {{!-- {{#if menu-toggle--icon}}
     {{> menu-toggle-icon}}
-  {{/if}}
+  {{/if}} --}}
   {{#if menu-toggle--text}}
     {{> menu-toggle-text}}
   {{/if}}

--- a/src/patternfly/components/Table/TableCells/table-cell-action.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-action.hbs
@@ -1,12 +1,8 @@
-{{!-- TODO: update `table-td` to `table-cell` --}}
-{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
-{{!-- TODO: automate attribution --}}
-
-{{#> table-td table-td--IsAction=true}}
+{{#> table-cell table-cell--classname='__action'}}
   {{> menu-toggle
       menu-toggle--IsPlain=true
       menu-toggle--HasKebab=true
       menu-toggle--IsSmall=table--IsCompact
       menu-toggle--aria-label='Table actions'
     }}
-{{/table-td}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-check.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-check.hbs
@@ -1,11 +1,7 @@
-{{!-- TODO: update `table-td` to `table-cell` --}}
-{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
-{{!-- TODO: automate attribution --}}
-
-{{#> table-td table-td--IsCheckbox=true}}
+{{#> table-cell table-cell--classname='__check' table-cell--aria-label=(ternary IsThead 'Check all rows' 'Check row')}}
   {{> check
       check--IsStandalone=true
       check--IsLabelWrapped=true
       check--id=(ternary table-cell-check--id table-cell-check--id (dasherize table--id 'checkrow' table-tr--index 'check'))
     }}
-{{/table-td}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-check.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-check.hbs
@@ -1,7 +1,8 @@
-{{#> table-cell table-cell--classname='__check' table-cell--aria-label=(ternary IsThead 'Check all rows' 'Check row')}}
+{{#> table-cell table-cell--classname='__check' table-cell--aria-label=(ternary IsThead 'Row select' 'Check row')}}
   {{> check
       check--IsStandalone=true
       check--IsLabelWrapped=true
+      check--aria-label=(ternary IsThead 'Select all rows' 'Select row')
       check--id=(ternary table-cell-check--id table-cell-check--id (dasherize table--id 'checkrow' table-tr--index 'check'))
     }}
 {{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-empty.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-empty.hbs
@@ -1,7 +1,3 @@
-{{!-- TODO: update `table-td` to `table-cell` --}}
-{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
-{{!-- TODO: automate attribution --}}
-
-{{#> table-td table-td--IsEmpty=true}}
-  {{> screen-reader screen-reader--text=table-cell--text}}
-{{/table-td}}
+{{#> table-cell table-cell--classname='__cell-empty'}}
+  {{> screen-reader screen-reader--text=(ternary table-cell--text table-cell--text 'Actions')}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-overflow-menu.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-overflow-menu.hbs
@@ -1,8 +1,4 @@
-{{!-- TODO: update `table-td` to `table-cell` --}}
-{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
-{{!-- TODO: automate attribution --}}
-
-{{#> table-td table-td--IsOverflowMenu=true}}
+{{#> table-cell table-cell--classname='__action'}}
   {{#> overflow-menu overflow-menu--id=(dasherize table--id 'overflow-menu' table-tr--index)}}
     {{#if table-cell-overflow-menu--IsCondensed}}
       {{#> overflow-menu-control menu-toggle--aria-label="Actions"}}
@@ -25,4 +21,4 @@
       {{/overflow-menu-content}}
     {{/if}}
   {{/overflow-menu}}
-{{/table-td}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-radio.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-radio.hbs
@@ -1,0 +1,7 @@
+{{#> table-cell table-cell--classname='__check'}}
+  {{#if table-cell--IsEmpty}}
+    {{> screen-reader screen-reader--text=(ternary table-cell--text table-cell--text 'Row select')}}
+  {{else}}
+    {{> radio radio--id=(concat table--id '-node' table-tr--index '-radio') radio--IsStandalone=true radio--IsLabelWrapped=true}}
+  {{/if}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
@@ -1,9 +1,5 @@
-{{!-- TODO: update `table-td` to `table-cell` --}}
-{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
-{{!-- TODO: automate attribution --}}
-
-{{#> table-td table-td--IsToggle=true}}
-  {{> button
+{{#> table-cell table-cell--classname='__toggle' table-cell--aria-label=(ternary IsThead 'Toggle all rows' 'Toggle all row')}}
+  {{#> button
     button--IsSmall=table--IsCompact
     button--IsPlain=true
     button--IsIcon=true
@@ -15,4 +11,7 @@
     button--aria-labelledby=(dasherize table--id 'node' table-tr--index)
     button--aria-controls=(dasherize table--id 'content' table-tr--index)
     button--id=(dasherize table--id 'expandable-toggle' table-tr--index)}}
-{{/table-td}}
+
+    {{> table-toggle-icon}}
+  {{/button}}
+{{/table-cell}}

--- a/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
@@ -1,4 +1,4 @@
-{{#> table-cell table-cell--classname='__toggle' table-cell--aria-label=(ternary IsThead 'Toggle all rows' 'Toggle all row')}}
+{{#> table-cell table-cell--classname='__toggle' table-cell--aria-label='Row expansion'}}
   {{#> button
     button--IsSmall=table--IsCompact
     button--IsPlain=true

--- a/src/patternfly/components/Table/TableCells/table-cell.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell.hbs
@@ -1,0 +1,16 @@
+{{!-- TODO: update `table-td` to `table-cell` --}}
+{{!-- TODO: automate `td/th` based up `IsThead/IsTbody` and make overridable --}}
+{{!-- TODO: automate attribution --}}
+
+{{#> config table-cell--tag=(ternary IsThead 'th' 'td')}}
+
+<{{table-cell--tag}} class="{{concat (pfv) 'table__' table-cell--tag ' ' (concat (pfv) 'table' table-cell--classname) ' ' table-cell--modifier}}{{ternary table-cell--IsEmpty (concat (pfv) 'table__cell-empty') null}}"
+  {{{ternary table-cell--aria-label (concat 'aria-label="' table-cell--aria-label '"') null}}}
+  {{{ternary table-cell--attribute table-cell--attribute null}}}>
+
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
+</{{table-cell--tag}}>
+
+{{/config}}

--- a/src/patternfly/components/Table/TableCells/table-cell.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell.hbs
@@ -4,9 +4,22 @@
 
 {{#> config table-cell--tag=(ternary IsThead 'th' 'td')}}
 
-<{{table-cell--tag}} class="{{concat (pfv) 'table__' table-cell--tag ' ' (concat (pfv) 'table' table-cell--classname) ' ' table-cell--modifier}}"
+<{{table-cell--tag}} class="{{concat (pfv) 'table__' table-cell--tag}}
+  {{setModifiers
+    table-cell--classname=(concat (pfv) 'table' table-cell--classname)
+    table-cell--IsFavorite=(concat (pfv) 'table__favorite')
+    table-cell--IsSortable=(concat (pfv) 'table__sort')
+    table-cell--modifier=table-cell--modifier
+  }}"
   {{{ternary table-cell--aria-label (concat 'aria-label="' table-cell--aria-label '"') null}}}
-  {{{ternary table-cell--attribute table-cell--attribute null}}}>
+  {{{ternary table-cell--attribute table-cell--attribute null}}}
+  {{{ternary IsThead 'role="columnheader" scope="col"' null}}}
+  {{{ternary table-cell--IsSortable (concat 'aria-sort="' (ternary table-cell--IsAsc 'ascending' (ternary table-cell--desc 'descending' 'none')) '"') null}}}>
+
+
+  {{#if (hasAll table-cell--IsFavorite table-cell--IsSortable)}}
+    {{> table-favorite-sort}}
+  {{/if}}
 
   {{#if @partial-block}}
     {{> @partial-block}}

--- a/src/patternfly/components/Table/TableCells/table-cell.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell.hbs
@@ -4,7 +4,7 @@
 
 {{#> config table-cell--tag=(ternary IsThead 'th' 'td')}}
 
-<{{table-cell--tag}} class="{{concat (pfv) 'table__' table-cell--tag ' ' (concat (pfv) 'table' table-cell--classname) ' ' table-cell--modifier}}{{ternary table-cell--IsEmpty (concat (pfv) 'table__cell-empty') null}}"
+<{{table-cell--tag}} class="{{concat (pfv) 'table__' table-cell--tag ' ' (concat (pfv) 'table' table-cell--classname) ' ' table-cell--modifier}}"
   {{{ternary table-cell--aria-label (concat 'aria-label="' table-cell--aria-label '"') null}}}
   {{{ternary table-cell--attribute table-cell--attribute null}}}>
 

--- a/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
@@ -4,8 +4,8 @@
     table--HasIcons=table-tree-view--HasIcons
     table--HasNoPosinset=table-tree-view--HasNoPosinset
   }}
-  {{#> table-thead table-tr--IsExpanded=true}}
-    {{#> table-tr newcontext table--HasActions=table-tree-view--HasActions}}
+  {{#> table-thead}}
+    {{#> table-tr table--HasActions=table-tree-view--HasActions}}
       {{#> table-th table-th--attribute='scope="col"' table-th--modifier=(prefix 'table__tree-view-title-header-cell')}}
         Name
       {{/table-th}}

--- a/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
@@ -1,10 +1,11 @@
-{{#> table table--IsTree-view="true"
+{{#>table
+    table--IsTree-view=true
     table--HasActions=table-tree-view--HasActions
     table--HasCheckboxes=table-tree-view--HasCheckboxes
     table--HasIcons=table-tree-view--HasIcons
     table--HasNoPosinset=table-tree-view--HasNoPosinset
   }}
-  {{#> table-thead}}
+  {{#> table-thead table-tr--HasNoPosinset=true}}
     {{#> table-tr table--HasActions=table-tree-view--HasActions}}
       {{#> table-th table-th--attribute='scope="col"' table-th--modifier=(prefix 'table__tree-view-title-header-cell')}}
         Name

--- a/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
@@ -21,9 +21,7 @@
 
       {{!-- TODO: fix this after merge --}}
       {{#if table--HasActions}}
-        {{#> table-th table-th--IsEmpty=true}}
-          {{> screen-reader screen-reader--text=table-cell--text}}
-        {{/table-th}}
+        {{> table-cell-empty}}
       {{/if}}
     {{/table-tr}}
   {{/table-thead}}

--- a/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
+++ b/src/patternfly/components/Table/Tree-table/table-tree-view--basic.hbs
@@ -20,8 +20,8 @@
       {{/table-th}}
 
       {{!-- TODO: fix this after merge --}}
-      {{#if table--HasActions}}
-        {{> table-cell-empty}}
+      {{#if table-tree-view--HasActions}}
+        {{> table-cell-empty table-cell--text='Actions'}}
       {{/if}}
     {{/table-tr}}
   {{/table-thead}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -344,7 +344,6 @@ These classes can be used to ensure that the table changes between the tabular a
       {{#> table-td table-td--data-label="Pull requests"}}
         25
       {{/table-td}}
-      <!-- TODO: update overflow menu with menu/menu toggle  -->
       {{> table-cell-overflow-menu}}
     {{/table-tr}}
 
@@ -566,7 +565,7 @@ These classes can be used to ensure that the table changes between the tabular a
     {{/table-tr}}
 
     {{#> table-tr table-tr--index="2"}}
-      {{> table--radio}}
+      {{> table-cell-radio}}
       {{> table--node}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -584,7 +583,7 @@ These classes can be used to ensure that the table changes between the tabular a
     {{/table-tr}}
 
     {{#> table-tr table-tr--index="3"}}
-      {{> table--radio}}
+      {{> table-cell-radio}}
       {{> table--node}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -602,7 +601,7 @@ These classes can be used to ensure that the table changes between the tabular a
     {{/table-tr}}
 
     {{#> table-tr table-tr--index="4"}}
-      {{> table--radio}}
+      {{> table-cell-radio}}
       {{> table--node}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -3502,6 +3501,7 @@ For sticky columns to function correctly, the parent table's width must be contr
 </div>
 ```
 ### Nested column header modifier usage
+## Favorites
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
@@ -3509,15 +3509,14 @@ For sticky columns to function correctly, the parent table's width must be contr
 | `.pf-m-border-right` | `<th>`, `<td>` | Modifies a table cell to show a right border. |
 | `.pf-m-border-left` | `<th>`, `<td>` | Modifies a table cell to show a left border. |
 
-## Favorites
 
 ### Favorites examples
 ```hbs
 {{#> table table--id="table-favorites" table--IsGrid=true table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a favorites table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
-      {{> table-cell-check}}
-      {{> table-cell-empty}}
+      {{> table-cell-check table-cell--aria-label=''}}
+      {{> table-cell-empty table-cell--text='Row favorited'}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3631,7 +3631,7 @@ For sticky columns to function correctly, the parent table's width must be contr
 {{#> table table--id="table-favorites-sortable" table--IsGrid=true table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a sortable with favorites table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="1"}}
-      {{> table-th table-th--attribute='scope="col"' table-th--IsFavorite="true" table-th--IsSortable=true table-th--IsSelected="true" table-button--attribute='aria-label="Favorite"'}}
+      {{> table-cell table-cell--IsFavorite=true table-cell--IsSortable=true table-cell--aria-label='Row favorited'}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -526,7 +526,7 @@ These classes can be used to ensure that the table changes between the tabular a
 {{#> table table--id="table-single-select-radio" table--IsGrid=true table--modifier="pf-m-grid-lg" table--attribute='aria-label="This is single select table with radio inputs"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{> table-cell-empty}}
+      {{> table-cell-radio table-cell--IsEmpty=true}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}
@@ -548,7 +548,7 @@ These classes can be used to ensure that the table changes between the tabular a
 
   {{#> table-tbody}}
     {{#> table-tr table-tr--index="1"}}
-      {{> table--radio}}
+      {{> table-cell-radio}}
       {{> table--node table--node--HasNoLink="true"}}
       {{#> table-td table-td--data-label="Branches"}}
         10
@@ -661,7 +661,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -941,7 +941,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -1191,7 +1191,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"'}}
        Last commit
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -1374,7 +1374,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"' table-th--IsIcon=true}}
         Icons
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -1495,7 +1495,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"'}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -1804,7 +1804,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -1913,7 +1913,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"' table-th--IsIcon=true}}
         Icons
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -2042,7 +2042,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"' table-th--IsIcon=true}}
         Icons
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -2152,7 +2152,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
 {{#> table table--id="borderless-table-expandable" table--IsGrid=true table--modifier="pf-m-grid-lg pf-m-no-border-rows" table--IsExpandable=true table--attribute='aria-label="Expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Expand rows'}}
       {{> table-cell-check}}
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-m-width-30" table-th--IsSelected="true" table-th--IsAsc="true"}}
         Repositories
@@ -2163,7 +2163,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -2298,7 +2298,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{#> table-th table-th--attribute='scope="col"'}}
        Last commit
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
@@ -2736,7 +2736,7 @@ To better control table cell behavior, PatternFly provides a series of modifiers
       {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-fit-content"}}
         Fit content
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Wrapping'}}
     {{/table-tr}}
   {{/table-thead}}
 
@@ -3248,8 +3248,8 @@ For sticky columns to function correctly, the parent table's width must be contr
   {{#> table table--id="nested-columns-expandable-example" table--attribute='aria-label="This is a nested column header table example"' table--IsExpandable=true table--IsGrid=true table--HasToggles=true table--HasChecks=true table--HasActions=true}}
     {{#> table-thead table-thead--modifier="pf-m-nested-column-header"}}
       {{#> table-tr}}
-        {{> table-cell-empty table-td--attribute='rowspan="2"'}}
-        {{> table-cell-check table-td--attribute='rowspan="2"'}}
+        {{> table-cell-empty table-cell--attribute='rowspan="2"' table-cell--text='Expandable toggle'}}
+        {{> table-cell-check table-cell--attribute='rowspan="2"'}}
         {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--sortable="true" table-th--modifier="pf-m-border-right"}}
           Team
         {{/table-th}}
@@ -3781,7 +3781,7 @@ For sticky columns to function correctly, the parent table's width must be contr
     {{/table-caption}}
     {{#> table-thead}}
       {{#> table-tr}}
-        {{> table-cell-empty}}
+        {{> table-cell-empty table-cell--text='Drag row'}}
         {{#> table-th table-th--attribute='scope="col"'}}
           Repositories
         {{/table-th}}
@@ -4010,7 +4010,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
 {{#> table table--id="table-striped-expandable" table--IsGrid=true table--modifier="pf-m-grid-lg pf-m-striped" table--IsExpandable=true table--attribute='aria-label="Striped expandable table example"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Expand row'}}
       {{> table-cell-check}}
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-m-width-30" table-th--IsSelected="true" table-th--IsAsc="true"}}
         Repositories
@@ -4021,7 +4021,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
         Pull requests
       {{/table-th}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Links'}}
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}

--- a/src/patternfly/components/Table/table-tbody.hbs
+++ b/src/patternfly/components/Table/table-tbody.hbs
@@ -1,7 +1,4 @@
-{{#>
-  config
-  IsBody=true
-}}
+{{#> config IsTbody=true}}
 
 <tbody class="{{pfv}}table__tbody
   {{#if table-tbody--IsClickable}} pf-m-clickable{{/if}}

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -1,7 +1,4 @@
-{{#>
-  config
-  table-th--tag=(ternary table-th--tag table-th--tag 'th')
-}}
+{{#> config table-th--tag=(ternary table-th--tag table-th--tag 'th')}}
 
 <{{table-th--tag}} class="{{pfv}}table__th
   {{#if table-th--modifier}} {{table-th--modifier}}{{/if}}

--- a/src/patternfly/components/Table/table-thead.hbs
+++ b/src/patternfly/components/Table/table-thead.hbs
@@ -1,7 +1,4 @@
-{{#>
-  config
-  IsThead=true
-}}
+{{#> config IsThead=true}}
 
 <thead class="{{pfv}}table__thead
   {{#if table-thead--modifier}}{{table-thead--modifier}}{{/if}}{{#if table-thead--IsNested}} pf-m-nested-column-header{{/if}}"

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -8,7 +8,7 @@
   {{#if table-tr--IsBorderRow}} pf-m-border-row{{/if}}
   {{#if table-tr--HasNoInset}} pf-m-no-inset{{/if}}
   {{#if table-tr--modifier}} {{table-tr--modifier}}{{/if}}"
-  {{#unless (concat table-tr--HasNoPosinset table--HasNoPosinset)}}
+  {{#unless (concat IsThead table-tr--HasNoPosinset table--HasNoPosinset)}}
     {{#if table--IsTree-view}}
       aria-level="{{table--IsTree-view--level}}"
       aria-setsize="{{table--IsTree-view--setsize}}"

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -8,7 +8,7 @@
   {{#if table-tr--IsBorderRow}} pf-m-border-row{{/if}}
   {{#if table-tr--HasNoInset}} pf-m-no-inset{{/if}}
   {{#if table-tr--modifier}} {{table-tr--modifier}}{{/if}}"
-  {{#unless (concat IsThead table-tr--HasNoPosinset table--HasNoPosinset)}}
+  {{#unless (concat table-tr--HasNoPosinset table--HasNoPosinset)}}
     {{#if table--IsTree-view}}
       aria-level="{{table--IsTree-view--level}}"
       aria-setsize="{{table--IsTree-view--setsize}}"

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -5,49 +5,28 @@
   {{#if table-tr--details--IsExpanded}} pf-m-tree-view-details-expanded{{/if}}
   {{#if table-tr--IsClickable}} pf-m-clickable{{/if}}
   {{#if table-tr--IsSelected}} pf-m-selected{{/if}}
-  {{#if table-tr--IsBorderRow}} pf-m-border-row{{/if}}
   {{#if table-tr--HasNoInset}} pf-m-no-inset{{/if}}
   {{#if table-tr--modifier}} {{table-tr--modifier}}{{/if}}"
-  {{#unless (concat table-tr--HasNoPosinset table--HasNoPosinset)}}
-    {{#if table--IsTree-view}}
-      aria-level="{{table--IsTree-view--level}}"
-      aria-setsize="{{table--IsTree-view--setsize}}"
-      aria-posinset="{{table--IsTree-view--posinset}}"
+  {{#if table--IsTree-view}}
+    {{#unless (concat table-tr--HasNoPosinset table--HasNoPosinset)}}
+      aria-level="{{ternary table--IsTree-view--level table--IsTree-view--level '1'}}"
+      aria-setsize="{{ternary table--IsTree-view--setsize table--IsTree-view--setsize '1'}}"
+      aria-posinset="{{ternary table--IsTree-view--posinset table--IsTree-view--posinset '1'}}"
 
       {{!-- if leaf and not expanded, apply hidden --}}
       {{#if table-tr--tree--IsLeaf}}
         tabindex="-1"
       {{else}}
         tabindex="0"
-        {{#if table-tr--IsExpanded}}
-          aria-expanded="true"
-        {{else}}
-          aria-expanded="false"
-        {{/if}}
+        aria-expanded="{{ternary table-tr--IsExpanded 'true' 'false'}}"
       {{/if}}
-      {{#if table-tr--IsHidden}}
-        hidden
-      {{/if}}
-    {{/if}}
-  {{/unless}}
-  {{#unless table-tr--IsBorderRow}}
-    {{#if table--IsGrid}}
-      role="row"
-    {{/if}}
-  {{/unless}}
-  {{#if table-tr--IsClickable}}
-    tabindex="0"
+      {{ternary table-tr--IsHidden 'hidden' null}}
+    {{/unless}}
   {{/if}}
-  {{#if table-tr--IsBorderRow}}
-    aria-hidden="true"
-  {{/if}}
+  {{ternary table--IsGrid 'role="row"'}}
+  {{ternary table-tr--IsClickable 'tabindex="0"'}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>
-  {{#if table-tr--IsBorderRow}}
-    {{!-- TODO: abstract the border row --}}
-    {{> table-cell-empty table-td--attribute=(concat 'colspan="' table-tr--colspan '"')}}
-  {{else}}
-    {{> @partial-block}}
-  {{/if}}
+  {{> @partial-block}}
 </tr>

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1092,6 +1092,10 @@
   .#{$table}__thead & {
     border-block-end: 0;
   }
+
+  &.pf-m-border-row {
+    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
+  }
 }
 
 // - Table icon inline

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1092,10 +1092,6 @@
   .#{$table}__thead & {
     border-block-end: 0;
   }
-
-  &.pf-m-border-row {
-    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
-  }
 }
 
 // - Table icon inline

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -400,6 +400,11 @@
   thead:where(.#{$table}__thead) {
     --#{$table}--cell--FontSize: var(--#{$table}__thead--cell--FontSize);
     --#{$table}--cell--FontWeight: var(--#{$table}__thead--cell--FontWeight);
+    --#{$table}--cell--MinWidth: var(--#{$table}--m-truncate--cell--MinWidth);
+    --#{$table}--cell--MaxWidth: var(--#{$table}--m-truncate--cell--MaxWidth);
+    --#{$table}--cell--Overflow: hidden;
+    --#{$table}--cell--TextOverflow: ellipsis;
+    --#{$table}--cell--WhiteSpace: nowrap;
 
     // stylelint-disable
     &.pf-m-nested-column-header {
@@ -461,50 +466,6 @@
   :where(.#{$table}__th, .#{$table}__td) {
     &.pf-m-help {
       min-width: var(--#{$table}__th--m-help--MinWidth);
-    }
-  }
-
-  // - Table truncate - Table wrap - Table nowrap - Table fit content - Table wrap - Table break word
-  :where([class*='#{$table}']),
-  :where(&) > :is(thead, tbody),
-  &.#{$table}__thead {
-    &.pf-m-truncate {
-      --#{$table}--cell--MinWidth: var(--#{$table}--m-truncate--cell--MinWidth);
-      --#{$table}--cell--MaxWidth: var(--#{$table}--m-truncate--cell--MaxWidth);
-      --#{$table}--cell--Overflow: hidden;
-      --#{$table}--cell--TextOverflow: ellipsis;
-      --#{$table}--cell--WhiteSpace: nowrap;
-    }
-
-    &.pf-m-wrap {
-      --#{$table}--cell--MinWidth: 0;
-      --#{$table}--cell--MaxWidth: none;
-      --#{$table}--cell--Overflow: visible;
-      --#{$table}--cell--TextOverflow: clip;
-      --#{$table}--cell--WhiteSpace: normal;
-    }
-
-    &.pf-m-nowrap {
-      --#{$table}--cell--MinWidth: 0;
-      --#{$table}--cell--MaxWidth: none;
-      --#{$table}--cell--Overflow: visible;
-      --#{$table}--cell--TextOverflow: clip;
-      --#{$table}--cell--WhiteSpace: nowrap;
-    }
-
-    .#{$table}__icon,
-    &.pf-m-fit-content {
-      --#{$table}--cell--MinWidth: fit-content;
-      --#{$table}--cell--MaxWidth: none;
-      --#{$table}--cell--Width: 1%;
-      --#{$table}--cell--Overflow: visible;
-      --#{$table}--cell--TextOverflow: clip;
-      --#{$table}--cell--WhiteSpace: nowrap;
-    }
-
-    &.pf-m-break-word {
-      --#{$table}--cell--WordBreak: break-word;
-      --#{$table}--cell--WhiteSpace: normal;
     }
   }
 
@@ -596,6 +557,48 @@
 
   .#{$button} .#{$table}__sort-indicator {
     --pf-v6-c-table__sort-indicator--MarginInlineStart: 0;
+  }
+}
+
+// - Table truncate - Table wrap - Table nowrap - Table fit content - Table wrap - Table break word
+[class*='#{$table}'] {
+  &.pf-m-truncate {
+    --#{$table}--cell--MinWidth: var(--#{$table}--m-truncate--cell--MinWidth);
+    --#{$table}--cell--MaxWidth: var(--#{$table}--m-truncate--cell--MaxWidth);
+    --#{$table}--cell--Overflow: hidden;
+    --#{$table}--cell--TextOverflow: ellipsis;
+    --#{$table}--cell--WhiteSpace: nowrap;
+  }
+
+  &.pf-m-wrap {
+    --#{$table}--cell--MinWidth: 0;
+    --#{$table}--cell--MaxWidth: none;
+    --#{$table}--cell--Overflow: visible;
+    --#{$table}--cell--TextOverflow: clip;
+    --#{$table}--cell--WhiteSpace: normal;
+  }
+
+  &.pf-m-nowrap {
+    --#{$table}--cell--MinWidth: 0;
+    --#{$table}--cell--MaxWidth: none;
+    --#{$table}--cell--Overflow: visible;
+    --#{$table}--cell--TextOverflow: clip;
+    --#{$table}--cell--WhiteSpace: nowrap;
+  }
+
+  .#{$table}__icon,
+  &.pf-m-fit-content {
+    --#{$table}--cell--MinWidth: fit-content;
+    --#{$table}--cell--MaxWidth: none;
+    --#{$table}--cell--Width: 1%;
+    --#{$table}--cell--Overflow: visible;
+    --#{$table}--cell--TextOverflow: clip;
+    --#{$table}--cell--WhiteSpace: nowrap;
+  }
+
+  &.pf-m-break-word {
+    --#{$table}--cell--WordBreak: break-word;
+    --#{$table}--cell--WhiteSpace: normal;
   }
 }
 
@@ -947,7 +950,7 @@
   }
 
   @at-root :not(.#{$table}__control-row) ~ .#{$table}__expandable-row {
-    > .#{$table}__th, 
+    > .#{$table}__th,
     > .#{$table}__td {
       padding-block-start: 0;
     }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -466,8 +466,8 @@
 
   // - Table truncate - Table wrap - Table nowrap - Table fit content - Table wrap - Table break word
   :where([class*='#{$table}']),
-  :where(&) > :is(thead, tbody) {
-    @at-root .#{$table} > thead,
+  :where(&) > :is(thead, tbody),
+  &.#{$table}__thead {
     &.pf-m-truncate {
       --#{$table}--cell--MinWidth: var(--#{$table}--m-truncate--cell--MinWidth);
       --#{$table}--cell--MaxWidth: var(--#{$table}--m-truncate--cell--MaxWidth);

--- a/src/patternfly/components/Toolbar/toolbar-toggle.hbs
+++ b/src/patternfly/components/Toolbar/toolbar-toggle.hbs
@@ -3,7 +3,7 @@
     {{{toolbar-toggle--attribute}}}
   {{/if}}>
   {{> menu-toggle
-      menu-toggle--icon=(ternary toolbar-toggle--icon toolbar-toggle--icon 'filter')
+      menu-toggle--icon='filter'
       menu-toggle--IsPlain=true
       menu-toggle--IsExpanded=toolbar-expandable-content--IsExpanded
       menu-toggle--attribute=(concat 'aria-label="Show filters" aria-controls="' toolbar--id '-expandable-content"')

--- a/src/patternfly/demos/Table/table-compact-table.hbs
+++ b/src/patternfly/demos/Table/table-compact-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--IsGrid=true table--modifier="pf-m-compact pf-m-grid-lg" table--attribute='aria-label="This is a compact table example"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Row select'}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Contributor
       {{/table-th}}

--- a/src/patternfly/demos/Table/table-empty-state-table.hbs
+++ b/src/patternfly/demos/Table/table-empty-state-table.hbs
@@ -1,11 +1,7 @@
 {{#> table table--id="empty-state-table-demo" table--IsGrid=true table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a table showing an empty state"'}}
   {{#> table-thead}}
     {{#> table-tr}}
-      {{#> table-td table-td--IsCheckbox=true}}
-        {{#> check check--modifier="pf-m-standalone"}}
-          {{#> check-input check-input--attribute='name="check-all" aria-label="Select all rows"'}}{{/check-input}}
-        {{/check}}
-      {{/table-td}}
+      {{> table-cell-check}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}
@@ -29,20 +25,20 @@
   {{#> table-tbody}}
     {{#> table-tr}}
       {{#> table-td table-td--attribute='colspan="8"'}}
-          {{#> empty-state empty-state--modifier="pf-m-sm"}}
-            {{#> empty-state-icon empty-state-icon--type="search"}}{{/empty-state-icon}}
-            {{#> title titleType="h2" title--modifier="pf-m-lg"}}
-              No results found
-            {{/title}}
-            {{#> empty-state-body}}
-              No results match the filter criteria. Remove all filters or clear all filters to show results.
-            {{/empty-state-body}}
-            {{#> empty-state-primary}}
-              {{#> button button--IsLink=true}}
-                Clear all filters
-              {{/button}}
-            {{/empty-state-primary}}
-          {{/empty-state}}
+        {{#> empty-state empty-state--modifier="pf-m-sm"}}
+          {{#> empty-state-icon empty-state-icon--type="search"}}{{/empty-state-icon}}
+          {{#> title titleType="h2" title--modifier="pf-m-lg"}}
+            No results found
+          {{/title}}
+          {{#> empty-state-body}}
+            No results match the filter criteria. Remove all filters or clear all filters to show results.
+          {{/empty-state-body}}
+          {{#> empty-state-primary}}
+            {{#> button button--IsLink=true}}
+              Clear all filters
+            {{/button}}
+          {{/empty-state-primary}}
+        {{/empty-state}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/demos/Table/table-expandable-table.hbs
+++ b/src/patternfly/demos/Table/table-expandable-table.hbs
@@ -2,7 +2,7 @@
   {{#> table-thead}}
     {{#> table-tr table-tr--index="thead"}}
       {{> table-cell-toggle}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Row select'}}
       {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-width-30"}}
         Repositories
       {{/table-th}}

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--IsGrid=true table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index='1'}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Row select'}}
       {{#> table-th table-th--attribute='scope="col"'}}
         Repositories
       {{/table-th}}

--- a/src/patternfly/demos/Table/table-sortable-table.hbs
+++ b/src/patternfly/demos/Table/table-sortable-table.hbs
@@ -1,7 +1,7 @@
 {{#> table table--id=(concat page--id '-table') table--IsGrid=true table--modifier="pf-m-grid-xl" table--attribute='aria-label="This is a sortable table example"'}}
   {{#> table-thead}}
     {{#> table-tr  table-tr--index='1'}}
-      {{> table-cell-empty}}
+      {{> table-cell-empty table-cell--text='Row select'}}
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--IsSelected="true" table-th--IsAsc="true"}}
         Repositories
       {{/table-th}}

--- a/src/patternfly/demos/Toolbar/toolbar-template.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template.hbs
@@ -32,7 +32,7 @@ Options: [
       {{!-- toggle group --}}
       {{#if toolbar-template--HasToggleGroup}}
         {{#> toolbar-group toolbar-group--IsToggleGroup=true toolbar-group--modifier="pf-m-show-on-xl"}}
-          {{> toolbar-toggle}}
+          {{> toolbar-toggle menu-toggle-icon='filter'}}
           {{> toolbar-template-content}}
         {{/toolbar-group}}
       {{else}}


### PR DESCRIPTION
closes #6272 
closes https://github.com/patternfly/patternfly/issues/6643

[Backstop Report](https://drive.google.com/file/d/1X98JYLHM_U5YtSaLwGvrg-8aX6j4krD-/view?usp=sharing)

## 8/26 Update

**Header shift is due to `pf-v6-c-table__cell-empty` and is expected**

[Backstop report](https://drive.google.com/file/d/11u1r8QELIo1m9e2a5Y8AAiFoKYNW5Wwz/view?usp=sharing)

Favorites example shouldn't be sorted, this diff is expected

<img width="1285" alt="Screenshot 2024-08-26 at 12 44 03 PM" src="https://github.com/user-attachments/assets/9ca04638-72cb-4dc8-ac41-f579e03c0346">


This PR creates a partial container for special table cells. The internals of the partials remain unchanged while the wrapping element detects `IsThead` and returns `th` if true, `td` if false. Empty cells' default screen reader text is set to "Action" (the most common use case) and optionally updated text via `table-cell--text`. 

This shift is due to updating action empty `th` to `pf-v6-c-table__cell-empty`

<img width="1081" alt="Screenshot 2024-08-20 at 12 34 35 PM" src="https://github.com/user-attachments/assets/e9e128e4-b664-423f-881b-8b84d6620343">

This  and all other search input shifts are due to button updates unrelated to this PR

<img width="389" alt="Screenshot 2024-08-20 at 12 36 42 PM" src="https://github.com/user-attachments/assets/68d640b9-3caf-4c80-86a0-1e0f3dc83124">


