### PR TITLE
feat(Panel): added Penta styles

### DIFF
--- a/src/patternfly/components/Panel/examples/Panel.md
+++ b/src/patternfly/components/Panel/examples/Panel.md
@@ -155,6 +155,7 @@ cssPrefix: pf-v6-c-panel
 | `.pf-v6-c-panel__header` | `<div>` | Initiates the panel header. |
 | `.pf-v6-c-panel__main` | `<div>` | Initiates the panel main content. |
 | `.pf-v6-c-panel__main-body` | `<div>` | Initiates a panel content body container. |
+| `.pf-v6-c-panel__menu` | `<div>` | Initiates a panel menu container, removing the padding from `.pf-v6-c-panel__main`. |
 | `.pf-v6-c-panel__footer` | `<div>` | Initiates the panel footer. |
 | `.pf-m-bordered` | `.pf-v6-c-panel` | Modifies the panel for bordered styles. |
 | `.pf-m-raised` | `.pf-v6-c-panel` | Modifies the panel for raised styles. |

--- a/src/patternfly/components/Panel/examples/Panel.md
+++ b/src/patternfly/components/Panel/examples/Panel.md
@@ -155,7 +155,7 @@ cssPrefix: pf-v6-c-panel
 | `.pf-v6-c-panel__header` | `<div>` | Initiates the panel header. |
 | `.pf-v6-c-panel__main` | `<div>` | Initiates the panel main content. |
 | `.pf-v6-c-panel__main-body` | `<div>` | Initiates a panel content body container. |
-| `.pf-v6-c-panel__menu` | `<div>` | Initiates a panel menu container, removing the padding from `.pf-v6-c-panel__main`. |
+| `.pf-v6-c-panel__menu` | `<div>` | Initiates a panel menu container. |
 | `.pf-v6-c-panel__footer` | `<div>` | Initiates the panel footer. |
 | `.pf-m-bordered` | `.pf-v6-c-panel` | Modifies the panel for bordered styles. |
 | `.pf-m-raised` | `.pf-v6-c-panel` | Modifies the panel for raised styles. |

--- a/src/patternfly/components/Panel/panel-menu.hbs
+++ b/src/patternfly/components/Panel/panel-menu.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}panel__menu{{#if panel-menu--modifier}} {{panel-menu--modifier}}{{/if}}"
+  {{#if panel-menu--attribute}}
+    {{{panel-menu--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</div>

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -110,13 +110,6 @@
   padding-block-end: var(--#{$panel}__main-body--PaddingBlockEnd);
   padding-inline-start: var(--#{$panel}__main-body--PaddingInlineStart);
   padding-inline-end: var(--#{$panel}__main-body--PaddingInlineEnd);
-
-  &:has(.#{$panel}__menu) {
-    --#{$panel}__main-body--PaddingBlockStart: 0;
-    --#{$panel}__main-body--PaddingBlockEnd: 0;
-    --#{$panel}__main-body--PaddingInlineStart: 0;
-    --#{$panel}__main-body--PaddingInlineEnd: 0;
-  }
 }
 
 .#{$panel}__footer {

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -4,10 +4,9 @@
   --#{$panel}--Width: auto;
   --#{$panel}--MinWidth: auto;
   --#{$panel}--MaxWidth: none;
-  --#{$panel}--ZIndex: auto;
   --#{$panel}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$panel}--BoxShadow: none;
-  --#{$panel}--BorderRadius: var(--pf-t--global--spacer--md);
+  --#{$panel}--BorderRadius: var(--pf-t--global--border--radius--small);
 
   // border
   --#{$panel}--before--BorderWidth: 0;
@@ -17,18 +16,17 @@
   --#{$panel}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
 
   // bordered
-  --#{$panel}--m-bordered--before--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$panel}--m-bordered--before--BorderWidth: var(--pf-t--global--border--width--box--default);
 
   // raised
   --#{$panel}--m-raised--BoxShadow: var(--pf-t--global--box-shadow--md);
-  --#{$panel}--m-raised--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // header
   --#{$panel}__header--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$panel}__header--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$panel}__header--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$panel}__header--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // main
   --#{$panel}__main--MaxHeight: none;
@@ -36,26 +34,27 @@
 
   // body
   --#{$panel}__main-body--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$panel}__main-body--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$panel}__main-body--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$panel}__main-body--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__main-body--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // footer
-  --#{$panel}__footer--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$panel}__footer--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$panel}__footer--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$panel}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$panel}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$panel}__footer--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$panel}__footer--BoxShadow: none;
 
   // scrollable
   --#{$panel}--m-scrollable__main--MaxHeight: #{pf-size-prem(300px)};
   --#{$panel}--m-scrollable__main--Overflow: auto;
-  --#{$panel}--m-scrollable__footer--BoxShadow: 0 #{pf-size-prem(-5px)} #{pf-size-prem(4px)} #{pf-size-prem(-4px)} rgba(0 0 0 / 16%); // insets the shadow so it doesn't show on left/right sides
+  --#{$panel}--m-scrollable__footer--BoxShadow: var(--pf-t--global--box-shadow--md--top);
+  --#{$panel}--m-scrollable__footer--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$panel}--m-scrollable__footer--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 }
 
 .#{$panel} {
   position: relative;
-  z-index: var(--#{$panel}--ZIndex);
   width: var(--#{$panel}--Width);
   min-width: var(--#{$panel}--MinWidth);
   max-width: var(--#{$panel}--MaxWidth);
@@ -83,13 +82,14 @@
   &.pf-m-raised {
     --#{$panel}--BackgroundColor: var(--#{$panel}--m-raised--BackgroundColor);
     --#{$panel}--BoxShadow: var(--#{$panel}--m-raised--BoxShadow);
-    --#{$panel}--ZIndex: var(--#{$panel}--m-raised--ZIndex);
   }
 
   &.pf-m-scrollable {
     --#{$panel}__main--MaxHeight: var(--#{$panel}--m-scrollable__main--MaxHeight);
     --#{$panel}__main--Overflow: var(--#{$panel}--m-scrollable__main--Overflow);
     --#{$panel}__footer--BoxShadow: var(--#{$panel}--m-scrollable__footer--BoxShadow);
+    --#{$panel}__footer--PaddingBlockStart: var(--#{$panel}--m-scrollable__footer--PaddingBlockStart);
+    --#{$panel}__footer--PaddingBlockEnd: var(--#{$panel}--m-scrollable__footer--PaddingBlockEnd);
   }
 }
 
@@ -110,6 +110,13 @@
   padding-block-end: var(--#{$panel}__main-body--PaddingBlockEnd);
   padding-inline-start: var(--#{$panel}__main-body--PaddingInlineStart);
   padding-inline-end: var(--#{$panel}__main-body--PaddingInlineEnd);
+
+  &:has(.#{$panel}__menu) {
+    --#{$panel}__main-body--PaddingBlockStart: 0;
+    --#{$panel}__main-body--PaddingBlockEnd: 0;
+    --#{$panel}__main-body--PaddingInlineStart: 0;
+    --#{$panel}__main-body--PaddingInlineEnd: 0;
+  }
 }
 
 .#{$panel}__footer {

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -7,6 +7,7 @@
   --#{$panel}--ZIndex: auto;
   --#{$panel}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$panel}--BoxShadow: none;
+  --#{$panel}--BorderRadius: var(--pf-t--global--spacer--md);
 
   // border
   --#{$panel}--before--BorderWidth: 0;
@@ -59,6 +60,7 @@
   min-width: var(--#{$panel}--MinWidth);
   max-width: var(--#{$panel}--MaxWidth);
   background-color: var(--#{$panel}--BackgroundColor);
+  border-radius: var(--#{$panel}--BorderRadius);
   box-shadow: var(--#{$panel}--BoxShadow);
 
   &::before {
@@ -67,6 +69,7 @@
     pointer-events: none;
     content: "";
     border: var(--#{$panel}--before--BorderWidth) solid var(--#{$panel}--before--BorderColor);
+    border-radius: var(--#{$panel}--BorderRadius);
   }
 
   &.pf-m-bordered {

--- a/src/patternfly/demos/Panel/Panel.md
+++ b/src/patternfly/demos/Panel/Panel.md
@@ -8,7 +8,7 @@ section: components
 ### With a menu
 
 ```hbs
-{{#> panel}}
+{{#> panel panel--modifier="pf-m-raised"}}
   {{#> panel-header}}
     Header content
   {{/panel-header}}

--- a/src/patternfly/demos/Panel/Panel.md
+++ b/src/patternfly/demos/Panel/Panel.md
@@ -15,7 +15,7 @@ section: components
   {{#> panel-main}}
     {{#> panel-main-body}}
       {{#> panel-menu}}
-        {{#> menu}}
+        {{#> menu menu--modifier="pf-m-plain"}}
           {{#> menu-content}}
             {{#> menu-list}}
               {{#> menu-list-item}}

--- a/src/patternfly/demos/Panel/Panel.md
+++ b/src/patternfly/demos/Panel/Panel.md
@@ -13,70 +13,68 @@ section: components
     Header content
   {{/panel-header}}
   {{#> panel-main}}
-    {{#> panel-main-body}}
-      {{#> panel-menu}}
-        {{#> menu menu--modifier="pf-m-plain"}}
-          {{#> menu-content}}
-            {{#> menu-list}}
-              {{#> menu-list-item}}
-                {{#> menu-item}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                      Action
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-              {{#> menu-list-item}}
-                {{#> menu-item menu-item--IsLink="true"}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                      Link
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-              {{#> menu-list-item menu-list-item--IsDisabled="true"}}
-                {{#> menu-item}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                    Disabled action
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-              {{#> menu-list-item menu-list-item--IsDisabled="true"}}
-                {{#> menu-item menu-item--IsLink="true"}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                    Disabled link
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-              {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
-                {{#> menu-item}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                    Aria-disabled action
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-              {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
-                {{#> menu-item menu-item--IsLink=true}}
-                  {{#> menu-item-main}}
-                    {{#> menu-item-text}}
-                    Aria-disabled link
-                    {{/menu-item-text}}
-                  {{/menu-item-main}}
-                {{/menu-item}}
-              {{/menu-list-item}}
-            {{/menu-list}}
-          {{/menu-content}}
-        {{/menu}}
-      {{/panel-menu}}
-    {{/panel-main-body}}
+    {{#> panel-menu}}
+      {{#> menu menu--modifier="pf-m-plain"}}
+        {{#> menu-content}}
+          {{#> menu-list}}
+            {{#> menu-list-item}}
+              {{#> menu-item}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                    Action
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+            {{#> menu-list-item}}
+              {{#> menu-item menu-item--IsLink="true"}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                    Link
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+            {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+              {{#> menu-item}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                  Disabled action
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+            {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+              {{#> menu-item menu-item--IsLink="true"}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                  Disabled link
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+            {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
+              {{#> menu-item}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                  Aria-disabled action
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+            {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
+              {{#> menu-item menu-item--IsLink=true}}
+                {{#> menu-item-main}}
+                  {{#> menu-item-text}}
+                  Aria-disabled link
+                  {{/menu-item-text}}
+                {{/menu-item-main}}
+              {{/menu-item}}
+            {{/menu-list-item}}
+          {{/menu-list}}
+        {{/menu-content}}
+      {{/menu}}
+    {{/panel-menu}}
   {{/panel-main}}
   {{#> panel-footer}}
     Footer content

--- a/src/patternfly/demos/Panel/Panel.md
+++ b/src/patternfly/demos/Panel/Panel.md
@@ -1,0 +1,85 @@
+---
+id: Panel
+section: components
+---
+
+## Demos
+
+### With a menu
+
+```hbs
+{{#> panel}}
+  {{#> panel-header}}
+    Header content
+  {{/panel-header}}
+  {{#> panel-main}}
+    {{#> panel-main-body}}
+      {{#> panel-menu}}
+        {{#> menu}}
+          {{#> menu-content}}
+            {{#> menu-list}}
+              {{#> menu-list-item}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Action
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item}}
+                {{#> menu-item menu-item--IsLink="true"}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                      Link
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                    Disabled action
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item menu-list-item--IsDisabled="true"}}
+                {{#> menu-item menu-item--IsLink="true"}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                    Disabled link
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
+                {{#> menu-item}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                    Aria-disabled action
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+              {{#> menu-list-item menu-list-item--IsAriaDisabled=true}}
+                {{#> menu-item menu-item--IsLink=true}}
+                  {{#> menu-item-main}}
+                    {{#> menu-item-text}}
+                    Aria-disabled link
+                    {{/menu-item-text}}
+                  {{/menu-item-main}}
+                {{/menu-item}}
+              {{/menu-list-item}}
+            {{/menu-list}}
+          {{/menu-content}}
+        {{/menu}}
+      {{/panel-menu}}
+    {{/panel-main-body}}
+  {{/panel-main}}
+  {{#> panel-footer}}
+    Footer content
+  {{/panel-footer}}
+{{/panel}}
+```


### PR DESCRIPTION
Closes #6732 

Worth noting that the scrollable example currently looks off. I can apply similar styling as the [scrollable menu example](https://pf6.patternfly.org/components/menus/menu#scrollable) (to make the scrollbar look like it has a curve to it), but may ultimately depend on how we want to proceed re: https://github.com/patternfly/patternfly/issues/6045