### PR TITLE
feat(alert-group): animate addition and removal of alerts

### DIFF
--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -94,6 +94,7 @@
     // make the item have no height and position it up above
     grid-template-rows: 0fr;
     margin-block: 0;
+    overflow: hidden;
     opacity: 0;
     transform: translateY(-100%);
 
@@ -102,7 +103,6 @@
       min-height: 0;
       padding-block-start: 0;
       padding-block-end: 0;
-      overflow: hidden;
       border-width: 0;
     }
   }
@@ -112,6 +112,7 @@
   &.pf-m-offstage-right {
     grid-template-rows: 0fr; // collapse vertically to bring up the items below
     margin-block: 0;
+    overflow: hidden;
     opacity: 0;
 
     // This transition will happen when the item is removed
@@ -125,7 +126,6 @@
       min-height: 0;
       padding-block-start: 0;
       padding-block-end: 0;
-      overflow: hidden;
       border-width: 0;
     }
 

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -102,6 +102,7 @@
       min-height: 0;
       padding-block-start: 0;
       padding-block-end: 0;
+      overflow: hidden;
       border-width: 0;
     }
   }
@@ -124,6 +125,7 @@
       min-height: 0;
       padding-block-start: 0;
       padding-block-end: 0;
+      overflow: hidden;
       border-width: 0;
     }
 

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -59,6 +59,89 @@
   border-width: var(--#{$alert-group}__overflow-button--BorderWidth);
   border-radius: var(--#{$alert-group}__overflow-button--BorderRadius);
   box-shadow: var(--#{$alert-group}__overflow-button--BoxShadow);
+}
+
+.#{$alert-group}__item {
+  // Properties to be transitioned on entry/exit
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+
+  // This transition will happen when the item is added (.pf-m-offstage-top is removed)
+  // Reduced motion by default
+  // transparency change only
+  transition: 
+  opacity var(--pf-t--global--motion--duration--fade--default) var(--pf-t--global--motion--timing-function--decelerate) 0s;
+  transform: translateX(0) translateY(0);
+
+  // This transition will happen when the item is added (.pf-m-offstage-top is removed)
+  // give it height, then slide it down into place
+  // These values are for regular motion
+  @media screen and (prefers-reduced-motion: no-preference) {
+    transition: 
+      opacity var(--pf-t--global--motion--duration--fade--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default), 
+      transform var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) var(--pf-t--global--motion--duration--slide-in--default), 
+      grid-template-rows var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) 0s, 
+      margin-block var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate) 0s;
+
+      & .pf-v6-c-alert {
+        transition: all var(--pf-t--global--motion--duration--slide-in--default) var(--pf-t--global--motion--timing-function--decelerate);
+      }
+  }
+
+  // This class is used BEFORE the alert item comes into the list
+  &.pf-m-offstage-top {
+    // make the item have no height and position it up above
+    grid-template-rows: 0fr;
+    margin-block: 0;
+    opacity: 0;
+    transform: translateY(-100%);
+
+    & .pf-v6-c-alert {
+      // make it small when it's first created off to the top
+      min-height: 0;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      border-width: 0;
+    }
+  }
+
+  // Add this class before removing an alert
+  // TODO auto dismissal should be the same motion, but has a different duration
+  &.pf-m-offstage-right {
+    grid-template-rows: 0fr; // collapse vertically to bring up the items below
+    margin-block: 0;
+    opacity: 0;
+
+    // This transition will happen when the item is removed
+    // Reduced motion by default
+    // transparency change only
+    transition: 
+      opacity var(--pf-t--global--motion--duration--fade--short) var(--pf-t--global--motion--timing-function--accelerate) 0s;
+    transform: translateX(100%);
+
+    & .pf-v6-c-alert {
+      min-height: 0;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      border-width: 0;
+    }
+
+    // This transition will happen when the item is added (.pf-m-offstage-top is removed)
+    // give it height, then slide it down into place
+    // These values are for regular motion
+    @media screen and (prefers-reduced-motion: no-preference) {
+      transition: 
+        transform var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) 0s, 
+        opacity var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) 0s,
+        margin-block var(--pf-t--global--motion--duration--fade--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short), 
+        grid-template-rows var(--pf-t--global--motion--duration--slide-in--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short);
+
+        & .pf-v6-c-alert {
+          transition: all var(--pf-t--global--motion--duration--slide-out--short) var(--pf-t--global--motion--timing-function--accelerate) var(--pf-t--global--motion--duration--slide-out--short);
+        }
+    }
+  }
 
   &:hover {
     --#{$alert-group}__overflow-button--Color: var(--#{$alert-group}__overflow-button--hover--Color);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -116,7 +116,6 @@
   padding-block-end: var(--#{$alert}--PaddingBlockEnd);
   padding-inline-start: var(--#{$alert}--PaddingInlineStart);
   padding-inline-end: var(--#{$alert}--PaddingInlineEnd);
-  overflow: hidden; // required for animation slide in
   font-size: var(--#{$alert}--FontSize);
   background-color: var(--#{$alert}--BackgroundColor);
   border: var(--#{$alert}--BorderWidth) solid var(--#{$alert}--BorderColor);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -116,12 +116,13 @@
   padding-block-end: var(--#{$alert}--PaddingBlockEnd);
   padding-inline-start: var(--#{$alert}--PaddingInlineStart);
   padding-inline-end: var(--#{$alert}--PaddingInlineEnd);
+  overflow: hidden; // required for animation slide in
   font-size: var(--#{$alert}--FontSize);
   background-color: var(--#{$alert}--BackgroundColor);
   border: var(--#{$alert}--BorderWidth) solid var(--#{$alert}--BorderColor);
   border-radius: var(--#{$alert}--BorderRadius);
   box-shadow: var(--#{$alert}--BoxShadow);
-
+  
   &.pf-m-custom {
     --#{$alert}--BorderColor: var(--#{$alert}--m-custom--BorderColor);
     --#{$alert}__icon--Color: var(--#{$alert}--m-custom__icon--Color);


### PR DESCRIPTION
This add animation on the alert group item when adding/removing an item.

For expediency, for now there are no additional component variables - motion tokens are used directly in the transitions.
One other TODO remains: a toast alert that times out should leave in the same way, but have a slower duration than an alert that is dismissed.

To test, go to the [toast alert full page example](https://patternfly-pr-6804.surge.sh/components/alert/html/toast-alert-group/). Add `.pf-m-offstage-top` to simulate the starting condition. Remove it to see the alert appear (slide in from the top). To simulate removal, add the `.pf-m-offstage-right` class and see it slide to the right.

To test reduced motion, turn on "Reduce motion" in the Display settings (MacOS). When this option is on, only opacity should transition and nothing should slide.

Fixes #6592 