### PR TITLE
feat(page): add context selector container in sidebar and add examples

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -258,6 +258,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-expanded` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the expanded state. |
 | `.pf-m-collapsed` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the collapsed state. |
 | `.pf-m-page-insets` | `.pf-v6-c-page__sidebar-body` | Modifies a sidebar body padding/inset to visually match padding of page elements. |
+| `.pf-m-context-selector` | `.pf-v6-c-page__sidebar-body` | Modifies a sidebar body to contain a context selector. |
 | `.pf-m-inset-none` | `.pf-v6-c-page__sidebar-body` | Removes a sidebar body left/right inset. |
 | `.pf-m-light` | `.pf-v6-c-page__sidebar` | Modifies the sidebar the light variation. **Note: for use with a light themed nav component** |
 | `.pf-m-light` | `.pf-v6-c-page__main-section` | Modifies a main page section to have a light theme. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -48,6 +48,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__sidebar-body--PaddingInlineStart: 0;
   --#{$page}__sidebar-body--m-page-insets--PaddingInlineEnd: var(--#{$page}--inset);
   --#{$page}__sidebar-body--m-page-insets--PaddingInlineStart: var(--#{$page}--inset);
+  --#{$page}__sidebar-body--m-context-selector--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$page}__sidebar-body--m-context-selector--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
     --#{$page}__sidebar--TranslateX: var(--#{$page}__sidebar--xl--TranslateX);
@@ -223,6 +225,11 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   &.pf-m-page-insets {
     --#{$page}__sidebar-body--PaddingInlineEnd: var(--#{$page}__sidebar-body--m-page-insets--PaddingInlineEnd);
     --#{$page}__sidebar-body--PaddingInlineStart: var(--#{$page}__sidebar-body--m-page-insets--PaddingInlineStart);
+  }
+
+  &.pf-m-context-selector {
+    --#{$page}__sidebar-body--PaddingInlineEnd: var(--#{$page}__sidebar-body--m-context-selector--PaddingInlineEnd);
+    --#{$page}__sidebar-body--PaddingInlineStart: var(--#{$page}__sidebar-body--m-context-selector--PaddingInlineStart);
   }
 
   &.pf-m-inset-none {

--- a/src/patternfly/demos/Page/examples/Page.css
+++ b/src/patternfly/demos/Page/examples/Page.css
@@ -1,5 +1,10 @@
+#ws-html-demos-c-page-context-selector-expanded-in-sidebar .pf-v6-c-page__sidebar-body.pf-m-context-selector { 
+  position: relative;
+}
+
 #ws-html-demos-c-page-context-selector-expanded-in-sidebar .pf-v6-c-page__sidebar-body.pf-m-context-selector .pf-v6-c-menu {
   position: absolute;
+  top: 100%;
   left: var(--pf-v6-c-page__sidebar-body--m-context-selector--PaddingInlineStart);
   right: var(--pf-v6-c-page__sidebar-body--m-context-selector--PaddingInlineEnd);
   z-index: var(--pf-t--global--z-index--sm);

--- a/src/patternfly/demos/Page/examples/Page.css
+++ b/src/patternfly/demos/Page/examples/Page.css
@@ -1,0 +1,6 @@
+#ws-html-demos-c-page-context-selector-expanded-in-sidebar .pf-v6-c-page__sidebar-body.pf-m-context-selector .pf-v6-c-menu {
+  position: absolute;
+  left: var(--pf-v6-c-page__sidebar-body--m-context-selector--PaddingInlineStart);
+  right: var(--pf-v6-c-page__sidebar-body--m-context-selector--PaddingInlineEnd);
+  z-index: var(--pf-t--global--z-index--sm);
+}

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -141,10 +141,10 @@ import './Page.css'
 
 ### Context selector in sidebar
 ```hbs isFullscreen
-{{> page-template page-template--id="nav-basic-example" page-template-sidebar--hasContextSelector='true'}}
+{{> page-template page-template--id="page-context-selector" page-template-sidebar--HasContextSelector=true}}
 ```
 
 ### Context selector expanded in sidebar
 ```hbs isFullscreen
-{{> page-template page-template--id="nav-basic-example" page-template-sidebar--hasContextSelector='true' page-template-sidebar--hasContextSelectorExpanded='true'}}
+{{> page-template page-template--id="page-context-selector-expanded" page-template-sidebar--HasContextSelector=true page-template-context-selector--IsExpanded=true}}
 ```

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -4,6 +4,8 @@ section: components
 wrapperTag: div
 ---
 
+import './Page.css'
+
 ## Demos
 
 ### Basic
@@ -135,4 +137,14 @@ wrapperTag: div
     {{/card}}
   {{/page-main-section}}
 {{/inline}}
+```
+
+### Context selector in sidebar
+```hbs isFullscreen
+{{> page-template page-template--id="nav-basic-example" page-template-sidebar--hasContextSelector='true'}}
+```
+
+### Context selector expanded in sidebar
+```hbs isFullscreen
+{{> page-template page-template--id="nav-basic-example" page-template-sidebar--hasContextSelector='true' page-template-sidebar--hasContextSelectorExpanded='true'}}
 ```

--- a/src/patternfly/demos/Page/page-template-context-selector.hbs
+++ b/src/patternfly/demos/Page/page-template-context-selector.hbs
@@ -1,15 +1,9 @@
-{{#> menu-toggle menu-toggle--modifier="pf-m-full-width" menu-toggle--IsExpanded=page-template-sidebar--hasContextSelectorExpanded}}
-  {{#> menu-toggle-icon}}
-    <i class="fas fa-fw fa-cogs" aria-hidden="true"></i>
-  {{/menu-toggle-icon}}
-  {{#> menu-toggle-text}}
-    Administrator
-  {{/menu-toggle-text}}
-  {{#> menu-toggle-controls}}
-    {{> menu-toggle-toggle-icon}}
-  {{/menu-toggle-controls}}
-{{/menu-toggle}}
-{{#if page-template-sidebar--hasContextSelectorExpanded}}
+{{> menu-toggle
+  menu-toggle--modifier="pf-m-full-width"
+  menu-toggle--IsExpanded=page-template-context-selector--IsExpanded
+  menu-toggle--text="Administrator"
+  menu-toggle--icon="cogs fa-fw"}}
+{{#if page-template-context-selector--IsExpanded}}
   {{#> menu}}
     {{#> menu-content}}
       {{#> menu-list}}

--- a/src/patternfly/demos/Page/page-template-context-selector.hbs
+++ b/src/patternfly/demos/Page/page-template-context-selector.hbs
@@ -1,0 +1,55 @@
+{{#> menu-toggle menu-toggle--modifier="pf-m-full-width" menu-toggle--IsExpanded=page-template-sidebar--hasContextSelectorExpanded}}
+  {{#> menu-toggle-icon}}
+    <i class="fas fa-fw fa-cogs" aria-hidden="true"></i>
+  {{/menu-toggle-icon}}
+  {{#> menu-toggle-text}}
+    Administrator
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+{{#if page-template-sidebar--hasContextSelectorExpanded}}
+  {{#> menu}}
+    {{#> menu-content}}
+      {{#> menu-list}}
+        {{#> menu-list-item}}
+          {{#> menu-item}}
+            {{#> menu-item-main}}
+              {{#> menu-item-icon}}
+                <i class="fas fa-fw fa-cogs" aria-hidden="true"></i>
+              {{/menu-item-icon}}
+              {{#> menu-item-text}}
+                Administrator
+              {{/menu-item-text}}
+            {{/menu-item-main}}
+          {{/menu-item}}
+        {{/menu-list-item}}
+        {{#> menu-list-item}}
+          {{#> menu-item}}
+            {{#> menu-item-main}}
+              {{#> menu-item-icon}}
+                <i class="fas fa-fw fa-code" aria-hidden="true"></i>
+              {{/menu-item-icon}}
+              {{#> menu-item-text}}
+                Developer
+              {{/menu-item-text}}
+            {{/menu-item-main}}
+          {{/menu-item}}
+        {{/menu-list-item}}
+        {{#> menu-list-item}}
+          {{#> menu-item}}
+            {{#> menu-item-main}}
+              {{#> menu-item-icon}}
+              <i class="fas fa-fw fa-cube" aria-hidden="true"></i>
+              {{/menu-item-icon}}
+              {{#> menu-item-text}}
+                User
+              {{/menu-item-text}}
+            {{/menu-item-main}}
+          {{/menu-item}}
+        {{/menu-list-item}}
+      {{/menu-list}}
+    {{/menu-content}}
+  {{/menu}}
+{{/if}}

--- a/src/patternfly/demos/Page/page-template-sidebar.hbs
+++ b/src/patternfly/demos/Page/page-template-sidebar.hbs
@@ -1,5 +1,5 @@
 {{#> page-sidebar page-sidebar--ExcludeSidebarBody=true}}
-  {{#if page-template-sidebar--hasContextSelector}}
+  {{#if page-template-sidebar--HasContextSelector}}
     {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-context-selector"}}
       {{> page-template-context-selector}}
     {{/page-sidebar-body}}

--- a/src/patternfly/demos/Page/page-template-sidebar.hbs
+++ b/src/patternfly/demos/Page/page-template-sidebar.hbs
@@ -1,4 +1,9 @@
 {{#> page-sidebar page-sidebar--ExcludeSidebarBody=true}}
+  {{#if page-template-sidebar--hasContextSelector}}
+    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-context-selector"}}
+      {{> page-template-context-selector}}
+    {{/page-sidebar-body}}
+  {{/if}}
   {{#if page-template-sidebar--nav--IsExpandable}}
     {{#> page-sidebar-body}}
       {{> page-template-expandable-nav}}


### PR DESCRIPTION
This adds an example for a context selector in the page sidebar, and another with it expanded.
It adds a container in the sidebar modified to hold a context selector.

Fixes #5776 