### PR TITLE
fix(progress-stepper): remove padding from help-text title button

### DIFF
--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -399,6 +399,7 @@ $pf-v5-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   border: 0;
 
   &.pf-m-help-text {
+    padding: 0;
     text-decoration: underline;
     text-decoration-thickness: var(--#{$progress-stepper}__step-title--m-help-text--TextDecorationThickness);
     text-decoration-style: dashed;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6730

scoped this to `__step-title.pf-m-help-text` (when we make the title a `<button>`) so it has less of a chance of impacting any existing user overrides.