### PR TITLE
fix(charts): color/token updates

### DIFF
--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -28,59 +28,66 @@ $chart: #{$pf-prefix} + 'chart';
   // Chart colors
   // blue
   --#{$chart}-color-blue-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-blue-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-blue-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-blue-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-blue-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-blue-200: var(--pf-t--chart--color--blue--200);
+  --#{$chart}-color-blue-300: var(--pf-t--chart--color--blue--300);
+  --#{$chart}-color-blue-400: var(--pf-t--chart--color--blue--400);
+  --#{$chart}-color-blue-500: var(--pf-t--chart--color--blue--500);
 
   // green
-  --#{$chart}-color-green-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-green-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-green-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-green-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-green-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-green-100: var(--pf-t--chart--color--green--100);
+  --#{$chart}-color-green-200: var(--pf-t--chart--color--green--200);
+  --#{$chart}-color-green-300: var(--pf-t--chart--color--green--300);
+  --#{$chart}-color-green-400: var(--pf-t--chart--color--green--400);
+  --#{$chart}-color-green-500: var(--pf-t--chart--color--green--500);
 
   // cyan
-  --#{$chart}-color-cyan-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-cyan-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-cyan-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-cyan-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-cyan-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-cyan-100: var(--pf-t--chart--color--teal--100);
+  --#{$chart}-color-cyan-200: var(--pf-t--chart--color--teal--200);
+  --#{$chart}-color-cyan-300: var(--pf-t--chart--color--teal--300);
+  --#{$chart}-color-cyan-400: var(--pf-t--chart--color--teal--400);
+  --#{$chart}-color-cyan-500: var(--pf-t--chart--color--teal--500);
 
   // purple
-  --#{$chart}-color-purple-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-purple-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-purple-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-purple-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-purple-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-purple-100: var(--pf-t--chart--color--purple--100);
+  --#{$chart}-color-purple-200: var(--pf-t--chart--color--purple--200);
+  --#{$chart}-color-purple-300: var(--pf-t--chart--color--purple--300);
+  --#{$chart}-color-purple-400: var(--pf-t--chart--color--purple--400);
+  --#{$chart}-color-purple-500: var(--pf-t--chart--color--purple--500);
 
   // gold
-  --#{$chart}-color-gold-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-gold-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-gold-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-gold-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-gold-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-gold-100: var(--pf-t--chart--color--yellow--100);
+  --#{$chart}-color-gold-200: var(--pf-t--chart--color--yellow--200);
+  --#{$chart}-color-gold-300: var(--pf-t--chart--color--yellow--300);
+  --#{$chart}-color-gold-400: var(--pf-t--chart--color--yellow--400);
+  --#{$chart}-color-gold-500: var(--pf-t--chart--color--yellow--500);
 
   // orange
-  --#{$chart}-color-orange-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-orange-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-orange-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-orange-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-orange-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-orange-100: var(--pf-t--chart--color--orange--100);
+  --#{$chart}-color-orange-200: var(--pf-t--chart--color--orange--200);
+  --#{$chart}-color-orange-300: var(--pf-t--chart--color--orange--300);
+  --#{$chart}-color-orange-400: var(--pf-t--chart--color--orange--400);
+  --#{$chart}-color-orange-500: var(--pf-t--chart--color--orange--500);
 
   // red
-  --#{$chart}-color-red-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-red-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-red-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-red-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-red-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-red-100: var(--pf-t--chart--color--red--100);
+  --#{$chart}-color-red-200: var(--pf-t--chart--color--red--200);
+  --#{$chart}-color-red-300: var(--pf-t--chart--color--red--300);
+  --#{$chart}-color-red-400: var(--pf-t--chart--color--red--400);
+  --#{$chart}-color-red-500: var(--pf-t--chart--color--red--500);
 
   // black
-  --#{$chart}-color-black-100: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-black-200: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-black-300: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-black-400: var(--pf-t--chart--color--blue--100);
-  --#{$chart}-color-black-500: var(--pf-t--chart--color--blue--100);
+  --#{$chart}-color-black-100: var(--pf-t--chart--color--black--100);
+  --#{$chart}-color-black-200: var(--pf-t--chart--color--black--200);
+  --#{$chart}-color-black-300: var(--pf-t--chart--color--black--300);
+  --#{$chart}-color-black-400: var(--pf-t--chart--color--black--400);
+  --#{$chart}-color-black-500: var(--pf-t--chart--color--black--500);
+
+  // red-orange
+  --#{$chart}-color-red-orange-100: var(--pf-t--chart--color--red-orange--100);
+  --#{$chart}-color-red-orange-200: var(--pf-t--chart--color--red-orange--200);
+  --#{$chart}-color-red-orange-300: var(--pf-t--chart--color--red-orange--300);
+  --#{$chart}-color-red-orange-400: var(--pf-t--chart--color--red-orange--400);
+  --#{$chart}-color-red-orange-500: var(--pf-t--chart--color--red-orange--500);
 
   // typography
   --#{$chart}-global--FontSize--xs: var(--pf-t--chart--global--FontSize--xs);
@@ -327,11 +334,11 @@ $chart: #{$pf-prefix} + 'chart';
   --#{$chart}-theme--blue--ColorScale--500: var(--pf-t--chart--theme--colorscales--blue--colorscale--500);
 
   // cyan
-  --#{$chart}-theme--cyan--ColorScale--100: var(--pf-t--chart--theme--colorscales--cyan--colorscale--100);
-  --#{$chart}-theme--cyan--ColorScale--200: var(--pf-t--chart--theme--colorscales--cyan--colorscale--200);
-  --#{$chart}-theme--cyan--ColorScale--300: var(--pf-t--chart--theme--colorscales--cyan--colorscale--300);
-  --#{$chart}-theme--cyan--ColorScale--400: var(--pf-t--chart--theme--colorscales--cyan--colorscale--400);
-  --#{$chart}-theme--cyan--ColorScale--500: var(--pf-t--chart--theme--colorscales--cyan--colorscale--500);
+  --#{$chart}-theme--cyan--ColorScale--100: var(--pf-t--chart--theme--colorscales--teal--colorscale--100);
+  --#{$chart}-theme--cyan--ColorScale--200: var(--pf-t--chart--theme--colorscales--teal--colorscale--200);
+  --#{$chart}-theme--cyan--ColorScale--300: var(--pf-t--chart--theme--colorscales--teal--colorscale--300);
+  --#{$chart}-theme--cyan--ColorScale--400: var(--pf-t--chart--theme--colorscales--teal--colorscale--400);
+  --#{$chart}-theme--cyan--ColorScale--500: var(--pf-t--chart--theme--colorscales--teal--colorscale--500);
 
   // gold
   --#{$chart}-theme--gold--ColorScale--100: var(--pf-t--chart--theme--colorscales--yellow--colorscale--100);
@@ -340,7 +347,7 @@ $chart: #{$pf-prefix} + 'chart';
   --#{$chart}-theme--gold--ColorScale--400: var(--pf-t--chart--theme--colorscales--yellow--colorscale--400);
   --#{$chart}-theme--gold--ColorScale--500: var(--pf-t--chart--theme--colorscales--yellow--colorscale--500);
 
-    // gray
+  // gray
   --#{$chart}-theme--gray--ColorScale--100: var(--pf-t--chart--theme--colorscales--gray--colorscale--100);
   --#{$chart}-theme--gray--ColorScale--200: var(--pf-t--chart--theme--colorscales--gray--colorscale--200);
   --#{$chart}-theme--gray--ColorScale--300: var(--pf-t--chart--theme--colorscales--gray--colorscale--300);


### PR DESCRIPTION
Included screenshots since the changes are only visible in the react codebase. Screenshots are from my local react dev server with the core npm package linked to this branch's dist build.

fixes https://github.com/patternfly/patternfly/issues/6681

* dark theme labels 
    <img width="758" alt="Screenshot 2024-05-23 at 1 45 36 PM" src="https://github.com/patternfly/patternfly/assets/35148959/53b99a12-5e90-43c9-a05d-af3b1022658e">
* cyan charts (also in ^)
    <img width="705" alt="Screenshot 2024-05-23 at 1 36 24 PM" src="https://github.com/patternfly/patternfly/assets/35148959/95de67f1-1634-4fe2-a276-41a5ef9378db">
* bullet charts
     <img width="871" alt="Screenshot 2024-05-23 at 1 40 41 PM" src="https://github.com/patternfly/patternfly/assets/35148959/44276fdb-e82a-49d2-b595-f0c7c8558ef8">
* threshold
    <img width="819" alt="Screenshot 2024-05-23 at 1 44 00 PM" src="https://github.com/patternfly/patternfly/assets/35148959/5c3fbf7c-1acd-4e54-bb05-ffa36bfe2def">
