### PR TITLE
chore(box tabs): remove before after border

### DIFF
--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -27,10 +27,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical__list--before--BorderBlockEndWidth: 0;
   --#{$tabs}--m-vertical__list--before--BorderInlineStartWidth: var(--#{$tabs}--before--border-width--base);
 
-  // Tabs, Box modifier
-  --#{$tabs}--m-box__item--m-current--first-child__link--before--BorderInlineStartWidth: var(--#{$tabs}__link--before--border-width--base);
-  --#{$tabs}--m-box__item--m-current--last-child__link--before--BorderInlineEndWidth: var(--#{$tabs}--before--border-width--base);
-
   // Tabs List
   --#{$tabs}__list--Display: flex;
 
@@ -273,15 +269,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
 
     // stylelint-disable
-    // Add border to first-child
-    .#{$tabs}__item.pf-m-current:first-child .#{$tabs}__link::before {
-      border-inline-start-width: var(--#{$tabs}--m-box__item--m-current--first-child__link--before--BorderInlineStartWidth);
-    }
-
-    // Add border to last-child
-    .#{$tabs}__item.pf-m-current:last-child .#{$tabs}__link::before {
-      border-inline-end-width: var(--#{$tabs}--m-box__item--m-current--last-child__link--before--BorderInlineEndWidth);
-    }
 
     // Collapse left border into scroll button when expanded
     &.pf-m-scrollable .#{$tabs}__item.pf-m-current:first-child .#{$tabs}__link::before {


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/6254
Removed the extra borders on the first/last child of the box tabs. This better aligns with the design.
<img width="842" alt="Screenshot 2024-05-28 at 12 38 55 PM" src="https://github.com/patternfly/patternfly/assets/28658548/0ecdde79-6fed-4717-a77c-1d7687b46019">
Added the 