### PR TITLE
fix(nav): add support for icon, text

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -531,58 +531,29 @@ import './Navigation.css'
 {{> nav--drilldown nav--drilldown--id="level-three-drilldown-example" menu--Drilldown--IsDrilledIn--list-1="true"  menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 284px;"' menu--Drilldown--HasCurrentMenuItem="true"}}
 ```
 
-### Nav link text
-When using anything other than a text node for the link text, wrap the link text in an element with `.pf-v6-c-nav__link-text`.
-
+### Nav item icons
 ```hbs isBeta
-{{#> nav nav--attribute='aria-label="Global"' nav-item--HasTextWrapper=true}}
+{{#> nav nav--attribute='aria-label="Global"'}}
   {{#> nav-list}}
     {{#> nav-item}}
-      {{#> nav-link nav-link--href="#"}}
-        Link 1 <i class="fas fa-arrow-right" aria-hidden="true"></i>
+      {{#> nav-link nav-link--href="#" nav-link--icon="cube"}}
+        Link 1
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
-      {{#> nav-link nav-link--href="#" nav-link--attribute='id="nav-link-text-link2"'}}
-        Link 2 <small>(small text)</small>
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--current="true" nav-link--icon="folder"}}
+        Current link
       {{/nav-link}}
-      {{#> nav-subnav nav-subnav--attribute='aria-labelledby="nav-link-text-link2"'}}
-        {{#> nav-item nav-item--HasTextWrapper=true}}
-          {{#> nav-link nav-link--href="#"}}
-            <i class="fas fa-user" aria-hidden="true"></i>
-            Subnav link 1
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item nav-item--HasTextWrapper=true}}
-          {{#> nav-link nav-link--href="#"}}
-            <i class="fas fa-user" aria-hidden="true"></i>
-            Subnav link 2
-          {{/nav-link}}
-        {{/nav-item}}
-      {{/nav-subnav}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--current="true"}}
-      {{#> nav-link nav-link--href="#" nav-link--attribute='id="nav-link-text-link4"'}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--icon="cloud"}}
         Link 3
-        <strong>(strong text)</strong>
       {{/nav-link}}
-      {{#> nav-subnav nav-subnav--attribute='aria-labelledby="nav-link-text-link4"'}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Subnav link 1
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-            Subnav link 2
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Subnav link 3
-          {{/nav-link}}
-        {{/nav-item}}
-      {{/nav-subnav}}
+    {{/nav-item}}
+    {{#> nav-item}}
+      {{#> nav-link nav-link--href="#" nav-link--icon="code"}}
+        Link 4
+      {{/nav-link}}
     {{/nav-item}}
   {{/nav-list}}
 {{/nav}}
@@ -620,6 +591,7 @@ The navigation system relies on several different sub-components:
 | `.pf-v6-c-nav__list` | `<ul>` | Initiates nav list. |
 | `.pf-v6-c-nav__item` | `<li>` | Initiates nav list item. |
 | `.pf-v6-c-nav__link` | `<a>` | Initiates nav list link. |
+| `.pf-v6-c-nav__link-icon` | `<span>` | Initiates nav list link icon. |
 | `.pf-v6-c-nav__link-text` | `<span>` | Initiates nav list link text. |
 | `.pf-v6-c-nav__section` | `<section>` | Initiates a nav section element. |
 | `.pf-v6-c-nav__section-title` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>` | Initiates a nav section title. |

--- a/src/patternfly/components/Nav/nav-link-icon.hbs
+++ b/src/patternfly/components/Nav/nav-link-icon.hbs
@@ -1,0 +1,10 @@
+<span class="{{pfv}}nav__link-icon{{#if nav-link-icon--modifier}} {{nav-link-icon--modifier}}{{/if}}"
+  {{#if nav-link-icon--attribute}}
+    {{{nav-link-icon--attribute}}}
+  {{/if}}>
+  {{#if nav-link--icon}}
+    <i class="fas fa-fw fa-{{nav-link--icon}}" aria-hidden="true"></i>
+  {{else if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
+</span>

--- a/src/patternfly/components/Nav/nav-link-text.hbs
+++ b/src/patternfly/components/Nav/nav-link-text.hbs
@@ -2,8 +2,8 @@
   {{#if nav-link-text--attribute}}
     {{{nav-link-text--attribute}}}
   {{/if}}>
-  {{#if nav-link-text--text}}
-    {{{nav-link-text--text}}}
+  {{#if nav-link--text}}
+    {{{nav-link--text}}}
   {{else if @partial-block}}
     {{> @partial-block}}
   {{/if}}

--- a/src/patternfly/components/Nav/nav-link.hbs
+++ b/src/patternfly/components/Nav/nav-link.hbs
@@ -23,12 +23,15 @@
   {{#if nav-link--attribute}}
     {{{nav-link--attribute}}}
   {{/if}}>
+  {{#if nav-link--icon}}
+    {{> nav-link-icon}}
+  {{/if}}
   {{#if nav-link--text}}
-    {{{nav-link--text}}}
-  {{else if nav-item--HasTextWrapper}}
     {{> nav-link-text}}
   {{else if @partial-block}}
-    {{> @partial-block}}
+    {{#> nav-link-text}}
+      {{> @partial-block}}
+    {{/nav-link-text}}
   {{/if}}
   {{#ifAny nav-item--IsExpandable nav-item--IsExpandable nav-item--IsFlyout nav-item--IsDrilldown}}
     {{> nav-toggle}}

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -54,6 +54,10 @@
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
 
+  // * Nav link icon
+  --#{$nav}__link-icon--Color: var(--pf-t--global--icon--color--subtle);
+  --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
+
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
@@ -230,9 +234,16 @@
 
   &.pf-m-current,
   &.pf-m-current:hover {
+    --#{$nav}__link-icon--Color: var(--#{$nav}__link--m-current__link-icon--Color);
+
     color: var(--#{$nav}__link--m-current--Color);
     background-color: var(--#{$nav}__link--m-current--BackgroundColor);
   }
+}
+
+// - Nav toggle caret
+.#{$nav}__link-icon {
+  color: var(--#{$nav}__link-icon--Color);
 }
 
 // - Nav toggle caret


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6527
fixes https://github.com/patternfly/patternfly/issues/6703

@andrew-ronaldson there is an "xs" spacer between the icon and text in figma, but because of the "icon component" in figma (the 21x21 box around the icon), the visual space between the icon and text is about 8px, so I used the small spacer instead.