### PR TITLE
fix(global): base stylesheets cleanup

### DIFF
--- a/src/patternfly/base/_index.scss
+++ b/src/patternfly/base/_index.scss
@@ -1,7 +1,7 @@
 // @use '../sass-utilities' as *;
 
-@forward './normalize';
 @forward './reset';
+@forward './normalize';
 @forward './patternfly-common';
 @forward './patternfly-fonts';
 @forward './patternfly-fa-icons';

--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -105,4 +105,8 @@
   ) {
     cursor: pointer;
   }
+
+  :where(.pf-v6-theme-dark) {
+    color-scheme: dark;
+  }
 }

--- a/src/patternfly/base/patternfly-variables.scss
+++ b/src/patternfly/base/patternfly-variables.scss
@@ -1,8 +1,8 @@
 @use '../sass-utilities' as *;
-@use "./tokens/tokens-local" as local;
 @use "./tokens/tokens-palette" as palette;
 @use "./tokens/tokens-default" as default;
 @use "./tokens/tokens-dark" as dark;
+@use "./tokens/tokens-local" as local;
 
 :where(:root) {
   @include pf-v6-set-inverse(false);

--- a/src/patternfly/base/tokens/_index.scss
+++ b/src/patternfly/base/tokens/_index.scss
@@ -1,7 +1,6 @@
-@forward './workspace-overrides';
-@forward './tokens-local';
 @forward './tokens-palette';
 @forward './tokens-default';
 @forward './tokens-dark';
 @forward './tokens-charts';
 @forward './tokens-charts-dark';
+@forward './tokens-local';

--- a/src/patternfly/base/tokens/workspace-overrides.scss
+++ b/src/patternfly/base/tokens/workspace-overrides.scss
@@ -1,7 +1,0 @@
-// stylelint-disable
-html {
-  .ws-preview {
-    background-color: var(--pf-t--global--background--color--primary--default);
-  }
-}
-// stylelint-enable


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6747
fixes https://github.com/patternfly/patternfly/issues/6679

@srambach @mattnolting changes discussed from today's working session, except I also moved reset.scss to come before normalize.scss. Seems like a change we would want to make - wdyt? I'll also run visual regression tests to make sure nothing unexpected changed from that.