### PR TITLE
fix(tokens): rename file and add no-motion modifier

### DIFF
--- a/src/patternfly/base/patternfly-variables.scss
+++ b/src/patternfly/base/patternfly-variables.scss
@@ -1,12 +1,12 @@
 @use '../sass-utilities' as *;
-@use "./tokens/tokens-font" as font;
+@use "./tokens/tokens-local" as local;
 @use "./tokens/tokens-palette" as palette;
 @use "./tokens/tokens-default" as default;
 @use "./tokens/tokens-dark" as dark;
 
 :where(:root) {
   @include pf-v6-set-inverse(false);
-  @include font.pf-v6-tokens;
+  @include local.pf-v6-tokens;
   @include palette.pf-v6-tokens;
   @include default.pf-v6-tokens;
 }

--- a/src/patternfly/base/tokens/_index.scss
+++ b/src/patternfly/base/tokens/_index.scss
@@ -1,5 +1,5 @@
 @forward './workspace-overrides';
-@forward './tokens-font';
+@forward './tokens-local';
 @forward './tokens-palette';
 @forward './tokens-default';
 @forward './tokens-dark';

--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -146,7 +146,23 @@
     var(--pf-t--global--box-shadow--spread--lg)
     var(--pf-t--global--box-shadow--color--lg);
 
-  // Transitions
+  // Motion
+  .pf-m-no-motion {
+    // Set all motion tokens to 0 for testing purposes
+    --pf-t--global--delay--400: 0ms;
+    --pf-t--global--delay--300: 0ms;
+    --pf-t--global--delay--200: 0ms;
+    --pf-t--global--delay--100: 0ms;
+    --pf-t--global--duration--600: 0ms;
+    --pf-t--global--duration--500: 0ms;
+    --pf-t--global--duration--400: 0ms;
+    --pf-t--global--duration--300: 0ms;
+    --pf-t--global--duration--200: 0ms;
+    --pf-t--global--duration--100: 0ms;
+    --pf-t--global--duration--50: 0ms;
+  }
+
+  // old transitions to be removed in future pr
   --pf-t--global--transition: all 250ms cubic-bezier(.42, 0, .58, 1);
   --pf-t--global--transition--timing-function: cubic-bezier(.645, .045, .355, 1);
   --pf-t--global--transition--duration: 250ms;


### PR DESCRIPTION
This renames the tokens-font file to be tokens-local since it evolved to include more than just font - e.g. the transition token override for turning off motion completely is added there in this PR.

Fixes #6516 
Fixes #6682 

