### PR TITLE
fix(card): update clickable to use button and anchor

### DIFF
--- a/src/patternfly/components/Card/card--actionable.hbs
+++ b/src/patternfly/components/Card/card--actionable.hbs
@@ -1,5 +1,12 @@
 {{#if card--actionable--IsLink}}
-  <a class="{{pfv}}card__clickable-action{{#if card--actionable--IsDisabled}} pf-m-disabled{{/if}}" {{#if card--actionable--IsDisabled}}tabindex="-1"{{/if}} href="{{ternary card--actionable--href card--actionable--href '#'}}"></a>
+  <a class="{{pfv}}card__clickable-action
+    {{~#if card--actionable--IsDisabled}} pf-m-disabled{{/if}}"
+    {{#if card--actionable--IsDisabled}}tabindex="-1"{{/if}}
+    aria-labelledby="{{card--id}}"
+    href="{{ternary card--actionable--href card--actionable--href '#'}}"></a>
 {{else}}
-  <button {{#if card--actionable--IsDisabled}}disabled{{/if}} type="button" class="{{pfv}}card__clickable-action"></button>
+  <button class="{{pfv}}card__clickable-action"
+    type="button"
+    aria-labelledby="{{card--id}}"
+    {{#if card--actionable--IsDisabled}}disabled{{/if}}></button>
 {{/if}}

--- a/src/patternfly/components/Card/card--actionable.hbs
+++ b/src/patternfly/components/Card/card--actionable.hbs
@@ -1,0 +1,5 @@
+{{#if card--actionable--IsLink}}
+  <a class="{{pfv}}card__clickable-action{{#if card--actionable--IsDisabled}} pf-m-disabled{{/if}}" {{#if card--actionable--IsDisabled}}tabindex="-1"{{/if}} href="{{ternary card--actionable--href card--actionable--href '#'}}"></a>
+{{else}}
+  <button {{#if card--actionable--IsDisabled}}disabled{{/if}} type="button" class="{{pfv}}card__clickable-action"></button>
+{{/if}}

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -146,6 +146,8 @@
   &.pf-m-current {
     --#{$card}--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
     --#{$card}--BorderWidth: var(--#{$card}--m-clickable--m-current--BorderWidth);
+    --#{$card}--m-selectable--hover--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
+    --#{$card}--m-selectable--focus--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
   }
 
   // stylelint-disable selector-max-class

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -37,6 +37,10 @@
   // Selectable/Clickable
   --#{$card}--m-selectable--BorderWidth: var(--#{$card}--BorderWidth);
 
+  // Clickable clicked
+  --#{$card}--m-clickable--m-current--BorderColor: var(--pf-t--global--border--color--clicked);
+  --#{$card}--m-clickable--m-current--BorderWidth: var(--pf-t--global--border--width--box--clicked);
+
   // Selected state (checked) of selectable card
   --#{$card}--m-selectable--m-selected--BorderColor: var(--pf-t--global--border--color--clicked);
   --#{$card}--m-selectable--m-selected--BorderWidth: var(--pf-t--global--border--width--box--clicked);
@@ -136,6 +140,12 @@
     &::before {
       border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border
     }
+  }
+
+  // CLICKABLE is clicked
+  &.pf-m-current {
+    --#{$card}--BorderColor: var(--#{$card}--m-clickable--m-current--BorderColor);
+    --#{$card}--BorderWidth: var(--#{$card}--m-clickable--m-current--BorderWidth);
   }
 
   // stylelint-disable selector-max-class
@@ -335,6 +345,7 @@
 
 // Focus on the card (focus on label but not checked)
 .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input, .#{$card}__clickable-action):where(:focus-visible) {
+  &,
   ~ :is(.#{$check}__label, .#{$radio}__label) {
     --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
     --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
@@ -360,6 +371,7 @@
 .#{$card}__clickable-action {
   background: none;
   border: 0;
+  outline: 0;
 
   &:disabled,
   &.pf-m-disabled {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -141,8 +141,7 @@
   // stylelint-disable selector-max-class
   // Cards that are BOTH SELECTABLE AND CLICKABLE
   &.pf-m-selectable.pf-m-clickable {
-    .#{$card}__selectable-actions .#{$check}__label,
-    .#{$card}__selectable-actions .#{$radio}__label {
+    .#{$card}__selectable-actions :is(.#{$check}__label, .#{$radio}__label) {
       position: unset;
 
       &::before {
@@ -153,15 +152,13 @@
     }
 
     // When SELECTABLE and CLICKABLE card is focused, don't show change of background or border on the card
-    .#{$card}__selectable-actions .#{$check}__input:where(:focus-visible) ~ .#{$check}__label,
-    .#{$card}__selectable-actions .#{$radio}__input:where(:focus-visible) ~ .#{$radio}__label {
+    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:focus-visible) ~ :is(.#{$check}__label, .#{$radio}__label) {
       --#{$card}--BackgroundColor: revert;
       --#{$card}--BorderColor: revert;
     }
 
     // SELECTABLE and CLICKABLE card is selected (Check box checked or marked .pf-m-selected)
-    .#{$card}__selectable-actions .#{$check}__input:where(:checked) ~ .#{$check}__label,
-    .#{$card}__selectable-actions .#{$radio}__input:where(:checked) ~ .#{$radio}__label,
+    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:checked) ~ :is(.#{$check}__label, .#{$radio}__label),
     &.pf-m-selected {
       --#{$card}--BorderColor: revert;
       --#{$card}--m-selectable--BorderWidth: revert;
@@ -174,8 +171,7 @@
     }
 
     // SELECTABLE and CLICKABLE but DISABLED card
-    .#{$card}__selectable-actions .#{$check}__input:where(:disabled) ~ .#{$check}__label,
-    .#{$card}__selectable-actions .#{$radio}__input:where(:disabled) ~ .#{$radio}__label,
+    .#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:disabled) ~ :is(.#{$check}__label, .#{$radio}__label),
     &.pf-m-disabled {
       --#{$card}--BackgroundColor: var(--#{$card}--m-selectable--m-disabled--BackgroundColor);
     }
@@ -309,8 +305,7 @@
 }
 
 // Labels are used to handle states of selectable and clickable cards
-.#{$card}__selectable-actions .#{$check}__label,
-.#{$card}__selectable-actions .#{$radio}__label {
+.#{$card}__selectable-actions :is(.#{$check}__label, .#{$radio}__label, .#{$card}__clickable-action) {
   position: absolute;
   inset: 0;
   justify-self: auto;
@@ -332,36 +327,44 @@
 }
 
 // Selected card (checked)
-.#{$card}__selectable-actions .#{$check}__input:where(:checked) ~ .#{$check}__label,
-.#{$card}__selectable-actions .#{$radio}__input:where(:checked) ~ .#{$radio}__label,
+.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:checked) ~ :is(.#{$radio}__label, .#{$check}__label),
 .#{$card}.pf-m-selected {
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-selected--BorderColor);
   --#{$card}--m-selectable--BorderWidth: var(--#{$card}--m-selectable--m-selected--BorderWidth); // this line used to be just BorderWidth, not m-selectable
 }
 
 // Focus on the card (focus on label but not checked)
-.#{$card}__selectable-actions .#{$check}__input:where(:focus-visible) ~ .#{$check}__label,
-.#{$card}__selectable-actions .#{$radio}__input:where(:focus-visible) ~ .#{$radio}__label {
-  --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
-  --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
+.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input, .#{$card}__clickable-action):where(:focus-visible) {
+  ~ :is(.#{$check}__label, .#{$radio}__label) {
+    --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
+    --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
+  }
 }
 
 // Focus on a selected card (focus + checked)
-.#{$card}__selectable-actions .#{$check}__input:where(:focus-visible):where(:checked) ~ .#{$check}__label,
-.#{$card}__selectable-actions .#{$radio}__input:where(:focus-visible):where(:checked) ~ .#{$radio}__label {
+.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:focus-visible):where(:checked) ~ :is(.#{$check}__label, .#{$radio}__label) {
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-selected--focus--BorderColor);
   --#{$card}--BorderWidth: var(--#{$card}--m-selectable--m-selected--focus--BorderWidth);
 }
 
 // Disabled card
-.#{$card}__selectable-actions .#{$check}__input:where(:disabled) ~ .#{$check}__label,
-.#{$card}__selectable-actions .#{$radio}__input:where(:disabled) ~ .#{$radio}__label,
+.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input):where(:disabled) ~ :is(.#{$check}__label, .#{$radio}__label),
 .#{$card}.pf-m-disabled {
   --#{$card}__title-text--Color: var(--#{$card}--m-selectable--m-disabled__title-text--Color);
   --#{$card}__body--Color: var(--#{$card}--m-selectable--m-disabled__body--Color);
   --#{$card}__footer--Color: var(--#{$card}--m-selectable--m-disabled__footer--Color);
   --#{$card}--BackgroundColor: var(--#{$card}--m-selectable--m-disabled--BackgroundColor);
   --#{$card}--BorderColor: var(--#{$card}--m-selectable--m-disabled--BorderColor);
+}
+
+.#{$card}__clickable-action {
+  background: none;
+  border: 0;
+
+  &:disabled,
+  &.pf-m-disabled {
+    pointer-events: none;
+  }
 }
 
 .#{$card}__header,

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -344,12 +344,10 @@
 }
 
 // Focus on the card (focus on label but not checked)
-.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input, .#{$card}__clickable-action):where(:focus-visible) {
-  &,
-  ~ :is(.#{$check}__label, .#{$radio}__label) {
-    --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
-    --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
-  }
+.#{$card}__selectable-actions .#{$card}__clickable-action:where(:focus-visible),
+.#{$card}__selectable-actions :is(.#{$check}__input, .#{$radio}__input, .#{$card}__clickable-action):where(:focus-visible) ~ :is(.#{$check}__label, .#{$radio}__label) {
+  --#{$card}--BorderColor: var(--#{$card}--m-selectable--focus--BorderColor);
+  --#{$card}--BorderWidth: var(--#{$card}--m-selectable--focus--BorderWidth);
 }
 
 // Focus on a selected card (focus + checked)

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -274,7 +274,7 @@ import './Card.css'
 {{/gallery}}
 ```
 
-### Selectable Secondary style
+### Selectable secondary style
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
 {{#> card card--id="card-selectable-secondary-example" card--modifier="pf-m-selectable pf-m-secondary" card--IsSelectable="true"}}
@@ -401,14 +401,14 @@ import './Card.css'
 {{/gallery}}
 ```
 
-### Clickable
+### Actionable (button)
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
-{{#> card card--id="card-clickable-example" card--modifier="pf-m-clickable" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-button-example" card--modifier="pf-m-clickable" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}
-        {{> card--hidden-input}}
+        {{> card--actionable}}
       {{/card-selectable-actions}}
     {{/card-actions}}
     {{#> card-header-main}}
@@ -423,11 +423,11 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-clickable-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-button-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}
-        {{> card--hidden-input card--hidden-input--IsDisabled="disabled "}}
+        {{> card--actionable card--actionable--IsDisabled=true}}
       {{/card-selectable-actions}}
     {{/card-actions}}
     {{#> card-header-main}}
@@ -442,11 +442,11 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-clickable-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-button-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}
-        {{> card--hidden-input card--hidden-input--IsDisabled="disabled "}}
+        {{> card--actionable card--actionable--IsDisabled=true}}
       {{/card-selectable-actions}}
     {{/card-actions}}
     {{#> card-header-main}}
@@ -464,7 +464,70 @@ import './Card.css'
 {{/gallery}}
 ```
 
-### Clickable secondary style
+### Actionable (link)
+```hbs
+{{#> gallery gallery--modifier="pf-m-gutter"}}
+{{#> card card--id="card-actionable-button-example" card--modifier="pf-m-clickable" card--IsClickable="true"}}
+  {{#> card-header}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> card-selectable-actions}}
+        {{> card--actionable card--actionable--IsLink=true}}
+      {{/card-selectable-actions}}
+    {{/card-actions}}
+    {{#> card-header-main}}
+      {{> card-title card-title-text--value="Title" card-title--attribute=(concat 'id="' card--id '-title"')}}
+    {{/card-header-main}}
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+
+{{#> card card--id="card-actionable-button-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
+  {{#> card-header}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> card-selectable-actions}}
+        {{> card--actionable card--actionable--IsLink=true card--actionable--IsDisabled=true}}
+      {{/card-selectable-actions}}
+    {{/card-actions}}
+    {{#> card-header-main}}
+      {{> card-title card-title-text--value="Disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
+    {{/card-header-main}}
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+
+{{#> card card--id="card-actionable-button-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
+  {{#> card-header}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> card-selectable-actions}}
+        {{> card--actionable card--actionable--IsLink=true card--actionable--IsDisabled=true}}
+      {{/card-selectable-actions}}
+    {{/card-actions}}
+    {{#> card-header-main}}
+      {{> card-title card-title-text--value="Selected but disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
+    {{/card-header-main}}
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+
+{{/gallery}}
+```
+
+### Actionable secondary style
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
 {{#> card card--id="card-clickable-secondary-example" card--modifier="pf-m-clickable pf-m-secondary" card--IsClickable="true"}}
@@ -527,7 +590,7 @@ import './Card.css'
 {{/gallery}}
 ```
 
-### Clickable and selectable
+### Actionable and selectable
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
 
@@ -618,7 +681,7 @@ import './Card.css'
 {{/gallery}}
 ```
 
-### Clickable and selectable secondary style
+### Actionable and selectable secondary style
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
 
@@ -708,7 +771,6 @@ import './Card.css'
 
 {{/gallery}}
 ```
-
 
 ### Secondary
 ```hbs

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -549,25 +549,6 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-clickable-secondary-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled pf-m-secondary" card--IsClickable="true"}}
-  {{#> card-header}}
-    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
-      {{#> card-selectable-actions}}
-        {{> card--hidden-input card--hidden-input--IsDisabled="disabled "}}
-      {{/card-selectable-actions}}
-    {{/card-actions}}
-    {{#> card-header-main}}
-      {{> card-title card-title-text--value="Selected but disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
-    {{/card-header-main}}
-  {{/card-header}}
-  {{#> card-body}}
-    Body
-  {{/card-body}}
-  {{#> card-footer}}
-    Footer
-  {{/card-footer}}
-{{/card}}
-
 {{/gallery}}
 ```
 

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -461,25 +461,6 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-actionable-button-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
-  {{#> card-header}}
-    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
-      {{#> card-selectable-actions}}
-        {{> card--actionable card--actionable--IsDisabled=true}}
-      {{/card-selectable-actions}}
-    {{/card-actions}}
-    {{#> card-header-main}}
-      {{> card-title card-title-text--value="Selected but disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
-    {{/card-header-main}}
-  {{/card-header}}
-  {{#> card-body}}
-    Body
-  {{/card-body}}
-  {{#> card-footer}}
-    Footer
-  {{/card-footer}}
-{{/card}}
-
 {{/gallery}}
 ```
 
@@ -514,25 +495,6 @@ import './Card.css'
     {{/card-actions}}
     {{#> card-header-main}}
       {{> card-title card-title-text--value="Disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
-    {{/card-header-main}}
-  {{/card-header}}
-  {{#> card-body}}
-    Body
-  {{/card-body}}
-  {{#> card-footer}}
-    Footer
-  {{/card-footer}}
-{{/card}}
-
-{{#> card card--id="card-actionable-link-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
-  {{#> card-header}}
-    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
-      {{#> card-selectable-actions}}
-        {{> card--actionable card--actionable--IsLink=true card--actionable--IsDisabled=true}}
-      {{/card-selectable-actions}}
-    {{/card-actions}}
-    {{#> card-header-main}}
-      {{> card-title card-title-text--value="Selected but disabled card" card-title--attribute=(concat 'id="' card--id '-title"')}}
     {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -423,6 +423,25 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
+{{#> card card--id="card-actionable-button-example-clicked" card--modifier="pf-m-clickable pf-m-current" card--IsClickable="true"}}
+  {{#> card-header}}
+    {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
+      {{#> card-selectable-actions}}
+        {{> card--actionable}}
+      {{/card-selectable-actions}}
+    {{/card-actions}}
+    {{#> card-header-main}}
+      {{> card-title card-title-text--value="Title (clicked)" card-title--attribute=(concat 'id="' card--id '-title"')}}
+    {{/card-header-main}}
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}
+
 {{#> card card--id="card-actionable-button-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
@@ -467,7 +486,7 @@ import './Card.css'
 ### Actionable (link)
 ```hbs
 {{#> gallery gallery--modifier="pf-m-gutter"}}
-{{#> card card--id="card-actionable-button-example" card--modifier="pf-m-clickable" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-link-example" card--modifier="pf-m-clickable" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}
@@ -486,7 +505,7 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-actionable-button-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-link-example-disabled" card--modifier="pf-m-clickable pf-m-disabled" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}
@@ -505,7 +524,7 @@ import './Card.css'
   {{/card-footer}}
 {{/card}}
 
-{{#> card card--id="card-actionable-button-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
+{{#> card card--id="card-actionable-link-example-selected-disabled" card--modifier="pf-m-clickable pf-m-selected pf-m-disabled" card--IsClickable="true"}}
   {{#> card-header}}
     {{#> card-actions card-actions--modifier="pf-m-no-offset"}}
       {{#> card-selectable-actions}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6948

Ran visual regressions and only the new/renamed examples failed (lack of a reference image to compare against)

Changes:
* Updates the selectors in the existing selectable/clickable blocks to group the radio/check stuff in `:is()` so they're in a single selector instead of multiple (should be no visual change from that)
* Adds the new button/link element class (`.#{$card}__clickable-action`) in the `:is()` groups where it's needed, just a couple of them

To test this in a local react dev environment:
* Check this branch out in a clone of the core repo somewhere
* Run `yarn build-patternfly`
  * This builds the dist package that we put on npm for `@patternfly/patternfly` at `./dist` in the core repo
* Rename the existing `@patternfly/patternfly` dir in the react repo where your dev server is running
  * assuming you're at the root of the patternfly-react repo, run `mv node_modules/\@patternfly/patternfly node_modules/\@patternfly/patternfly.bak`
* Create a symlink of the core/dist dir to `node_modules/@patternfly/patternfly` in your react repo
  * Assuming you're still at the root of the patternfly-react repo, and the core repo is a sibling of the patternfly-react repo, run `ln -s ../patternfly/dist node_modules/\@patternfly/patternfly`. You can also specify the full paths to those dirs if that's more clear, like `ln -s /path/to/the/core-repo/dist /path/to/the/patternfly-react-repo/node_modules/\@patternfly/patternfly`

You may need to restart the react dev server for these changes to take effect? If you want to make modifications to the core CSS, you can just edit files in the core repo (currently checked out to this PR's branch), and when you're done, just run `yarn build-patternfly`, which will publish the changes to the ./dist dir. When that's done, the react dev server should auto-reload with the core changes.