### PR TITLE
fix(tokens): pull in updates to semantic tokens

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -32,6 +32,7 @@
     }],
     "color-function-notation": null,
     "color-named": "never",
+    "color-hex-length": null,
     "comment-empty-line-before": ["always", {
       "except": ["first-nested"],
       "ignore": [
@@ -88,6 +89,7 @@
     "selector-max-id": 0,
     "selector-max-type": 2,
     "selector-nested-pattern": "^(?!.*&[-_])",
-    "selector-no-qualifying-type": true
+    "selector-no-qualifying-type": true,
+    "value-keyword-case": ["lower", { "ignoreKeywords": ["Helvetica", "Arial", "Courier"] }]
   }
 }

--- a/src/patternfly/base/tokens/tokens-charts-dark.scss
+++ b/src/patternfly/base/tokens/tokens-charts-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Jul 2024 15:40:40 GMT
+// Generated on Tue, 16 Jul 2024 23:44:44 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-charts.scss
+++ b/src/patternfly/base/tokens/tokens-charts.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Jul 2024 15:40:40 GMT
+// Generated on Tue, 16 Jul 2024 23:44:44 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-dark.scss
+++ b/src/patternfly/base/tokens/tokens-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Jul 2024 15:40:40 GMT
+// Generated on Tue, 16 Jul 2024 23:44:44 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);

--- a/src/patternfly/base/tokens/tokens-default.scss
+++ b/src/patternfly/base/tokens/tokens-default.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Jul 2024 15:40:40 GMT
+// Generated on Tue, 16 Jul 2024 23:44:44 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);
@@ -55,9 +55,9 @@
   --pf-t--global--duration--50: 50ms;
   --pf-t--global--duration--500: 500ms;
   --pf-t--global--duration--600: 600ms;
-  --pf-t--global--font--family--100: "Red Hat Text", "RedHatText", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", helvetica, arial, sans-serif;
-  --pf-t--global--font--family--200: "Red Hat Display", "RedHatDisplay", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", helvetica, arial, sans-serif;
-  --pf-t--global--font--family--300: "Red Hat Mono", "RedHatMono", "Courier New", courier, monospace;
+  --pf-t--global--font--family--100: "Red Hat Text", "RedHatText", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--200: "Red Hat Display", "RedHatDisplay", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--300: "Red Hat Mono", "RedHatMono", "Courier New", Courier, monospace;
   --pf-t--global--font--line-height--100: 1.3;
   --pf-t--global--font--line-height--200: 1.5;
   --pf-t--global--font--size--100: 0.75rem;
@@ -453,10 +453,9 @@
   --pf-t--global--motion--duration--slide-out--short: var(--pf-t--global--motion--duration--lg);
   --pf-t--global--spacer--action--horizontal--compact: var(--pf-t--global--spacer--md);
   --pf-t--global--spacer--action--horizontal--default: var(--pf-t--global--spacer--lg);
-  --pf-t--global--spacer--action--horizontal--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--action--horizontal--plain--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--action--horizontal--plain--default: var(--pf-t--global--spacer--sm);
   --pf-t--global--spacer--action--horizontal--spacious: var(--pf-t--global--spacer--xl);
-  --pf-t--global--spacer--action--vertical--compact: var(--pf-t--global--spacer--xs);
-  --pf-t--global--spacer--action--vertical--spacious: var(--pf-t--global--spacer--md);
   --pf-t--global--spacer--control--horizontal--compact: var(--pf-t--global--spacer--sm);
   --pf-t--global--spacer--control--horizontal--default: var(--pf-t--global--spacer--md);
   --pf-t--global--spacer--control--horizontal--plain: var(--pf-t--global--spacer--sm);
@@ -464,6 +463,7 @@
   --pf-t--global--spacer--control--vertical--compact: var(--pf-t--global--spacer--xs);
   --pf-t--global--spacer--control--vertical--default: var(--pf-t--global--spacer--sm);
   --pf-t--global--spacer--control--vertical--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--vertical--spacious: var(--pf-t--global--spacer--md);
   --pf-t--global--spacer--gap--action-to-action--default: var(--pf-t--global--spacer--md);
   --pf-t--global--spacer--gap--action-to-action--plain: var(--pf-t--global--spacer--xs);
   --pf-t--global--spacer--gap--control-to-control--default: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -1,16 +1,16 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Jul 2024 15:40:40 GMT
+// Generated on Tue, 16 Jul 2024 23:44:44 GMT
 
 @mixin pf-v6-tokens {
-  --pf-t--color--black: #000;
+  --pf-t--color--black: #000000;
   --pf-t--color--blue--10: #e0f0ff;
   --pf-t--color--blue--20: #b9dafc;
   --pf-t--color--blue--30: #92c5f9;
   --pf-t--color--blue--40: #4394e5;
-  --pf-t--color--blue--50: #06c;
+  --pf-t--color--blue--50: #0066cc;
   --pf-t--color--blue--60: #004d99;
-  --pf-t--color--blue--70: #036;
+  --pf-t--color--blue--70: #003366;
   --pf-t--color--gray--10: #f2f2f2;
   --pf-t--color--gray--20: #e0e0e0;
   --pf-t--color--gray--30: #c7c7c7;
@@ -46,7 +46,7 @@
   --pf-t--color--red--20: #fbc5c5;
   --pf-t--color--red--30: #f9a8a8;
   --pf-t--color--red--40: #f56e6e;
-  --pf-t--color--red--50: #e00;
+  --pf-t--color--red--50: #ee0000;
   --pf-t--color--red--60: #a60000;
   --pf-t--color--red--70: #5f0000;
   --pf-t--color--red-orange--10: #ffe3d9;
@@ -63,7 +63,7 @@
   --pf-t--color--teal--50: #37a3a3;
   --pf-t--color--teal--60: #147878;
   --pf-t--color--teal--70: #004d4d;
-  --pf-t--color--white: #fff;
+  --pf-t--color--white: #ffffff;
   --pf-t--color--yellow--10: #fff4cc;
   --pf-t--color--yellow--20: #ffe072;
   --pf-t--color--yellow--30: #ffcc17;

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -30,7 +30,7 @@
   --#{$card}__header-toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$card}__header-toggle--MarginInlineEnd: var(--pf-t--global--spacer--xs);
   --#{$card}__header-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
-  --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain) * -1);
+  --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header-toggle-icon--Transition: var(--pf-t--global--transition);
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6894

* Pulls in latest tokens
* Adds stylelint rules to
  * unset [color-hex-length](https://stylelint.io/user-guide/rules/color-hex-length/) (allow for `#000000` instead of failing in favor of `#000`)
  * Add the capitalized font-names as ignored values for [value-keyword-case](https://stylelint.io/user-guide/rules/value-keyword-case/) - references https://github.com/liubich/weather-vue/pull/154 and https://github.com/vicompany/stylelint-config-vi/issues/3
* Updates an instance of `--pf-t--global--spacer--action--horizontal--plain` to `--pf-t--global--spacer--action--horizontal--plain--default`