### PR TITLE
fix(global): use tokens for links/help-text/editable-text

### DIFF
--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -91,12 +91,12 @@
 
   :where(a) {
     color: var(--pf-t--global--text--color--link--default);
-    text-decoration: var(--pf-t--global--link--text-decoration);
+    text-decoration: var(--pf-t--global--text-decoration--link--line--default);
   }
 
-  :where(a:hover) {
+  :where(a:hover, a:focus) {
     color: var(--pf-t--global--text--color--link--hover);
-    text-decoration: var(--pf-t--global--link--text-decoration--hover);
+    text-decoration: var(--pf-t--global--text-decoration--link--line--hover);
   }
 
   :where(

--- a/src/patternfly/base/tokens/tokens-charts-dark.scss
+++ b/src/patternfly/base/tokens/tokens-charts-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Jul 2024 23:44:44 GMT
+// Generated on Thu, 18 Jul 2024 22:27:54 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-charts.scss
+++ b/src/patternfly/base/tokens/tokens-charts.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Jul 2024 23:44:44 GMT
+// Generated on Thu, 18 Jul 2024 22:27:54 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-dark.scss
+++ b/src/patternfly/base/tokens/tokens-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Jul 2024 23:44:44 GMT
+// Generated on Thu, 18 Jul 2024 22:27:54 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);

--- a/src/patternfly/base/tokens/tokens-default.scss
+++ b/src/patternfly/base/tokens/tokens-default.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Jul 2024 23:44:44 GMT
+// Generated on Thu, 18 Jul 2024 22:27:54 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);
@@ -300,8 +300,8 @@
   --pf-t--global--text-decoration--help-text--line--hover: var(--pf-t--global--text-decoration--line--200);
   --pf-t--global--text-decoration--help-text--style--default: var(--pf-t--global--text-decoration--style--200);
   --pf-t--global--text-decoration--help-text--style--hover: var(--pf-t--global--text-decoration--style--200);
-  --pf-t--global--text-decoration--link--line--default: var(--pf-t--global--text-decoration--style--200);
-  --pf-t--global--text-decoration--link--line--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--link--line--hover: var(--pf-t--global--text-decoration--line--200);
   --pf-t--global--text-decoration--link--style--default: var(--pf-t--global--text-decoration--style--100);
   --pf-t--global--text-decoration--link--style--hover: var(--pf-t--global--text-decoration--style--100);
   --pf-t--global--z-index--2xl: var(--pf-t--global--z-index--600);

--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -19,12 +19,6 @@
   --pf-t--global--font--weight--heading--bold--legacy: 700;
 
   // Other missing ones
-  // text-decoration
-  --pf-t--global--text-decoration--100: none;
-  --pf-t--global--text-decoration--200: underline;
-  --pf-t--global--link--text-decoration: var(--pf-t--global--text-decoration--100);
-  --pf-t--global--link--text-decoration--hover: var(--pf-t--global--text-decoration--200);
-
   // sm box-shadow
   --pf-t--global--box-shadow--sm: 
     var(--pf-t--global--box-shadow--X--sm--default) 

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Jul 2024 23:44:44 GMT
+// Generated on Thu, 18 Jul 2024 22:27:54 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--color--black: #000000;

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -15,9 +15,11 @@
   --#{$breadcrumb}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm); // use a mutable value for alignment control
   --#{$breadcrumb}__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm); // use a mutable value for alignment control
   --#{$breadcrumb}__link--Color: var(--pf-t--global--text--color--link--default);
-  --#{$breadcrumb}__link--TextDecoration: var(--pf-t--global--link--text-decoration);
+  --#{$breadcrumb}__link--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--default);
+  --#{$breadcrumb}__link--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--default);
   --#{$breadcrumb}__link--hover--Color: var(--pf-t--global--text--color--link--hover);
-  --#{$breadcrumb}__link--hover--TextDecoration: var(--pf-t--global--link--text-decoration--hover);
+  --#{$breadcrumb}__link--hover--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
+  --#{$breadcrumb}__link--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
   --#{$breadcrumb}__link--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$breadcrumb}__link--BackgroundColor: transparent;
 
@@ -79,13 +81,14 @@
   font-weight: var(--#{$breadcrumb}__link--FontWeight);
   line-height: inherit;
   color: var(--#{$breadcrumb}__link--Color);
-  text-decoration: var(--#{$breadcrumb}__link--TextDecoration);
+  text-decoration: var(--#{$breadcrumb}__link--TextDecorationLine) var(--#{$breadcrumb}__link--TextDecorationStyle);
   word-break: break-word;
   background-color: var(--#{$breadcrumb}__link--BackgroundColor);
 
-  &:hover {
+  &:is(:hover, :focus) {
     --#{$breadcrumb}__link--Color: var(--#{$breadcrumb}__link--hover--Color);
-    --#{$breadcrumb}__link--TextDecoration: var(--#{$breadcrumb}__link--hover--TextDecoration);
+    --#{$breadcrumb}__link--TextDecorationLine: var(--#{$breadcrumb}__link--hover--TextDecorationLine);
+    --#{$breadcrumb}__link--TextDecorationStyle: var(--#{$breadcrumb}__link--hover--TextDecorationStyle);
   }
 
 
@@ -94,7 +97,7 @@
     cursor: default;
 
     &,
-    &:hover {
+    &:is(:hover, :focus) {
       color: var(--#{$breadcrumb}__link--m-current--Color);
       text-decoration: none;
     }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -17,7 +17,8 @@
   --#{$button}--BorderColor: transparent;
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
-  --#{$button}--TextDecoration: none;
+  --#{$button}--TextDecorationLine: none;
+  --#{$button}--TextDecorationStyle: none;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
@@ -26,7 +27,8 @@
   --#{$button}--hover--BackgroundColor: transparent;
   --#{$button}--hover--BorderColor: transparent;
   --#{$button}--hover--BorderWidth: var(--pf-t--global--border--width--action--hover);
-  --#{$button}--hover--TextDecoration: none;
+  --#{$button}--hover--TextDecorationLine: none;
+  --#{$button}--hover--TextDecorationStyle: none;
 
   // Clicked
   --#{$button}--m-clicked--BackgroundColor: transparent;
@@ -110,7 +112,10 @@
   --#{$button}--m-link--m-inline--PaddingInlineEnd: 0;
   --#{$button}--m-link--m-inline--PaddingBlockEnd: 0;
   --#{$button}--m-link--m-inline--PaddingInlineStart: 0;
-  --#{$button}--m-link--m-inline--hover--TextDecoration: var(--pf-t--global--link--text-decoration--hover);
+  --#{$button}--m-link--m-inline--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--default);
+  --#{$button}--m-link--m-inline--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--default);
+  --#{$button}--m-link--m-inline--hover--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
+  --#{$button}--m-link--m-inline--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
   --#{$button}--m-link--m-inline__progress--InsetInlineStart: var(--pf-t--global--spacer--xs);
   --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InsetInlineStart) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -297,7 +302,7 @@
   line-height: var(--#{$button}--LineHeight, inherit);
   color: var(--#{$button}--Color);
   text-align: center;
-  text-decoration: var(--#{$button}--TextDecoration);
+  text-decoration: var(--#{$button}--TextDecorationLine) var(--#{$button}--TextDecorationStyle);
   white-space: nowrap;
   cursor: pointer; // needed for when a button does not use <button> - eg, <span>
   user-select: none;
@@ -413,7 +418,10 @@
       --#{$button}--PaddingInlineStart: var(--#{$button}--m-link--m-inline--PaddingInlineStart);
       --#{$button}--BackgroundColor: transparent;
       --#{$button}__progress--InsetInlineStart: var(--#{$button}--m-link--m-inline__progress--InsetInlineStart);
-      --#{$button}--hover--TextDecoration: var(--#{$button}--m-link--m-inline--hover--TextDecoration);
+      --#{$button}--TextDecorationLine: var(--#{$button}--m-link--m-inline--TextDecorationLine);
+      --#{$button}--TextDecorationStyle: var(--#{$button}--m-link--m-inline--TextDecorationStyle);
+      --#{$button}--hover--TextDecorationLine: var(--#{$button}--m-link--m-inline--hover--TextDecorationLine);
+      --#{$button}--hover--TextDecorationStyle: var(--#{$button}--m-link--m-inline--hover--TextDecorationStyle);
       --#{$button}--hover--BackgroundColor: transparent;
       --#{$button}--m-clicked--BackgroundColor: transparent;
       --#{$button}--disabled--BackgroundColor: transparent;
@@ -598,8 +606,9 @@
     --#{$button}--BackgroundColor: var(--#{$button}--hover--BackgroundColor);
     --#{$button}--BorderColor: var(--#{$button}--hover--BorderColor);
     --#{$button}--BorderWidth: var(--#{$button}--hover--BorderWidth);
-    --#{$button}--TextDecoration: var(--#{$button}--hover--TextDecoration);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
+
+    text-decoration: var(--#{$button}--hover--TextDecorationLine) var(--#{$button}--hover--TextDecorationStyle);
   }
 
   &.pf-m-clicked {
@@ -633,7 +642,8 @@
   }
 
   &.pf-m-aria-disabled {
-    --#{$button}--m-link--m-inline--hover--TextDecoration: none;
+    --#{$button}--m-link--m-inline--hover--TextDecorationLine: var(--#{$button}--TextDecorationLine);
+    --#{$button}--m-link--m-inline--hover--TextDecorationStyle: var(--#{$button}--TextDecorationStyle);
 
     cursor: default;
   }

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -63,9 +63,11 @@
 
   // Links
   --#{$content}--a--Color: var(--pf-t--global--text--color--link--default);
-  --#{$content}--a--TextDecoration: var(--pf-t--global--link--text-decoration);
+  --#{$content}--a--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--default);
+  --#{$content}--a--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--default);
   --#{$content}--a--hover--Color: var(--pf-t--global--text--color--link--hover);
-  --#{$content}--a--hover--TextDecoration: var(--pf-t--global--link--text-decoration);
+  --#{$content}--a--hover--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
+  --#{$content}--a--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
   --#{$content}--a--visited--Color: var(--pf-t--global--text--color--link--visited);
 
   // Blockquote
@@ -103,11 +105,12 @@
     & a
   ) {
     color: var(--#{$content}--a--Color);
-    text-decoration: var(--#{$content}--a--TextDecoration);
+    text-decoration: var(--#{$content}--a--TextDecorationLine) var(--#{$content}--a--TextDecorationStyle);
 
-    &:hover {
+    &:is(:hover, :focus) {
       --#{$content}--a--Color: var(--#{$content}--a--hover--Color);
-      --#{$content}--a--TextDecoration: var(--#{$content}--a--hover--TextDecoration);
+      --#{$content}--a--TextDecorationLine: var(--#{$content}--a--hover--TextDecorationLine);
+      --#{$content}--a--TextDecorationStyle: var(--#{$content}--a--hover--TextDecorationStyle);
     }
   }
 

--- a/src/patternfly/components/DescriptionList/description-list-term.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-term.hbs
@@ -1,8 +1,8 @@
-{{#> wrapper description-list-text--type="span"}}{{!-- in a term, always make the text a span --}}
+{{#> wrapper description-list-text--type="span" description-list-text--IsHelp=description-list-term--IsHelp}}{{!-- in a term, always make the text a span --}}
   <dt class="{{pfv}}description-list__term{{#if description-list-term--modifier}} {{description-list-term--modifier}}{{/if}}"
     {{#if description-list-term--attribute}}
       {{{description-list-term--attribute}}}
     {{/if}}>
-      {{> @partial-block}}
+    {{> @partial-block}}
   </dt>
 {{/wrapper}}

--- a/src/patternfly/components/DescriptionList/description-list-text.hbs
+++ b/src/patternfly/components/DescriptionList/description-list-text.hbs
@@ -1,4 +1,6 @@
-<{{#if description-list-text--type}}{{description-list-text--type}}{{else}}div{{/if}} class="{{pfv}}description-list__text{{#if description-list-text--modifier}} {{description-list-text--modifier}}{{/if}}{{#if description-list-text--IsHelp}} pf-m-help-text{{/if}}"
+<{{#if description-list-text--type}}{{description-list-text--type}}{{else}}div{{/if}} class="{{pfv}}description-list__text
+  {{#if description-list-text--modifier}} {{description-list-text--modifier}}{{/if}}
+  {{#if description-list-text--IsHelp}} pf-m-help-text{{/if}}"
   {{#if description-list-text--IsHelp}}
     role="button"
     type="button"

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -54,11 +54,11 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   --#{$description-list}--m-auto-fit--GridTemplateColumns--minmax--min: var(--#{$description-list}--m-auto-fit--GridTemplateColumns--min);
 
   // help text
-  --#{$description-list}__text--m-help-text--TextDecorationColor: currentcolor;
-  --#{$description-list}__text--m-help-text--TextDecorationThickness: var(--pf-t--global--border--width--regular);
-  --#{$description-list}__text--m-help-text--TextDecorationOffset: #{pf-size-prem(4px)};
-  --#{$description-list}__text--m-help-text--hover--TextDecorationColor: var(--pf-t--global--border--color--hover);
-  --#{$description-list}__text--m-help-text--focus--TextDecorationColor: var(--pf-t--global--border--color--hover);
+  --#{$description-list}__text--m-help-text--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--default);
+  --#{$description-list}__text--m-help-text--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--default);
+  --#{$description-list}__text--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --#{$description-list}__text--m-help-text--hover--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--hover);
+  --#{$description-list}__text--m-help-text--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--hover);
 
   // Display modifiers
   --#{$description-list}--m-display-lg__description--FontSize: var(--pf-t--global--font--size--body--lg); // TODO replace with new font tokens when available
@@ -179,19 +179,13 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   min-width: 0; // this allows overflow-wrap to work
 
   &.pf-m-help-text {
-    text-decoration: underline;
-    text-decoration-thickness: var(--#{$description-list}__text--m-help-text--TextDecorationThickness);
-    text-decoration-style: dashed;
-    text-decoration-color: var(--#{$description-list}__text--m-help-text--TextDecorationColor);
-    text-underline-offset: var(--#{$description-list}__text--m-help-text--TextDecorationOffset);
+    text-decoration: var(--#{$description-list}__text--m-help-text--TextDecorationLine) var(--#{$description-list}__text--m-help-text--TextDecorationStyle);
+    text-underline-offset: var(--#{$description-list}__text--m-help-text--TextUnderlineOffset);
     cursor: pointer;
 
-    &:hover {
-      --#{$description-list}__text--m-help-text--TextDecorationColor: var(--#{$description-list}__text--m-help-text--hover--TextDecorationColor);
-    }
-
-    &:focus {
-      --#{$description-list}__text--m-help-text--TextDecorationColor: var(--#{$description-list}__text--m-help-text--focus--TextDecorationColor);
+    &:is(:hover, :focus) {
+      --#{$description-list}__text--m-help-text--TextDecorationLine: var(--#{$description-list}__text--m-help-text--hover--TextDecorationLine);
+      --#{$description-list}__text--m-help-text--TextDecorationStyle: var(--#{$description-list}__text--m-help-text--hover--TextDecorationStyle);
     }
   }
 }

--- a/src/patternfly/components/DescriptionList/examples/DescriptionList.md
+++ b/src/patternfly/components/DescriptionList/examples/DescriptionList.md
@@ -13,7 +13,7 @@ cssPrefix: pf-v6-c-description-list
 
 ### Term help text
 ```hbs
-{{> description-list__example description-list--title="Term help text" description-list-term--TextIsHelp="true"}}
+{{> description-list__example description-list--title="Term help text" description-list-term--IsHelp="true"}}
 ```
 
 ### Default, two column

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -162,8 +162,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   text-decoration: none;
   outline-offset: var(--#{$jump-links}__link--OutlineOffset);
 
-  &:hover,
-  &:focus {
+  &:is(:hover, :focus) {
     --#{$jump-links}__link-text--Color: var(--#{$jump-links}__link--hover__link-text--Color);
   }
 

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -201,7 +201,7 @@
   --#{$label}--m-compact--PaddingBlockEnd: 0;
   --#{$label}--m-compact--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$label}--m-compact--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$label}--m-compact--m-editable--TextDecorationOffset: #{pf-size-prem(1px)};
+  --#{$label}--m-compact--m-editable--TextUnderlineOffset: #{pf-size-prem(1px)};
 
   // Content
   --#{$label}__content--MaxWidth: 100%;
@@ -228,16 +228,16 @@
   --#{$label}__actions--c-button--PaddingInlineStart: var(--pf-t--global--spacer--xs);
 
   // Editable
-  --#{$label}--m-editable--TextDecoration: underline;
-  --#{$label}--m-editable--TextDecorationStyle: dashed;
-  --#{$label}--m-editable--TextDecorationThickness: var(--pf-t--global--border--width--regular);
-  --#{$label}--m-editable--TextDecorationOffset: #{pf-size-prem(4px)};
-  --#{$label}--m-editable--TextDecorationColor: currentcolor;
+  --#{$label}--m-editable--TextDecorationLine: var(--pf-t--global--text-decoration--editable-text--line--default);
+  --#{$label}--m-editable--TextDecorationStyle: var(--pf-t--global--text-decoration--editable-text--style--default);
+  --#{$label}--m-editable--hover--TextDecorationLine: var(--pf-t--global--text-decoration--editable-text--line--hover);
+  --#{$label}--m-editable--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--editable-text--style--hover);
+  --#{$label}--m-editable--TextUnderlineOffset: #{pf-size-prem(4px)};
   --#{$label}--m-editable__content--MaxWidth: 16ch;
   --#{$label}--m-editable__content--Cursor: pointer;
 
   // Editable active
-  --#{$label}--m-editable--m-editable-active--TextDecoration: none;
+  --#{$label}--m-editable--m-editable-active--TextDecorationLine: none;
   --#{$label}--m-editable--m-editable-active--BackgroundColor: transparent;
   --#{$label}--m-editable--m-editable-active--Color: var(--pf-t--global--text--color--regular);
   --#{$label}--m-editable--m-editable-active__content--Cursor: initial;
@@ -422,7 +422,7 @@
     --#{$label}--PaddingBlockEnd: var(--#{$label}--m-compact--PaddingBlockEnd);
     --#{$label}--PaddingInlineStart: var(--#{$label}--m-compact--PaddingInlineStart);
     --#{$label}--FontSize: var(--#{$label}--m-compact--FontSize);
-    --#{$label}--m-editable--TextDecorationOffset: var(--#{$label}--m-compact--m-editable--TextDecorationOffset);
+    --#{$label}--m-editable--TextUnderlineOffset: var(--#{$label}--m-compact--m-editable--TextUnderlineOffset);
   }
 
   &.pf-m-filled {
@@ -448,17 +448,19 @@
     --#{$label}__content--MaxWidth: var(--#{$label}--m-editable__content--MaxWidth);
     --#{$label}__content--Cursor: var(--#{$label}--m-editable__content--Cursor);
 
+    .#{$label}__content:is(:hover, :focus) {
+      --#{$label}--m-editable--TextDecorationLine: var(--#{$label}--m-editable--hover--TextDecorationLine);
+      --#{$label}--m-editable--TextDecorationStyle: var(--#{$label}--m-editable--hover--TextDecorationStyle);
+    }
+
     .#{$label}__text {
-      text-decoration: var(--#{$label}--m-editable--TextDecoration);
-      text-decoration-thickness: var(--#{$label}--m-editable--TextDecorationThickness);
-      text-decoration-style: var(--#{$label}--m-editable--TextDecorationStyle);
-      text-decoration-color: var(--#{$label}--m-editable--TextDecorationColor);
-      text-underline-offset: var(--#{$label}--m-editable--TextDecorationOffset);
+      text-decoration: var(--#{$label}--m-editable--TextDecorationLine) var(--#{$label}--m-editable--TextDecorationStyle);
+      text-underline-offset: var(--#{$label}--m-editable--TextUnderlineOffset);
     }
   }
 
   &.pf-m-editable-active {
-    --#{$label}--m-editable--TextDecoration: var(--#{$label}--m-editable--m-editable-active--TextDecoration);
+    --#{$label}--m-editable--TextDecorationLine: var(--#{$label}--m-editable--m-editable-active--TextDecorationLine);
     --#{$label}--BackgroundColor: var(--#{$label}--m-editable--m-editable-active--BackgroundColor);
     --#{$label}--Color: var(--#{$label}--m-editable--m-editable-active--Color);
     --#{$label}__content--Cursor: var(--#{$label}--m-editable--m-editable-active__content--Cursor);

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -171,9 +171,11 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   // Help text variables for the step title
   --#{$progress-stepper}__step-title--m-help-text--PaddingInlineStart: 0;
   --#{$progress-stepper}__step-title--m-help-text--PaddingInlineEnd: 0;
-  --#{$progress-stepper}__step-title--m-help-text--TextDecorationColor: currentcolor;
-  --#{$progress-stepper}__step-title--m-help-text--TextDecorationThickness: var(--pf-t--global--link--text-decoration);
+  --#{$progress-stepper}__step-title--m-help-text--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--default);
+  --#{$progress-stepper}__step-title--m-help-text--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--default);
   --#{$progress-stepper}__step-title--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
+  --#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--hover);
+  --#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--hover);
   --#{$progress-stepper}__step-title--m-help-text--hover--Color: var(--pf-t--global--text--color--brand--hover);
 
   // Help text variables the step title for failure state
@@ -404,15 +406,13 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   &.pf-m-help-text {
     padding-inline-start: var(--#{$progress-stepper}__step-title--m-help-text--PaddingInlineStart);
     padding-inline-end: var(--#{$progress-stepper}__step-title--m-help-text--PaddingInlineEnd);
-    text-decoration: underline;
-    text-decoration-thickness: var(--#{$progress-stepper}__step-title--m-help-text--TextDecorationThickness);
-    text-decoration-style: dashed;
-    text-decoration-color: var(--#{$progress-stepper}__step-title--m-help-text--TextDecorationColor);
+    text-decoration: var(--#{$progress-stepper}__step-title--m-help-text--TextDecorationLine) var(--#{$progress-stepper}__step-title--m-help-text--TextDecorationStyle);
     text-underline-offset: var(--#{$progress-stepper}__step-title--m-help-text--TextUnderlineOffset);
     cursor: pointer;
 
-    &:hover,
-    &:focus {
+    &:is(:hover, :focus) {
+      --#{$progress-stepper}__step-title--m-help-text--TextDecorationLine: var(--#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationLine);
+      --#{$progress-stepper}__step-title--m-help-text--TextDecorationStyle: var(--#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationStyle);
       --#{$progress-stepper}__step-title--Color: var(--#{$progress-stepper}__step-title--m-help-text--hover--Color);
     }
   }

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -54,8 +54,7 @@
     --#{$simple-list}__item-link--m-current--Color:  var(--#{$simple-list}__item-link--m-link--hover--Color);
   }
 
-  &:hover,
-  &:focus {
+  &:is(:hover, :focus) {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--hover--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--hover--Color);
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -627,9 +627,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__link--after--BorderWidth: 0;
   }
 
-  &:disabled,
-  &.pf-m-disabled,
-  &.pf-m-aria-disabled {
+  &:is(:disabled, .pf-m-disabled, .pf-m-aria-disabled) {
     --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__link--disabled--BackgroundColor);
   }
 

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -6,15 +6,12 @@
   --#{$timestamp}--OutlineOffset: #{pf-size-prem(3px)};
 
   // Help text variables for the timestamp
-  --#{$timestamp}--m-help-text--TextDecorationLine: underline;
-  --#{$timestamp}--m-help-text--TextDecorationStyle: dashed;
-  --#{$timestamp}--m-help-text--TextDecorationThickness: var(--pf-t--global--border--width--regular);
+  --#{$timestamp}--m-help-text--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--default);
+  --#{$timestamp}--m-help-text--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--default);
   --#{$timestamp}--m-help-text--TextUnderlineOffset: #{pf-size-prem(4px)};
-  --#{$timestamp}--m-help-text--TextDecorationColor: var(--pf-t--global--border--color--default);
   --#{$timestamp}--m-help-text--hover--Color: var(--pf-t--global--text--color--regular);
-  --#{$timestamp}--m-help-text--focus--Color: var(--pf-t--global--text--color--regular);
-  --#{$timestamp}--m-help-text--hover--TextDecorationColor: var(--pf-t--global--text--color--regular);
-  --#{$timestamp}--m-help-text--focus--TextDecorationColor: var(--pf-t--global--text--color--regular);
+  --#{$timestamp}--m-help-text--hover--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--hover);
+  --#{$timestamp}--m-help-text--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--hover);
 }
 
 .#{$timestamp} {
@@ -24,21 +21,14 @@
   outline-offset: var(--#{$timestamp}--OutlineOffset);
 
   &.pf-m-help-text {
-    text-decoration-line: var(--#{$timestamp}--m-help-text--TextDecorationLine);
-    text-decoration-thickness: var(--#{$timestamp}--m-help-text--TextDecorationThickness);
-    text-decoration-style: var(--#{$timestamp}--m-help-text--TextDecorationStyle);
-    text-decoration-color: var(--#{$timestamp}--m-help-text--TextDecorationColor);
+    text-decoration: var(--#{$timestamp}--m-help-text--TextDecorationLine) var(--#{$timestamp}--m-help-text--TextDecorationStyle);
     text-underline-offset: var(--#{$timestamp}--m-help-text--TextUnderlineOffset);
     cursor: pointer;
 
-    &:hover {
+    &:is(:hover, :focus) {
       --#{$timestamp}--Color: var(--#{$timestamp}--m-help-text--hover--Color);
-      --#{$timestamp}--m-help-text--TextDecorationColor: var(--#{$timestamp}--m-help-text--hover--TextDecorationColor);
-    }
-
-    &:focus {
-      --#{$timestamp}--Color: var(--#{$timestamp}--m-help-text--focus--Color);
-      --#{$timestamp}--m-help-text--TextDecorationColor: var(--#{$timestamp}--m-help-text--focus--TextDecorationColor);
+      --#{$timestamp}--m-help-text--TextDecorationLine: var(--#{$timestamp}--m-help-text--hover--TextDecorationLine);
+      --#{$timestamp}--m-help-text--TextDecorationStyle: var(--#{$timestamp}--m-help-text--hover--TextDecorationStyle);
     }
   }
 }

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -117,8 +117,7 @@
     border-inline-end-color: var(--#{$toggle-group}__button--before--BorderInlineEndColor, var(--#{$toggle-group}__button--before--BorderColor));
   }
 
-  &:hover,
-  &:focus {
+  &:is(:hover, :focus) {
     --#{$toggle-group}__button--BackgroundColor: var(--#{$toggle-group}__button--hover--BackgroundColor);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--hover--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--hover--before--BorderColor);
@@ -133,8 +132,7 @@
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--m-selected--before--BorderColor);
   }
 
-  &:disabled,
-  &.pf-m-disabled {
+  &:is(:disabled, .pf-m-disabled) {
     --#{$toggle-group}__button--BackgroundColor: var(--#{$toggle-group}__button--disabled--BackgroundColor);
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--disabled--Color);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--disabled--ZIndex);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6869
fixes https://github.com/patternfly/patternfly/issues/6900

For testing, I verified the styles are showing up as intended, then pasted this into the dev tools console to make sure I was using the right tokens and the hover/focus styles were working as expected, since the hover/focus styles match the default styles, it's hard to validate that part was working.

```
document.documentElement.style.setProperty("--pf-t--global--text-decoration--editable-text--line--default", "underline green");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--editable-text--style--default", "dotted");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--editable-text--line--hover", "overline green");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--editable-text--style--hover", "wavy");

document.documentElement.style.setProperty("--pf-t--global--text-decoration--help-text--line--default", "underline red");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--help-text--style--default", "dotted");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--help-text--line--hover", "overline red");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--help-text--style--hover", "wavy");

document.documentElement.style.setProperty("--pf-t--global--text-decoration--link--line--default", "underline blue");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--link--style--default", "dotted");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--link--line--hover", "overline blue");
document.documentElement.style.setProperty("--pf-t--global--text-decoration--link--style--hover", "wavy");
```