### PR TITLE
feat(page): add fill modifier for page container

### DIFF
--- a/src/patternfly/components/Page/examples/Page.css
+++ b/src/patternfly/components/Page/examples/Page.css
@@ -1,5 +1,5 @@
 /* Because the page component has height:100dvh, override it just for the embedded examples */
-.ws-mdx-content-content [id^=ws-core-c-page-] .ws-preview-html .pf-v6-c-page {
+.ws-mdx-content-content [id^=ws-core-c-page-] .pf-v6-c-page {
   height: min-content;
   min-height: 30em;
 }

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -125,7 +125,7 @@ import './Page.css'
       This section uses <code>.pf-m-fill</code> to fill the available space.
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-no-fill"}}
-      This section uses <code>.pf-m-no-fill</code> to not fill the available space.
+      This section uses <code>.pf-m-no-fill</code> not to fill the available space.
     {{/page-main-section}}
   {{/page-main}}
 {{/page}}
@@ -244,12 +244,12 @@ This component provides the basic chrome for a page, including sidebar and main 
 | -- | -- | -- |
 | `.pf-v6-c-page` | `<div>` | Declares the page component. |
 | `.pf-v6-c-page__sidebar` | `<aside>` | Declares the page sidebar. |
-| `.pf-v6-c-page__sidebar-body` | `<div>` | Creates a wrapper within the sidebar to hold content. **Note: The last/only `.pf-v6-c-page__sidebar-body` element will grow to fill the availble vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.** |
+| `.pf-v6-c-page__sidebar-body` | `<div>` | Creates a wrapper within the sidebar to hold content. **Note: The last/only `.pf-v6-c-page__sidebar-body` element will grow to fill the available vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.** |
 | `.pf-v6-c-page__main` | `<main>` | Declares the main page area. |
 | `.pf-v6-c-page__main-nav` | `<section>` | Creates a container to nest the (deprecated) tertiary navigation component in the main page area. |
 | `.pf-v6-c-page__main-subnav` | `<section>` | Creates a container to nest the horizontal subnav navigation component in the main page area. |
 | `.pf-v6-c-page__main-breadcrumb` | `<section>` | Creates a container to nest the breadcrumb component in the main page area. |
-| `.pf-v6-c-page__main-section` | `<section>` | Creates a section container in the main page area. **Note: The last/only `.pf-v6-c-page__main-section` element will grow to fill the available vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
+| `.pf-v6-c-page__main-section` | `<section>` | Creates a section container in the main page area. **Note: This section will not fill the vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.**  |
 | `.pf-v6-c-page__main-tabs` | `<section>` | Creates a container to nest the tabs component in the main page area. |
 | `.pf-v6-c-page__main-wizard` | `<section>` | Creates a container to nest the wizard component in the main page area. |
 | `.pf-v6-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required** |
@@ -266,8 +266,8 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-light-200` | `.pf-v6-c-page__main-wizard` | Modifies a wizard page section to have a light 200 theme. |
 | `.pf-m-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Modifies the main page section to add padding back in at an optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). Should be used with pf-m-no-padding. |
 | `.pf-m-no-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Removes padding from the main page section at an optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
-| `.pf-m-fill` | `.pf-v6-c-page__main-section`, `.pf-v6-c-page__sidebar-body` | Modifies the element to grow to fill the available space. |
-| `.pf-m-no-fill` | `.pf-v6-c-page__main-section`, `.pf-v6-c-page__sidebar-body` | Modifies the element to not grow to fill the available vertical space. |
+| `.pf-m-fill` | `.pf-v6-c-page__main-container`, `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element to grow to fill the available space. |
+| `.pf-m-no-fill` | `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element not to grow to fill the available vertical space. |
 | `.pf-m-limit-width` | `.pf-v6-c-page__main-section` | Modifies a page section to limit the `max-width` of the content inside. |
 | `.pf-m-align-center` | `.pf-v6-c-page__main-section.pf-m-limit-width` | Modifies a page section body to align center. |
 | `.pf-m-sticky-top{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the top of its container at an optional height breakpoint. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -423,7 +423,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 .#{$page}__main-section,
 .#{$page}__main-group,
 .#{$page}__main-wizard {
-  &:last-child,
   &:only-child,
   &.pf-m-fill {
     flex-grow: 1;

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -324,10 +324,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   border-radius: var(--#{$page}__main-container--BorderRadius);
 
   &.pf-m-fill,
-  &:has(.#{$page}__main-section.pf-m-fill,
-    .#{$page}__main-group.pf-m-fill,
-    .#{$page}__main-wizard,
-    .#{$drawer}) {
+  &:has(.#{$page}__main-wizard) {
     align-self: stretch;
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -313,6 +313,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 .#{$page}__main-container {
   display: flex;
   flex-direction: column;
+  align-self: start;
   max-height: var(--#{$page}__main-container--MaxHeight);
   margin-block-start: 0;
   margin-inline-start: var(--#{$page}__main-container--MarginInlineStart);
@@ -321,6 +322,13 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   background: var(--#{$page}__main-container--BackgroundColor);
   border: var(--#{$page}__main-container--BorderWidth) solid var(--#{$page}__main-container--BorderColor);
   border-radius: var(--#{$page}__main-container--BorderRadius);
+
+  &.pf-m-fill,
+  &:has(.#{$page}__main-section.pf-m-fill,
+    .#{$page}__main-group.pf-m-fill,
+    .#{$page}__main-wizard.pf-m-fill) {
+    align-self: stretch;
+  }
 }
 
 .#{$page}__main-container,

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -326,7 +326,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   &.pf-m-fill,
   &:has(.#{$page}__main-section.pf-m-fill,
     .#{$page}__main-group.pf-m-fill,
-    .#{$page}__main-wizard.pf-m-fill) {
+    .#{$page}__main-wizard,
+    .#{$drawer}) {
     align-self: stretch;
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -421,7 +421,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 .#{$page}__main-section,
 .#{$page}__main-group,
 .#{$page}__main-wizard {
-  &:only-child,
   &.pf-m-fill {
     flex-grow: 1;
   }


### PR DESCRIPTION
Closes #6653 

This changes the main container not to fill unless it either a) has `.pf-m-fill` or b) it contains a section with `.pf-m-fill` 

Note: I'm not sure we really need `.pf-m-no-fill` now but I left it because it might be useful in some instances?

Also, I removed the flex-grow on last child because that causes it to take space even if another section has fill. I don't think the last section should automatically fill. There's one case I see that might have to be adjusted:
```
pf-c-main-container.pf-m-fill
  pf-c-main-section 
  pf-c-main-section pf-m-secondary
```
Here the secondary section wouldn't fill the space, but a `.pf-m-fill` could be added to that section.
Alternatively, if we automatically fill the last section, if you didn't want it to take extra space when another section has a fill, then it would need `.pf-m-no-fill`
