### PR TITLE
fix(card): update header-main vs actions width

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -248,7 +248,7 @@
 }
 
 .#{$card}__header-main {
-  flex: 1;
+  flex-grow: 1;
 }
 
 .#{$card}__header-toggle {


### PR DESCRIPTION
Closes #6575 

This PR updates the `flex` to `flex-grow` on the Card's `header__main` to prevent it from shrinking in favor of the Card actions.