### PR TITLE
fix(where): removed `where()` pseudo

### DIFF
--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -8,14 +8,13 @@
     box-sizing: border-box;
   }
 
-  :where(
-    html,
-    body
-  ) {
+
+  html,
+  body {
     height: 100%;
   }
 
-  :where(body) {
+  body {
     font-family: var(--pf-t--global--font--family--body);
     font-size: var(--pf-t--global--font--size--body--default);
     font-weight: var(--pf-t--global--font--weight--body--default);
@@ -23,29 +22,27 @@
     color: var(--pf-t--global--text--color--regular);
   }
 
-  :where(
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6
-  ) {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-size: 100%;
     font-weight: var(--pf-t--global--font--weight--body--default);
   }
 
-  :where(ul) {
+  ul {
     list-style: none;
   }
 
-  :where(
-    button,
-    input,
-    optgroup,
-    select,
-    textarea
-  ) {
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
     margin: 0;
     font-family: inherit;
     font-size: 100%;
@@ -53,60 +50,55 @@
     color: var(--pf-t--global--text--color--regular);
   }
 
-  :where(
-    img,
-    embed,
-    iframe,
-    object,
-    audio,
-    video
-  ) {
+
+  img,
+  embed,
+  iframe,
+  object,
+  audio,
+  video {
     max-width: 100%;
     height: auto;
   }
 
-  :where(iframe) {
+  iframe {
     border: 0;
   }
 
-  :where(table) {
+  table {
     border-spacing: 0;
     border-collapse: collapse;
   }
 
-  :where(
-    td,
-    th
-  ) {
+
+  td,
+  th {
     padding: 0;
     text-align: start;
   }
 
-  :where(
-    code,
-    pre
-  ) {
+
+  code,
+  pre {
     font-family: var(--pf-t--global--font--family--mono);
   }
 
-  :where(a) {
+  a {
     color: var(--pf-t--global--text--color--link--default);
     text-decoration: var(--pf-t--global--text-decoration--link--line--default);
   }
 
-  :where(a:hover, a:focus) {
+  a:hover, a:focus {
     color: var(--pf-t--global--text--color--link--hover);
     text-decoration: var(--pf-t--global--text-decoration--link--line--hover);
   }
 
-  :where(
-    a,
-    button
-  ) {
+  a,
+  button {
     cursor: pointer;
   }
 
-  :where(.pf-v6-theme-dark) {
+  .pf-v6-theme-dark {
     color-scheme: dark;
   }
 }

--- a/src/patternfly/base/patternfly-variables.scss
+++ b/src/patternfly/base/patternfly-variables.scss
@@ -4,14 +4,15 @@
 @use "./tokens/tokens-dark" as dark;
 @use "./tokens/tokens-local" as local;
 
-:where(:root) {
+:root,
+.pf-v6-reset {
   @include pf-v6-set-inverse(false);
   @include palette.pf-v6-tokens;
   @include default.pf-v6-tokens;
   @include local.pf-v6-tokens;
 }
 
-:where(.pf-v6-theme-dark) {
+.pf-v6-theme-dark {
   @include dark.pf-v6-tokens;
 }
 

--- a/src/patternfly/base/reset.scss
+++ b/src/patternfly/base/reset.scss
@@ -2,7 +2,6 @@
 
 // Reset - based on minireset.css v0.0.3 | MIT License github.com/jgthms/minireset.css
 @if $pf-v6-global--enable-reset {
-  :where(
     html,
     body,
     p,
@@ -26,7 +25,7 @@
     h4,
     h5,
     h6
-    ) {
+     {
     padding: 0;
     margin: 0;
   }

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$about-modal-box}) {
+@include pf-root($about-modal-box) {
     // Component variables
   --#{$about-modal-box}--BackgroundImage: none;
   --#{$about-modal-box}--BackgroundColor: var(--pf-t--global--background--color--floating--default);

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$accordion}) {
+@include pf-root($accordion) {
   // accordion
   --#{$accordion}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}--RowGap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/ActionList/action-list.scss
+++ b/src/patternfly/components/ActionList/action-list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$action-list}) {
+@include pf-root($action-list) {
   --#{$action-list}--RowGap: var(--pf-t--global--spacer--gap--group--vertical);
   --#{$action-list}--ColumnGap: var(--pf-t--global--spacer--gap--group-to-group--horizontal);
 

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 // Tabs
-:where(:root, .#{$alert-group}) {
+@include pf-root($alert-group) {
   // Alert group variables
   --#{$alert-group}__item--MarginBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
 
@@ -70,7 +70,7 @@
   // This transition will happen when the item is added (.pf-m-offstage-top is removed)
   // Reduced motion by default
   // transparency change only
-  transition: 
+  transition:
   opacity var(--pf-t--global--motion--duration--fade--default) var(--pf-t--global--motion--timing-function--decelerate) 0s;
   transform: translateX(0) translateY(0);
 
@@ -78,10 +78,10 @@
   // give it height, then slide it down into place
   // These values are for regular motion
   @media screen and (prefers-reduced-motion: no-preference) {
-    transition: 
-      opacity var(--pf-t--global--motion--duration--fade--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default), 
-      transform var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default), 
-      grid-template-rows var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) 0s, 
+    transition:
+      opacity var(--pf-t--global--motion--duration--fade--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default),
+      transform var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default),
+      grid-template-rows var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) 0s,
       margin-block var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) 0s;
 
       & .pf-v6-c-alert {
@@ -118,7 +118,7 @@
     // This transition will happen when the item is removed
     // Reduced motion by default
     // transparency change only
-    transition: 
+    transition:
       opacity var(--pf-t--global--motion--duration--fade--short) var(--pf-t--global--motion--timing-function--accelerate) 0s;
     transform: translateX(100%);
 
@@ -133,10 +133,10 @@
     // give it height, then slide it down into place
     // These values are for regular motion
     @media screen and (prefers-reduced-motion: no-preference) {
-      transition: 
-        transform var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) 0s, 
+      transition:
+        transform var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) 0s,
         opacity var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) 0s,
-        margin-block var(--pf-t--global--motion--duration--fade--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short), 
+        margin-block var(--pf-t--global--motion--duration--fade--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short),
         grid-template-rows var(--pf-t--global--motion--duration--slide-in--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short);
 
         & .pf-v6-c-alert {

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$alert}) {
+@include pf-root($alert) {
   // Alert variables
   --#{$alert}--BoxShadow: var(--pf-t--global--box-shadow--lg);
   --#{$alert}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
@@ -118,7 +118,7 @@
   border: var(--#{$alert}--BorderWidth) solid var(--#{$alert}--BorderColor);
   border-radius: var(--#{$alert}--BorderRadius);
   box-shadow: var(--#{$alert}--BoxShadow);
-  
+
   &.pf-m-custom {
     --#{$alert}--BorderColor: var(--#{$alert}--m-custom--BorderColor);
     --#{$alert}__icon--Color: var(--#{$alert}--m-custom__icon--Color);
@@ -226,8 +226,11 @@
   margin-inline-end: var(--#{$alert}__action--MarginInlineEnd);
   transform: translateY(var(--#{$alert}__action--TranslateY));
 
-  > .#{$button} {
+  .#{$button},
+  .#{$button}.pf-m-plain {
     --#{$button}--LineHeight: 1;
+
+    min-width: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   }
 }
 

--- a/src/patternfly/components/Avatar/avatar.scss
+++ b/src/patternfly/components/Avatar/avatar.scss
@@ -3,7 +3,7 @@
 $pf-v6-c-avatar--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-avatar--sizes: "sm", "md", "lg", "xl";
 
-:where(:root, .#{$avatar}) {
+@include pf-root($avatar) {
   --#{$avatar}--BorderColor: transparent;
   --#{$avatar}--BorderWidth: 0;
   --#{$avatar}--BorderRadius: var(--pf-t--global--border--radius--pill);

--- a/src/patternfly/components/BackToTop/back-to-top.scss
+++ b/src/patternfly/components/BackToTop/back-to-top.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$back-to-top}) {
+@include pf-root($back-to-top) {
   --#{$back-to-top}--InsetInlineEnd: var(--pf-t--global--spacer--2xl);
   --#{$back-to-top}--InsetBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$back-to-top}--md--InsetBlockEnd: var(--pf-t--global--spacer--2xl);

--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$backdrop}) {
+@include pf-root($backdrop) {
   --#{$backdrop}--Position: fixed;
   --#{$backdrop}--ZIndex: var(--pf-t--global--z-index--lg);
   --#{$backdrop}--BackgroundColor: var(--pf-t--global--background--color--backdrop--default);

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$background-image}) {
+@include pf-root($background-image) {
   --#{$background-image}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$background-image}--BackgroundImage: none;
   --#{$background-image}--BackgroundSize--min-width: 200px;

--- a/src/patternfly/components/Badge/badge.scss
+++ b/src/patternfly/components/Badge/badge.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$badge}) {
+@include pf-root($badge) {
   // Component
   --#{$badge}--BorderColor: transparent;
   --#{$badge}--BorderWidth: var(--pf-t--global--border--width--regular);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$banner}) {
+@include pf-root($banner) {
   --#{$banner}--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$banner}--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$banner}--md--PaddingInlineEnd: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Brand/brand.scss
+++ b/src/patternfly/components/Brand/brand.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-brand--breakpoint-map: build-breakpoint-map();
 
-:where(:root, .#{$brand}) {
+@include pf-root($brand) {
   --#{$brand}--Width: auto;
   --#{$brand}--Height: auto;
 }

--- a/src/patternfly/components/Brand/examples/Brand.css
+++ b/src/patternfly/components/Brand/examples/Brand.css
@@ -1,12 +1,12 @@
 .show-dark,
-:where(.pf-v6-theme-dark) .show-light {
+.pf-v6-theme-dark .show-light {
   display: none;
 }
 
-:where(.pf-v6-theme-dark) .show-dark {
+.pf-v6-theme-dark .show-dark {
   display: revert;
 }
 
-:where(.pf-v6-theme-dark) .show-dark .pf-m-picture {
+.pf-v6-theme-dark .show-dark .pf-m-picture {
   display: inline-flex;
 }

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$breadcrumb}) {
+@include pf-root($breadcrumb) {
   // Breadcrumb item
   --#{$breadcrumb}__item--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$breadcrumb}__item--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$button}) {
+@include pf-root($button) {
   --#{$button}--Display: inline-flex;
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
@@ -131,7 +131,6 @@
   --#{$button}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain__icon--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$button}--m-plain--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--m-plain--hover--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$button}--m-plain--m-clicked--Color: var(--pf-t--global--icon--color--regular);
@@ -565,10 +564,10 @@
       --#{$button}--m-plain--PaddingInlineEnd: var(--#{$button}--m-plain--m-no-padding--PaddingInlineEnd);
       --#{$button}--m-plain--PaddingInlineStart: var(--#{$button}--m-plain--m-no-padding--PaddingInlineStart);
 
-      min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
+      min-width: auto;
     }
 
-    min-width: var(--#{$button}--m-plain--MinWidth);
+    min-width: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   }
 
   &.pf-m-block {

--- a/src/patternfly/components/CalendarMonth/calendar-month.scss
+++ b/src/patternfly/components/CalendarMonth/calendar-month.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$calendar-month}) {
+@include pf-root($calendar-month) {
   --#{$calendar-month}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$calendar-month}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$calendar-month}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$card}) {
+@include pf-root($card) {
   --#{$card}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$card}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$card}--BorderStyle: solid;
@@ -36,10 +36,6 @@
 
   // Selectable/Clickable
   --#{$card}--m-selectable--BorderWidth: var(--#{$card}--BorderWidth);
-
-  // Clickable clicked
-  --#{$card}--m-clickable--m-current--BorderColor: var(--pf-t--global--border--color--clicked);
-  --#{$card}--m-clickable--m-current--BorderWidth: var(--pf-t--global--border--width--box--clicked);
 
   // Selected state (checked) of selectable card
   --#{$card}--m-selectable--m-selected--BorderColor: var(--pf-t--global--border--color--clicked);
@@ -135,6 +131,8 @@
   // SELECTABLE or CLICKABLE CARDS
   &.pf-m-selectable,
   &.pf-m-clickable {
+    // --#{$card}--m-selectable--m-clickable--m-current--BorderWidth: 0;
+
     isolation: isolate;
 
     &::before {
@@ -142,35 +140,31 @@
     }
   }
 
-  // CLICKABLE is clicked
-  &.pf-m-current {
-    --#{$card}--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
-    --#{$card}--BorderWidth: var(--#{$card}--m-clickable--m-current--BorderWidth);
-    --#{$card}--m-selectable--hover--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
-    --#{$card}--m-selectable--focus--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
-  }
-
   // stylelint-disable selector-max-class
   // Cards that are BOTH SELECTABLE AND CLICKABLE
   &.pf-m-selectable.pf-m-clickable {
-    .#{$card}__selectable-actions :is(.#{$check}__label, .#{$radio}__label) {
+    .#{$card}__selectable-actions .#{$check}__label,
+    .#{$card}__selectable-actions .#{$radio}__label {
       position: unset;
 
       &::before {
         position: absolute;
         inset: 0;
         cursor: pointer;
+        border: var(--#{$card}--BorderColor, transparent) solid var(--#{$card}--BorderWidth);
       }
     }
 
     // When SELECTABLE and CLICKABLE card is focused, don't show change of background or border on the card
-    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:focus-visible) ~ :is(.#{$check}__label, .#{$radio}__label) {
+    .#{$card}__selectable-actions .#{$check}__input:focus-visible ~ .#{$check}__label,
+    .#{$card}__selectable-actions .#{$radio}__input:focus-visible ~ .#{$radio}__label {
       --#{$card}--BackgroundColor: revert;
       --#{$card}--BorderColor: revert;
     }
 
     // SELECTABLE and CLICKABLE card is selected (Check box checked or marked .pf-m-selected)
-    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:checked) ~ :is(.#{$check}__label, .#{$radio}__label),
+    .#{$card}__selectable-actions .#{$check}__input:checked ~ .#{$check}__label,
+    .#{$card}__selectable-actions .#{$radio}__input:checked ~ .#{$radio}__label,
     &.pf-m-selected {
       --#{$card}--BorderColor: revert;
       --#{$card}--m-selectable--BorderWidth: revert;
@@ -183,7 +177,8 @@
     }
 
     // SELECTABLE and CLICKABLE but DISABLED card
-    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:disabled) ~ :is(.#{$check}__label, .#{$radio}__label),
+    .#{$card}__selectable-actions .#{$check}__input:disabled ~ .#{$check}__label,
+    .#{$card}__selectable-actions .#{$radio}__input:disabled ~ .#{$radio}__label,
     &.pf-m-disabled {
       --#{$card}--BackgroundColor: var(--#{$card}--m-selectable--m-disabled--BackgroundColor);
     }
@@ -317,7 +312,8 @@
 }
 
 // Labels are used to handle states of selectable and clickable cards
-.#{$card}__selectable-actions :is(.#{$check}__label, .#{$radio}__label, .#{$card}__clickable-action) {
+.#{$card}__selectable-actions .#{$check}__label,
+.#{$card}__selectable-actions .#{$radio}__label {
   position: absolute;
   inset: 0;
   justify-self: auto;
@@ -339,44 +335,36 @@
 }
 
 // Selected card (checked)
-.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:checked) ~ :is(.#{$radio}__label, .#{$check}__label),
+.#{$card}__selectable-actions .#{$check}__input:checked ~ .#{$check}__label,
+.#{$card}__selectable-actions .#{$radio}__input:checked ~ .#{$radio}__label,
 .#{$card}.pf-m-selected {
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-selected--BorderColor);
   --#{$card}--m-selectable--BorderWidth: var(--#{$card}--m-selectable--m-selected--BorderWidth); // this line used to be just BorderWidth, not m-selectable
 }
 
 // Focus on the card (focus on label but not checked)
-.#{$card}__selectable-actions .#{$card}__clickable-action:where(:focus-visible),
-.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input, .#{$card}__clickable-action):where(:focus-visible) ~ :is(.#{$check}__label, .#{$radio}__label) {
+.#{$card}__selectable-actions .#{$check}__input:focus-visible ~ .#{$check}__label,
+.#{$card}__selectable-actions .#{$radio}__input:focus-visible ~ .#{$radio}__label {
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
   --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
 }
 
 // Focus on a selected card (focus + checked)
-.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:focus-visible):where(:checked) ~ :is(.#{$check}__label, .#{$radio}__label) {
+.#{$card}__selectable-actions .#{$check}__input:focus-visible:checked ~ .#{$check}__label,
+.#{$card}__selectable-actions .#{$radio}__input:focus-visible:checked ~ .#{$radio}__label {
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-selected--focus--BorderColor);
   --#{$card}--BorderWidth: var(--#{$card}--m-selectable--m-selected--focus--BorderWidth);
 }
 
 // Disabled card
-.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:disabled) ~ :is(.#{$check}__label, .#{$radio}__label),
+.#{$card}__selectable-actions .#{$check}__input:disabled ~ .#{$check}__label,
+.#{$card}__selectable-actions .#{$radio}__input:disabled ~ .#{$radio}__label,
 .#{$card}.pf-m-disabled {
   --#{$card}__title-text--Color: var(--#{$card}--m-selectable--m-disabled__title-text--Color);
   --#{$card}__body--Color: var(--#{$card}--m-selectable--m-disabled__body--Color);
   --#{$card}__footer--Color: var(--#{$card}--m-selectable--m-disabled__footer--Color);
   --#{$card}--BackgroundColor: var(--#{$card}--m-selectable--m-disabled--BackgroundColor);
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-disabled--BorderColor);
-}
-
-.#{$card}__clickable-action {
-  background: none;
-  border: 0;
-  outline: 0;
-
-  &:disabled,
-  &.pf-m-disabled {
-    pointer-events: none;
-  }
 }
 
 .#{$card}__header,
@@ -402,10 +390,6 @@
   .#{$button}.pf-m-inline:disabled {
     --#{$button}--disabled--Color: var(--#{$card}--c-button--disabled--Color);
   }
-}
-
-.#{$card}__expandable-content {
-  --#{$card}--first-child--PaddingBlockStart: 0;
 }
 
 .#{$card}__body:not(.pf-m-no-fill) {

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$check}) {
+@include pf-root($check) {
   --#{$check}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
   --#{$check}--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$clipboard-copy}) {
+@include pf-root($clipboard-copy) {
   // Toggle icon
   --#{$clipboard-copy}__toggle-icon--Transition: .2s ease-in 0s;
   --#{$clipboard-copy}--m-expanded__toggle-icon--Rotate: 90deg;

--- a/src/patternfly/components/CodeBlock/code-block.scss
+++ b/src/patternfly/components/CodeBlock/code-block.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$code-block}) {
+@include pf-root($code-block) {
   --#{$code-block}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$code-block}--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$code-block}__header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$code-editor}) {
+@include pf-root($code-editor) {
   // controls
   --#{$code-editor}__controls--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$code-editor}__controls--Gap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$content}) {
+@include pf-root($content) {
   // Body
   --#{$content}--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -96,6 +96,7 @@
   --#{$content}--hr--Height: var(--pf-t--global--border--width--divider--default);
   --#{$content}--hr--BackgroundColor: var(--pf-t--global--border--color--default);
 }
+
 
 [class*="#{$content}"] {
   font-size: var(--#{$content}--FontSize);

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -1,8 +1,8 @@
 @use '../../sass-utilities' as *;
 @use './data-list-grid' as *;
 
-:where(:root, .#{$data-list}) {
-  --#{$data-list}--FontSize: var( --pf-t--global--font--size--body);
+@include pf-root($data-list) {
+  --#{$data-list}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$data-list}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$data-list}--BorderBlockStartColor: var(--pf-t--global--border--color--default);
   --#{$data-list}--BorderBlockStartWidth: var(--pf-t--global--border--width--strong);
@@ -59,7 +59,6 @@
   --#{$data-list}__toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1); // offset toggle to align left
   --#{$data-list}__toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$data-list}__toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$data-list}__toggle-icon--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   --#{$data-list}__toggle-icon--Transition: .2s ease-in 0s;
   --#{$data-list}__toggle-icon--Rotate: 0;
   --#{$data-list}__item--m-expanded__toggle-icon--Rotate: 90deg;
@@ -133,8 +132,6 @@
   --#{$data-list}--m-compact__item-action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-action--MarginInlineStart: var(--pf-t--global--spacer--md);
-  --#{$data-list}--m-compact__action--MarginBlockStart: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockStart) * -1);
-  --#{$data-list}--m-compact__action--MarginBlockEnd: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd) * -1);
   --#{$data-list}--m-compact__item-content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1);
   --#{$data-list}--m-compact__item-draggable-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--sm) * -1);
@@ -150,13 +147,9 @@
   border-block-start: var(--#{$data-list}--BorderBlockStartWidth) solid var(--#{$data-list}--BorderBlockStartColor);
 
   &.pf-m-compact {
-    --#{$data-list}__check--FontSize: var(--#{$data-list}--m-compact__check--FontSize);
-    --#{$data-list}--FontSize: var(--#{$data-list}--m-compact--FontSize);
     --#{$data-list}__item-action--MarginInlineStart: var(--#{$data-list}--m-compact__item-action--MarginInlineStart);
     --#{$data-list}__item-action--PaddingBlockStart: var(--#{$data-list}--m-compact__item-action--PaddingBlockStart);
     --#{$data-list}__item-action--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd);
-    --#{$data-list}__action--MarginBlockStart: var(--#{$data-list}--m-compact__action--MarginBlockStart);
-    --#{$data-list}__action--MarginBlockEnd: var(--#{$data-list}--m-compact__action--MarginBlockEnd);
     --#{$data-list}__item-control--MarginInlineEnd: var(--#{$data-list}--m-compact__item-control--MarginInlineEnd);
     --#{$data-list}__item-control--PaddingBlockStart: var(--#{$data-list}--m-compact__item-control--PaddingBlockStart);
     --#{$data-list}__item-control--PaddingBlockEnd: var(--#{$data-list}--m-compact__item-control--PaddingBlockEnd);
@@ -169,6 +162,11 @@
 
     font-size: var(--#{$data-list}--m-compact--FontSize);
 
+    .#{$data-list}__action {
+      margin-block-start: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockStart) * -1);
+      margin-block-end: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd) * -1);
+    }
+
     .#{$data-list}__cell {
       --#{$data-list}__cell--PaddingBlockStart: var(--#{$data-list}--m-compact__cell--PaddingBlockStart);
       --#{$data-list}__cell--PaddingBlockEnd: var(--#{$data-list}--m-compact__cell--PaddingBlockEnd);
@@ -177,6 +175,7 @@
     }
 
     .#{$data-list}__check {
+      height: calc(var(--#{$data-list}--m-compact--FontSize) * var(--#{$data-list}--m-compact--LineHeight));
       font-size: var(--#{$data-list}--m-compact__check--FontSize);
     }
   }
@@ -343,7 +342,7 @@
 .#{$data-list}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  height: var(--#{$data-list}__toggle-icon--Height);
+  height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   pointer-events: none;
   transition: var(--#{$data-list}__toggle-icon--Transition);
   transform: rotate(var(--#{$data-list}__toggle-icon--Rotate));

--- a/src/patternfly/components/DatePicker/date-picker.scss
+++ b/src/patternfly/components/DatePicker/date-picker.scss
@@ -1,12 +1,11 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$date-picker}) {
+@include pf-root($date-picker) {
   --#{$date-picker}--m-top__calendar--InsetBlockStart: 0;
   --#{$date-picker}--m-top__calendar--TranslateY: calc(-100% - var(--pf-t--global--spacer--xs));
   --#{$date-picker}__helper-text--MarginBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$date-picker}__input--c-form-control--Width: calc(var(--#{$date-picker}__input--c-form-control--width-chars) * 1ch + var(--#{$date-picker}__input--c-form-control--width-base));
-  --#{$date-picker}__input--c-form-control--width-base: calc(var(--pf-t--global--spacer--xl) + var(--pf-t--global--spacer--sm)); // form control left/right padding + status icon width and spacer
-  --#{$date-picker}__input--c-form-control--width-chars: 11;
+  --#{$date-picker}__input--c-form-control--width-base: calc(var(--#{$form-control}--PaddingInlineStart) + var(--#{$form-control}--PaddingInlineEnd)); // form control left/right padding + status icon width and spacer
+  --#{$date-picker}__input--c-form-control--width-chars-base: 11ch;
   --#{$date-picker}__calendar--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$date-picker}__calendar--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$date-picker}__calendar--ZIndex: var(--pf-t--global--z-index--sm);
@@ -28,7 +27,7 @@
 
 .#{$date-picker}__input {
   .#{$form-control} {
-    width: var(--#{$date-picker}__input--c-form-control--Width);
+    width: var(--#{$date-picker}__input--c-form-control--Width, calc(var(--#{$date-picker}__input--c-form-control--width-chars-base) + var(--#{$date-picker}__input--c-form-control--width-base)));
   }
 }
 

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -81,7 +81,7 @@ import './DatePicker.css'
 
 ### Custom width input based on number of characters
 ```hbs
-{{#> date-picker date-picker--id="custom-width-input-based-on-number-of-characters" date-picker--attribute='style="--pf-v6-c-date-picker__input--c-form-control--width-chars: 18;"'}}
+{{#> date-picker date-picker--id="custom-width-input-based-on-number-of-characters" date-picker--attribute='style="--pf-v6-c-date-picker__input--c-form-control--Width: 22ch;"'}}
   {{#> input-group}}
     {{#> input-group-item input-group-item--IsFill=true}}
       {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="November 20, 2020" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -1,8 +1,9 @@
 @use '../../sass-utilities' as *;
 
 $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
+$pf-v6-c-description-list--term-width: 12ch;
 
-:where(:root, .#{$description-list}) {
+@include pf-root($description-list) {
   --#{$description-list}--RowGap: var(--pf-t--global--spacer--lg);
   --#{$description-list}--ColumnGap: var(--pf-t--global--spacer--lg);
   --#{$description-list}--GridTemplateColumns--count: 1;
@@ -12,7 +13,6 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   // group
   --#{$description-list}__group--RowGap: var(--pf-t--global--spacer--sm);
   --#{$description-list}__group--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$description-list}__group--GridTemplateColumns: auto;
   --#{$description-list}__group--GridTemplateRows: auto 1fr;
   --#{$description-list}__group--GridColumn: auto;
 
@@ -26,6 +26,7 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   --#{$description-list}__term--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$description-list}__term--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$description-list}__term--LineHeight: var(--pf-t--global--font--line-height--body);
+  --#{$description-list}__term--width--base: 12ch;
 
   @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
     --#{$description-list}__term--Display: var(--#{$description-list}__term--sm--Display);
@@ -36,22 +37,11 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   --#{$description-list}__term-icon--MarginInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$description-list}__term-icon--Color: var(--pf-t--global--icon--color--subtle);
 
-  // vertical
-  --#{$description-list}--m-vertical__group--GridTemplateColumns: repeat(var(--#{$description-list}--GridTemplateColumns--count));
-  --#{$description-list}--m-vertical__group--GridTemplateRows: auto 1fr;
-
   // horizontal
-  --#{$description-list}--m-horizontal__term--width: 12ch;
-  --#{$description-list}--m-horizontal__description--width: minmax(10ch, auto);
-  --#{$description-list}--m-horizontal__group--GridTemplateColumns: var(--#{$description-list}__term--width) var(--#{$description-list}--m-horizontal__description--width); // use --#{$description-list}__term--width here as it is re-defined on line 45
-  --#{$description-list}--m-horizontal__group--GridTemplateRows: auto;
-  --#{$description-list}--m-1-col--GridTemplateColumns--count: 1;
-  --#{$description-list}--m-2-col--GridTemplateColumns--count: 2;
-  --#{$description-list}--m-3-col--GridTemplateColumns--count: 3;
+  --#{$description-list}__description--width: minmax(10ch, auto);
 
   // auto-fit
-  --#{$description-list}--m-auto-fit--GridTemplateColumns--min: #{pf-size-prem(250px)};
-  --#{$description-list}--m-auto-fit--GridTemplateColumns--minmax--min: var(--#{$description-list}--m-auto-fit--GridTemplateColumns--min);
+  --#{$description-list}--m-auto-fit--GridTemplateColumns--min--base: #{pf-size-prem(250px)};
 
   // help text
   --#{$description-list}__text--m-help-text--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--default);
@@ -64,8 +54,9 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   --#{$description-list}--m-display-lg__description--FontSize: var(--pf-t--global--font--size--body--lg); // TODO replace with new font tokens when available
   --#{$description-list}--m-display-2xl__description--FontSize: var(--pf-t--global--font--size--heading--lg); // TODO replace with new font tokens when available
 
-  @include pf-v6-output-root-variables("--#{$description-list}--m-horizontal__term--width", $pf-v6-c-description-list--breakpoint-map);
-  @include pf-v6-build-css-variable-stack("--#{$description-list}__term--width", "--#{$description-list}--m-horizontal__term--width", $pf-v6-c-description-list--breakpoint-map);
+  @include pf-v6-output-root-variables("--#{$description-list}__term--width", $breakpoint-map: $pf-v6-c-description-list--breakpoint-map);
+  @include pf-v6-build-css-variable-stack("--#{$description-list}__term--width", "--#{$description-list}__term--width--base", $breakpoint-map: $pf-v6-c-description-list--breakpoint-map);
+  @include pf-v6-build-css-variable-stack("--#{$description-list}--m-auto-fit--GridTemplateColumns--min", "--#{$description-list}--m-auto-fit--GridTemplateColumns--min--base", $pf-v6-c-description-list--breakpoint-map);
 }
 
 .#{$description-list} {
@@ -79,23 +70,9 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
     display: inline-grid;
   }
 
-  &.pf-m-auto-column-widths {
-    --#{$description-list}--GridTemplateColumns--width: minmax(8ch, max-content);
-  }
-
-  &.pf-m-auto-fit {
-    grid-template-columns: repeat(auto-fit, minmax(var(--#{$description-list}--m-auto-fit--GridTemplateColumns--minmax--min), 1fr));
-
-    @include pf-v6-build-css-variable-stack("--#{$description-list}--GridTemplateColumns--minmax--min", "--#{$description-list}--GridTemplateColumns--min", $pf-v6-c-description-list--breakpoint-map);
-  }
-
   &.pf-m-compact {
     --#{$description-list}--RowGap: var(--#{$description-list}--m-compact--RowGap);
     --#{$description-list}--ColumnGap: var(--#{$description-list}--m-compact--ColumnGap);
-  }
-
-  &.pf-m-fluid {
-    --#{$description-list}--m-horizontal__term--width: fit-content(20ch);
   }
 
   &.pf-m-fill-columns {
@@ -103,8 +80,8 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
     column-count: var(--#{$description-list}--GridTemplateColumns--count);
     margin-block-end: calc(var(--#{$description-list}--RowGap) * -1);
 
-    .#{$description-list}__group,
-    > .#{$card} {
+    > .#{$card},
+    > .#{$description-list}__group {
       display: inline-grid;
       width: 100%;
       margin-block-end: var(--#{$description-list}--RowGap);
@@ -139,7 +116,7 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 .#{$description-list} > .#{$card} {
   display: grid;
   grid-template-rows: var(--#{$description-list}__group--GridTemplateRows);
-  grid-template-columns: var(--#{$description-list}__group--GridTemplateColumns);
+  grid-template-columns: auto;
   grid-column: var(--#{$description-list}__group--GridColumn);
   row-gap: var(--#{$description-list}__group--RowGap);
   column-gap: var(--#{$description-list}__group--ColumnGap);
@@ -198,26 +175,47 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 
     @include pf-v6-apply-breakpoint($breakpoint) {
       &.pf-m-1-col#{$breakpoint-name} {
-        --#{$description-list}--GridTemplateColumns--count: var(--#{$description-list}--m-1-col--GridTemplateColumns--count);
+        --#{$description-list}--GridTemplateColumns--count: 1;
       }
 
       &.pf-m-2-col#{$breakpoint-name} {
-        --#{$description-list}--GridTemplateColumns--count: var(--#{$description-list}--m-2-col--GridTemplateColumns--count);
+        --#{$description-list}--GridTemplateColumns--count: 2;
       }
 
       &.pf-m-3-col#{$breakpoint-name} {
-        --#{$description-list}--GridTemplateColumns--count: var(--#{$description-list}--m-3-col--GridTemplateColumns--count);
+        --#{$description-list}--GridTemplateColumns--count: 3;
       }
 
       &.pf-m-horizontal#{$breakpoint-name} {
-        --#{$description-list}__group--GridTemplateColumns: var(--#{$description-list}--m-horizontal__group--GridTemplateColumns);
-        --#{$description-list}__group--GridTemplateRows: var(--#{$description-list}--m-horizontal__group--GridTemplateRows);
+        > .#{$card},
+        > .#{$description-list}__group {
+          grid-template-rows: auto;
+          grid-template-columns: var(--#{$description-list}__term--width) var(--#{$description-list}__description--width); // use --#{$description-list}__term--width here as it is re-defined on line 45
+        }
       }
 
       &.pf-m-vertical#{$breakpoint-name} {
-        --#{$description-list}__group--GridTemplateColumns: var(--#{$description-list}--m-vertical__group--GridTemplateColumns);
-        --#{$description-list}__group--GridTemplateRows: var(--#{$description-list}--m-vertical__group--GridTemplateRows);
+        > .#{$card},
+        > .#{$description-list}__group {
+          grid-template-rows: auto 1fr;
+          grid-template-columns: repeat(var(--#{$description-list}--GridTemplateColumns--count));
+        }
       }
+    }
+  }
+
+  &.pf-m-auto-column-widths {
+    grid-template-columns: repeat(var(--#{$description-list}--GridTemplateColumns--count), minmax(8ch, max-content));
+  }
+
+  &.pf-m-auto-fit {
+    grid-template-columns: repeat(auto-fit, minmax(var(--#{$description-list}--m-auto-fit--GridTemplateColumns--min), 1fr));
+  }
+
+  &.pf-m-fluid {
+    > .#{$card},
+    > .#{$description-list}__group {
+      grid-template-columns: fit-content(20ch) auto;
     }
   }
 }

--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -17,7 +17,7 @@ $pf-v6-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
   height: inherit;
 }
 
-:where(:root, .#{$divider}) {
+@include pf-root($date-picker) {
   // * Divider
   --#{$divider}--Display: flex;
   --#{$divider}--Color: var(--pf-t--global--border--color--default);

--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$draggable}) {
+@include pf-root($draggable) {
   --#{$draggable}--Cursor: auto;
   --#{$draggable}--m-dragging--Cursor: grabbing;
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
@@ -40,7 +40,7 @@
   }
 }
 
-:where(:root, .#{$droppable}) {
+@include pf-root($droppable) {
   --#{$droppable}--before--BackgroundColor: transparent;
   --#{$droppable}--before--Opacity: 0;
   --#{$droppable}--after--BorderWidth: 0;

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -5,7 +5,7 @@ $pf-v6-c-drawer--breakpoint-map: build-breakpoint-map("base", "lg", "xl", "2xl")
 $pf-v6-c-drawer--breakpoint-map--width: build-breakpoint-map("base", "lg", "xl", "2xl");
 $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
-:where(:root, .#{$drawer}) {
+@include pf-root($drawer) {
   // Section
   --#{$drawer}__section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$drawer}__section--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
@@ -358,20 +358,19 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 // Remove tab focus
 @include pf-v6-animate-remove-tab-focus(".#{$drawer}__panel", var(--#{$drawer}__panel--TransitionDuration));
 
+
+// TODO: figure
 // Panel head
 .#{$drawer}__head {
   display: grid;
   grid-template-columns: auto;
   grid-auto-columns: max-content;
+  grid-auto-flow: column;
   column-gap: var(--#{$drawer}__head--ColumnGap);
   padding-block-start: var(--#{$drawer}__head--PaddingBlockStart);
   padding-block-end: var(--#{$drawer}__head--PaddingBlockEnd);
   padding-inline-start: var(--#{$drawer}__head--PaddingInlineStart);
   padding-inline-end: var(--#{$drawer}__head--PaddingInlineEnd);
-
-  > * {
-    grid-column: 1;
-  }
 }
 
 // Panel actions

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
-:where(:root, .#{$dual-list-selector}) {
+@include pf-root($dual-list-selector) {
   // Grid
   --#{$dual-list-selector}__header--GridArea: pane-header;
   --#{$dual-list-selector}__tools--GridArea: pane-tools;

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$empty-state}) {
+@include pf-root($empty-state) {
   --#{$empty-state}--PaddingBlockStart: var(--pf-t--global--spacer--xl);
   --#{$empty-state}--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
   --#{$empty-state}--PaddingBlockEnd: var(--pf-t--global--spacer--xl);

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$expandable-section}) {
+@include pf-root($expandable-section) {
   // Toggle
   --#{$expandable-section}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$file-upload}) {
+@include pf-root($file-upload) {
   --#{$file-upload}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$file-upload}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$file-upload}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -25,7 +25,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   }
 }
 
-:where(:root, .#{$form}) {
+@include pf-root($form) {
   --#{$form}--GridGap: var(--pf-t--global--spacer--lg);
 
   // Group

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$form-control}) {
+@include pf-root($form-control) {
   --#{$form-control}--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$form-control}--Color: var(--pf-t--global--text--color--regular);
   --#{$form-control}--FontSize: var(--pf-t--global--font--size--body--default);
@@ -189,7 +189,8 @@
 
     &.pf-m-plain {
       --#{$form-control}--m-readonly--BackgroundColor: var(--#{$form-control}--m-readonly--m-plain--BackgroundColor);
-      --#{$form-control}--inset--base: var(--#{$form-control}--m-readonly--m-plain--inset--base);
+      --#{$form-control}--PaddingInlineStart: var(--#{$form-control}--m-readonly--m-plain--inset--base);
+      --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--m-readonly--m-plain--inset--base);
       --#{$form-control}--before--BorderStyle: none;
       --#{$form-control}--after--BorderStyle: none;
       --#{$form-control}--OutlineOffset: var(--#{$form-control}--m-readonly--m-plain--OutlineOffset);

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$helper-text}) {
+@include pf-root($helper-text) {
   --#{$helper-text}--Gap: var(--pf-t--global--spacer--xs);
   --#{$helper-text}--FontSize: var(--pf-t--global--font--size--body--sm);
 

--- a/src/patternfly/components/Hint/hint.scss
+++ b/src/patternfly/components/Hint/hint.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$hint}) {
+@include pf-root($hint) {
   --#{$hint}--GridRowGap: var(--pf-t--global--spacer--sm);
   --#{$hint}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$hint}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Icon/icon.scss
+++ b/src/patternfly/components/Icon/icon.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$icon}) {
+@include pf-root($icon) {
   // Sizes
   --#{$icon}--Width: var(--pf-t--global--icon--size--font--body--default);
   --#{$icon}--Height: var(--pf-t--global--icon--size--font--body--default);
@@ -99,12 +99,6 @@
     --#{$icon}--Height: var(--#{$icon}--m-inline--Height);
     --#{$icon}__content--FontSize: var(--#{$icon}--m-inline__content--FontSize);
     --#{$icon}__content--Color: var(--#{$icon}--m-inline__content--Color);
-
-    line-height: 1;
-
-    .#{$spinner} {
-      --#{$spinner}--diameter: 1em;
-    }
   }
 
   // Standalone size modifiers

--- a/src/patternfly/components/InlineEdit/inline-edit.scss
+++ b/src/patternfly/components/InlineEdit/inline-edit.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$inline-edit}) {
+@include pf-root($inline-edit) {
   // Group
   --#{$inline-edit}__group--item--MarginInlineEnd: var(--pf-t--global--spacer--gap--action-to-action--default);
 

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$input-group}) {
+@include pf-root($input-group) {
   --#{$input-group}--Gap: var(--pf-t--global--spacer--xs);
 
   // Input group item

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root, .#{$jump-links}) {
+@include pf-root($jump-links) {
   // list
   --#{$jump-links}__list--Display: flex;
   --#{$jump-links}__list--PaddingBlockStart: 0;

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$label-group}) {
+@include pf-root($label-group) {
   // Label group - spaces main with the close button
   --#{$label-group}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$label-group}--ColumnGap: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$label}) {
+@include pf-root($label) {
   --#{$label}--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$label}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$label}--PaddingBlockEnd: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/List/list.scss
+++ b/src/patternfly/components/List/list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$list}) {
+@include pf-root($list) {
   // list
   --#{$list}--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$list}--ul--ListStyle: var(--pf-t--global--list-style);
@@ -55,8 +55,7 @@
   }
 
   &.pf-m-plain {
-    --#{$list}--PaddingInlineStart: var(--#{$list}--m-plain--PaddingInlineStart);
-
+    padding-inline-start: var(--#{$list}--m-plain--PaddingInlineStart);
     list-style: none;
   }
 

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$login}) {
+@include pf-root($login) {
   --#{$login}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$login}--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
 

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -3,7 +3,7 @@
 $pf-v6-c-masthead--breakpoint-map: build-breakpoint-map();
 $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root, .#{$masthead}) {
+@include pf-root($masthead) {
   // * Masthead
   --#{$masthead}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$masthead}--ColumnGap: var(--pf-t--global--spacer--gutter--default);
@@ -44,11 +44,11 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$masthead}--m-display-inline--ColumnGap: 0;
   --#{$masthead}--m-display-inline--GridTemplateColumns: min-content 1fr;
   --#{$masthead}--m-display-inline--breakpoint--xl--GridTemplateColumns: subgrid;
-  --#{$masthead}--m-display-inline__brand--GridColumn: initial; 
+  --#{$masthead}--m-display-inline__brand--GridColumn: initial;
   --#{$masthead}--m-display-inline__brand--Order: initial;
   --#{$masthead}--m-display-inline__brand--PaddingBlockEnd: 0;
   --#{$masthead}--m-display-inline__brand--BorderBlockEnd: 0;
-  --#{$masthead}--m-display-inline__main--GridColumn: 1; 
+  --#{$masthead}--m-display-inline__main--GridColumn: 1;
   --#{$masthead}--m-display-inline__content--GridColumn: 2;
   --#{$masthead}--m-display-inline__content--Order: 0;
   --#{$masthead}--m-display-inline__main--toggle--content--GridColumn: 2;
@@ -92,7 +92,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$masthead}__content--GridColumn: var(--#{$masthead}--m-display-inline__content--GridColumn);
   --#{$masthead}__content--Order: var(--#{$masthead}--m-display-inline__content--Order);
   --#{$masthead}__main--toggle--content--GridColumn: var(--#{$masthead}--m-display-inline__main--toggle--content--GridColumn);
-  --#{$masthead}__main--Display: var(--#{$masthead}--m-display-inline__main--Display); 
+  --#{$masthead}__main--Display: var(--#{$masthead}--m-display-inline__main--Display);
   --#{$masthead}__main--ColumnGap: var(--#{$masthead}--m-display-inline__main--ColumnGap);
 }
 
@@ -108,7 +108,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   @include pf-v6-c-masthead--m-display-stack;
 
   // Set layout to inline at medium breakpoint
-  :where(:not(.pf-m-resize-observer)) & {
+  :not(.pf-m-resize-observer) & {
     @media screen and (min-width: $pf-v6-global--breakpoint--md) {
       @include pf-v6-c-masthead--m-display-inline;
     }
@@ -215,11 +215,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     max-height: 100%;
     vertical-align: middle;
  }
-}
-
-// - Masthead toggle
-.#{$masthead}__toggle {
-  --#{$button}--FontSize: var(--#{$masthead}__toggle--Size);
 }
 
 // - Masthead expandable content

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$menu}) {
+@include pf-root($menu) {
   // * Menu
   --#{$menu}--RowGap: var(--pf-t--global--spacer--sm);
   --#{$menu}--Width: auto;
@@ -264,7 +264,7 @@
       transition: var(--#{$menu}--m-drilldown__content--Transition);
     }
 
-    :where(.#{$menu}) {
+    .#{$menu} {
       padding: 0;
     }
 
@@ -437,7 +437,7 @@
 }
 
 // - Menu list
-.#{$menu}__list :where(.#{$divider}:is(li)) {
+.#{$menu}__list .#{$divider}:is(li) {
   margin-block-start: var(--#{$menu}__list--divider--MarginBlockStart);
   margin-block-end: var(--#{$menu}__list--divider--MarginBlockEnd);
 }
@@ -463,8 +463,8 @@
   }
 
   // - Menu item load
-  &.pf-m-load {
-    --#{$menu}__item--Color: var(--#{$menu}__list-item--m-load__item--Color);
+  &.pf-m-load .#{$menu}__item {
+    color: var(--#{$menu}__list-item--m-load__item--Color);
   }
 
   // - Menu item loading
@@ -480,10 +480,10 @@
 
   // - Menu item danger
   &.pf-m-danger {
-    --#{$menu}__item--Color: var(--#{$menu}__list-item--m-danger--Color);
+    color: var(--#{$menu}__list-item--m-danger--Color);
 
-    &:is(:hover, :focus) {
-      --#{$menu}__item--Color: var(--#{$menu}__list-item--m-danger--hover--Color, var(--#{$menu}__list-item--m-danger--Color));
+    &:is(:hover, :focus) .#{$menu}__item {
+      color: var(--#{$menu}__list-item--m-danger--hover--Color, var(--#{$menu}__list-item--m-danger--Color));
     }
   }
 
@@ -494,7 +494,7 @@
   &.pf-m-focus,
   &:focus-within,
   &:has(> :hover) {
-    --#{$menu}__list-item--BackgroundColor: var(--#{$menu}__list-item--hover--BackgroundColor);
+    background-color: var(--#{$menu}__list-item--hover--BackgroundColor);
 
     .#{$menu}__item-select-icon,
     .#{$menu}__item-external-icon {
@@ -516,21 +516,21 @@
   font-size: var(--#{$menu}__item--FontSize);
   font-weight: var(--#{$menu}__item--FontWeight);
   line-height: var(--#{$menu}__item--LineHeight);
-  color: var(--#{$menu}__item--Color);
   text-align: start;
-  text-decoration: none;
   background-color: var(--#{$menu}__item--BackgroundColor);
   border: 0;
   outline-offset: var(--#{$menu}--OutlineOffset);
 
   @include pf-v6-hidden-visible(flex);
 
-  @at-root :where(label)#{&} {
-    cursor: pointer;
-  }
 
   &.pf-m-selected {
     --#{$menu}__item-select-icon--Color: var(--#{$menu}__item--m-selected__item-select-icon--Color);
+  }
+
+  &, &:hover, &:focus, &.pf-m-selected {
+    color: var(--#{$menu}__item--Color);
+    text-decoration: none;
   }
 
   &:is(:hover, :focus, .pf-m-selected) {
@@ -543,6 +543,10 @@
       color: var(--#{$menu}__item-external--Color);
     }
   }
+}
+
+label.#{$menu}__item {
+  cursor: pointer;
 }
 
 // - Menu item select icon
@@ -619,12 +623,11 @@
 
 // - Menu breadcrumb
 .#{$menu}__breadcrumb {
-  --#{$breadcrumb}__item--FontSize: var(--#{$menu}__breadcrumb--FontSize);
-
   padding-block-start: var(--#{$menu}__breadcrumb--PaddingBlockStart);
   padding-block-end: var(--#{$menu}__breadcrumb--PaddingBlockEnd);
   padding-inline-start: var(--#{$menu}__breadcrumb--PaddingInlineStart);
   padding-inline-end: var(--#{$menu}__breadcrumb--PaddingInlineEnd);
+  font-size: var(--#{$menu}__breadcrumb--FontSize);
 
   .#{$menu} {
     min-width: auto;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -8,7 +8,7 @@
 // TODO: update text-input-button to use gap
 // TODO: label all variables group - // * Menu toggle (vars) // - Menu toggle (selectors)
 
-:where(:root, .#{$menu-toggle}) {
+@include pf-root($menu-toggle) {
   --#{$menu-toggle}--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
   --#{$menu-toggle}--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -43,18 +43,13 @@
 
   // * Menu toggle disabled
   --#{$menu-toggle}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$menu-toggle}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
-  --#{$menu-toggle}--disabled__toggle-icon--Color: var(--pf-t--global--icon--color--on-disabled);
-  --#{$menu-toggle}--disabled__status-icon--Color: var(--pf-t--global--icon--color--on-disabled);
   --#{$menu-toggle}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // * Menu toggle icon
   --#{$menu-toggle}__icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
-  --#{$menu-toggle}__icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Menu toggle toggle icon
   --#{$menu-toggle}__toggle-icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
-  --#{$menu-toggle}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Menu toggle primary
   --#{$menu-toggle}--m-primary--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--default);
@@ -73,6 +68,7 @@
   --#{$menu-toggle}--m-primary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--hover);
   --#{$menu-toggle}--m-primary--expanded__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--clicked);
 
+
   // * Menu toggle secondary
   --#{$menu-toggle}--m-secondary--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$menu-toggle}--m-secondary--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
@@ -86,7 +82,7 @@
   --#{$menu-toggle}--m-secondary--expanded--BorderWidth: var(--pf-t--global--border--width--action--clicked);
   --#{$menu-toggle}--m-secondary--expanded--BorderColor: var(--pf-t--global--border--color--brand--clicked);
   --#{$menu-toggle}--m-secondary__toggle-icon--Color: var(--pf-t--global--icon--color--brand--default);
-  --#{$menu-toggle}--m-secondary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--brand--hover);
+  --#{$menu-toggle}--m-secondary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--brand--clicked);
   --#{$menu-toggle}--m-secondary--expanded__toggle-icon--Color: var(--pf-t--global--icon--color--brand--clicked);
 
   // Controls
@@ -145,7 +141,6 @@
 
   // Status icon
   --#{$menu-toggle}__status-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // Success
   --#{$menu-toggle}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -158,9 +153,6 @@
   // Danger
   --#{$menu-toggle}--m-danger--BorderColor: var(--pf-t--global--border--color--status--danger--default);
   --#{$menu-toggle}--m-danger__status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
-
-  // Placeholder
-  --#{$menu-toggle}--m-placeholder--Color: var(--pf-t--global--text--color--placeholder);
 }
 
 .#{$menu-toggle} {
@@ -184,7 +176,7 @@
   transition-timing-function: var(--#{$menu-toggle}--TransitionTimingFunction);
   transition-duration: var(--#{$menu-toggle}--TransitionDuration);
   transition-property: var(--#{$menu-toggle}--TransitionProperty);
-  
+
   &,
   &::before {
     border-radius: var(--#{$menu-toggle}--BorderRadius);
@@ -205,8 +197,6 @@
 
   &.pf-m-primary {
     // TODO: abstract padding updates to control/button variant
-    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-primary--PaddingInlineStart);
-    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-primary--PaddingInlineEnd);
     --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-primary--Color);
     --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--m-primary--BackgroundColor);
     --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-primary--BorderRadius);
@@ -219,13 +209,13 @@
     --#{$menu-toggle}--expanded--BorderColor: var(--#{$menu-toggle}--m-primary--expanded--BorderColor);
     --#{$menu-toggle}--hover__toggle-icon--Color: var(--#{$menu-toggle}--m-primary--hover__toggle-icon--Color);
     --#{$menu-toggle}--expanded__toggle-icon--Color: var(--#{$menu-toggle}--m-primary--expanded__toggle-icon--Color);
-    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--m-primary__toggle-icon--Color);
+
+    padding-inline-start: var(--#{$menu-toggle}--m-primary--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--m-primary--PaddingInlineEnd);
   }
 
   &.pf-m-secondary {
     // TODO: abstract padding updates to control/button variant
-    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-secondary--PaddingInlineStart);
-    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-secondary--PaddingInlineEnd);
     --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-secondary--Color);
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-secondary--BorderColor);
     --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-secondary--BorderRadius);
@@ -236,16 +226,18 @@
     --#{$menu-toggle}--expanded--BorderWidth: var(--#{$menu-toggle}--m-secondary--expanded--BorderWidth);
     --#{$menu-toggle}--hover__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary--hover__toggle-icon--Color);
     --#{$menu-toggle}--expanded__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary--expanded__toggle-icon--Color);
-    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary__toggle-icon--Color);
+
+    padding-inline-start: var(--#{$menu-toggle}--m-secondary--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--m-secondary--PaddingInlineEnd);
   }
 
   &.pf-m-full-height {
-    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-full-height--PaddingInlineEnd);
-    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-full-height--PaddingInlineStart);
     --#{$menu-toggle}--BorderBlockStartWidth: var(--#{$menu-toggle}--m-full-height__toggle--BorderBlockStartWidth);
 
     align-items: center;
     height: 100%;
+    padding-inline-start: var(--#{$menu-toggle}--m-full-height--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--m-full-height--PaddingInlineEnd);
   }
 
   &.pf-m-full-width {
@@ -263,6 +255,9 @@
     --#{$menu-toggle}--expanded--BackgroundColor: var(--#{$menu-toggle}--m-plain--expanded--BackgroundColor);
     --#{$menu-toggle}--disabled--Color: var(--#{$menu-toggle}--m-plain--disabled--Color);
     --#{$menu-toggle}--disabled--BackgroundColor: var(--#{$menu-toggle}--m-plain--disabled--BackgroundColor);
+
+    padding-inline-start: var(--#{$menu-toggle}--m-plain--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--m-plain--PaddingInlineEnd);
 
     &::before {
       border: none;
@@ -285,6 +280,16 @@
     --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--expanded__toggle-icon--Color);
   }
 
+  &:is(:disabled, .pf-m-disabled) {
+    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--disabled--Color);
+    --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--disabled--BackgroundColor);
+
+    &,
+    .#{$button} {
+      pointer-events: none;
+    }
+  }
+
   &.pf-m-primary,
   &:is(:disabled, .pf-m-disabled) {
     &::before {
@@ -294,10 +299,10 @@
 
   // - Menu item small
   &.pf-m-small {
-    --#{$menu-toggle}--PaddingBlockStart: var(--#{$menu-toggle}--m-small--PaddingBlockStart);
-    --#{$menu-toggle}--PaddingBlockEnd: var(--#{$menu-toggle}--m-small--PaddingBlockEnd);
-    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-small--PaddingInlineStart);
-    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-small--PaddingInlineEnd);
+    padding-block-start: var(--#{$menu-toggle}--m-small--PaddingBlockStart);
+    padding-block-end: var(--#{$menu-toggle}--m-small--PaddingBlockEnd);
+    padding-inline-start: var(--#{$menu-toggle}--m-small--PaddingInlineStart);
+    padding-inline-end: var(--#{$menu-toggle}--m-small--PaddingInlineEnd);
   }
 
   &:has(.#{$button}) {
@@ -317,23 +322,6 @@
   &.pf-m-danger {
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-danger--BorderColor);
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--m-danger__status-icon--Color);
-  }
-
-  &.pf-m-placeholder {
-    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-placeholder--Color);
-  }
-
-  &:is(:disabled, .pf-m-disabled) {
-    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--disabled--Color);
-    --#{$menu-toggle}__icon--Color: var(--#{$menu-toggle}--disabled__icon--Color);
-    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--disabled__toggle-icon--Color);
-    --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--disabled__status-icon--Color);
-    --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--disabled--BackgroundColor);
-
-    &,
-    .#{$button} {
-      pointer-events: none;
-    }
   }
 }
 
@@ -362,12 +350,12 @@
   }
 
   > .#{$check} {
-    --#{$menu-toggle}--PaddingInlineEnd: 0;
     --#{$check}__label--Color: currentcolor;
     --#{$check}__label--disabled--Color: currentcolor;
 
     align-items: center;
     align-self: stretch;
+    padding-inline-end: 0;
 
     .#{$check}__input {
       --#{$check}__input--TranslateY: 0;
@@ -400,7 +388,7 @@
 
     // stylelint-disable max-nesting-depth, selector-max-class, selector-not-notation
     // update to single :not() in breaking change
-    > :where(:not(.pf-m-disabled):not([disabled])) {
+    > :not(.pf-m-disabled):not([disabled]) {
       background-color: var(--#{$menu-toggle}--m-split-button--m-action--m-primary--child--BackgroundColor);
 
       &:is(:hover, :focus) {
@@ -446,20 +434,18 @@
   padding: 0;
 
   .#{$menu-toggle}__button {
-    --#{$menu-toggle}__button--PaddingInlineEnd: 0;
+    padding-inline-end: 0;
   }
 
   .#{$menu-toggle}__controls {
-    --#{$menu-toggle}__button--PaddingInlineEnd: 0;
-
     display: flex;
     align-items: stretch;
+    padding-inline-end: 0;
   }
 
   .#{$text-input-group} {
-    --#{$text-input-group}__utilities--MarginInlineEnd: 0;
-
     flex: 1;
+    margin-inline-end: 0;
   }
 }
 

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$modal-box}) {
+@include pf-root($modal-box) {
   --#{$modal-box}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$modal-box}--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$modal-box}--BoxShadow: var(--pf-t--global--box-shadow--lg);

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$multiple-file-upload}) {
+@include pf-root($multiple-file-upload) {
   --#{$multiple-file-upload}--GridTemplateColumns: 1fr;
   --#{$multiple-file-upload}--Gap: var(--pf-t--global--spacer--md);
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$nav}) {
+@include pf-root($nav) {
   // * Nav shared values
   --#{$nav}__link--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$nav}__link--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
@@ -128,7 +128,7 @@
 
   &.pf-m-inset {
     --#{$nav}--PaddingInlineStart: var(--pf-t--global--spacer--md);
-    --#{$nav}--PaddingInlineEnd: var(--pf-t--global--spacer--md);  
+    --#{$nav}--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   }
 
   &.pf-m-fill {
@@ -282,11 +282,11 @@
 
   @include pf-v6-mirror-inline-on-rtl;
 
-  .#{$nav}__item:where(.pf-m-flyout) & {
+  .#{$nav}__item.pf-m-flyout & {
     --#{$nav}__item--m-expanded__toggle-icon--Rotate: 0;
   }
 
-  .#{$nav}__link:where([aria-expanded="true"]) & {
+  .#{$nav}__link[aria-expanded="true"] & {
     transform: rotate(var(--#{$nav}__item--m-expanded__toggle-icon--Rotate));
   }
 }
@@ -334,7 +334,7 @@
 }
 
 // - Nav horizontal
-.#{$nav}:where(.pf-m-horizontal) {
+.#{$nav}.pf-m-horizontal {
   padding: 0;
   overflow: hidden;
 

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$notification-drawer}) {
+@include pf-root($notification-drawer) {
   --#{$notification-drawer}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
 
   // Header

--- a/src/patternfly/components/NumberInput/number-input.scss
+++ b/src/patternfly/components/NumberInput/number-input.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$number-input}) {
+@include pf-root($number-input) {
   // unit
   --#{$number-input}__unit--c-input-group--MarginInlineStart: var(--pf-t--global--spacer--sm);
 
@@ -11,12 +11,6 @@
   --#{$number-input}--c-form-control--width-base: calc(var(--pf-t--global--spacer--md) * 2 + var(--pf-t--global--border--width--box--default) * 2); // form controls's padding
   --#{$number-input}--c-form-control--width-icon: var(--pf-t--global--spacer--xl); // extra width to accommodate a status icon
   --#{$number-input}--c-form-control--width-chars: 4;
-  --#{$number-input}--c-form-control--Width:
-    calc(
-      calc(
-        var(--#{$number-input}--c-form-control--width-base) + var(--#{$number-input}--c-form-control--width-chars) * 1ch
-      ) + var(--#{$number-input}--c-form-control--width-icon)
-    );
 }
 
 .#{$number-input} {
@@ -24,7 +18,11 @@
   align-items: center;
 
   .#{$form-control} {
-    width: var(--#{$number-input}--c-form-control--Width);
+    width: calc(
+      calc(
+        var(--#{$number-input}--c-form-control--width-base) + var(--#{$number-input}--c-form-control--width-chars) * 1ch
+      ) + var(--#{$number-input}--c-form-control--width-icon)
+    );
 
     > :is(input) {
       text-align: end;

--- a/src/patternfly/components/OverflowMenu/overflow-menu.scss
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$overflow-menu}) {
+@include pf-root($overflow-menu) {
   --#{$overflow-menu}--ColumnGap: var(--pf-t--global--spacer--md);
 
   // * Overflow menu group

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -9,6 +9,46 @@ import './Page.css'
 
 ## Examples
 
+### Theming example
+```hbs
+{{#> page page--modifier='mui-theme'}}
+  {{#> masthead}}
+    {{#> masthead-main}}
+      {{> masthead-toggle}}
+      {{#> masthead-brand}}
+        {{#> masthead-logo}}
+          Logo
+        {{/masthead-logo}}
+      {{/masthead-brand}}
+    {{/masthead-main}}
+    {{> masthead-content}}
+  {{/masthead}}
+  {{#> page-sidebar}}
+    Navigation
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-main-section}}
+      {{#> content--element content--element--type="h2"}}Apply MUI theme to page{{/content--element}}
+      {{#> button button--IsPrimary=true}}
+        Mui button
+      {{/button}}
+      {{#> button button--IsSecondary=true}}
+        PatternFly button
+      {{/button}}
+    {{/page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-v6-c-page-reset pf-v6-c-content-reset pf-v6-c-button-reset"}}
+      {{#> content--element content--element--type="h2"}}Let's reset this section to PF default page{{/content--element}}
+      {{#> button button--IsPrimary=true}}
+        Mui button
+      {{/button}}
+      {{#> button button--IsSecondary=true button--modifier='pf-v6-c-button-reset'}}
+        PatternFly button
+      {{/button}}
+    {{/page-main-section}}
+  {{/page-main}}
+{{/page}}
+```
+
 ### Vertical nav
 ```hbs
 {{#> page}}

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -5,7 +5,7 @@ $pf-page-v6--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl"
 $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 // stylelint-enable
 
-:where(:root, .#{$page}) {
+@include pf-root($page) {
   --#{$page}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$page}--inset: var(--pf-t--global--spacer--inset--page-chrome);
 
@@ -57,7 +57,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--masthead--main-container--GridArea: sidebar / sidebar / main / main; // no sidebar
   --#{$page}__main-container--MaxHeight: calc(100% - var(--pf-t--global--spacer--lg));
   --#{$page}__main-container--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$page}__main-container--MarginInlineStart: var(--#{$page}--inset); 
+  --#{$page}__main-container--MarginInlineStart: var(--#{$page}--inset);
   --#{$page}__main-container--MarginInlineEnd: var(--#{$page}--inset);
   --#{$page}__main-container--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$page}__main-container--BorderWidth: var(--pf-t--global--spacer--sm); // TODO Change to be a page outline token
@@ -76,7 +76,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Limit width
   --#{$page}--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--#{$page}__sidebar--Width));
-  
+
   // Sticky
   --#{$page}--section--m-sticky-top--ZIndex: var(--pf-t--global--z-index--md);
   --#{$page}--section--m-sticky-top--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -3,7 +3,7 @@
 $pf-v6-c-pagination--breakpoint-map: build-breakpoint-map();
 $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root, .#{$pagination}) {
+@include pf-root($pagination) {
   --#{$pagination}--inset: 0;
   --#{$pagination}--ColumnGap: var(--pf-t--global--spacer--lg);
 

--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$panel}) {
+@include pf-root($panel) {
   --#{$panel}--Width: auto;
   --#{$panel}--MinWidth: auto;
   --#{$panel}--MaxWidth: none;

--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -7,7 +7,10 @@ cssPrefix: pf-v6-c-popover
 import './Popover.css'
 
 ## Examples
-    {{> popover-close}}
+```hbs isFullscreen
+{{> popover-close}}
+```
+
 ### Top
 ```hbs isFullscreen
 {{#> popover popover--modifier="pf-m-top" popover--attribute='aria-labelledby="popover-top-header" aria-describedby="popover-top-body"'}}

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -1,10 +1,8 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$popover}) {
+@include pf-root($popover) {
   // Component
   --#{$popover}--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$popover}--MinWidth: calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)});
-  --#{$popover}--MaxWidth: calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)});
   --#{$popover}--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$popover}--BorderRadius: var(--pf-t--global--border--radius--medium);
 
@@ -47,7 +45,7 @@
   --#{$popover}__arrow--m-block-right--InsetInlineEnd: var(--pf-t--global--border--radius--medium);
 
   // Close
-  --#{$popover}__close--InsetBlockStart: calc(var(--#{$popover}__content--PaddingBlockStart) - var(--pf-t--global--spacer--control--vertical--default)); // align top of button with top of text 
+  --#{$popover}__close--InsetBlockStart: calc(var(--#{$popover}__content--PaddingBlockStart) - var(--pf-t--global--spacer--control--vertical--default)); // align top of button with top of text
   --#{$popover}__close--InsetInlineEnd: var(--#{$popover}__content--PaddingInlineEnd); // align right of content
   --#{$popover}__close--sibling--PaddingInlineEnd: var(--pf-t--global--spacer--2xl);
 
@@ -70,20 +68,22 @@
 
 .#{$popover} {
   position: relative;
-  min-width: var(--#{$popover}--MinWidth);
-  max-width: var(--#{$popover}--MaxWidth);
+  min-width: var(--#{$popover}--MinWidth, calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)}));
+  max-width: var(--#{$popover}--MaxWidth, calc(var(--#{$popover}__content--PaddingInlineStart) + var(--#{$popover}__content--PaddingInlineEnd) + #{pf-size-prem(300px)}));
   font-size: var(--#{$popover}--FontSize);
   border-radius: var(--#{$popover}--BorderRadius);
   box-shadow: var(--#{$popover}--BoxShadow);
 
   &.pf-m-no-padding {
-    // Use px values below so the min/max-width calc() doesn't break
-    // stylelint-disable length-zero-no-unit
-    --#{$popover}__content--PaddingBlockStart: 0px;
-    --#{$popover}__content--PaddingInlineEnd: 0px;
-    --#{$popover}__content--PaddingBlockEnd: 0px;
-    --#{$popover}__content--PaddingInlineStart: 0px;
-    // stylelint-enable
+    min-width: #{pf-size-prem(300px)};
+    max-width: #{pf-size-prem(300px)};
+
+    .#{$popover}__content {
+      padding-block-start: 0;
+      padding-block-end: 0;
+      padding-inline-start: 0;
+      padding-inline-end: 0;
+    }
   }
 
   &.pf-m-width-auto {
@@ -205,7 +205,7 @@
 // Close button
 .#{$popover}__close {
   position: absolute;
-  inset-block-start: var(--#{$popover}__close--InsetBlockStart);
+  inset-block-start: calc(var(--#{$popover}__content--PaddingBlockStart) - var(--pf-t--global--spacer--control--vertical--default)); // align top of button with top of text
   inset-inline-end: var(--#{$popover}__close--InsetInlineEnd);
 
   // Create room for the close button

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$progress}) {
+@include pf-root($progress) {
   // Component variables
   --#{$progress}--GridGap: var(--pf-t--global--spacer--md);
 
@@ -10,7 +10,7 @@
   --#{$progress}__measure--m-static-width--MinWidth: 4.5ch; // 4.5 because the % character is wider than a 0
   --#{$progress}__status--Gap: var(--pf-t--global--spacer--sm);
   --#{$progress}__status-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$progress}__indicator--Height: var(--#{$progress}__bar--Height);
+  --#{$progress}__indicator--Height: 100%;
   --#{$progress}__indicator--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$progress}__helper-text--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) - var(--#{$progress}--GridGap));
 

--- a/src/patternfly/components/ProgressStepper/_progress-stepper-layout.scss
+++ b/src/patternfly/components/ProgressStepper/_progress-stepper-layout.scss
@@ -1,0 +1,130 @@
+@use '../../sass-utilities' as *;
+
+// - Progress stepper vertical
+@mixin pf-v6-c-progress-stepper--m-vertical {
+  grid-auto-flow: row;
+
+  // - Progress stepper step
+  .#{$progress-stepper}__step {
+    grid-template-columns: max-content 1fr;
+  }
+
+  // - Progress stepper - Progress stepper compact
+  &,
+  &.pf-m-compact {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      // show first-child border -/ hide last child border
+      &:first-child .#{$progress-stepper}__step-connector::before { content: ""; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: none; }
+    }
+
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: var(--#{$progress-stepper}__step-icon--size);
+      inset-inline: calc(var(--#{$progress-stepper}__step-icon--size) / 2) 100%;
+      height: calc(100% + var(--#{$progress-stepper}--RowGap));
+    }
+  }
+
+  // - Progress stepper compact
+  &.pf-m-compact {
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector {
+      grid-row: auto;
+      grid-column: 1;
+    }
+
+    // - Progress stepper step connector before
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 0 -100%;
+      inset-inline: calc(var(--#{$progress-stepper}--m-compact__step-icon--size) / 2) 100%;
+      height: auto;
+    }
+  }
+
+  // - Progress stepper center
+  &.pf-m-center {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      grid-template-columns: 1fr;
+
+      // hide first-child border -/ shoe last child border
+      &:first-child .#{$progress-stepper}__step-connector::before { content: none; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: ""; }
+    }
+
+     // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: -100% 0;
+      inset-inline: 50%;
+      height: auto;
+    }
+  }
+
+  &.pf-m-compact.pf-m-center {
+    grid-template-columns: 1fr;
+  }
+}
+
+// - Progress stepper horizontal
+@mixin pf-v6-c-progress-stepper--m-horizontal {
+  grid-auto-flow: column;
+
+  // - Progress stepper step
+  .#{$progress-stepper}__step {
+    grid-template-columns: 1fr;
+  }
+
+  // - Progress stepper step connector
+  .#{$progress-stepper}__step-connector::before {
+    inset-inline: 0 calc(var(--#{$progress-stepper}--ColumnGap) * -1);
+  }
+
+  // - Progress stepper - Progress stepper center - Progress stepper compact
+  &,
+  &.pf-m-center,
+  &.pf-m-compact {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      // show first child / hide last child
+      &:first-child .#{$progress-stepper}__step-connector::before { content: ""; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: none; }
+    }
+
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      height: auto;
+    }
+  }
+
+  // - Progress stepper compact
+  &.pf-m-compact,
+  &.pf-m-compact.pf-m-center {
+    grid-template-columns: repeat(auto-fit, var(--#{$progress-stepper}--m-compact__step-icon--size));
+  }
+
+  &.pf-m-compact {
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector {
+      grid-row: 2;
+      grid-column: auto;
+    }
+
+    // connector positioning
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      inset-inline: 100% -100%;
+    }
+  }
+
+  // - Progress stepper center
+  &.pf-m-center {
+    // connector positioning
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      inset-inline: 50% -50%;
+    }
+  }
+}

--- a/src/patternfly/components/ProgressStepper/progress-stepper-layout-breakpoints.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper-layout-breakpoints.scss
@@ -1,0 +1,26 @@
+@use '../../sass-utilities' as *;
+@use './progress-stepper-layout';
+
+$pf-v6--include-progress-stepper-breakpoints: true !default;
+$pf-v6-c-progress-stepper--breakpoint-map: "base";
+
+@if $pf-v6--include-progress-stepper-breakpoints {
+  $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map('sm', 'md', 'lg', 'xl', '2xl');
+}
+
+// stylelint-disable
+.#{$progress-stepper} {
+  @each $breakpoint, $breakpoint-value in $pf-v6-c-progress-stepper--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-v6-apply-breakpoint($breakpoint) {
+      &.pf-m-horizontal#{$breakpoint-name} {
+        @include progress-stepper-layout.pf-v6-c-progress-stepper--m-horizontal;
+      }
+
+      &.pf-m-vertical#{$breakpoint-name} {
+        @include progress-stepper-layout.pf-v6-c-progress-stepper--m-vertical;
+      }
+    }
+  }
+}

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$radio}) {
+@include pf-root($radio) {
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
   --#{$radio}--Height: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -4,7 +4,7 @@
 $pf-v6-c-sidebar--breakpoint-map--width: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
-:where(:root, .#{$sidebar}) {
+@include pf-root($sidebar) {
   --#{$sidebar}--inset: var(--pf-t--global--spacer--md);
   --#{$sidebar}--xl--inset: var(--pf-t--global--spacer--lg);
   --#{$sidebar}--BorderWidth--base: var(--pf-t--global--border--width--regular);
@@ -44,7 +44,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}__main--child--MarginBlockStart: 0;
 
   // Gutter
-  --#{$sidebar}--m-gutter__main--Gap: var(--#{$sidebar}--inset);
+  --#{$sidebar}--m-gutter__main--Gap: var(--pf-t--global--spacer--gutter--default);
 
   // Border
   --#{$sidebar}__main--m-border--before--Display: none;
@@ -182,24 +182,24 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   box-shadow: var(--#{$sidebar}__panel--BoxShadow);
 
   &.pf-m-padding {
-    --#{$sidebar}__panel--PaddingBlockStart: var(--#{$sidebar}__panel--m-padding--PaddingBlockStart);
-    --#{$sidebar}__panel--PaddingInlineEnd: var(--#{$sidebar}__panel--m-padding--PaddingInlineEnd);
-    --#{$sidebar}__panel--PaddingBlockEnd: var(--#{$sidebar}__panel--m-padding--PaddingBlockEnd);
-    --#{$sidebar}__panel--PaddingInlineStart: var(--#{$sidebar}__panel--m-padding--PaddingInlineStart);
+    padding-block-start: var(--#{$sidebar}__panel--m-padding--PaddingBlockStart);
+    padding-block-end: var(--#{$sidebar}__panel--m-padding--PaddingBlockEnd);
+    padding-inline-start: var(--#{$sidebar}__panel--m-padding--PaddingInlineStart);
+    padding-inline-end: var(--#{$sidebar}__panel--m-padding--PaddingInlineEnd);
   }
 
   &.pf-m-sticky {
-    --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--m-sticky--Position);
-    --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}__panel--m-sticky--InsetBlockStart);
+    position: var(--#{$sidebar}__panel--m-sticky--Position);
+    inset-block-start: var(--#{$sidebar}__panel--m-sticky--InsetBlockStart);
   }
 
   &.pf-m-static {
-    --#{$sidebar}__panel--Position: static;
-    --#{$sidebar}__panel--InsetBlockStart: auto;
+    position: static;
+    inset-block-start: auto;
   }
 
   &.pf-m-secondary {
-    --#{$sidebar}__panel--BackgroundColor: var(--#{$sidebar}__panel--m-secondary--BackgroundColor);
+    background-color: var(--#{$sidebar}__panel--m-secondary--BackgroundColor);
   }
 }
 
@@ -213,26 +213,26 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   background-color: var(--#{$sidebar}__content--BackgroundColor);
 
   &.pf-m-padding {
-    --#{$sidebar}__content--PaddingBlockStart: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
-    --#{$sidebar}__content--PaddingInlineEnd: var(--#{$sidebar}__content--m-padding--PaddingInlineEnd);
-    --#{$sidebar}__content--PaddingBlockEnd: var(--#{$sidebar}__content--m-padding--PaddingBlockEnd);
-    --#{$sidebar}__content--PaddingInlineStart: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
+    padding-block-start: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
+    padding-block-end: var(--#{$sidebar}__content--m-padding--PaddingBlockEnd);
+    padding-inline-start: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
+    padding-inline-end: var(--#{$sidebar}__content--m-padding--PaddingInlineEnd);
   }
 
   &.pf-m-no-background {
-    --#{$sidebar}__content--BackgroundColor: transparent;
+    background-color: transparent;
   }
 
   &.pf-m-secondary {
-    --#{$sidebar}__content--BackgroundColor: var(--#{$sidebar}__content--m-secondary--BackgroundColor);
+    background-color: var(--#{$sidebar}__content--m-secondary--BackgroundColor);
   }
 
   & + .#{$sidebar}__panel {
-    --#{$sidebar}__panel--Order: 1;
+    order: 1;
   }
 
-  :where(&:first-child) {
-    --#{$sidebar}__content--Order: -1;
+  &:first-child {
+    order: -1;
   }
 }
 

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$simple-list}) {
+@include pf-root($simple-list) {
   // Simple list item link
   --#{$simple-list}__item-link--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$simple-list}__item-link--PaddingInlineEnd: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Skeleton/skeleton.scss
+++ b/src/patternfly/components/Skeleton/skeleton.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$skeleton}) {
+@include pf-root($skeleton) {
   --#{$skeleton}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$skeleton}--Width: auto;
   --#{$skeleton}--Height: auto;

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$skip-to-content}) {
+@include pf-root($skip-to-content) {
   --#{$skip-to-content}--InsetBlockStart: var(--pf-t--global--spacer--md);
   --#{$skip-to-content}--ZIndex: var(--pf-t--global--z-index--2xl);
   --#{$skip-to-content}--focus--InsetInlineStart: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$slider}) {
+@include pf-root($slider) {
   --#{$slider}--value: 0; // should always be set inline
   --#{$slider}__step--InsetInlineStart: 0; // should always be set inline
 
@@ -11,7 +11,6 @@
   --#{$slider}__rail-track--before--base--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
   --#{$slider}__rail-track--before--fill--BackgroundColor: var(--pf-t--global--border--color--hover);
   --#{$slider}__rail-track--before--BorderRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$slider}__rail-track--before--fill--BackgroundColor--gradient-stop: var(--#{$slider}--value);
 
   // steps
   --#{$slider}__steps--FontSize: var(--pf-t--global--font--size--sm);
@@ -38,7 +37,6 @@
   --#{$slider}__thumb--InsetBlockStart: calc(var(--#{$slider}__rail-track--Height) / 2 + var(--pf-t--global--spacer--md));
   --#{$slider}__thumb--Width: #{pf-size-prem(16px)};
   --#{$slider}__thumb--Height: #{pf-size-prem(16px)};
-  --#{$slider}__thumb--InsetInlineStart: var(--#{$slider}--value);
   --#{$slider}__thumb--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$slider}__thumb--TranslateX: -50%;
   --#{$slider}__thumb--TranslateY: -50%;
@@ -64,7 +62,6 @@
   --#{$slider}__value--c-form-control--Width: calc(var(--#{$slider}__value--c-form-control--width-base) + var(--#{$slider}__value--c-form-control--width-chars) * 1ch);
   --#{$slider}__value--m-floating--TranslateX: -50%;
   --#{$slider}__value--m-floating--TranslateY: -100%;
-  --#{$slider}__value--m-floating--InsetInlineStart: var(--#{$slider}--value);
   --#{$slider}__value--m-floating--ZIndex: var(--pf-t--global--z-index--sm);
 
   // actions
@@ -88,8 +85,11 @@
 
   &.pf-m-disabled {
     --#{$slider}__rail-track--before--fill--BackgroundColor: var(--#{$slider}--m-disabled__rail-track--before--fill--BackgroundColor);
-    --#{$slider}__step--m-active__slider-tick--BackgroundColor: var(--#{$slider}--m-disabled__step--m-active__slider-tick--BackgroundColor);
     --#{$slider}__thumb--BackgroundColor: var(--#{$slider}--m-disabled__thumb--BackgroundColor);
+
+    .#{$slider}__step-tick {
+      background-color: var(--#{$slider}--m-disabled__step--m-active__slider-tick--BackgroundColor);
+    }
 
     .#{$slider}__rail,
     .#{$slider}__thumb {
@@ -124,8 +124,8 @@
       linear-gradient(
         to var(--#{$slider}__rail-track--before--fill--direction),
         var(--#{$slider}__rail-track--before--fill--BackgroundColor),
-        var(--#{$slider}__rail-track--before--fill--BackgroundColor) var(--#{$slider}__rail-track--before--fill--BackgroundColor--gradient-stop),
-        var(--#{$slider}__rail-track--before--base--BackgroundColor) var(--#{$slider}__rail-track--before--fill--BackgroundColor--gradient-stop)
+        var(--#{$slider}__rail-track--before--fill--BackgroundColor) var(--#{$slider}--value),
+        var(--#{$slider}__rail-track--before--base--BackgroundColor) var(--#{$slider}--value)
       );
     border-radius: var(--#{$slider}__rail-track--before--BorderRadius);
   }
@@ -144,7 +144,7 @@
   content: "";
 
   &.pf-m-active {
-    --#{$slider}__step-tick--BackgroundColor: var(--#{$slider}__step--m-active__slider-tick--BackgroundColor);
+    background-color: var(--#{$slider}__step--m-active__slider-tick--BackgroundColor);
   }
 
   &:first-child {
@@ -195,7 +195,7 @@
 
   position: absolute;
   inset-block-start: var(--#{$slider}__thumb--InsetBlockStart);
-  inset-inline-start: var(--#{$slider}__thumb--InsetInlineStart);
+  inset-inline-start: var(--#{$slider}--value);
   width: var(--#{$slider}__thumb--Width);
   height: var(--#{$slider}__thumb--Height);
   cursor: pointer;
@@ -244,16 +244,15 @@
       $rtl-val: translate(#{pf-v6-calc-inverse(var(--#{$slider}__value--m-floating--TranslateX))}, var(--#{$slider}__value--m-floating--TranslateY)),
     );
 
-    --#{$slider}__value--MarginInlineStart: 0;
-
     position: absolute;
     inset-block-start: 0;
-    inset-inline-start: var(--#{$slider}__value--m-floating--InsetInlineStart);
+    inset-inline-start: var(--#{$slider}--value);
     z-index: var(--#{$slider}__value--m-floating--ZIndex);
+    margin-inline-start: 0;
   }
 
   .#{$form-control} {
-    width: var(--#{$slider}__value--c-form-control--Width);
+    width: calc(var(--#{$slider}__value--c-form-control--width-base) + var(--#{$slider}__value--c-form-control--width-chars) * 1ch);
   }
 }
 
@@ -262,8 +261,7 @@
   margin-inline-end: var(--#{$slider}__actions--MarginInlineEnd);
 
   .#{$slider}__main ~ & {
-    --#{$slider}__actions--MarginInlineEnd: 0;
-
     margin-inline-start: var(--#{$slider}__main--actions--MarginInlineStart);
+    margin-inline-end: 0;
   }
 }

--- a/src/patternfly/components/Spinner/spinner.scss
+++ b/src/patternfly/components/Spinner/spinner.scss
@@ -1,9 +1,7 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$spinner}) {
+@include pf-root($spinner) {
   --#{$spinner}--diameter: var(--pf-t--global--icon--size--2xl);
-  --#{$spinner}--Width: var(--#{$spinner}--diameter);
-  --#{$spinner}--Height: var(--#{$spinner}--diameter);
   --#{$spinner}--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$spinner}--AnimationDuration: 1.4s;
   --#{$spinner}--AnimationTimingFunction: linear;
@@ -24,8 +22,8 @@
 }
 
 .#{$spinner} {
-  width: var(--#{$spinner}--Width);
-  height: var(--#{$spinner}--Height);
+  width: var(--#{$spinner}--diameter);
+  height: var(--#{$spinner}--diameter);
   overflow: hidden;
   animation: #{$spinner}-animation-rotate calc(var(--#{$spinner}--AnimationDuration) * 2) var(--#{$spinner}--AnimationTimingFunction) infinite;
 

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$switch}) {
+@include pf-root($switch) {
   // Switch - the vars for this file don't follow our normal order so that the IE11 script can convert the vars correctly
   --#{$switch}--FontSize: var(--pf-t--global--font--size--sm);
   --#{$switch}--ColumnGap: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/TabContent/tab-content.scss
+++ b/src/patternfly/components/TabContent/tab-content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$tab-content}) {
+@include pf-root($tab-content) {
   --#{$tab-content}__body--PaddingBlockStart: 0;
   --#{$tab-content}__body--PaddingInlineEnd: 0;
   --#{$tab-content}__body--PaddingBlockEnd: 0;

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -3,7 +3,7 @@
 $pf-v6-c-tabs--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-:where(:root, .#{$tabs}) {
+@include pf-root($tabs) {
   --#{$tabs}--inset: 0;
   --#{$tabs}--Width: auto;
   --#{$tabs}--before--BorderColor: var(--pf-t--global--border--color--default);
@@ -607,9 +607,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
   }
 
-  &:where(:hover, :focus) {
+  &:hover,
+  &:focus {
     --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__link--hover--BackgroundColor);
-      }
+  }
 
   &:disabled,
   &.pf-m-disabled {

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$text-input-group}) {
+@include pf-root($text-input-group) {
   --#{$text-input-group}--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$text-input-group}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$text-input-group}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -15,7 +15,7 @@
   --#{$text-input-group}--m-hover--m-success--BorderColor: var(--pf-t--global--border--color--status--success--hover);
   --#{$text-input-group}--m-hover--m-warning--BorderColor: var(--pf-t--global--border--color--status--warning--hover);
   --#{$text-input-group}--m-hover--m-error--BorderColor: var(--pf-t--global--border--color--status--danger--hover);
-  
+
 
   // Main
   --#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--plain) / 2);
@@ -64,7 +64,7 @@
 
   // Utilities
   --#{$text-input-group}__utilities--child--MarginInlineStart: var(--pf-t--global--spacer--xs);
-  
+
   // input disabled style
   --#{$text-input-group}--m-disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$text-input-group}--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
@@ -109,32 +109,34 @@
 
     &::before {
       border: 0;
-    }    
+    }
   }
 
   &.pf-m-success {
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-success--BorderColor);
     --#{$text-input-group}--m-hover--BorderColor: var(--#{$text-input-group}--m-hover--m-success--BorderColor);
-    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-success__icon--m-status--Color);  
+    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-success__icon--m-status--Color);
   }
 
   &.pf-m-warning {
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-warning--BorderColor);
     --#{$text-input-group}--m-hover--BorderColor: var(--#{$text-input-group}--m-hover--m-warning--BorderColor);
-    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-warning__icon--m-status--Color);  
+    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-warning__icon--m-status--Color);
   }
 
   &.pf-m-error {
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-error--BorderColor);
     --#{$text-input-group}--m-hover--BorderColor: var(--#{$text-input-group}--m-hover--m-error--BorderColor);
-    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-error__icon--m-status--Color);  
+    --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-error__icon--m-status--Color);
   }
-  
+
   &:hover {
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-hover--BorderColor);
   }
 
-  &:where(.pf-m-success, .pf-m-warning, .pf-m-error) {
+  &.pf-m-success,
+  &.pf-m-warning,
+  &.pf-m-error {
     --#{$text-input-group}__text-input--PaddingInlineEnd: var(--#{$text-input-group}--status__text-input--PaddingInlineEnd);
   }
 
@@ -150,7 +152,7 @@
   flex-wrap: wrap;
   gap: var(--#{$text-input-group}__main--RowGap) var(--#{$text-input-group}__main--ColumnGap);
   min-width: 0;
-  
+
   &.pf-m-icon {
     --#{$text-input-group}__text--Position: relative;
     --#{$text-input-group}__text-input--PaddingInlineStart: var(--#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart);

--- a/src/patternfly/components/Tile/tile.scss
+++ b/src/patternfly/components/Tile/tile.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$tile}) {
+@include pf-root($tile) {
   --#{$tile}--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$tile}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$tile}--PaddingBlockEnd: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$timestamp}) {
+@include pf-root($timestamp) {
   --#{$timestamp}--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$timestamp}--Color: var(--pf-t--global--text--color--subtle);
   --#{$timestamp}--OutlineOffset: #{pf-size-prem(3px)};

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$title}) {
+@include pf-root($title) {
   --#{$title}--FontFamily: var(--pf-t--global--font--family--heading);
 
   // SIZE modifiers (note that the modifier names match PF5 sizes but use tokens that don't match in name

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$toggle-group}) {
+@include pf-root($toggle-group) {
   // button
   --#{$toggle-group}__button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$toggle-group}__button--PaddingInlineEnd: var(--pf-t--global--spacer--md);

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -5,7 +5,6 @@ cssPrefix: pf-v6-c-toolbar
 ---
 
 import './Toolbar.css'
-
 <!-- TODO: add documentation for resize observer/responsive variable usage -->
 
 Toolbar relies on groups (`.pf-v6-c-toolbar__group`) and items (`.pf-v6-c-toolbar__item`), with default col/row gap values. Groups and items can be siblings and/or items can be nested within groups. Modifier selectors adjust spacing based on the type of group. The default `column-gap` value for items and groups is set to `--pf-v6-c--ColumnGap`, whose value is `--pf-t--global--spacer--md` or 16px. The default `row-gap` value for items and groups is set to `--pf-v6-c--RowGap`, whose value is `--pf-t--global--spacer--sm` or 8px.

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -10,8 +10,9 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   $pf-v6-c-toolbar--breakpoint-map: build-breakpoint-map();
 }
 
-:where(:root, .#{$toolbar}) {
+@include pf-root($toolbar) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--md);
+  --#{$toolbar}--ColumnGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlockStart: 0;
   --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingInlineStart: 0;
@@ -389,7 +390,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     }
 
     // - Toolbar toggle group
-    .#{$toolbar}__group:where(.pf-m-toggle-group) {
+    .#{$toolbar}__group.pf-m-toggle-group {
       &.pf-m-show#{$breakpoint-name} {
         .#{$toolbar}__group,
         .#{$toolbar}__item {

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$tooltip}) {
+@include pf-root($toolbar) {
   // Component variables
   --#{$tooltip}--MaxWidth: #{pf-size-prem(300px)};
   --#{$tooltip}--BoxShadow: var(--pf-t--global--box-shadow--md);

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -2,7 +2,7 @@
 
 $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
-:where(:root, .#{$tree-view}) {
+@include pf-root($tree-view) {
   // Node base
   --#{$tree-view}__node--indent--base: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$tree-view}__node-toggle-icon--MinWidth)); // based off of the expected width of the toggle button
   --#{$tree-view}__node--nested-indent--base: calc(var(--#{$tree-view}__node--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$truncate}) {
+@include pf-root($truncate) {
   --#{$truncate}--MinWidth: 6ch;
   --#{$truncate}__start--MinWidth: 6ch;
 }

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$wizard}) {
+@include pf-root($wizard) {
   --#{$wizard}--Height: initial;
   --#{$wizard}--Height--base: 100%;
   --#{$modal-box}--c-wizard--Height--base: #{pf-size-prem(762px)}; // this is a specific height from design for the wizard in a modal
@@ -493,7 +493,8 @@
     --#{$wizard}__nav-link-status-icon--Color: var(--#{$wizard}__nav-link--m-danger__nav-link-status-icon--Color);
   }
 
-  &:where(:hover, :focus) {
+  &:hover,
+  &:focus {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--hover--BackgroundColor);
   }
@@ -570,8 +571,8 @@
     padding: 0;
   }
 
-  &:last-child { 
-    flex-grow: 1; 
+  &:last-child {
+    flex-grow: 1;
   }
 }
 

--- a/src/patternfly/demos/Card/card-template-gallery.hbs
+++ b/src/patternfly/demos/Card/card-template-gallery.hbs
@@ -14,7 +14,7 @@
   {{/card}}
   {{#> card card--id=(concat card-template-gallery--id '-card-1') card--modifier="pf-m-selectable-raised pf-m-compact"}}
     {{#> card-header}}
-      <img src="/assets/images/PF-IconLogo.svg" alt="PatternFly logo"> 
+      <img src="/assets/images/PF-IconLogo.svg" alt="PatternFly logo">
       {{#> card-actions}}
         {{> menu-toggle menu-toggle--IsPlain=true menu-toggle--HasKebab=true menu-toggle--id=(dasherize card--id "toggle")}}
         {{#> check check--modifier="pf-m-standalone"}}

--- a/src/patternfly/demos/Dashboard/examples/Dashboard.md
+++ b/src/patternfly/demos/Dashboard/examples/Dashboard.md
@@ -21,14 +21,8 @@ cssPrefix: pf-d-dashboard
         {{/l-flex}}
       {{/grid-item}}
       {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:2"'}}
-        {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-md pf-m-column-on-lg"}}
-          {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
-            {{> card-template-details card-template-details--id=(concat page-template--id '-details-card-1')}}
-          {{/l-flex-item}}
-          {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
-            {{> card-template-data-list card-template-data-list--id=(concat page-template--id '-data-list-card-1')}}
-          {{/l-flex-item}}
-        {{/l-flex}}
+        {{> card-template-details card-template-details--id=(concat page-template--id '-details-card-1')}}
+        {{> card-template-data-list card-template-data-list--id=(concat page-template--id '-data-list-card-1')}}
       {{/grid-item}}
       {{#> grid-item grid-item--modifier="pf-m-4-col-on-lg pf-m-3-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:4"'}}
         {{#> l-flex l-flex--modifier="pf-m-column"}}

--- a/src/patternfly/layouts/Bullseye/bullseye.scss
+++ b/src/patternfly/layouts/Bullseye/bullseye.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$bullseye}) {
+@include pf-root($bullseye) {
   --#{$bullseye}--Padding: 0;
 }
 

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -6,7 +6,7 @@ $pf-v6-l-flex--spacer-map: build-spacer-map();
 $pf-v6-l-flex--gap-map: build-spacer-map("base", "none", "xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl");
 $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $pf-v6-l-flex--spacer-map);
 
-:where(:root, .#{$flex}) {
+@include pf-root($flex) {
   --#{$flex}--Display: flex;
   --#{$flex}--FlexWrap: wrap;
   --#{$flex}--AlignItems: baseline;
@@ -84,15 +84,14 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
 
       // inline flex
       &.pf-m-inline-flex#{$breakpoint-name} {
-        --#{$flex}--Display: inline-flex;
+        display: inline-flex;
       }
 
       // flex-direction
       &.pf-m-column#{$breakpoint-name} {
-        --#{$flex}--RowGap: 0;
-        --#{$flex}--ColumnGap: var(--#{$flex}--spacer--column--base);
-
         flex-direction: column;
+        row-gap: 0;
+        column-gap: var(--#{$flex}--spacer--column--base);
         align-items: normal;
 
         > * {
@@ -335,33 +334,33 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
     }
   }
 
-    // .pf-m-gap{-[size]}{-on-[breakpoint]}
-    @each $breakpoint, $breakpoint-value in $pf-v6-l-flex--breakpoint-map {
-      $pf-v6-l-flex--gap--selectors: ();
+  // .pf-m-gap{-[size]}{-on-[breakpoint]}
+  @each $breakpoint, $breakpoint-value in $pf-v6-l-flex--breakpoint-map {
+    $pf-v6-l-flex--gap--selectors: ();
 
-      @include pf-v6-apply-breakpoint($breakpoint) {
-        @each $spacer, $value in $pf-v6-l-flex--gap-map {
-          $breakpoint-name: if($breakpoint == "base", "", -on-#{$breakpoint});
-          $spacer-name: if($spacer == "base", "", -#{$spacer});
-          $spacer-row: if($spacer == "base", var(--#{$flex}--m-gap--RowGap), $value);
-          $spacer-column: if($spacer == "base", var(--#{$flex}--m-gap--ColumnGap), $value);
-          $selector: ".pf-m-gap#{$spacer-name}#{$breakpoint-name}";
-          $pf-v6-l-flex--gap--selectors: append($pf-v6-l-flex--gap--selectors, $selector, $separator: comma);
+    @include pf-v6-apply-breakpoint($breakpoint) {
+      @each $spacer, $value in $pf-v6-l-flex--gap-map {
+        $breakpoint-name: if($breakpoint == "base", "", -on-#{$breakpoint});
+        $spacer-name: if($spacer == "base", "", -#{$spacer});
+        $spacer-row: if($spacer == "base", var(--#{$flex}--m-gap--RowGap), $value);
+        $spacer-column: if($spacer == "base", var(--#{$flex}--m-gap--ColumnGap), $value);
+        $selector: ".pf-m-gap#{$spacer-name}#{$breakpoint-name}";
+        $pf-v6-l-flex--gap--selectors: append($pf-v6-l-flex--gap--selectors, $selector, $separator: comma);
 
-          &#{$selector} {
-            --#{$flex}--RowGap: #{$spacer-row};
-            --#{$flex}--ColumnGap: #{$spacer-column};
-          }
+        &#{$selector} {
+          row-gap: #{$spacer-row};
+          column-gap: #{$spacer-column};
         }
+      }
 
-        &:is(#{$pf-v6-l-flex--gap--selectors}) {
-          > * {
-            --#{$flex}--spacer--row: 0;
-            --#{$flex}--spacer--column: 0;
-          }
+      &#{$pf-v6-l-flex--gap--selectors} {
+        > * {
+          margin-block-end: 0;
+          margin-inline-end: 0;
         }
       }
     }
+  }
 
   // .pf-m-row-gap{-[size]}{-on-[breakpoint]}
   @each $breakpoint, $breakpoint-value in $pf-v6-l-flex--breakpoint-map {
@@ -376,13 +375,13 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
         $pf-v6-l-flex--row-gap--selectors: append($pf-v6-l-flex--row-gap--selectors, $selector, $separator: comma);
 
        &#{$selector} {
-          --#{$flex}--RowGap: #{$spacer-value};
+          margin-block-end: #{$spacer-value};
         }
       }
 
       &:is(#{$pf-v6-l-flex--row-gap--selectors}) {
         > * {
-          --#{$flex}--spacer--row: 0;
+          margin-block-end: 0;
         }
       }
     }
@@ -401,13 +400,13 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
         $pf-v6-l-flex--column-gap--selectors: append($pf-v6-l-flex--column-gap--selectors, $selector, $separator: comma);
 
         &#{$selector} {
-          --#{$flex}--ColumnGap: #{$spacer-value};
+          margin-inline-end: #{$spacer-value};
         }
       }
 
       &:is(#{$pf-v6-l-flex--column-gap--selectors}) {
         > * {
-          --#{$flex}--spacer--column: 0;
+          margin-inline-end: 0;
         }
       }
     }

--- a/src/patternfly/layouts/Gallery/gallery.scss
+++ b/src/patternfly/layouts/Gallery/gallery.scss
@@ -2,20 +2,19 @@
 
 $pf-v6-l-gallery--breakpoint-map: build-breakpoint-map();
 
-:where(:root, .#{$gallery}) {
+@include pf-root($gallery) {
   --#{$gallery}--m-gutter--GridGap: var(--pf-t--global--spacer--gutter--default);
   --#{$gallery}--GridTemplateColumns--min: 250px;
   --#{$gallery}--GridTemplateColumns--minmax--min: var(--#{$gallery}--GridTemplateColumns--min);
   --#{$gallery}--GridTemplateColumns--max: 1fr;
   --#{$gallery}--GridTemplateColumns--minmax--max: var(--#{$gallery}--GridTemplateColumns--max);
-  --#{$gallery}--GridTemplateColumns: repeat(auto-fill, minmax(var(--#{$gallery}--GridTemplateColumns--minmax--min), var(--#{$gallery}--GridTemplateColumns--minmax--max)));
   --#{$gallery}--GridTemplateRows: auto;
 }
 
 .#{$gallery} {
   display: grid;
   grid-template-rows: var(--#{$gallery}--GridTemplateRows);
-  grid-template-columns: var(--#{$gallery}--GridTemplateColumns);
+  grid-template-columns: repeat(auto-fill, minmax(var(--#{$gallery}--GridTemplateColumns--minmax--min), var(--#{$gallery}--GridTemplateColumns--minmax--max)));
 
   &.pf-m-gutter {
     grid-gap: var(--#{$gallery}--m-gutter--GridGap);

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -9,7 +9,7 @@ $pf-v6-l-grid--breakpoint-map: build-breakpoint-map(); // currently only used fo
   @for $col-num from 1 through 12 {
     &.pf-m-all-#{$col-num}-col#{$suffix} {
       > * {
-        --#{$grid}__item--GridColumnEnd: span #{$col-num};
+        grid-column-end: span #{$col-num};
       }
     }
   }
@@ -21,14 +21,14 @@ $pf-v6-l-grid--breakpoint-map: build-breakpoint-map(); // currently only used fo
   // generate column span modifier
   @for $col-num from 1 through 12 {
     > .pf-m-#{$col-num}-col#{$suffix} {
-      --#{$grid}__item--GridColumnEnd: span #{$col-num};
+      grid-column-end: span #{$col-num};
     }
   }
 
   // generate column offset modfiers
   @for $col-num from 1 through 12 {
     > .pf-m-offset-#{$col-num}-col#{$suffix} {
-      --#{$grid}__item--GridColumnStart: col-start calc(#{$col-num} + 1);
+      grid-column-start: col-start calc(#{$col-num} + 1);
     }
   }
 
@@ -41,7 +41,7 @@ $pf-v6-l-grid--breakpoint-map: build-breakpoint-map(); // currently only used fo
 }
 
 // Grid base
-:where(:root, .#{$grid}) {
+@include pf-root($grid) {
   --#{$grid}--m-gutter--GridGap: var(--pf-t--global--spacer--gutter--default);
   --#{$grid}__item--GridColumnStart: auto;
   --#{$grid}__item--GridColumnEnd: span 12;

--- a/src/patternfly/layouts/Level/level.scss
+++ b/src/patternfly/layouts/Level/level.scss
@@ -1,6 +1,7 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$level}) {
+@include pf-root($level) {
+  --#{$level}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
   --#{$level}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 

--- a/src/patternfly/layouts/Split/split.scss
+++ b/src/patternfly/layouts/Split/split.scss
@@ -1,6 +1,7 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$split}) {
+@include pf-root($split) {
+  --#{$split}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
   --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 
@@ -19,5 +20,5 @@
 }
 
 .#{$split}.pf-m-gutter {
-  gap: var(--#{$stack}--m-gutter--Gap);
+  gap: var(--#{$split}--m-gutter--Gap);
 }

--- a/src/patternfly/layouts/Stack/stack.scss
+++ b/src/patternfly/layouts/Stack/stack.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-:where(:root, .#{$stack}) {
+@include pf-root($stack) {
   --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 

--- a/src/patternfly/my-theme.scss
+++ b/src/patternfly/my-theme.scss
@@ -1,0 +1,37 @@
+@use './sass-utilities' as *;
+
+// stylelint-disable
+// Global customizations
+.mui-theme {
+  --pf-t--global--text--color--regular: #525252;
+  --pf-t--global--color--brand--default: #0f62fe;
+
+  // * MUI primary button
+  // --#{$button}--m-primary--BackgroundColor: lightsalmon;
+  // --#{$button}--m-primary--hover--BackgroundColor: red;
+  // --#{$button}--m-primary--Color: rgb(57, 36, 27);
+
+  // // * MUI secondary button
+  // --#{$button}--m-secondary--BackgroundColor: lightblue;
+
+  // // * MUI page
+  // --#{$content}--Color: #fff;
+  // // --#{$page}__main-section--BackgroundColor: #4d586d;
+  // --#{$page}__main-section--BorderColor: red;
+  // --#{$page}__main-container--BorderColor: goldenrod;
+}
+
+// Targeted customizations
+:root {
+  // --#{$page}--BackgroundColor: lightsalmon;
+  // --#{masthead}--BackgroundColor: #fff;
+}
+
+// .#{$page} {
+//   --pf-v6-c-page__main-section--m-secondary--BackgroundColor: lightsalmon;
+// }
+
+.my-theme {
+  // --pf-v6-c-page__main-section--m-secondary--BackgroundColor: lightblue;
+}
+// stylelint-enable

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -13,18 +13,18 @@ $chart: #{$pf-prefix} + 'chart';
 }
 
 // Charts tokens
-:where(:root) {
+:root {
   @include charts.pf-v6-tokens;
 }
 
 // Charts dark tokens
-:where(.pf-v6-theme-dark) {
+.pf-v6-theme-dark {
   @include charts-dark.pf-v6-tokens;
 }
 
 // Charts styles
 // stylelint-disable-next-line no-duplicate-selectors
-:where(:root) {
+:root {
   // Chart colors
   // blue
   --#{$chart}-color-blue-100: var(--pf-t--chart--color--blue--100);

--- a/src/patternfly/patternfly.scss
+++ b/src/patternfly/patternfly.scss
@@ -1,3 +1,4 @@
 @use './patternfly-base';
 @use './components';
 @use './layouts';
+@use './my-theme'

--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -81,7 +81,6 @@
   @return $map;
 }
 
-
 // Build spacer map
 // Based on $pf-v6-global--spacer-map
 @function build-spacer-map($map-items...) {

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -313,7 +313,7 @@
 }
 
 // Build variable stack
-@mixin pf-v6-output-root-variables($css-var, $breakpoint-map: $pf-v6-global--breakpoint-map) {
+@mixin pf-v6-output-root-variables($css-var, $value: "inherit", $breakpoint-map: $pf-v6-global--breakpoint-map) {
   $list: ();
 
   @each $breakpoint, $breakpoint-value in $breakpoint-map {
@@ -326,13 +326,13 @@
   }
 
   @each $item in $list {
-    #{$item}: inherit;
+    #{$item}: #{$value};
   }
 }
 
 // Dark theme style block
 @mixin pf-v6-theme-dark($theme-dark-class: $pf-v6--theme-dark--class, $theme-dark-target: $pf-v6--theme-dark--target) {
-  #{$theme-dark-target}:where(#{$theme-dark-class}) {
+  #{$theme-dark-target}#{$theme-dark-class} {
     @content;
   }
 }
@@ -371,14 +371,14 @@
 //   background: red;
 // }
 @mixin pf-v6-rtl {
-  @at-root :where(.#{$pf-prefix}m-dir-rtl, [dir="rtl"]) #{&} {
+  @at-root .#{$pf-prefix}m-dir-rtl, [dir="rtl"] #{&} {
     @content;
   }
 }
 
 // Used to create the LTR selector for LTR specific styles
 @mixin pf-v6-ltr {
-  @at-root :where(.#{$pf-prefix}m-dir-ltr, [dir="ltr"]) #{&} {
+  @at-root .#{$pf-prefix}m-dir-ltr, [dir="ltr"] #{&} {
     @content;
   }
 }
@@ -415,4 +415,11 @@
 // Declares a global inverse multiplier var used for returning the inverse of a number. Defined within blocks that reference the global var in calc() functions to conditionally return the default or inverse value of a number.
 @mixin pf-v6-set-inverse($val: true) {
   --#{$pf-global}--inverse--multiplier: #{if($val, -1, 1)};
+}
+
+@mixin pf-root($selector) {
+  :root,
+  .#{$selector}-reset {
+    @content
+  }
 }


### PR DESCRIPTION
# TLDR
This PR eliminates 5,974,169 selector matching attempts.
By removing :where(:root, .component) alone, match attempts went from 6,516,114 to 541,945, resulting in a total reduction of 5,974,169 match attempts.

**Before**
<img width="1209" alt="Screenshot 2024-08-19 at 9 52 39 AM" src="https://github.com/user-attachments/assets/2dd457f6-7e2d-4beb-9d96-ff00784ff767">

**After**
<img width="847" alt="Screenshot 2024-08-19 at 9 59 26 AM" src="https://github.com/user-attachments/assets/f9cf4336-1531-4fba-9ba1-a418d72660e9">

Closes #6722  

[Backstop report](https://drive.google.com/file/d/17tqL5f4V7mIresRuY45Zc_g24jkNgnsN/view?usp=sharing)

## Update: 8/19/24

As I was recorded performance metrics, I found interesting results. While attempting to compare metrics (`match attempts/count` increase/decrease).

![Image](https://github.com/user-attachments/assets/683c9db8-59d9-4d61-a93e-8c204cf70a6f)

I realized that that the selectors I was looking for were no longer available. 

![Image](https://github.com/user-attachments/assets/5f2e6b6e-8e2e-4702-9852-d4b58d8f65fa)

The comparison I was looking for didn't exist because it was completely eliminated. 

By removing `:where(:root, .component)` alone,  `match attempts` went from 6,516,114 to 541,945, resulting in a total reduction of 5,974,169 `match attempts`. 


The use of :where(:root) is having a significant impact upon performance. References to :where(:root) need to be updated to :root as :where() tells the browser engine to look at every element for :root().
This change 

* **Increases performance by -** 
* **Reduces elapsed time by 22.66%**
* **Reduces match attempts by 7.32%**
* **Increases match count by 2.46%** (misconfigured selectors were corrected and matched with their corresponding component)

----

## Current performance profile:
<table style="width: 100%;">
  <thead>
    <tr>
      <th colspan="2">V6</th>
      <th colspan="2">Removing floating `:where()`</th>
    </tr>
  </thead>

<tbody>
    <tr>
      <td colspan="2">
        <img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/3eff6f52-0e1b-4505-88ee-e9bdf466163f">
      </td>
      <td colspan="2">
        <img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/f488b784-dcbd-47c8-984c-6fcd344589fe">
      </td>
    </tr>
    <tr>
      <td colspan="2">
        <img width="396" alt="Screenshot 2024-08-01 at 8 20 26 AM" src="https://github.com/user-attachments/assets/d289e22d-847d-4d64-b87c-8236d325409a">
       </td>
       <td colspan="2">
<img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/26f25939-28f6-40d9-b2ae-ce0a34943fe0">
      </td>
    </tr>
</tbody>
</table>

Change metrics | Previous | Update | Difference | Percentage
-- | -- | -- | -- | --
Elapsed time (ms) | 218ms | 89ms | -129ms | 40.73%
Match attempts | 7129491 | 2807321 | -4322170 | 39.38%
Match count | 105605 | 42356 | -63249 | 40.11%
% of slow-path non-matches | 58.9 | 58.9 | 0 | 100.00%


