### PR TITLE
fix(truncate): updated min-widths to match

### DIFF
--- a/src/patternfly/components/Truncate/examples/Truncate.css
+++ b/src/patternfly/components/Truncate/examples/Truncate.css
@@ -2,7 +2,6 @@
   width: 320px;
   resize: horizontal;
   overflow: auto;
-  min-width: 161px;
   max-width: 100%;
   padding: var(--pf-t--global--spacer--sm);
   border: var(--pf-t--global--border--width--box--default) solid var(--pf-t--global--border--color--default);

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$truncate}) {
-  --#{$truncate}--MinWidth: 12ch;
+  --#{$truncate}--MinWidth: 6ch;
   --#{$truncate}__start--MinWidth: 6ch;
 }
 


### PR DESCRIPTION
# TLDR
`min-width` value of `pf-c-truncate` is too large. 

Closes #6261 

## Summary 

Because the `ch` unit [is measured as the width of “0” in the prescribed font](https://www.w3.org/TR/css3-values/#ch), `min-width` for `pf-c-truncate` should be no greater than `pf-c-truncate__start`. This is because `pf-c-truncate__end` has no `min-width` value by default as it contains a discrete charset via `trailingNumChars={foo}` and its css is defined as `white-space: nowrap; overflow: visible`. Thusly, `pf-c-truncate__end` will never shrink. 

`min-width` for `pf-c-truncate` could be removed altogether if not for the `start` variant, which uses the `pf-c-truncate__end` container to create an ellipsis at the beginning of the applicable string. In order to prevent `pf-c-truncate` from shrinking to `0`, we need to apply a `min-width` when `pf-c-truncate__start` is not present in the markup.