### PR TITLE
fix(clipboard-copy): adjust inline icons

### DIFF
--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -24,22 +24,17 @@
   --#{$clipboard-copy}__group--Gap: var(--pf-t--global--spacer--xs);
 
   // Inline
-  --#{$clipboard-copy}--m-inline--PaddingBlockStart: 0; // remove at breaking change
-  --#{$clipboard-copy}--m-inline--PaddingBlockEnd: 0; // remove at breaking change
   --#{$clipboard-copy}--m-inline--PaddingInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}--m-inline--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
   --#{$clipboard-copy}--m-inline--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$clipboard-copy}__actions--Gap: var(--pf-t--global--spacer--sm);
+  --#{$clipboard-copy}__actions--MarginInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$clipboard-copy}__actions-item--button--Color: var(--pf-t--global--icon--color--subtle);
+  --#{$clipboard-copy}__actions-item--button--hover--Color: var(--pf-t--global--icon--color--regular);
 
   // Text
   --#{$clipboard-copy}__text--m-code--FontFamily: var(--pf-t--global--font--family--mono);
   --#{$clipboard-copy}__text--m-code--FontSize: var(--pf-t--global--font--size--body--default);
-
-  // Actions
-  --#{$clipboard-copy}__actions-item--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$clipboard-copy}__actions-item--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$clipboard-copy}__actions-item--button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
-  --#{$clipboard-copy}__actions-item--button--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 }
 
 .#{$clipboard-copy} {
@@ -52,9 +47,8 @@
 
   &.pf-m-inline {
     display: inline;
-    padding-block-start: var(--#{$clipboard-copy}--m-inline--PaddingBlockStart);
-    padding-block-end: var(--#{$clipboard-copy}--m-inline--PaddingBlockEnd);
     padding-inline-start: var(--#{$clipboard-copy}--m-inline--PaddingInlineStart);
+    padding-inline-end: var(--#{$clipboard-copy}--m-inline--PaddingInlineEnd);
     white-space: nowrap;
     background-color: var(--#{$clipboard-copy}--m-inline--BackgroundColor);
 
@@ -114,17 +108,15 @@
 
 .#{$clipboard-copy}__actions {
   display: inline-flex;
+  gap: var(--#{$clipboard-copy}__actions--Gap);
+  margin-inline-start: var(--#{$clipboard-copy}__actions--MarginInlineStart);
 }
 
 .#{$clipboard-copy}__actions-item {
-  margin-block-start: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingBlockStart));
-  margin-block-end: calc(-1 * var(--#{$clipboard-copy}__actions-item--button--PaddingBlockEnd));
 
-  .#{$button} {
-    --#{$button}--PaddingBlockStart: var(--#{$clipboard-copy}__actions-item--button--PaddingBlockStart);
-    --#{$button}--PaddingInlineEnd: var(--#{$clipboard-copy}__actions-item--button--PaddingInlineEnd);
-    --#{$button}--PaddingBlockEnd: var(--#{$clipboard-copy}__actions-item--button--PaddingBlockEnd);
-    --#{$button}--PaddingInlineStart: var(--#{$clipboard-copy}__actions-item--button--PaddingInlineStart);
+  .#{$button}.pf-m-plain {
+    --#{$button}--m-plain--Color: var(--#{$clipboard-copy}__actions-item--button--Color);
+    --#{$button}--m-plain--hover--Color: var(--#{$clipboard-copy}__actions-item--button--hover--Color);
   }
 }
 

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -158,7 +158,7 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
@@ -174,7 +174,7 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
@@ -190,12 +190,12 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Run in web terminal"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Run in web terminal"}}
         <i class="fas fa-play" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
@@ -213,7 +213,7 @@ Lorem ipsum&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
@@ -231,7 +231,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}
@@ -248,7 +248,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Copy to clipboard"'}}
+      {{#> button button--IsPlain=true button--HasNoPadding=true button--aria-label="Copy to clipboard"}}
         <i class="fas fa-copy" aria-hidden="true"></i>
       {{/button}}
     {{/clipboard-copy-actions-item}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6762

@andrew-ronaldson is there a formula for when we use the subtle icon color by default and regular color on hover? I know we've added that in a few places, but it currently exists as overrides in components where that style exists. I'm wondering if this should be a variation or something instead. Should the "no padding" icon button have this style by default?

FWIW here are all of the places in the CSS we're using that token. I can provide more info if that's helpful

```
ClipboardCopy/clipboard-copy.scss:  --#{$clipboard-copy}__actions-item--button--Color: var(--pf-t--global--icon--color--subtle);
DataList/data-list.scss:  --#{$data-list}__item-draggable-button-icon--Color: var(--pf-t--global--icon--color--subtle);
DescriptionList/description-list.scss:  --#{$description-list}__term-icon--Color: var(--pf-t--global--icon--color--subtle);
EmptyState/empty-state.scss:  --#{$empty-state}__icon--Color: var(--pf-t--global--icon--color--subtle);
HelperText/helper-text.scss:  --#{$helper-text}__item-icon--m-indeterminate--Color: var(--pf-t--global--icon--color--subtle);
HelperText/helper-text.scss:  --#{$helper-text}--m-dynamic--m-indeterminate__item-icon--Color: var(--pf-t--global--icon--color--subtle);
Menu/menu.scss:  --#{$menu}__item-action--Color: var(--pf-t--global--icon--color--subtle);
Menu/menu.scss:  --#{$menu}__item-select-icon--Color: var(--pf-t--global--icon--color--subtle);
Nav/nav.scss:  --#{$nav}__link-icon--Color: var(--pf-t--global--icon--color--subtle);
Slider/slider.scss:  --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--subtle);
Switch/switch.scss:  --#{$switch}__input--not-checked__toggle--before--BackgroundColor: var(--pf-t--global--icon--color--subtle);
Table/table.scss:  --#{$table}__sort-indicator--Color: var(--pf-t--global--icon--color--subtle);
TreeView/tree-view.scss:  --#{$tree-view}__node-toggle--Color--base: var(--pf-t--global--icon--color--subtle);
TreeView/tree-view.scss:  --#{$tree-view}__node-icon--Color: var(--pf-t--global--icon--color--subtle);

```