### PR TITLE
chore(nav): remove references to pf-m-expandable

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -603,7 +603,6 @@ The navigation system relies on several different sub-components:
 | `.pf-m-full-width` | `.pf-v6-c-nav` | Modifies nav for to full width of parent. |
 | `.pf-m-flyout` | `.pf-v6-c-nav__item` | Modifies nav item for the flyout variation. |
 | `.pf-m-scrollable` | `.pf-v6-c-nav` | Modifies nav for the scrollable state. |
-| `.pf-m-expandable` | `.pf-v6-c-nav__item` | Modifies for the expandable state. |
 | `.pf-m-expanded` | `.pf-v6-c-nav__item` | Modifies for the expanded state. |
 | `.pf-m-current` | `.pf-v6-c-nav__link` | Modifies for the current state. |
 | `.pf-m-hover` | `.pf-v6-c-nav__link` | Modifies for the hover state. |

--- a/src/patternfly/components/Nav/examples/Navigation.md
+++ b/src/patternfly/components/Nav/examples/Navigation.md
@@ -135,7 +135,7 @@ import './Navigation.css'
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
   {{#> nav-list}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true" nav-item--current="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true" nav-item--current="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute='id="expandable-example1"'}}
         Link 1 (current and expanded example)
       {{/nav-link}}
@@ -157,7 +157,7 @@ import './Navigation.css'
         {{/nav-item}}
       {{/nav-subnav}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute='id="expandable-example2"'}}
         Link 2 (expanded, but not current example)
       {{/nav-link}}
@@ -199,7 +199,7 @@ import './Navigation.css'
 ```hbs
 {{#> nav nav--attribute='aria-label="Global"'}}
   {{#> nav-list}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true" nav-item--current="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true" nav-item--current="true"}}
       {{#> nav-link nav-link--href="#"}}
         Link 1
       {{/nav-link}}
@@ -221,7 +221,7 @@ import './Navigation.css'
         {{/nav-item}}
       {{/nav-subnav}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true"}}
       {{#> nav-link nav-link--href="#"}}
         Link 2
       {{/nav-link}}
@@ -251,7 +251,7 @@ import './Navigation.css'
         Link 1 (not expandable)
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute='id="nav-mixed-link2"'}}
         Link 2 (expanded, but not current example)
       {{/nav-link}}
@@ -330,7 +330,7 @@ import './Navigation.css'
         {{/nav-item}}
       {{/nav-subnav}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute=(concat 'id="' nav--id '-example-2"')}}
         Cost management
       {{/nav-link}}
@@ -345,7 +345,7 @@ import './Navigation.css'
             Openshift
           {{/nav-link}}
         {{/nav-item}}
-        {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true"}}
+        {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true"}}
           {{#> nav-link nav-link--href="#" nav-link--attribute=(concat 'id="' nav--id '-sub-example-1"')}}
             Public clouds
           {{/nav-link}}

--- a/src/patternfly/components/Nav/nav-item.hbs
+++ b/src/patternfly/components/Nav/nav-item.hbs
@@ -1,7 +1,5 @@
 <li class="{{pfv}}nav__item
   {{setModifiers
-    nav-item--expandable='pf-m-expandable'
-    nav-item--IsExpandable='pf-m-expandable'
     nav-item--IsDrilldown='pf-m-drilldown'
     nav-item--IsFlyout='pf-m-flyout'
     nav-item--modifier=nav--modifier

--- a/src/patternfly/components/Nav/nav-item.hbs
+++ b/src/patternfly/components/Nav/nav-item.hbs
@@ -5,9 +5,9 @@
     nav-item--modifier=nav--modifier
   }}
   {{#unless nav-item--IsFlyout}}
-    {{#ifAny nav-item--expanded nav-item--IsExpanded}}
+    {{#if nav-item--IsExpanded}}
       pf-m-expanded
-    {{/ifAny}}
+    {{/if}}
   {{/unless}}"
   {{#if nav-item--attribute}}
     {{{nav-item--attribute}}}

--- a/src/patternfly/components/Nav/nav-link.hbs
+++ b/src/patternfly/components/Nav/nav-link.hbs
@@ -1,6 +1,6 @@
 {{setTag nav-item--IsExpandable 'button' 'a'}}
 
-<{{tag}}{{#unless (concat nav-item--IsExpandable nav-item--IsExpandable)}} href="{{ternary nav-link--href nav-link--href '#'}}"{{/unless}} class="{{pfv}}nav__link
+<{{tag}}{{#unless nav-item--IsExpandable}} href="{{ternary nav-link--href nav-link--href '#'}}"{{/unless}} class="{{pfv}}nav__link
   {{setModifiers
     nav-link--current='pf-m-current'
     nav-link--IsCurrent='pf-m-current'
@@ -13,7 +13,7 @@
   {{#if nav-item--IsFlyout}}
     aria-haspopup="true"
   {{/if}}
-  {{#ifAny nav-item--IsFlyout nav-item--IsDrilldown nav-item--IsExpandable nav-item--IsExpandable}}
+  {{#ifAny nav-item--IsFlyout nav-item--IsDrilldown nav-item--IsExpandable}}
     {{#ifAny nav-item--expanded nav-item--IsExpanded}}
       aria-expanded="true"
     {{else}}
@@ -33,7 +33,7 @@
       {{> @partial-block}}
     {{/nav-link-text}}
   {{/if}}
-  {{#ifAny nav-item--IsExpandable nav-item--IsExpandable nav-item--IsFlyout nav-item--IsDrilldown}}
+  {{#ifAny nav-item--IsExpandable nav-item--IsFlyout nav-item--IsDrilldown}}
     {{> nav-toggle}}
   {{/ifAny}}
 </{{tag}}>

--- a/src/patternfly/components/Nav/nav-link.hbs
+++ b/src/patternfly/components/Nav/nav-link.hbs
@@ -14,11 +14,11 @@
     aria-haspopup="true"
   {{/if}}
   {{#ifAny nav-item--IsFlyout nav-item--IsDrilldown nav-item--IsExpandable}}
-    {{#ifAny nav-item--expanded nav-item--IsExpanded}}
+    {{#if nav-item--IsExpanded}}
       aria-expanded="true"
     {{else}}
       aria-expanded="false"
-    {{/ifAny}}
+    {{/if}}
   {{/ifAny}}
   {{#if nav-link--attribute}}
     {{{nav-link--attribute}}}

--- a/src/patternfly/components/Nav/nav-subnav.hbs
+++ b/src/patternfly/components/Nav/nav-subnav.hbs
@@ -7,7 +7,7 @@
   {{#if nav-section-title--text}}
     {{> nav-section-title nav-section-title--id=(dasherize nav--id nav-section--id nav-section-title--text)}}
   {{/if}}
-  {{#> nav-list (reset nav-item--IsExpandable nav-item--expanded nav-item--IsExpandable nav-item--IsExpanded)}}
+  {{#> nav-list (reset nav-item--expanded nav-item--IsExpandable nav-item--IsExpanded)}}
     {{#if @partial-block}}
       {{> @partial-block}}
     {{/if}}

--- a/src/patternfly/components/Nav/nav-subnav.hbs
+++ b/src/patternfly/components/Nav/nav-subnav.hbs
@@ -1,13 +1,13 @@
 <section class="{{pfv}}nav__subnav{{#if nav-subnav--modifier}} {{nav-subnav--modifier}}{{/if}}"
   aria-labelledby="{{ternary nav-subnav--aria-labelledby nav-subnav--aria-labelledby nav-item--id}}"
-  {{ternary (concat nav-item--expanded nav-item--IsExpanded) '' 'hidden'}}
+  {{ternary nav-item--IsExpanded '' 'hidden'}}
   {{#if nav-subnav--attribute}}
     {{{nav-subnav--attribute}}}
   {{/if}}>
   {{#if nav-section-title--text}}
     {{> nav-section-title nav-section-title--id=(dasherize nav--id nav-section--id nav-section-title--text)}}
   {{/if}}
-  {{#> nav-list (reset nav-item--expanded nav-item--IsExpandable nav-item--IsExpanded)}}
+  {{#> nav-list (reset nav-item--IsExpanded nav-item--IsExpandable)}}
     {{#if @partial-block}}
       {{> @partial-block}}
     {{/if}}

--- a/src/patternfly/components/Nav/templates/nav--drilldown--nav-item-submenu.hbs
+++ b/src/patternfly/components/Nav/templates/nav--drilldown--nav-item-submenu.hbs
@@ -1,5 +1,5 @@
 {{#> nav-subnav}}
-  {{#> nav-list nav-item--IsDrilldown=reset nav-item--expanded=reset}}
+  {{#> nav-list nav-item--IsDrilldown=reset nav-item--IsExpanded=reset}}
     {{#> nav-item nav-item--IsDrillup="true"}}
       {{#> nav-link nav-link--href="#"}}
         Subscriptions
@@ -10,12 +10,12 @@
         Container platform
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsDrilldown="true" nav-item--expanded=nav--drilldown--level-3}}
+    {{#> nav-item nav-item--IsDrilldown="true" nav-item--IsExpanded=nav--drilldown--level-3}}
       {{#> nav-link nav-link--href="#"}}
         Dedicated
       {{/nav-link}}
       {{#> nav-subnav}}
-        {{#> nav-list nav-item--expanded=reset nav-item--IsDrilldown=reset}}
+        {{#> nav-list nav-item--IsExpanded=reset nav-item--IsDrilldown=reset}}
           {{#> nav-item nav-item--IsDrillup="true"}}
             {{#> nav-link nav-link--href="#"}}
               Dedicated

--- a/src/patternfly/components/Nav/templates/nav--drilldown-bu.hbs
+++ b/src/patternfly/components/Nav/templates/nav--drilldown-bu.hbs
@@ -15,7 +15,7 @@
         Releases
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsDrilldown="true" nav-item--expanded=nav--drilldown--level-2}}
+    {{#> nav-item nav-item--IsDrilldown="true" nav-item--IsExpanded=nav--drilldown--level-2}}
       {{#> nav-link nav-link--href="#"}}
         Subscriptions
       {{/nav-link}}

--- a/src/patternfly/components/Nav/templates/nav--flyout.hbs
+++ b/src/patternfly/components/Nav/templates/nav--flyout.hbs
@@ -15,7 +15,7 @@
         Releases
       {{/nav-link}}
     {{/nav-item}}
-    {{#> nav-item nav-item--IsFlyout="true" nav-item--expanded="true"}}
+    {{#> nav-item nav-item--IsFlyout="true" nav-item--IsExpanded="true"}}
       {{#> nav-link nav-link--href="#" nav-link--IsCurrent=true}}
         Subscriptions
       {{/nav-link}}

--- a/src/patternfly/demos/DataList/data-list-page-nav.hbs
+++ b/src/patternfly/demos/DataList/data-list-page-nav.hbs
@@ -1,6 +1,6 @@
 {{#> nav nav--attribute=(concat 'id="' page--id '-primary-nav" aria-label="Global"')}}
   {{#> nav-list}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true" nav-item--current="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true" nav-item--current="true"}}
       {{#> nav-link nav-link--href="#"}}
         Components
       {{/nav-link}}

--- a/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
+++ b/src/patternfly/demos/Page/page-demo-expandable-nav.hbs
@@ -6,7 +6,7 @@
   {{#> page-sidebar}}
     {{#> nav nav--IsExpandable="true" nav--attribute=(concat 'id="' page--id '-expandable-nav" aria-label="Global"')}}
       {{#> nav-list}}
-        {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true" nav-item--current="true"}}
+        {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true" nav-item--current="true"}}
           {{#> nav-link nav-link--href="#" nav-link--attribute=(concat 'id="' page--id '-expandable-nav-link1"')}}
             System panel
           {{/nav-link}}

--- a/src/patternfly/demos/Page/page-template-expandable-nav.hbs
+++ b/src/patternfly/demos/Page/page-template-expandable-nav.hbs
@@ -1,6 +1,6 @@
 {{#> nav nav--IsExpandable="true" nav--attribute=(concat 'id="' page--id '-expandable-nav" aria-label="Global"')}}
   {{#> nav-list}}
-    {{#> nav-item nav-item--IsExpandable="true" nav-item--expanded="true" nav-item--current="true"}}
+    {{#> nav-item nav-item--IsExpandable="true" nav-item--IsExpanded="true" nav-item--current="true"}}
       {{#> nav-link nav-link--href="#" nav-link--attribute=(concat 'id="' page--id '-expandable-nav-link1"')}}
         System panel
       {{/nav-link}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6248

#### Expandable
* removes `.pf-m-expandable`
* removes `nav-item--expandable` - it's never used
* removes dupes of `nav-item--IsExpandable`

#### Expanded
* removes `nav-item--IsExpanded` - this is never set, it's only checked for
* renames `nav-item--expanded` to `nav-item--IsExpanded` - more consistent with the other attributes