### PR TITLE
fix(TextInputGroup): updated inline padding of icons

### DIFF
--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -21,6 +21,7 @@
   --#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--plain) / 2);
   --#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
   --#{$text-input-group}--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
+  --#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--sm) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
   --#{$text-input-group}__main--RowGap: var(--pf-t--global--spacer--xs);
   --#{$text-input-group}__main--ColumnGap: var(--pf-t--global--spacer--xs);
 
@@ -139,6 +140,7 @@
 
   &:has(> .#{$text-input-group}__utilities) {
     --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--#{$text-input-group}--utilities--icon--m-status--InsetInlineEnd);
+    --#{$text-input-group}--status__text-input--PaddingInlineEnd: var(--#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -20,7 +20,7 @@
   // Main
   --#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--plain) / 2);
   --#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
-  --#{$text-input-group}--status__text-input--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$text-input-group}--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
   --#{$text-input-group}__main--RowGap: var(--pf-t--global--spacer--xs);
   --#{$text-input-group}__main--ColumnGap: var(--pf-t--global--spacer--xs);
 
@@ -51,6 +51,7 @@
   --#{$text-input-group}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
   --#{$text-input-group}__icon--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$text-input-group}__c-utilities__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
   --#{$text-input-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$text-input-group}--m-disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$text-input-group}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);
@@ -134,6 +135,10 @@
 
   &:where(.pf-m-success, .pf-m-warning, .pf-m-error) {
     --#{$text-input-group}__text-input--PaddingInlineEnd: var(--#{$text-input-group}--status__text-input--PaddingInlineEnd);
+  }
+
+  &:has(> .#{$text-input-group}__utilities) {
+    --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--#{$text-input-group}__c-utilities__icon--m-status--InsetInlineEnd);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -49,8 +49,8 @@
 
   // Icon
   --#{$text-input-group}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
-  --#{$text-input-group}__icon--InsetInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$text-input-group}__icon--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$text-input-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$text-input-group}--m-disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$text-input-group}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -51,7 +51,7 @@
   --#{$text-input-group}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
   --#{$text-input-group}__icon--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
-  --#{$text-input-group}__c-utilities__icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
+  --#{$text-input-group}--utilities--icon--m-status--InsetInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$text-input-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$text-input-group}--m-disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$text-input-group}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);
@@ -138,7 +138,7 @@
   }
 
   &:has(> .#{$text-input-group}__utilities) {
-    --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--#{$text-input-group}__c-utilities__icon--m-status--InsetInlineEnd);
+    --#{$text-input-group}__icon--m-status--InsetInlineEnd: var(--#{$text-input-group}--utilities--icon--m-status--InsetInlineEnd);
   }
 }
 


### PR DESCRIPTION
Closes #6930 

Couple of notes;
- The gap between the status icon and utilities is slightly larger now.
  This PR: 
  ![image](https://github.com/user-attachments/assets/934c0c7b-5e3a-43a3-8df0-36ccecd029e0)
  
  Staging:
  ![image](https://github.com/user-attachments/assets/5c4d51f4-2f2d-4938-bd86-8db1346e40bc)

- Did we want padding at the end of the utilities, to create more of a visual gap? Right now when the close button is hovered there's not much of a gap:
  ![image](https://github.com/user-attachments/assets/72e552c8-e616-408c-8d2b-07c6b6f6f169)

  But if we used the same spacing as the icons it may create too much of a visual gap when the button isn't focused:
  ![image](https://github.com/user-attachments/assets/9e81dff3-1b38-4d88-b113-39b7301584eb)
