### PR TITLE
fix(layouts): updating gutters tokens

### DIFF
--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -13,7 +13,7 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
   --#{$flex}--m-row--AlignItems: baseline;
   --#{$flex}--m-row-reverse--AlignItems: baseline;
   --#{$flex}--item--Order: 0;
-  --#{$flex}--spacer--column--base: var(--pf-t--global--spacer--lg); // default spacer/gap for columns
+  --#{$flex}--spacer--column--base: var(--pf-t--global--spacer--gutter--default); // default spacer/gap for columns
   --#{$flex}--spacer--row--base: var(--pf-t--global--spacer--sm); // default spacer/gap for rows
   --#{$flex}--RowGap: var(--#{$flex}--spacer--row--base);
   --#{$flex}--ColumnGap: 0;

--- a/src/patternfly/layouts/Gallery/gallery.scss
+++ b/src/patternfly/layouts/Gallery/gallery.scss
@@ -3,7 +3,7 @@
 $pf-v6-l-gallery--breakpoint-map: build-breakpoint-map();
 
 :where(:root, .#{$gallery}) {
-  --#{$gallery}--m-gutter--GridGap: var(--pf-t--global--spacer--lg);
+  --#{$gallery}--m-gutter--GridGap: var(--pf-t--global--spacer--gutter--default);
   --#{$gallery}--GridTemplateColumns--min: 250px;
   --#{$gallery}--GridTemplateColumns--minmax--min: var(--#{$gallery}--GridTemplateColumns--min);
   --#{$gallery}--GridTemplateColumns--max: 1fr;

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -42,7 +42,7 @@ $pf-v6-l-grid--breakpoint-map: build-breakpoint-map(); // currently only used fo
 
 // Grid base
 :where(:root, .#{$grid}) {
-  --#{$grid}--m-gutter--GridGap: var(--pf-t--global--spacer--lg);
+  --#{$grid}--m-gutter--GridGap: var(--pf-t--global--spacer--gutter--default);
   --#{$grid}__item--GridColumnStart: auto;
   --#{$grid}__item--GridColumnEnd: span 12;
   --#{$grid}--item--Order: 0;

--- a/src/patternfly/layouts/Level/level.scss
+++ b/src/patternfly/layouts/Level/level.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$level}) {
-  --#{$level}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
+  --#{$level}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 
 .#{$level} {

--- a/src/patternfly/layouts/Split/split.scss
+++ b/src/patternfly/layouts/Split/split.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$split}) {
-  --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
+  --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 
 .#{$split} {

--- a/src/patternfly/layouts/Stack/stack.scss
+++ b/src/patternfly/layouts/Stack/stack.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$stack}) {
-  --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--lg);
+  --#{$stack}--m-gutter--Gap: var(--pf-t--global--spacer--gutter--default);
 }
 
 .#{$stack} {


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/6771

One question I have is the Flex layout update. Not sure if this is intended @lboehling ?

`  --#{$flex}--spacer--column--base: var(--pf-t--global--spacer--gutter--default); // default spacer/gap for columns`

That trickles down as the base for other spacers. It was using `spacer--lg` before the update.
