### PR TITLE
fix(card): move borders to pseudoelement

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -115,6 +115,7 @@
   &::before {
     position: absolute;
     inset: 0;
+    pointer-events: none;
     content: "";
     border: var(--#{$card}--BorderColor) var(--#{$card}--BorderStyle) var(--#{$card}--BorderWidth);
     border-radius: inherit;

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -156,6 +156,7 @@
     // When SELECTABLE and CLICKABLE card is focused, don't show change of background or border on the card
     .#{$card}__selectable-actions .#{$check}__input:where(:focus-visible) ~ .#{$check}__label,
     .#{$card}__selectable-actions .#{$radio}__input:where(:focus-visible) ~ .#{$radio}__label {
+      --#{$card}--BackgroundColor: revert;
       --#{$card}--BorderColor: revert;
     }
 
@@ -163,6 +164,7 @@
     .#{$card}__selectable-actions .#{$check}__input:where(:checked) ~ .#{$check}__label,
     .#{$card}__selectable-actions .#{$radio}__input:where(:checked) ~ .#{$radio}__label,
     &.pf-m-selected {
+      --#{$card}--BorderColor: revert;
       --#{$card}--m-selectable--BorderWidth: revert;
     }
 

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -109,8 +109,16 @@
   flex-direction: column;
   overflow: auto;
   background-color: var(--#{$card}--BackgroundColor);
-  border: var(--#{$card}--BorderColor) var(--#{$card}--BorderStyle) var(--#{$card}--BorderWidth);
+  border: 0;
   border-radius: var(--#{$card}--BorderRadius);
+
+  &::before {
+    position: absolute;
+    inset: 0;
+    content: "";
+    border: var(--#{$card}--BorderColor) var(--#{$card}--BorderStyle) var(--#{$card}--BorderWidth);
+    border-radius: inherit;
+  }
 
   // SELECTABLE CARDS
   &.pf-m-selectable {
@@ -124,7 +132,10 @@
   &.pf-m-selectable,
   &.pf-m-clickable {
     isolation: isolate;
-    border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border
+
+    &::before {
+      border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border
+    }
   }
 
   // stylelint-disable selector-max-class
@@ -144,7 +155,6 @@
     // When SELECTABLE and CLICKABLE card is focused, don't show change of background or border on the card
     .#{$card}__selectable-actions .#{$check}__input:where(:focus-visible) ~ .#{$check}__label,
     .#{$card}__selectable-actions .#{$radio}__input:where(:focus-visible) ~ .#{$radio}__label {
-      --#{$card}--BackgroundColor: revert;
       --#{$card}--BorderColor: revert;
     }
 
@@ -152,7 +162,6 @@
     .#{$card}__selectable-actions .#{$check}__input:where(:checked) ~ .#{$check}__label,
     .#{$card}__selectable-actions .#{$radio}__input:where(:checked) ~ .#{$radio}__label,
     &.pf-m-selected {
-      --#{$card}--BorderColor: revert;
       --#{$card}--m-selectable--BorderWidth: revert;
     }
 


### PR DESCRIPTION
Closes #6234 

This PR:
- Moves Card borders to `::before` pseudoelement
- Removes two unneeded `revert` rules