### PR TITLE
fix(css): added :where(:root, .selector)

### DIFF
--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 // Tabs
-.#{$alert-group} {
+:where(:root, .#{$alert-group}) {
   // Alert group variables
   --#{$alert-group}__item--MarginBlockStart: var(--pf-t--global--spacer--md);
 
@@ -28,7 +28,9 @@
   --#{$alert-group}__overflow-button--focus--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
   --#{$alert-group}__overflow-button--active--Color: var(--pf-t--global--text--color--link--hover);
   --#{$alert-group}__overflow-button--active--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
+}
 
+.#{$alert-group} {
   // Spacing between alerts
   > * + * {
     margin-block-start: var(--#{$alert-group}__item--MarginBlockStart);

--- a/src/patternfly/components/Brand/brand.scss
+++ b/src/patternfly/components/Brand/brand.scss
@@ -2,10 +2,12 @@
 
 $pf-v6-c-brand--breakpoint-map: build-breakpoint-map();
 
-.#{$brand} {
+:where(:root, .#{$brand}) {
   --#{$brand}--Width: auto;
   --#{$brand}--Height: auto;
+}
 
+.#{$brand} {
   width: var(--#{$brand}--Width--base);
   height: var(--#{$brand}--Height--base);
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -24,7 +24,7 @@
   --#{$button}--hover--BorderColor: transparent;
   --#{$button}--hover--BorderWidth: var(--pf-t--global--border--width--button--hover);
   --#{$button}--hover--TextDecoration: none;
-  
+
   // Clicked
   --#{$button}--m-clicked--BackgroundColor: transparent;
   --#{$button}--m-clicked--BorderColor: transparent;

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -24,7 +24,6 @@
   --#{$calendar-month}__day--FontWeight: var(--pf-t--global--font--weight--body);
   --#{$calendar-month}__day--Color: var(--pf-t--global--text--color--regular);
 
-
   // dates td
   --#{$calendar-month}__dates-cell--PaddingBlockStart: #{pf-size-prem(2px)};
   --#{$calendar-month}__dates-cell--PaddingInlineEnd: #{pf-size-prem(2px)};
@@ -71,7 +70,7 @@
   --#{$calendar-month}__date--after--focus--OutlineOffset: -2px;
 }
 
-:where(.#{$calendar-month}) {
+.#{$calendar-month} {
   display: inline-flex;
   flex-direction: column;
   padding-block-start: var(--#{$calendar-month}--PaddingBlockStart);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -34,7 +34,6 @@
   --#{$card}__header-toggle-icon--Transition: var(--pf-t--global--transition);
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
-
   // Selectable/Clickable
   --#{$card}--m-selectable--BorderWidth: var(--#{$card}--BorderWidth);
 

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -91,7 +91,6 @@
   --#{$data-list}__check--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   --#{$data-list}__check--MarginBlockStart: #{pf-size-prem(-1px)}; // slightly offset input
 
-
   // actions
   --#{$data-list}__item-action--Display: flex;
   --#{$data-list}__item-action--PaddingBlockStart: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -318,7 +318,6 @@
 
     overflow: auto;
   }
-
 }
 
 .#{$form-control}__icon {

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -29,6 +29,7 @@
   // icon
   --#{$helper-text}__item-icon--MarginInlineEnd: var(--pf-t--global--spacer--xs);
 }
+
 .#{$helper-text} {
   // text
 

--- a/src/patternfly/components/InlineEdit/inline-edit.scss
+++ b/src/patternfly/components/InlineEdit/inline-edit.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root,  .#{$inline-edit}) {
+:where(:root, .#{$inline-edit}) {
   // Group
   --#{$inline-edit}__group--item--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 

--- a/src/patternfly/components/List/list.scss
+++ b/src/patternfly/components/List/list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-.#{$list} {
+:where(:root, .#{$list}) {
   // list
   --#{$list}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$list}--nested--MarginBlockStart: var(--pf-t--global--spacer--sm);
@@ -25,7 +25,9 @@
   --#{$list}--m-icon-lg__item-icon--MinWidth: var(--pf-t--global--icon--size--lg);
   --#{$list}--m-icon-lg__item-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$list}--m-icon-lg__item-icon--FontSize: var(--pf-t--global--icon--size--lg);
+}
 
+.#{$list} {
   padding-inline-start: var(--#{$list}--PaddingInlineStart);
 
   ol,

--- a/src/patternfly/components/LogViewer/log-viewer.scss
+++ b/src/patternfly/components/LogViewer/log-viewer.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-.#{$log-viewer} {
+:where(:root, .#{$log-viewer}) {
   --#{$log-viewer}--Height: 100%;
   --#{$log-viewer}--MaxHeight: auto;
   --#{$log-viewer}--m-line-numbers__index--Display: inline;
@@ -67,7 +67,9 @@
 
   // Dark theme
   --#{$log-viewer}--m-dark__main--BorderWidth: 0;
+}
 
+.#{$log-viewer} {
   &.pf-m-dark {
     --#{$log-viewer}__main--BorderWidth: var(--#{$log-viewer}--m-dark__main--BorderWidth);
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -17,7 +17,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     --#{$page}--inset: var(--#{$page}--xl--inset);
   }
 
- 
   // Sidebar
   --#{$page}__sidebar--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$page}__sidebar--Width: #{pf-size-prem(290px)};
@@ -124,7 +123,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-wizard--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$page}__main-wizard--BorderBlockStartColor: var(--pf-t--global--border--color--default);
   --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--button--default);
-  }
+}
 
 .#{$page} {
   // Base

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-.#{$popover} {
+:where(:root, .#{$popover}) {
   // Component
   --#{$popover}--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$popover}--MinWidth: calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)});
@@ -67,7 +67,9 @@
 
   // Footer
   --#{$popover}__footer--MarginBlockStart: var(--pf-t--global--spacer--md);
+}
 
+.#{$popover} {
   position: relative;
   min-width: var(--#{$popover}--MinWidth);
   max-width: var(--#{$popover}--MaxWidth);

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -32,7 +32,7 @@
 }
 
 // - Table grid
-.#{$table}[class*="pf-m-grid"] {
+:where(:root, .#{$table}[class*="pf-m-grid"]) {
   // ============================================================ //
   // Start non-conformant variables
   //

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -108,7 +108,7 @@
   --#{$wizard}__toggle--m-danger__nav-link-status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
   --#{$wizard}__toggle-status-icon--InsetBlockStart: 2px; // not spacer-based but needed to align
   --#{$wizard}__toggle-status-icon--FontSize: var(--pf-t--global--icon--size--font--xl);
-  
+
   // Toggle list
   --#{$wizard}__toggle-list--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__toggle-list--MarginBlockEnd: calc(var(--#{$wizard}__toggle-list-item--MarginBlockEnd) * -1);
@@ -145,7 +145,7 @@
   // Nav item
   --#{$wizard}__nav-item--MarginBlockStart: var(--pf-t--global--spacer--md);
 
-  // Outer wrap 
+  // Outer wrap
   --#{$wizard}__outer-wrap--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}__outer-wrap--lg--PaddingInlineStart: var(--#{$wizard}__nav--Width);
   --#{$wizard}__outer-wrap--MinHeight: #{pf-size-prem(250px)};
@@ -477,7 +477,7 @@
     &::before {
       display: none;
     }
-  }    
+  }
 
   &:where(:hover, :focus) {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);


### PR DESCRIPTION
closes #6751

Looks like we missed a few `:where(:root, .selector)` and closures. This PR addresses those. 