### PR TITLE
chore(css): minify compiled css

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -3,7 +3,7 @@ import path from 'path';
 import gulp from'gulp';
 import rimraf from'rimraf';
 import { copyFA, copySource, copyAssets, copyDocs, watchCopyDocs } from'./scripts/gulp/copy.mjs';
-import { compileSASS, minifyCSS, watchSASS } from'./scripts/gulp/sass.mjs';
+import { compileSASS, minifyPF, minifyPFAddons, watchSASS } from'./scripts/gulp/sass.mjs';
 import { pfIconFont as definedPfIconFont, pfIcons as definedPfIcons } from'./scripts/gulp/icons.mjs';
 import { compileHBS, compileMD, watchHBS, watchMD, watchHelpers } from'./scripts/gulp/html.mjs';
 import { generateSnippets } from'./scripts/gulp/snippets.mjs';
@@ -104,10 +104,11 @@ async function startWebpackDevServer() {
 
 const buildSrc = parallel(compileSrcSASS, series(compileSrcHBS, compileSrcMD));
 const buildDocs = series(buildSrc, copyDocs);
+console.log(buildDocs);
 const watchAll = parallel(watchSrcSASS, watchSrcHBS, watchSrcMD, watchCopyDocs, watchSrcHelpers, startWebpackDevServer);
 
 // Builds `dist` folder
-export const buildPatternfly = parallel(series(buildDocs, minifyCSS), pfIcons, copyFA, copySourceFiles);
+export const buildPatternfly = parallel(series(buildDocs, minifyPF, minifyPFAddons), pfIcons, copyFA, copySourceFiles);
 
 export const build = series(buildPatternfly, buildWebpack); // Builds `dist` and `public` folders
 

--- a/scripts/gulp/sass.mjs
+++ b/scripts/gulp/sass.mjs
@@ -99,9 +99,17 @@ const postcssOptions = {
   preset: ['default', { mergeLonghand: false }]
 };
 
-export function minifyCSS() {
+export function minifyPF() {
   return src('./dist/patternfly.css')
-    .pipe(rename('patternfly.min.css'))
+    .pipe(sourcemaps.init())
+    .pipe(postcss([cssnano(postcssOptions)]))
+    .pipe(sourcemaps.write('.'))
+    .pipe(dest('dist'));
+}
+
+export function minifyPFAddons() {
+  return src('./dist/patternfly-addons.css')
+    .pipe(rename('patternfly-addons.css'))
     .pipe(sourcemaps.init())
     .pipe(postcss([cssnano(postcssOptions)]))
     .pipe(sourcemaps.write('.'))


### PR DESCRIPTION
closes #6941 

CSS is currently un-minified in Core workspace, resulting in lagging pageload speed. This update minifies workspace CSS and improves pageload speed for development. 