### PR TITLE
fix(hint): remove extra hint actions space

### DIFF
--- a/src/patternfly/components/Hint/examples/Hint.md
+++ b/src/patternfly/components/Hint/examples/Hint.md
@@ -90,3 +90,4 @@ cssPrefix: pf-v6-c-hint
 | `.pf-v6-c-hint__body` | `<div>` | Initiates the hint body element. |
 | `.pf-v6-c-hint__footer` | `<div>` | Initiates the hint footer element. |
 | `.pf-v6-c-hint__actions` | `<div>` | Initiates the hint actions element. |
+| `.pf-m-no-offset` | `.pf-v6-c-hint__actions` | Removes the negative vertical margins on the actions element intended to align the action content with the hint title. |

--- a/src/patternfly/components/Hint/examples/Hint.md
+++ b/src/patternfly/components/Hint/examples/Hint.md
@@ -79,6 +79,21 @@ cssPrefix: pf-v6-c-hint
 {{/hint}}
 ```
 
+### Actions with no offset
+```hbs
+{{#> hint hint--id='hint-actions-with-no-offset'}}
+  {{#> hint-actions hint-actions--modifier='pf-m-no-offset'}}
+    {{#> button button--modifier="pf-m-primary"}}Action{{/button}}
+ {{/hint-actions}}
+  {{#> hint-title}}
+    Do more with Find it Fix it capabilities
+  {{/hint-title}}
+  {{#> hint-body}}
+    Upgrade to Red Hat Smart Management to remediate all your systems across regions and geographies.
+  {{/hint-body}}
+{{/hint}}
+```
+
 ## Documentation
 
 

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -28,6 +28,7 @@
   // Hint Actions
   --#{$hint}__actions--MarginInlineStart: var(--pf-t--global--spacer--2xl);
   --#{$hint}__actions--c-menu-toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
+  --#{$hint}__actions--c-menu-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
 }
 
 .#{$hint} {
@@ -60,7 +61,9 @@
   text-align: end;
 
   .#{$menu-toggle}.pf-m-plain {
+    // --pf-v6-c-menu-toggle--PaddingBlockEnd: 0;
     margin-block-start: var(--#{$hint}__actions--c-menu-toggle--MarginBlockStart);
+    margin-block-end: var(--#{$hint}__actions--c-menu-toggle--MarginBlockEnd);
   }
 
   + .#{$hint}__body {

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -57,13 +57,14 @@
   grid-column: 2;
   grid-auto-flow: column;
   align-self: start;
+  margin-block-start: var(--#{$hint}__actions--c-menu-toggle--MarginBlockStart);
+  margin-block-end: var(--#{$hint}__actions--c-menu-toggle--MarginBlockEnd);
   margin-inline-start: var(--#{$hint}__actions--MarginInlineStart);
   text-align: end;
 
-  .#{$menu-toggle}.pf-m-plain {
-    // --pf-v6-c-menu-toggle--PaddingBlockEnd: 0;
-    margin-block-start: var(--#{$hint}__actions--c-menu-toggle--MarginBlockStart);
-    margin-block-end: var(--#{$hint}__actions--c-menu-toggle--MarginBlockEnd);
+  &.pf-m-no-offset {
+    --#{$hint}__actions--c-menu-toggle--MarginBlockStart: 0;
+    --#{$hint}__actions--c-menu-toggle--MarginBlockEnd: 0;
   }
 
   + .#{$hint}__body {


### PR DESCRIPTION
Closes #6116 

This PR mirrors the negative margin-start on hint actions to the margin-bottom, to remove extra spacing added in the hint by the hint actions.