### PR TITLE
chore(fonts): update font names and remove extra tokens

### DIFF
--- a/src/patternfly/base/patternfly-fonts.scss
+++ b/src/patternfly/base/patternfly-fonts.scss
@@ -1,7 +1,7 @@
 @use '../sass-utilities' as *;
 
 @font-face {
-  font-family: RedHatTextVF;
+  font-family: "Red Hat Text";
   font-style: normal;
   font-weight: 400 500;
   src: url("#{$pf-v6-global--font-path}/RedHatText/RedHatTextVF.woff2") format("woff2-variations");
@@ -9,7 +9,7 @@
 }
 
 @font-face {
-  font-family: RedHatTextVF;
+  font-family: "Red Hat Text";
   font-style: italic;
   font-weight: 400 500;
   src: url("#{$pf-v6-global--font-path}/RedHatText/RedHatTextVF-Italic.woff2") format("woff2-variations");
@@ -17,7 +17,7 @@
 }
 
 @font-face {
-  font-family: RedHatDisplayVF;
+  font-family: "Red Hat Display";
   font-style: normal;
   font-weight: 400 700;
   src: url("#{$pf-v6-global--font-path}/RedHatDisplay/RedHatDisplayVF.woff2") format("woff2-variations");
@@ -25,7 +25,7 @@
 }
 
 @font-face {
-  font-family: RedHatDisplayVF;
+  font-family: "Red Hat Display";
   font-style: italic;
   font-weight: 400 700;
   src: url("#{$pf-v6-global--font-path}/RedHatDisplay/RedHatDisplayVF-Italic.woff2") format("woff2-variations");
@@ -33,7 +33,7 @@
 }
 
 @font-face {
-  font-family: RedHatMonoVF;
+  font-family: "Red Hat Mono";
   font-style: normal;
   font-weight: 400;
   src: url("#{$pf-v6-global--font-path}/RedHatMono/RedHatMonoVF.woff2") format("woff2-variations");
@@ -41,7 +41,7 @@
 }
 
 @font-face {
-  font-family: RedHatMonoVF;
+  font-family: "Red Hat Mono";
   font-style: italic;
   font-weight: 400;
   src: url("#{$pf-v6-global--font-path}/RedHatMono/RedHatMonoVF-Italic.woff2") format("woff2-variations");

--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -1,15 +1,9 @@
 // LOCAL TOKENS
 
 @mixin pf-v6-tokens {
-  // Missing base font tokens
-  --pf-t--global--font--weight--body--100: 400; // not currently used
-  --pf-t--global--font--weight--body--200: 500;
-  --pf-t--global--font--weight--heading--100: 700; // not currently used
-  --pf-t--global--font--weight--heading--200: 700;
-
-  // Missing semantic font tokens
-  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--body--200);
-  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--heading--200);
+  // TODO Missing semantic font tokens not getting exported from Figma properly
+  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--200);
+  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--400);
 
   // TODO Maintaining these in addition to the h1-h6 sizes
   --pf-t--global--font--size--heading--xs: var(--pf-t--global--font--size--md);

--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -1,29 +1,14 @@
-// FONT TOKENS
-// Manually added from hackathon values
-// Currently not being exported from Figma because they are styles rather than variables
-// The ability to make font variables is reportedly coming by the end of the year
+// LOCAL TOKENS
 
 @mixin pf-v6-tokens {
-  // Base tokens for fonts
-  --pf-t--global--font--family--100: redhattextvf, redhattext, helvetica, arial, sans-serif;
-  --pf-t--global--font--family--200: redhatdisplayvf, redhatdisplay, helvetica, arial, sans-serif;
-  --pf-t--global--font--family--300: redhatmonovf, redhatmono, liberationmono, consolas, sfmono-regular, menlo, monaco, courier new, monospace;
-  --pf-t--global--font--line-height--100: 1.3;
-  --pf-t--global--font--line-height--200: 1.5;
-  --pf-t--global--font--weight--body--100: 400;
+  // Missing base font tokens
+  --pf-t--global--font--weight--body--100: 400; // not currently used
   --pf-t--global--font--weight--body--200: 500;
-  --pf-t--global--font--weight--heading--100: 700;
+  --pf-t--global--font--weight--heading--100: 700; // not currently used
   --pf-t--global--font--weight--heading--200: 700;
 
-  // Semantic tokens for fonts
-  --pf-t--global--font--family--body: var(--pf-t--global--font--family--100);
-  --pf-t--global--font--family--heading: var(--pf-t--global--font--family--200);
-  --pf-t--global--font--family--mono: var(--pf-t--global--font--family--300);
-  --pf-t--global--font--line-height--body: var(--pf-t--global--font--line-height--200);
-  --pf-t--global--font--line-height--heading: var(--pf-t--global--font--line-height--100);
-  --pf-t--global--font--weight--body: var(--pf-t--global--font--weight--body--100);
+  // Missing semantic font tokens
   --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--body--200);
-  --pf-t--global--font--weight--heading: var(--pf-t--global--font--weight--heading--100);
   --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--heading--200);
 
   // TODO Maintaining these in addition to the h1-h6 sizes


### PR DESCRIPTION
Fixes #6790 

Updates font names to match tokens (include spaces)
Also removes font tokens from the local token file since they are now in the default token file from Figma.

Note: There are two local tokens for font weight that are used but not in Figma - `--pf-t--global--font--weight--body--bold` and `--pf-t--global--font--weight--heading--bold`. These point to base tokens that also don't exist. (see diff for details) @lboehling should these semantic font weight tokens exist and should they point to existing base font weigh tokens?
