### PR TITLE
fix(:has): 

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -54,7 +54,7 @@
   white-space: nowrap; // Keeps the item-divider and __link text on the same line
   list-style: none;
 
-  &:first-child:has(.#{$breadcrumb}__link) {
+  &:first-child {
     --#{$breadcrumb}__link--PaddingInlineStart: 0; // remove padding from first child if link
   }
 

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -491,9 +491,13 @@
     padding-inline-end: var(--#{$menu}__list-item--has--menu-action--PaddingInlineEnd);
   }
 
+  .#{$menu}__item-action:last-child {
+    padding-inline-end: var(--#{$menu}__item--PaddingInlineEnd);
+  }
+
   &.pf-m-focus,
   &:focus-within,
-  &:has(> :hover) {
+  &:hover {
     --#{$menu}__list-item--BackgroundColor: var(--#{$menu}__list-item--hover--BackgroundColor);
 
     .#{$menu}__item-select-icon,

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -184,7 +184,7 @@
   transition-timing-function: var(--#{$menu-toggle}--TransitionTimingFunction);
   transition-duration: var(--#{$menu-toggle}--TransitionDuration);
   transition-property: var(--#{$menu-toggle}--TransitionProperty);
-  
+
   &,
   &::before {
     border-radius: var(--#{$menu-toggle}--BorderRadius);
@@ -385,12 +385,14 @@
 .#{$menu-toggle}.pf-m-split-button.pf-m-action {
   --#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor: var(--#{$menu-toggle}--BorderColor);
 
+  background-color: transparent;
+
   // all subsequent buttons
   > :not(:first-child) {
     border-inline-start: var(--#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartWidth) solid var(--#{$menu-toggle}--m-split-button--m-action--child--BorderInlineStartColor);
   }
 
-  > :has(.#{$menu-toggle}__controls) {
+  .#{$menu-toggle}__button:has(.#{$menu-toggle}__controls) {
     padding-inline-end: 0;
   }
 
@@ -449,13 +451,13 @@
     --#{$menu-toggle}__button--PaddingInlineEnd: 0;
   }
 
+
   .#{$menu-toggle}__controls {
     --#{$menu-toggle}__button--PaddingInlineEnd: 0;
 
     display: flex;
     align-items: stretch;
   }
-
   .#{$text-input-group} {
     --#{$text-input-group}__utilities--MarginInlineEnd: 0;
 

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -130,6 +130,7 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--m-selected--Color, inherit);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--m-selected--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--m-selected--before--BorderColor);
+    --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor);
   }
 
   &:is(:disabled, .pf-m-disabled) {
@@ -137,6 +138,7 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--disabled--Color);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--disabled--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--disabled--before--BorderColor);
+    --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor);
 
     pointer-events: none;
   }
@@ -156,4 +158,3 @@
 .#{$toggle-group}__text + .#{$toggle-group}__icon {
   margin-inline-start: var(--#{$toggle-group}__icon--text--MarginInlineStart);
 }
-

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -369,6 +369,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   &.pf-m-current {
     --#{$tree-view}__node--Color: var(--#{$tree-view}__node--m-current--Color);
+
+    background-color: var(--#{$tree-view}__node--m-current--BackgroundColor);
   }
 
   .#{$tree-view}__node-count {
@@ -479,11 +481,6 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
 .#{$tree-view}__action {
   margin-inline-end: var(--#{$tree-view}__action--MarginInlineEnd);
-}
-
-// TODO - make sure we can use :has(), maybe move pf-m-current modifier to __content
-.#{$tree-view}__content:has(> .#{$tree-view}__node.pf-m-current) {
-  --#{$tree-view}__content--BackgroundColor: var(--#{$tree-view}__node--m-current--BackgroundColor);
 }
 
 // stylelint-disable no-duplicate-selectors


### PR DESCRIPTION
Closes #6716 

[Backstop report](https://drive.google.com/file/d/1fC_F1VLIcNrjuLMX4zxwIT8pPFFWkyC-/view?usp=sharing)

The use of detached `:has()` pseudo is having a significant impact upon performance. Detached `:has()` pseudos need to be coupled with a selector. As with other problematic, detached psuedo selectors, the browser engine to look at every element on every page for `:has()`.

This change 

* **Increases performance by 9%** 
* **Reduces elapsed time by 40.7%**
* **Reduces match attempts by 40.7%**
* **Reduces match count by 40.11%**

----

## Current performance profile:
<table style="width: 100%;">
  <thead>
    <tr>
      <th colspan="2">V6</th>
      <th colspan="2">Removing floating `:has()`</th>
    </tr>
  </thead>

<tbody>
    <tr>
      <td colspan="2">
        <img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/3eff6f52-0e1b-4505-88ee-e9bdf466163f">
      </td>
      <td colspan="2">
        <img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/f488b784-dcbd-47c8-984c-6fcd344589fe">
      </td>
    </tr>
    <tr>
      <td colspan="2">
        <img width="396" alt="Screenshot 2024-08-01 at 8 20 26 AM" src="https://github.com/user-attachments/assets/d289e22d-847d-4d64-b87c-8236d325409a">
       </td>
       <td colspan="2">
<img width="392" alt="Screenshot 2024-08-01 at 7 51 07 AM" src="https://github.com/user-attachments/assets/26f25939-28f6-40d9-b2ae-ce0a34943fe0">
      </td>
    </tr>
</tbody>
</table>

Change metrics | Previous | Update | Difference | Percentage
-- | -- | -- | -- | --
Elapsed time (ms) | 218ms | 89ms | -129ms | 40.73%
Match attempts | 7129491 | 2807321 | -4322170 | 39.38%
Match count | 105605 | 42356 | -63249 | 40.11%
% of slow-path non-matches | 58.9 | 58.9 | 0 | 100.00%


