### PR TITLE
fix(button): add icon/text wrapper

### DIFF
--- a/src/patternfly/components/Badge/badge.hbs
+++ b/src/patternfly/components/Badge/badge.hbs
@@ -1,4 +1,5 @@
 <span class="{{pfv}}badge
+  {{#if badge--IsRead}}pf-m-read {{/if}}
   {{#if badge--IsUnread}}pf-m-unread {{/if}}
   {{#if badge--IsDisabled}}pf-m-disabled {{/if}}
   {{#if badge--modifier}} {{badge--modifier}}{{/if}}"

--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -3,12 +3,12 @@
 <br><br>
 
 <div><strong>Icon</strong></div>
-{{> button-list button--HasIcon=true}}
+{{> button-list button--icon="plus-circle"}}
 
 <br><br>
 
 <div><strong>Icon end</strong></div>
-{{> button-list button--HasIconEnd=true}}
+{{> button-list button-icon--IsEnd=true button--icon="plus-circle"}}
 
 {{#*inline "button-list"}}
   {{#> button button--IsPrimary=true}}
@@ -49,9 +49,7 @@
     Inline link
   {{/button}}
 
-  {{#> button button--IsPlain=true button--attribute='aria-label="Remove"' button--HasIcon=false button--HasIconEnd=false}}
-    <i class="fas fa-times" aria-hidden="true"></i>
-  {{/button}}
+  {{> button button--IsPlain=true button--aria-label="Remove" button--icon="times"}}
 
   <br><br>
 
@@ -59,7 +57,5 @@
     Control
   {{/button}}
 
-  {{#> button button--IsControl=true button--HasIcon=false button--HasIconEnd=false button--attribute='aria-label="Copy input"'}}
-    <i class="fas fa-copy" aria-hidden="true"></i>
-  {{/button}}
+  {{> button button--IsControl=true button--aria-label="Copy input" button--icon="copy"}}
 {{/inline}}

--- a/src/patternfly/components/Button/button-count.hbs
+++ b/src/patternfly/components/Button/button-count.hbs
@@ -2,5 +2,11 @@
   {{#if button-count--attribute}}
     {{{button-count--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#if button--count}}
+    {{#> badge badge--IsRead=button-count--IsRead badge--IsUnread=button-count--IsUnread}}
+      {{button--count}}
+    {{/badge}}
+  {{else if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
 </span>

--- a/src/patternfly/components/Button/button-icon.hbs
+++ b/src/patternfly/components/Button/button-icon.hbs
@@ -2,9 +2,9 @@
   {{#if button-icon--attribute}}
     {{{button-icon--attribute}}}
   {{/if}}>
-  {{#if button-icon--name}}
-    <i class="{{{button-icon--name}}}" aria-hidden="true"></i>
-  {{else}}
+  {{#if button--icon}}
+    <i class="fas fa-{{button--icon}}" aria-hidden="true"></i>
+  {{else if @partial-block}}
     {{> @partial-block}}
   {{/if}}
 </span>

--- a/src/patternfly/components/Button/button-icon.hbs
+++ b/src/patternfly/components/Button/button-icon.hbs
@@ -1,4 +1,10 @@
-<span class="{{pfv}}button__icon{{#if button-icon--modifier}} {{button-icon--modifier}}{{/if}}"
+<span class="{{pfv}}button__icon
+  {{#if button-icon--IsEnd}}
+    pf-m-end
+  {{else}}
+    pf-m-start
+  {{/if}}
+  {{#if button-icon--modifier}} {{button-icon--modifier}}{{/if}}"
   {{#if button-icon--attribute}}
     {{{button-icon--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Button/button-text.hbs
+++ b/src/patternfly/components/Button/button-text.hbs
@@ -1,0 +1,6 @@
+<span class="{{pfv}}button__text{{#if button-text--modifier}} {{button-text--modifier}}{{/if}}"
+  {{#if button-text--attribute}}
+    {{{button-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -18,6 +18,12 @@
     button--HasNoPadding='pf-m-no-padding'
     button--IsSmall='pf-m-small'
     button--IsClicked='pf-m-clicked'
+    button--IsStateful='pf-m-stateful'
+    button--IsRead='pf-m-read'
+    button--IsUnread='pf-m-unread'
+    button--IsAttention='pf-m-attention'
+    button--IsDisplayLg='pf-m-display-lg'
+    button--IsBlock='pf-m-block'
     button--modifier=button--modifier
   }}
   {{#if button--IsDisabled}}
@@ -74,16 +80,21 @@
     {{> button-progress}}
   {{/if}}
   {{#if button--icon}}
-    <i class="fas fa-{{button--icon}}" aria-hidden="true"></i>
-  {{else if button--HasIcon}}
-    {{#> button-icon button-icon--modifier="pf-m-start"}}
-      <i class="fas fa-plus-circle" aria-hidden="true"></i>
-    {{/button-icon}}
+    {{#unless button-icon--IsEnd}}
+      {{> button-icon}}
+    {{/unless}}
   {{/if}}
-  {{> @partial-block}}
-  {{#if button--HasIconEnd}}
-    {{#> button-icon button-icon--modifier="pf-m-end"}}
-      <i class="fas fa-plus-circle" aria-hidden="true"></i>
-    {{/button-icon}}
+  {{#if @partial-block}}
+    {{#> button-text}}
+      {{> @partial-block}}
+    {{/button-text}}
+  {{/if}}
+  {{#if button--icon}}
+    {{#if button-icon--IsEnd}}
+      {{> button-icon}}
+    {{/if}}
+  {{/if}}
+  {{#if button--count}}
+    {{> button-count}}
   {{/if}}
 </{{#if button--type}}{{button--type}}{{else if button--IsSpan}}span{{else if button--IsAnchor}}a{{else}}button{{/if}}>

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -115,6 +115,8 @@
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--m-link--m-inline--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$button}--span--m-link--m-inline--Display: inline;
+  --#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$button}--span--m-link--m-inline__icon--m-end--MarginInlineStart: var(--pf-t--global--spacer--xs);
 
   // Plain
   --#{$button}--m-plain--BorderRadius: var(--pf-t--global--border--radius--small);
@@ -248,6 +250,10 @@
   --#{$button}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--hover__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-clicked__icon--Color: var(--pf-t--global--icon--color--regular);
+  --#{$button}__icon--MarginInlineStart: 0;
+  --#{$button}__icon--MarginInlineEnd: 0;
+  --#{$button}__icon--m-start--MarginInlineEnd: 0;
+  --#{$button}__icon--m-end--MarginInlineStart: 0;
 
   // Progress
   --#{$button}__progress--width: calc(var(--#{$spinner}--m-md--diameter) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
@@ -390,6 +396,8 @@
     &.pf-m-inline {
       @at-root span#{&} {
         --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
+        --#{$button}__icon--m-start--MarginInlineEnd: var(--#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd);
+        --#{$button}__icon--m-end--MarginInlineStart: var(--#{$button}--span--m-link--m-inline__icon--m-end--MarginInlineStart);
       }
 
       --#{$button}--Display: var(--#{$button}--m-link--m-inline--Display);
@@ -650,7 +658,17 @@
 }
 
 .#{$button}__icon {
+  margin-inline-start: var(--#{$button}__icon--MarginInlineStart);
+  margin-inline-end: var(--#{$button}__icon--MarginInlineEnd);
   color: var(--#{$button}__icon--Color);
+
+  &.pf-m-start {
+    --#{$button}__icon--MarginInlineEnd: var(--#{$button}__icon--m-start--MarginInlineEnd);
+  }
+
+  &.pf-m-end {
+    --#{$button}__icon--MarginInlineStart: var(--#{$button}__icon--m-end--MarginInlineStart);
+  }
 }
 
 .#{$button}__progress {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -272,7 +272,6 @@
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
 
   // Count
-  --#{$button}__count--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$button}--m-primary__c-badge--BorderColor: var(--pf-t--global--border--color--default);
 
   // Block
@@ -687,5 +686,4 @@
 .#{$button}__count {
   display: inline-flex;
   align-items: center;
-  margin-inline-start: var(--#{$button}__count--MarginInlineStart);
 }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -101,6 +101,7 @@
   --#{$button}--m-link--m-danger--m-clicked__icon--Color: var(--pf-t--global--text--color--status--danger--clicked);
 
   // Link inline
+  --#{$button}--m-link--m-inline--Display: inline-flex;
   --#{$button}--m-link--m-inline--FontSize: initial;
   --#{$button}--m-link--m-inline--LineHeight: initial;
   --#{$button}--m-link--m-inline--FontWeight: initial;
@@ -113,6 +114,7 @@
   --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InsetInlineStart) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--m-link--m-inline--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
+  --#{$button}--span--m-link--m-inline--Display: inline;
 
   // Plain
   --#{$button}--m-plain--BorderRadius: var(--pf-t--global--border--radius--small);
@@ -386,6 +388,11 @@
     --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-link--m-clicked__icon--Color);
 
     &.pf-m-inline {
+      @at-root span#{&} {
+        --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
+      }
+
+      --#{$button}--Display: var(--#{$button}--m-link--m-inline--Display);
       --#{$button}--FontSize: var(--#{$button}--m-link--m-inline--FontSize);
       --#{$button}--LineHeight: var(--#{$button}--m-link--m-inline--LineHeight);
       --#{$button}--FontWeight: var(--#{$button}--m-link--m-inline--FontWeight);
@@ -402,7 +409,6 @@
       --#{$button}--disabled--Color: var(--#{$button}--m-link--m-inline--disabled--Color);
       --#{$button}--disabled__icon--Color: var(--#{$button}--m-link--m-inline--disabled__icon--Color);
 
-      display: inline;
       text-align: start;
       white-space: normal;
       outline-offset: #{pf-size-prem(2px)};

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -131,7 +131,8 @@
   --#{$button}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$button}--m-plain--m-clicked--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--m-clicked--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
-  --#{$button}--m-plain--disabled--Color: var(--pf-t--global--icon--color--disabled);
+  --#{$button}--m-plain--disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$button}--m-plain--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$button}--m-plain--disabled--BackgroundColor: transparent;
   --#{$button}--m-plain--m-small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$button}--m-plain--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
@@ -544,6 +545,7 @@
     --#{$button}--m-clicked--Color: var(--#{$button}--m-plain--m-clicked--Color);
     --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
     --#{$button}--disabled--Color: var(--#{$button}--m-plain--disabled--Color);
+    --#{$button}--disabled__icon--Color: var(--#{$button}--m-plain--disabled__icon--Color);
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
     --#{$button}--m-small--PaddingBlockStart: var(--#{$button}--m-plain--m-small--PaddingBlockStart);
     --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-small--PaddingInlineEnd);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,7 +1,10 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$button}) {
-  --#{$button}--Display: inline-block;
+  --#{$button}--Display: inline-flex;
+  --#{$button}--AlignItems: baseline;
+  --#{$button}--JustifyContent: center;
+  --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
   --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
@@ -243,8 +246,6 @@
   --#{$button}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--hover__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-clicked__icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$button}__icon--m-start--MarginInlineEnd: var(--pf-t--global--spacer--xs);
-  --#{$button}__icon--m-end--MarginInlineStart: var(--pf-t--global--spacer--xs);
 
   // Progress
   --#{$button}__progress--width: calc(var(--#{$spinner}--m-md--diameter) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
@@ -265,14 +266,18 @@
   // Count
   --#{$button}__count--MarginInlineStart: var(--pf-t--global--spacer--sm);
   --#{$button}--m-primary__c-badge--BorderColor: var(--pf-t--global--border--color--default);
+
+  // Block
+  --#{$button}--m-block--Display: flex;
+  --#{$button}--m-block--Width: 100%;
 }
 
 .#{$button} {
   position: relative;
   display: var(--#{$button}--Display);
-  flex: var(--#{$button}--Flex, initial);
-  align-items: var(--#{$button}--AlignItems, initial);
-  justify-content: var(--#{$button}--JustifyContent, initial);
+  gap: var(--#{$button}--Gap);
+  align-items: var(--#{$button}--AlignItems);
+  justify-content: var(--#{$button}--JustifyContent);
   padding-block-start: var(--#{$button}--PaddingBlockStart);
   padding-block-end: var(--#{$button}--PaddingBlockEnd);
   padding-inline-start: var(--#{$button}--PaddingInlineStart);
@@ -548,8 +553,9 @@
   }
 
   &.pf-m-block {
-    display: block;
-    width: 100%;
+    --#{$button}--Display: var(--#{$button}--m-block--Display);
+
+    width: var(--#{$button}--m-block--Width);
   }
 
   &.pf-m-small {
@@ -639,14 +645,6 @@
 
 .#{$button}__icon {
   color: var(--#{$button}__icon--Color);
-
-  &.pf-m-start {
-    margin-inline-end: var(--#{$button}__icon--m-start--MarginInlineEnd);
-  }
-
-  &.pf-m-end {
-    margin-inline-start: var(--#{$button}__icon--m-end--MarginInlineStart);
-  }
 }
 
 .#{$button}__progress {

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -34,27 +34,27 @@ import './Button.css'
 
 ### Links as buttons
 ```hbs
-{{#> button button--IsAnchor="true" button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--modifier="pf-m-primary"}}
+{{#> button button--IsAnchor=true button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--IsPrimary=true}}
   Primary link to W3.org
 {{/button}}
 
-{{#> button button--IsAnchor="true" button--url="#overview" button--attribute='aria-label="Read more about button documentation"' button--modifier="pf-m-secondary"}}
+{{#> button button--IsAnchor=true button--url="#overview" button--aria-label="Read more about button documentation" button--IsSecondary=true}}
   Secondary link to anchor
 {{/button}}
 
-{{#> button button--IsAnchor="true" button--url="#overview" button--attribute='aria-label="Read more about button documentation"' button--modifier="pf-m-secondary pf-m-danger"}}
+{{#> button button--IsAnchor=true button--url="#overview" button--aria-label="Read more about button documentation" button--IsSecondary=true button--IsDanger=true}}
   Secondary danger link to anchor
 {{/button}}
 
-{{#> button button--IsAnchor="true" button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--attribute='aria-disabled="true" tabindex="-1"' button--modifier="pf-m-tertiary pf-m-disabled"}}
+{{#> button button--IsAnchor=true button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--attribute='aria-disabled=true tabindex="-1"' button--IsDisabled=true button--IsTertiary=true}}
   Tertiary link to W3.org
 {{/button}}
 
-{{#> button button--IsAnchor="true" button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--modifier="pf-m-link"}}
+{{#> button button--IsAnchor=true button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--IsLink=true}}
   Link to W3.org
 {{/button}}
 
-{{#> button button--IsAnchor="true" button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--modifier="pf-m-link pf-m-danger"}}
+{{#> button button--IsAnchor=true button--url="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" button--IsLink=true button--IsDanger=true}}
   Link danger to W3.org
 {{/button}}
 ```
@@ -63,20 +63,16 @@ import './Button.css'
 ```hbs
 <strong>Plain</strong>
 <br>
-{{#> button button--attribute='aria-label="Remove"' button--IsSpan=true button--IsPlain=true}}
-  <i class="fas fa-times" aria-hidden="true"></i>
-{{/button}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--icon="times"}}
 <br><br>
 <strong>Plain no padding</strong>
 <br>
-{{#> button button--attribute='aria-label="Remove"' button--IsSpan=true button--IsPlain=true button--HasNoPadding=true}}
-  <i class="fas fa-times" aria-hidden="true"></i>
-{{/button}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--HasNoPadding=true button--icon="times"}}
 <br><br>
 <strong>Inline link</strong>
 <br>
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-{{#> button button--IsSpan="true" button--modifier="pf-m-link pf-m-inline"}}
+{{#> button button--IsSpan=true button--IsLink=true button--IsInline=true}}
   This is long button text that needs to be a span so that it will wrap inline with the text around it.
 {{/button}}
 Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum velit elementum non.
@@ -84,22 +80,22 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 
 ### Block level
 ```hbs
-{{#> button button--modifier="pf-m-primary pf-m-block"}}
+{{#> button button--IsPrimary=true button--IsBlock=true}}
   Block level button
 {{/button}}
 ```
 
 ### Types
 ```hbs
-{{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+{{#> button button--IsPrimary=true button--IsSubmit=true}}
   Submit
 {{/button}}
 
-{{#> button button--modifier="pf-m-primary" button--IsReset="true"}}
+{{#> button button--IsPrimary=true button--IsReset=true}}
   Reset
 {{/button}}
 
-{{#> button button--modifier="pf-m-primary"}}
+{{#> button button--IsPrimary=true}}
   Default
 {{/button}}
 ```
@@ -107,70 +103,60 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 ### Call to action
 ```hbs
 {{#*inline "cta-buttons"}}
-  {{#> button button--modifier="pf-m-primary pf-m-display-lg"}}
+  {{#> button button--IsPrimary=true }}
     Call to action
   {{/button}}
 
-  {{#> button button--modifier="pf-m-secondary pf-m-display-lg"}}
+  {{#> button button--IsSecondary=true}}
     Call to action
   {{/button}}
 
-  {{#> button button--modifier="pf-m-tertiary pf-m-display-lg"}}
+  {{#> button button--IsTertiary=true}}
     Call to action
   {{/button}}
 
-  {{#> button button--modifier="pf-m-link pf-m-display-lg"}}
+  {{#> button button--IsLink=true button--IsDisplayLg=true button--icon="arrow-right" button-icon--IsEnd=true}}
     Call to action
-    {{#> button-icon button-icon--modifier="pf-m-end"}}
-      <i class="fas fa-arrow-right" aria-hidden="true"></i>
-    {{/button-icon}}
   {{/button}}
 
-  {{#> button button--modifier="pf-m-link pf-m-inline pf-m-display-lg"}}
+  {{#> button button--IsLink=true button--IsInline=true button--IsDisplayLg=true button--icon="arrow-right" button-icon--IsEnd=true}}
     Call to action
-    {{#> button-icon button-icon--modifier="pf-m-end"}}
-      <i class="fas fa-arrow-right" aria-hidden="true"></i>
-    {{/button-icon}}
   {{/button}}
 {{/inline}}
-{{> cta-buttons}}
+{{> cta-buttons button--IsDisplayLg=true}}
 <br><br>
 <strong>disabled</strong>
 <br>
-{{> cta-buttons button--IsDisabled=true}}
+{{> cta-buttons button--IsDisabled=true button--IsDisplayLg=true}}
 ```
 
 ### Progress
 ```hbs
-{{#> button button--modifier="pf-m-primary" button--IsProgress="true"}}
+{{#> button button--IsPrimary=true button--IsProgress=true}}
   Primary loader
 {{/button}}
 
-{{#> button button--modifier="pf-m-primary" button--IsProgress="true" button--IsInProgress="true"}}
+{{#> button button--IsPrimary=true button--IsProgress=true button--IsInProgress=true}}
   Primary loading
 {{/button}}
 <br/>
-{{#> button button--modifier="pf-m-secondary" button--IsProgress="true"}}
+{{#> button button--IsSecondary=true button--IsProgress=true}}
   Secondary loader
 {{/button}}
 
-{{#> button button--modifier="pf-m-secondary" button--IsProgress="true" button--IsInProgress="true"}}
+{{#> button button--IsSecondary=true button--IsProgress=true button--IsInProgress=true}}
   Secondary loading
 {{/button}}
 <br/>
-{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Upload"'}}
-  <i class="fas fa-upload" aria-hidden="true"></i>
-{{/button}}
+{{> button button--IsPlain=true button--aria-label="Upload" button--icon="upload"}}
 
-{{#> button button--modifier="pf-m-plain" button--IsInProgress="true" button--progress-text="Uploading..."}}
-  <i class="fas fa-upload" aria-hidden="true"></i>
-{{/button}}
+{{> button button--IsPlain=true button--icon="upload" button--IsInProgress=true button--progress-text="Uploading..."}}
 <br/>
-{{#> button button--modifier="pf-m-link" button--IsInline="true" button--IsProgress="true"}}
+{{#> button button--IsLink=true button--IsInline=true button--IsProgress=true}}
   Inline loader
 {{/button}}
 
-{{#> button button--modifier="pf-m-link" button--IsInline="true" button--IsProgress="true" button--IsInProgress="true"}}
+{{#> button button--IsLink=true button--IsInline=true button--IsProgress=true button--IsInProgress=true}}
   Inline loading
 {{/button}}
 ```
@@ -178,87 +164,66 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 ### Counts
 ```hbs isBeta
 {{#*inline "button-counts"}}
-{{#> button button--modifier="pf-m-primary" button--attribute='aria-label="View 7 issues"'}}
-  View issues
-  {{#> button-count}}
-    {{#> badge badge--modifier="pf-m-unread"}}
-      7
-    {{/badge}}
-  {{/button-count}}
-{{/button}}
-{{#> button button--modifier="pf-m-primary" button--attribute='aria-label="View 7 issues"'}}
-  View issues
-  {{#> button-count}}
-    {{#> badge badge--modifier="pf-m-read"}}
-      7
-    {{/badge}}
-  {{/button-count}}
-{{/button}}
-
-{{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
-  View issues
-  {{#> button-count}}
-    {{#> badge badge--modifier="pf-m-unread"}}
-      7
-    {{/badge}}
-  {{/button-count}}
-{{/button}}
-{{#> button button--modifier="pf-m-link" button--attribute='aria-label="View 7 issues"'}}
-  View issues
-  {{#> button-count}}
-    {{#> badge badge--modifier="pf-m-read"}}
-      7
-    {{/badge}}
-  {{/button-count}}
-{{/button}}
+  {{#> button button--IsPrimary=true button-count--IsUnread=true}}
+    View issues
+  {{/button}}
+  {{#> button button--IsPrimary=true button-count--IsRead=true}}
+    View issues
+  {{/button}}
+  {{#> button button--IsLink=true button-count--IsUnread=true}}
+    View issues
+  {{/button}}
+  {{#> button button--IsLink=true button-count--IsRead=true}}
+    View issues
+  {{/button}}
 {{/inline}}
 
-{{> button-counts}}
+{{> button-counts button--count="7"}}
 <br>
 <strong>disabled</strong>
 <br>
-{{> button-counts button--IsDisabled=true badge--IsDisabled=true}}
+{{> button-counts button--IsDisabled=true badge--IsDisabled=true button--count="7"}}
 ```
 
 ### Plain with no padding
 ```hbs
-For when a plain/icon button is placed inline with text {{#> button button--modifier="pf-m-plain pf-m-no-padding" button--attribute='aria-label="More info"'}}<i class="fas fa-question-circle" aria-hidden="true"></i>{{/button}}.
+For when a plain/icon button is placed inline with text {{> button button--IsPlain=true button--HasNoPadding=true button--aria-label="More info" button--icon="question-circle"}}.
 ```
 
 ### Stateful
 ```hbs
 <strong>Read</strong>
 <br>
-{{#> button button--modifier="pf-m-stateful pf-m-read"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}items{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsRead=true button--icon="bell"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
 {{/button}}
 
-{{#> button button--modifier="pf-m-stateful pf-m-read pf-m-clicked"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}items{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsRead=true button--IsClicked=true button--icon="bell"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
 {{/button}}
 
 <br><br>
 
 <strong>Unread</strong>
 <br>
-{{#> button button--modifier="pf-m-stateful pf-m-unread"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}unread items{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsUnread=true button--icon="bell"}}
+  10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
-{{#> button button--modifier="pf-m-stateful pf-m-unread pf-m-clicked"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}unread items{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsUnread=true button--IsClicked=true button--icon="bell"}}
+  10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
 <br><br>
 
 <strong>Attention</strong>
 <br>
-{{#> button button--modifier="pf-m-stateful pf-m-attention"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsAttention=true button--icon="bell"}}
+  10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 
-{{#> button button--modifier="pf-m-stateful pf-m-attention pf-m-clicked"}}
-  <i class="fas fa-bell" aria-hidden="true"></i> 10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
+{{#> button button--IsStateful=true button--IsAttention=true button--IsClicked=true button--icon="bell"}}
+  10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 ```
 
@@ -272,13 +237,13 @@ Semantic buttons and links are important for usability as well as accessibility.
 ### Accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `aria-pressed="true or false"` | `.pf-v6-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
+| `aria-pressed="true or false"` | `.pf-v6-c-button` | Indicates that the button is a toggle. When set to true, `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
 | `aria-label="[button label text]"` | `.pf-v6-c-button.pf-m-plain` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-label="[descriptive text]"` | `a.pf-v6-c-button`, `span.pf-v6-c-button.pf-m-link.pf-m-inline` | The button component's text should adequately describe its purpose. If it does not, `aria-label` can provide more detailed interaction information. |
 | `disabled` | `button.pf-v6-c-button` | When a button element is used, indicates that it is unavailable and removes it from keyboard focus. **Required when button is disabled** |
-| `aria-disabled="true"` | `button.pf-v6-c-button` | When a button element is used, indicates that it is unavailable but does not prevent keyboard or hover interactions. Used when a disabled button provides interactive elements like a tooltip. |
-| `aria-disabled="true"` | `a.pf-v6-c-button.pf-m-disabled`, `span.pf-v6-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, indicates that it is unavailable. **Required when element is disabled** |
-| `aria-expanded="true"` | `.pf-v6-c-button.pf-m-expanded` | Indicates that the expanded content element is visible. **Required** |
+| `aria-disabled=true` | `button.pf-v6-c-button` | When a button element is used, indicates that it is unavailable but does not prevent keyboard or hover interactions. Used when a disabled button provides interactive elements like a tooltip. |
+| `aria-disabled=true` | `a.pf-v6-c-button.pf-m-disabled`, `span.pf-v6-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, indicates that it is unavailable. **Required when element is disabled** |
+| `aria-expanded=true` | `.pf-v6-c-button.pf-m-expanded` | Indicates that the expanded content element is visible. **Required** |
 | `tabindex="-1"` | `a.pf-v6-c-button.pf-m-disabled`, `span.pf-v6-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, removes it from keyboard focus. **Required when element is disabled** |
 | `tabindex="0"` | `span.pf-v6-c-button.pf-m-link.pf-m-inline` | Inserts the span into the tab order of the page so that it is focusable. **Required when the element is a span** |
 

--- a/src/patternfly/demos/Button/button-template-form.hbs
+++ b/src/patternfly/demos/Button/button-template-form.hbs
@@ -26,10 +26,7 @@
           Linking account
         {{/button}}
       {{else if button-template-form--IsComplete}}
-        {{#> button button--modifier="pf-m-primary pf-m-start" button--IsSubmit="true"}}
-          {{#> button-icon button-icon--modifier="pf-m-start"}}
-            <i class="fas fa-check-circle" aria-hidden="true"></i>
-          {{/button-icon}}
+        {{#> button button--IsPrimary=true button--IsSubmit="true" button--icon="check-circle"}}
           Logged in
         {{/button}}
       {{else}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/5944
fixes https://github.com/patternfly/patternfly/issues/6245

~~[BackstopJS Report-6.18.24.pdf](https://github.com/user-attachments/files/15891164/BackstopJS.Report-6.18.24.pdf)~~

Backstop visual regression report - [backstop-new-new-6.18.24.pdf](https://github.com/user-attachments/files/15892839/backstop-new-new-6.18.24.pdf)

[First commit](https://github.com/patternfly/patternfly/pull/6806/commits/ff4c7e2822c0298283b10dc4333a9b1788050338) is the CSS change if you want to look at just that. [Second commit](https://github.com/patternfly/patternfly/pull/6806/commits/1ee915881aa07f924420c4040ea39cbeea83641e) is the hbs updates.

I only updated the button component examples/demos (not in any of the other  but the backstop report looks good. A follow up would be to update the use of button in other component examples/demos.

TL;DR of the hbs change creates a similar API to the proposed react component change. The `{{#> button}}`'s `@partial-block` (or "children" in react) will always be the button text. Any time an icon is used, we'll pass it as an hbs attr/prop. With the change in hbs, that means all the other stuff (like count or whatever) will also need to be added via an hbs attr/prop.

