### PR TITLE
feat(MenuToggle): split action toggle text modifier

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -249,7 +249,7 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 ```
 
-### Split button (checkbox with toggle text)
+### Split button (checkbox with label)
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-example" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check check-label--text="10 selected"}}
@@ -276,6 +276,45 @@ import './MenuToggle.css'
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check check-label--text="10 selected" check--IsDisabled=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+```
+
+### Split button (checkbox with toggle button text)
+```hbs
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+&nbsp;
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+&nbsp;
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
     {{/menu-toggle-controls}}
@@ -643,6 +682,7 @@ import './MenuToggle.css'
 | `.pf-v6-c-menu-toggle__button` | `<button>` | Initiates the menu toggle button. |
 | `.pf-m-split-button` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the split button variation. |
 | `.pf-m-action` | `.pf-v6-c-menu-toggle.pf-m-split-button` | Modifies the menu toggle component for the action, split button variation. |
+| `.pf-m-text` | `.pf-v5-c-menu-toggle__button` | Modifies the menu toggle component split button variation with text. |
 | `.pf-m-disabled` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the disabled variation. |
 | `.pf-m-primary` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the primary variation. |
 | `.pf-m-secondary` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -285,7 +285,7 @@ import './MenuToggle.css'
 
 ### Split button (checkbox with toggle button text)
 ```hbs
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
@@ -297,7 +297,7 @@ import './MenuToggle.css'
   {{/menu-toggle-button}}
 {{/menu-toggle}}
 &nbsp;
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true"}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
@@ -309,7 +309,7 @@ import './MenuToggle.css'
   {{/menu-toggle-button}}
 {{/menu-toggle}}
 &nbsp;
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-expanded-example" menu-toggle--IsDiv="true" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-expanded-example"  menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -682,7 +682,7 @@ import './MenuToggle.css'
 | `.pf-v6-c-menu-toggle__button` | `<button>` | Initiates the menu toggle button. |
 | `.pf-m-split-button` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the split button variation. |
 | `.pf-m-action` | `.pf-v6-c-menu-toggle.pf-m-split-button` | Modifies the menu toggle component for the action, split button variation. |
-| `.pf-m-text` | `.pf-v5-c-menu-toggle__button` | Modifies the menu toggle component split button variation with text. |
+| `.pf-m-text` | `.pf-v6-c-menu-toggle__button` | Modifies the menu toggle component split button variation with text. |
 | `.pf-m-disabled` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the disabled variation. |
 | `.pf-m-primary` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the primary variation. |
 | `.pf-m-secondary` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |

--- a/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
@@ -7,9 +7,7 @@
     {{#> check check--type="label" check--attribute=(concat 'for="' menu-toggle--check--id '-input"') check--IsDisabled=menu-toggle--IsDisabled}}
       {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input"')}}
       {{#if menu-toggle--check--text}}
-        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}{{menu-toggle--check--text}}{{/check-label}}
-      {{else}}
-        {{#> check-label check-label--IsDisabled=menu-toggle--IsDisabled check-label--type="span"}}Label{{/check-label}}
+        {{#> check-label check-label--type="span" check-label--IsDisabled=menu-toggle--IsDisabled}}{{menu-toggle--check--text}}{{/check-label}}
       {{/if}}
     {{/check}}
   {{/if}}

--- a/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-button.hbs
@@ -1,4 +1,4 @@
-<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}}"
+<button class="{{pfv}}menu-toggle__button{{#if menu-toggle-button--modifier}} {{menu-toggle-button--modifier}}{{/if}}  {{#if menu-toggle-button--IsTextToggle}}pf-m-text{{/if}}"
   type="button"
   {{#if menu-toggle-button--IsToggle}}
     aria-expanded="{{#if menu-toggle--IsExpanded}}true{{else}}false{{/if}}"

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -135,7 +135,7 @@
   --#{$menu-toggle}__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
-  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
+  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // Menu toggle plain
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -479,8 +479,6 @@
   }
 
   &.pf-m-text {
-    --#{$menu-toggle}--m-split-button--last-child--PaddingLeft: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);
-
     display: inline-flex;
     align-items: baseline;
     padding-inline-start: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -135,7 +135,7 @@
   --#{$menu-toggle}__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
-  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--pf-t--global--spacer--sm);
 
   // Menu toggle plain
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -135,6 +135,7 @@
   --#{$menu-toggle}__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
+  --#{$menu-toggle}__button--m-text--PaddingInlineStart: var(--#{$pf-global}--spacer--xs);
 
   // Menu toggle plain
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);
@@ -475,6 +476,14 @@
 
   &:has(.#{$menu-toggle}__controls) {
     padding-inline-start: 0;
+  }
+
+  &.pf-m-text {
+    --#{$menu-toggle}--m-split-button--last-child--PaddingLeft: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);
+
+    display: inline-flex;
+    align-items: baseline;
+    padding-inline-start: var(--#{$menu-toggle}__button--m-text--PaddingInlineStart);
   }
 }
 


### PR DESCRIPTION
Closes #6778.

Same changes as https://github.com/patternfly/patternfly/pull/6668 but for v6 branch.