### PR TITLE
fix(tree-table): fixed cell border mobile positioning

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -269,6 +269,7 @@
     }
 
     &::before {
+      position: revert;
       font-weight: bold;
       text-align: start;
       content: attr(data-label);

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -257,10 +257,15 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     }
 
     &::before {
+      position: revert;
       font-weight: var(--pf-t--global--font--weight--body--bold);
       text-align: start;
       content: attr(data-label);
     }
+  }
+
+  .#{$table}__tr > :where(th, td).pf-m-border-right::before {
+    border-inline-end: 0;
   }
 
   // - Table tree view tr tree view details expanded


### PR DESCRIPTION
closes #6283 

@rebeccaalpert bordered cells paint a border in mobile view. This PR prevents that from happening. Does this address you issue fully? 