### PR TITLE
fix(MenuToggle): removed nested label elements

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -215,10 +215,10 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 ```
 
-### Split button (checkbox)
+### Split toggle with checkbox
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-example" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check--IsStandalone=true}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -229,7 +229,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-expanded-example" menu-toggle--IsExpanded="true" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check--IsStandalone=true}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -239,8 +239,8 @@ import './MenuToggle.css'
 
 &nbsp;
 
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check--IsStandalone=true check--IsDisabled=true}}
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-disabled-example" menu-toggle--IsDisabled="true" menu-toggle--IsSplitButton="true" check--standalone--label="Select all items"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone=true check--IsDisabled=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -249,10 +249,13 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 ```
 
-### Split button (checkbox with label)
+### Split toggle with labeled checkbox
+
+To add a label to a split toggle that will be linked to the checkbox, pass the text wrapped in `span.pf-v6-c-check__label` as a child to `label.pf-v6-c-check`. Clicking the text will update the checked state of the split toggle's checkbox.
+
 ```hbs
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-example" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -263,7 +266,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -274,7 +277,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
-  {{> menu-toggle--check check-label--text="10 selected" check--IsDisabled=true}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items" check--IsDisabled=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -283,20 +286,11 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 ```
 
-### Split button (checkbox with toggle button text)
+### Split toggle with checkbox and toggle text
+
+To add a label to a split toggle that will be linked to the toggle button, pass the text wrapped in `span.pf-v6-c-menu-toggle__text` as a child to `button.pf-v6-c-menu-toggle__button.pf-m-text`. Clicking the text should trigger any click action on the toggle.
+
 ```hbs
-{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
-  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
-  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
-    {{#> menu-toggle-text}}
-      Toggle button text
-    {{/menu-toggle-text}}
-    {{#> menu-toggle-controls}}
-      {{> menu-toggle-toggle-icon}}
-    {{/menu-toggle-controls}}
-  {{/menu-toggle-button}}
-{{/menu-toggle}}
-&nbsp;
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-example" menu-toggle--IsSplitButton="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
@@ -310,6 +304,18 @@ import './MenuToggle.css'
 {{/menu-toggle}}
 &nbsp;
 {{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-expanded-example"  menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
+  {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
+  {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
+    {{#> menu-toggle-text}}
+      Toggle button text
+    {{/menu-toggle-text}}
+    {{#> menu-toggle-controls}}
+      {{> menu-toggle-toggle-icon}}
+    {{/menu-toggle-controls}}
+  {{/menu-toggle-button}}
+{{/menu-toggle}}
+&nbsp;
+{{#> menu-toggle menu-toggle--id="split-button-checkbox-with-toggle-button-text-disabled-example" menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
   {{> menu-toggle--check menu-toggle--check--IsStandalone="true"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true" menu-toggle-button--IsTextToggle="true"}}
     {{#> menu-toggle-text}}
@@ -343,7 +349,7 @@ import './MenuToggle.css'
 ### Split button, primary
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-example" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -354,7 +360,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -365,7 +371,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-primary" menu-toggle--id="split-button-checkbox-primary-disabled-example"  menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
-  {{> menu-toggle--check check-label--text="10 selected" check--IsDisabled=true}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items" check--IsDisabled=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -377,7 +383,7 @@ import './MenuToggle.css'
 ### Split button, secondary
 ```hbs
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-example" menu-toggle--IsSplitButton="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -388,7 +394,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-expanded-example" menu-toggle--IsSplitButton="true" menu-toggle--IsExpanded="true"}}
-  {{> menu-toggle--check check-label--text="10 selected"}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items"}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}
@@ -399,7 +405,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--modifier="pf-m-secondary" menu-toggle--id="split-button-checkbox-secondary-disabled-example"  menu-toggle--IsSplitButton="true" menu-toggle--IsDisabled="true"}}
-  {{> menu-toggle--check check-label--text="10 selected" check--IsDisabled=true}}
+  {{> menu-toggle--check menu-toggle--check--text="Select all items" check--IsDisabled=true}}
   {{#> menu-toggle-button menu-toggle-button--IsToggle="true"}}
     {{#> menu-toggle-controls}}
       {{> menu-toggle-toggle-icon}}

--- a/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle--check.hbs
@@ -1,13 +1,15 @@
 {{#> id-wrapper menu-toggle--check--id=menu-toggle--id check-input--IsChecked=(ternary check--IsChecked true check-input--IsChecked)}}
   {{#if menu-toggle--check--IsStandalone}}
     {{#> check check--type="label" check--modifier="pf-m-standalone" check--IsDisabled=menu-toggle--IsDisabled}}
-      {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input" aria-label="Standalone input"')}}
+      {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input" aria-label="Select all items"')}}
     {{/check}}
   {{else}}
     {{#> check check--type="label" check--attribute=(concat 'for="' menu-toggle--check--id '-input"') check--IsDisabled=menu-toggle--IsDisabled}}
       {{> check-input check-input--attribute=(concat 'id="' menu-toggle--check--id '-input" name="' menu-toggle--check--id '-input"')}}
       {{#if menu-toggle--check--text}}
-        {{#> check-label check-label--type="span" check-label--IsDisabled=menu-toggle--IsDisabled}}{{menu-toggle--check--text}}{{/check-label}}
+        {{#> check-label check--IsLabelWrapped=true check-label--IsDisabled=menu-toggle--IsDisabled}}
+          {{menu-toggle--check--text}}
+        {{/check-label}}
       {{/if}}
     {{/check}}
   {{/if}}


### PR DESCRIPTION
Closes #6776 

Also updated some labeling in examples. We should also update other examples/demos (post v6) so that any dynamic text inside a split toggle isn't tied to the checkbox input itself. Otherwise it runs into a similar issue that we had to fix for the Switch, where the dynamic labeling will cause confusion. 

For example, the [Bulk Select React example](https://patternfly-react-v6.surge.sh/components/table/react-demos/bulk-select/) updates the input's labeling to "Deselect all cards" when at least 1 item is selected; if all items are selected, the labeling conveys that all cards are already deselected ("deselect all cards, checked checkbox"), when the opposite is actually true (all cards are selected, but clicking the checkbox will cause all cards to be deselected). 

Likewise, if the text is tied to the checkbox and it's constantly being updated ("1 selected", "5 selected", etc), assuming a total of 10 items, it being announced "1 selected, mixed checkbox" and "5 selected, mixed checkbox" may not be totally clear. Are 5 items currently selected, or are some of the 5 total items selected (which may be more confusing if there's actually more than 5 items total)? Maybe having the text be the input's description would be better (it'd then announce something like "Select all items, 5 selected, mixed checkbox").

cc @kmcfaul @edonehoo regarding the example descriptions I added based on the [React split toggle examples](https://patternfly-react-v6.surge.sh/components/menus/menu-toggle#split-toggle-with-labeled-checkbox). Wasn't sure if  I got the descriptions + naming right or if the React examples are reversed?