### PR TITLE
fix(Table): remove duplicate bottom border on mobile collapsed expandable rows

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -295,10 +295,6 @@
     --#{$table}__tr--responsive--PaddingInlineStart: var(--#{$table}__tr--responsive--nested-table--PaddingInlineStart);
 
     border: 0;
-
-    tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) + tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) {
-      --#{$table}__tr--responsive--PaddingBlockStart: 0;
-    }
   }
 
   // - Table grid compound expansion toggle

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -49,6 +49,9 @@
   --#{$table}__tbody--after--BorderInlineStartWidth: 0;
   --#{$table}__tbody--after--BorderColor: var(--pf-t--global--border--color--clicked);
 
+  // * Table body responsive
+  --#{$table}__tbody--responsive--m-expandable--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
+
   // * Table tr responsive
   --#{$table}__tr--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
   --#{$table}__tr--responsive--last-child--BorderBlockEndWidth: var(--#{$table}__tbody--responsive--border-width--base);
@@ -178,36 +181,15 @@
   }
 
   // Remove border on tr inside non-expanded tbody in of expandable tables
-  &.pf-m-expandable tbody:not(.pf-m-expanded) tr {
-    border-block-end: 0;
-  }
+  // &.pf-m-expandable tbody:not(.pf-m-expanded) tr {
+  //   border-block-end: 0;
+  // }
+  &.pf-m-expandable {
+    --#{$table}__tr--BorderBlockEndWidth: 0; // nested table rows have no border
 
-  // Remove the border from the body inside of the nested table
-  .#{$table}.pf-m-compact > tbody:where(.#{$table}__tbody) {
-    border-block-start: 0;
-  }
-
-  // - Table grid not expandable row
-  tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) {
-    border-block-end: var(--#{$table}__tr--responsive--border-width--base) solid var(--#{$table}--responsive--BorderColor);
-  }
-
-  // The last tr should always have a border width of 1px
-  tr:where(.#{$table}__tr):last-child,
-  tbody:where(.#{$table}__tbody):last-of-type:not(:only-of-type) > tr:where(.#{$table}__tr) {
-    border-block-end-width: var(--#{$table}__tr--responsive--last-child--BorderBlockEndWidth);
-  }
-
-  // - Table grid tbody expanded
-  tbody:where(.#{$table}__tbody).pf-m-expanded {
-    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
-
-    tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) {
-      border-block-end: 0;
-    }
-
-    &:not(:last-of-type) {
-      border-block-end: var(--#{$table}__tbody--responsive--border-width--base) solid var(--#{$table}--responsive--BorderColor);
+    .#{$table}__tbody,
+    .#{$table}__tbody.pf-m-expanded {
+      border-block-end: var(--#{$table}__tbody--responsive--m-expandable--BorderBlockEndWidth) solid var(--#{$table}--responsive--BorderColor);
     }
   }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -50,7 +50,7 @@
   --#{$table}__tbody--after--BorderColor: var(--pf-t--global--border--color--clicked);
 
   // * Table tr responsive
-  --#{$table}__tr--responsive--border-width--base: 0;
+  --#{$table}__tr--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
   --#{$table}__tr--responsive--last-child--BorderBlockEndWidth: var(--#{$table}__tbody--responsive--border-width--base);
   --#{$table}__tr--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}__tr--responsive--MarginBlockStart: var(--#{$table}__tbody--responsive--border-width--base);
@@ -175,6 +175,11 @@
     &:first-of-type {
       border-block-start: var(--#{$table}__tbody--responsive--border-width--base) solid var(--#{$table}--responsive--BorderColor);
     }
+  }
+
+  // Remove border on tr inside non-expanded tbody in of expandable tables
+  &.pf-m-expandable tbody:not(.pf-m-expanded) tr {
+    border-block-end: 0;
   }
 
   // Remove the border from the body inside of the nested table

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -50,7 +50,7 @@
   --#{$table}__tbody--after--BorderColor: var(--pf-t--global--border--color--clicked);
 
   // * Table tr responsive
-  --#{$table}__tr--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
+  --#{$table}__tr--responsive--border-width--base: 0;
   --#{$table}__tr--responsive--last-child--BorderBlockEndWidth: var(--#{$table}__tbody--responsive--border-width--base);
   --#{$table}__tr--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}__tr--responsive--MarginBlockStart: var(--#{$table}__tbody--responsive--border-width--base);

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -181,9 +181,6 @@
   }
 
   // Remove border on tr inside non-expanded tbody in of expandable tables
-  // &.pf-m-expandable tbody:not(.pf-m-expanded) tr {
-  //   border-block-end: 0;
-  // }
   &.pf-m-expandable {
     --#{$table}__tr--BorderBlockEndWidth: 0; // nested table rows have no border
 


### PR DESCRIPTION
Closes #6556 

This PR removes the bottom border on collapsed expandable rows on mobile, which is causes a double border to appear.