### PR TITLE
fix(toolbar): changed toolbar `inline-padding` default to zero, updated toolbar demo examples

### DIFF
--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -74,7 +74,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 .#{$masthead} {
   .#{$toolbar} {
     --#{$toolbar}--Width: var(--#{$masthead}--c-toolbar--Width);
-    --#{$toolbar}__content--PaddingBlock: var(--#{$masthead}--c-toolbar--PaddingBlock);
+    --#{$toolbar}--PaddingBlockEnd: 0;
     --#{$toolbar}__content--PaddingInline: var(--#{$masthead}--c-toolbar--PaddingInline);
     --#{$toolbar}__content--MinWidth: 0;
   }

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -132,10 +132,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   line-height: var(--#{$toolbar}--LineHeight);
   background-color: var(--#{$toolbar}--BackgroundColor);
 
-  &:only-child {
-    padding-block-end: 0;
-  }
-
   // - Toolbar sticky
   &.pf-m-sticky {
     --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 :where(:root, .#{$toolbar}) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlockStart: 0;
-  --#{$toolbar}--PaddingBlockEnd: 0;
+  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingInlineStart: 0;
   --#{$toolbar}--PaddingInlineEnd: 0;
   --#{$toolbar}--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -41,8 +41,8 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // * Toolbar content
   --#{$toolbar}__content--RowGap: var(--pf-t--global--spacer--md);
-  --#{$toolbar}__content--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$toolbar}__content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$toolbar}__content--PaddingInlineStart: 0;
+  --#{$toolbar}__content--PaddingInlineEnd: 0;
 
   // * Toolbar content section
   --#{$toolbar}__content-section--RowGap: var(--pf-t--global--spacer--gap--group--vertical);
@@ -131,6 +131,10 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   font-size: var(--#{$toolbar}--FontSize);
   line-height: var(--#{$toolbar}--LineHeight);
   background-color: var(--#{$toolbar}--BackgroundColor);
+
+  &:only-child {
+    padding-block-end: 0;
+  }
 
   // - Toolbar sticky
   &.pf-m-sticky {
@@ -247,6 +251,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // - Toolbar action group inline
   &.pf-m-action-group-inline {
+    flex-wrap: wrap;
     column-gap: var(--#{$toolbar}__group--m-action-group-inline--ColumnGap);
   }
 

--- a/src/patternfly/demos/CardView/examples/CardView.md
+++ b/src/patternfly/demos/CardView/examples/CardView.md
@@ -9,10 +9,9 @@ section: patterns
 {{> page-template page-template--id="card-view-basic-example" page-template-sidebar--nav--IsExpandable="true"}}
 
 {{#* inline "page-template-section"}}
-  {{#> page-main-section page-main-section--modifier="pf-m-light pf-m-no-padding"}}
+  {{#> page-main-section page-main-section--modifier="pf-m-light"}}
     {{> toolbar-template
         toolbar-template--id=(concat page-template--id '-toolbar')
-        toolbar-template--modifier="pf-m-page-insets"
         toolbar-template--HasToggleGroup=true
         toolbar-template--HasBulkSelect=true
         toolbar-template--HasOverflowMenu=true

--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -26,7 +26,7 @@ wrapperTag: div
 
 {{#*inline "masthead-template-content-toolbar-content"}}
   {{#> toolbar-content-section}}
-    {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+    {{#> toolbar-group toolbar--IsFilterGroup=true}}
       {{#> toolbar-item}}
         {{> masthead-template-context-selector}}
       {{/toolbar-item}}
@@ -54,7 +54,7 @@ wrapperTag: div
 
 {{#*inline "masthead-template-content-toolbar-content"}}
   {{#> toolbar-content-section}}
-    {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show pf-m-align-end"}}
+    {{#> toolbar-group toolbar-group--IsToggleGroup=true toolbar-group--modifier="pf-m-show pf-m-align-end"}}
       {{> toolbar-toggle toolbar-toggle--IsExpanded="true"}}
       {{> toolbar-item-search-filter button--id=(concat masthead--id '-content')}}
     {{/toolbar-group}}
@@ -72,7 +72,7 @@ wrapperTag: div
 
 {{#*inline "masthead-template-content-toolbar-content"}}
   {{#> toolbar-content-section}}
-    {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show-on-lg pf-m-align-end"}}
+    {{#> toolbar-group toolbar-group--IsToggleGroup=true toolbar-group--modifier="pf-m-show-on-lg pf-m-align-end"}}
       {{> toolbar-toggle toolbar-toggle--IsExpanded="true"}}
       {{> toolbar-item-search-filter button--id=(concat masthead--id '-content')}}
     {{/toolbar-group}}
@@ -160,7 +160,7 @@ wrapperTag: div
       {{> menu-toggle menu-toggle--IsPlain=true menu-toggle--attribute='aria-label="Actions"' menu-toggle--icon="ellipsis-v"}}
     {{/toolbar-item}}
   {{/toolbar-content-section}}
-  {{#> toolbar-expandable-content toolbar--id=(concat masthead--id '-toolbar') toolbar-expandable-content--IsExpanded="true"}}
+  {{#> toolbar-expandable-content toolbar--id=(concat masthead--id '-toolbar') toolbar-expandable-content--IsExpanded=true}}
     {{> toolbar-item-search-filter button--id=(concat masthead--id '-expandable-content')}}
   {{/toolbar-expandable-content}}
 {{/inline}}

--- a/src/patternfly/demos/Masthead/examples/Masthead.md
+++ b/src/patternfly/demos/Masthead/examples/Masthead.md
@@ -26,7 +26,7 @@ wrapperTag: div
 
 {{#*inline "masthead-template-content-toolbar-content"}}
   {{#> toolbar-content-section}}
-    {{#> toolbar-group toolbar--IsFilterGroup=true}}
+    {{#> toolbar-group toolbar-group--IsFilterGroup=true}}
       {{#> toolbar-item}}
         {{> masthead-template-context-selector}}
       {{/toolbar-item}}

--- a/src/patternfly/demos/Masthead/masthead-template-content-icon-group.hbs
+++ b/src/patternfly/demos/Masthead/masthead-template-content-icon-group.hbs
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 {{#> toolbar-group toolbar-group--IsActionGroupPlain=true toolbar-group--id=(concat masthead-template--id '-icon-group-') toolbar-group--modifier="pf-m-align-end pf-m-spacer-none pf-m-spacer-md-on-md"}}
+=======
+{{#> toolbar-group toolbar-group--id=(concat masthead-template--id '-icon-group-') toolbar-group--IsActionGroupPlain=true toolbar-group--modifier="pf-m-align-end pf-m-spacer-none pf-m-spacer-md-on-md"}}
+>>>>>>> 304b592b0 (fix(toolbar): added toolbar padding to page layout, removed default padding, updated demos)
   {{#if masthead-template--HasNotificationDrawer}}
     {{#> toolbar-item}}
       {{> notification-badge notification-badge--IsExpanded=notification-drawer--IsExpanded notification-badge--IsAttention=notification-drawer--IsAttention notification-badge--IsUnread=notification-drawer--IsUnread}}

--- a/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
+++ b/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
@@ -23,7 +23,6 @@ wrapperTag: div
         {{#> drawer-content}}
           {{> toolbar-template
               toolbar-template--id=(concat drawer--id '-toolbar')
-              toolbar-template--modifier="pf-m-page-insets"
               toolbar-template--HasFilterGroup=true
               toolbar-template--HasOverflowMenu=true
               toolbar-template--HasSearchFilter=true
@@ -72,7 +71,6 @@ wrapperTag: div
         {{#> drawer-content}}
           {{> toolbar-template
               toolbar-template--id=(concat drawer--id '-toolbar')
-              toolbar-template--modifier="pf-m-page-insets"
               toolbar-template--HasFilterGroup=true
               toolbar-template--HasOverflowMenu=true
               toolbar-template--HasSearchFilter=true
@@ -117,7 +115,6 @@ wrapperTag: div
         {{#> drawer-content drawer-content--modifier="pf-m-no-background" drawer-body--modifier="pf-m-padding"}}
           {{> toolbar-template
               toolbar-template--id=(concat drawer--id '-toolbar')
-              toolbar-template--modifier="pf-m-page-insets"
               toolbar-template--HasFilterGroup=true
               toolbar-template--HasOverflowMenu=true
               toolbar-template--HasSortButton=true
@@ -157,7 +154,6 @@ wrapperTag: div
       {{#> drawer-section}}
         {{> toolbar-template
             toolbar-template--id=(concat drawer--id '-toolbar')
-            toolbar-template--modifier="pf-m-page-insets"
             toolbar-template--HasBulkSelect=true
             toolbar-template--HasSearchFilter=true
             toolbar-template--HasSortButton=true
@@ -283,7 +279,6 @@ wrapperTag: div
       {{#> drawer-content}}
         {{> toolbar-template
             toolbar-template--id=(concat drawer--id '-toolbar')
-            toolbar-template--modifier="pf-m-page-insets"
             toolbar-template--HasMenu=true
             toolbar-template--HasOverflowMenu=true
             toolbar-template--HasOverflowMenuSecondButton=true

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -308,10 +308,9 @@ section: components
 
 {{#* inline 'page-template-section'}}
   {{#> tabs-template tabs-template--id=(concat page-template--id '-tabs')}}
-    {{#> page-main-section page-main-section--modifier='pf-m-no-padding pf-m-light' tab-content--id=(concat tabs-template--id '-tabs')}}
+    {{#> page-main-section page-main-section--modifier='pf-m-light' tab-content--id=(concat tabs-template--id '-tabs')}}
       {{> toolbar-template
           toolbar-template--id=(concat tabs-template--id '-toolbar')
-          toolbar-template--modifier='pf-m-page-insets'
           toolbar-template--HasToggleGroup=true
           toolbar-template--HasFilter=true
           toolbar-template--HasNoPagination=true

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -35,7 +35,7 @@ import './Toolbar.css'
           {{#> toolbar-content-section}}
             {{#> toolbar-group toolbar-group--IsToggleGroup=true toolbar-group--modifier="pf-m-show-on-lg"}}
               {{> toolbar-toggle}}
-              {{#> toolbar-group reset='toolbar-group--IsToggleGroup' toolbar-group--modifier="pf-m-filter-group"}}
+              {{#> toolbar-group  toolbar-group--IsFilterGroup=true reset='toolbar-group--IsToggleGroup'}}
                 {{#> toolbar-item}}
                   {{#> input-group input-group--attribute=(concat 'aria-label="search filter" role="group"')}}
                     {{#> input-group-item}}

--- a/src/patternfly/demos/Toolbar/toolbar-template-content.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template-content.hbs
@@ -24,7 +24,7 @@
 
 {{!-- filter group --}}
 {{#if toolbar-template--HasFilterGroup}}
-  {{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+  {{#> toolbar-group toolbar-group--IsFilterGroup=true}}
     {{#> toolbar-item}}
       {{> menu-toggle menu-toggle--text="Status" menu-toggle--id=(concat toolbar--id '-select-checkbox-status')}}
     {{/toolbar-item}}

--- a/src/patternfly/demos/Toolbar/toolbar-template-filter-group.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template-filter-group.hbs
@@ -1,4 +1,4 @@
-{{#> toolbar-group toolbar-group--modifier="pf-m-filter-group"}}
+{{#> toolbar-group toolbar-group--IsFilterGroup=true}}
   {{#> toolbar-item}}
     {{> menu-toggle menu-toggle--text="Status" menu-toggle--id=(concat toolbar--id '-select-checkbox-status')}}
   {{/toolbar-item}}

--- a/src/patternfly/demos/Toolbar/toolbar-template.hbs
+++ b/src/patternfly/demos/Toolbar/toolbar-template.hbs
@@ -31,7 +31,7 @@ Options: [
 
       {{!-- toggle group --}}
       {{#if toolbar-template--HasToggleGroup}}
-        {{#> toolbar-group toolbar-group--modifier="pf-m-toggle-group pf-m-show-on-xl"}}
+        {{#> toolbar-group toolbar-group--IsToggleGroup=true toolbar-group--modifier="pf-m-show-on-xl"}}
           {{> toolbar-toggle}}
           {{> toolbar-template-content}}
         {{/toolbar-group}}


### PR DESCRIPTION
closes #6889 

* updated `toolbar-group--modifier="pf-m-icon-button-group"` to `toolbar-group--IsActionGroupPlain=true`
* updated `toolbar-group--modifier="pf-m-filter-group"` to `toolbar--IsFilterGroup=true`
* updated `toolbar-group--modifier="pf-m-icon-button-group"` to `toolbar-group--IsActionGroupPlain=true`
* removed `page-main-section--modifier='pf-m-no-padding` from demos/examples
* updated demo padding
* set toolbar padding inline to zero