### PR TITLE
fix(content): added editorial styling

### DIFF
--- a/src/patternfly/components/Content/content--element.hbs
+++ b/src/patternfly/components/Content/content--element.hbs
@@ -1,4 +1,6 @@
-<{{content--element--type}} class="{{#unless content--element--ExcludeClass}}{{pfv}}content--{{content--element--type}}{{/unless}}{{#if content--element--modifier}} {{content--element--modifier}}{{/if}}"
+<{{content--element--type}} class="{{#unless content--element--ExcludeClass}}{{pfv}}content--{{content--element--type}}{{/unless}}
+  {{~#if content--element--IsEditorial}} pf-m-editorial{{/if}}
+  {{~#if content--element--modifier}} {{content--element--modifier}}{{/if}}"
   {{#if content--element--attribute}}
     {{{content--element--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Content/content.hbs
+++ b/src/patternfly/components/Content/content.hbs
@@ -1,4 +1,6 @@
-<div class="{{pfv}}content{{#if content--modifier}} {{content--modifier}}{{/if}}"
+<div class="{{pfv}}content
+  {{~#if content--IsEditorial}} pf-m-editorial{{/if}}
+  {{~#if content--modifier}} {{content--modifier}}{{/if}}"
   {{#if content--attribute}}
     {{{content--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -5,6 +5,7 @@
   --#{$content}--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$content}--FontSize: var(--pf-t--global--font--size--body--default);
+  --#{$content}--m-editorial--FontSize: var(--pf-t--global--font--size--body--lg);
   --#{$content}--FontWeight: var(--pf-t--global--font--weight--body--default);
 
   // this ensures color is not overridden
@@ -59,6 +60,7 @@
   --#{$content}--small--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--small--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$content}--small--FontSize: var(--pf-t--global--font--size--body--sm);
+  --#{$content}--m-editorial--small--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$content}--small--Color: var(--pf-t--global--text--color--subtle);
 
   // Links
@@ -95,11 +97,18 @@
   --#{$content}--hr--BackgroundColor: var(--pf-t--global--border--color--default);
 }
 
-.#{$content} {
+[class*="#{$content}"] {
   font-size: var(--#{$content}--FontSize);
   line-height: var(--#{$content}--LineHeight);
   color: var(--#{$content}--Color);
 
+  &.pf-m-editorial {
+    --#{$content}--FontSize: var(--#{$content}--m-editorial--FontSize);
+    --#{$content}--small--FontSize: var(--#{$content}--m-editorial--small--FontSize);
+  }
+}
+
+.#{$content} {
   @at-root :is(
     .#{$content}--a,
     & a

--- a/src/patternfly/components/Content/examples/Content.md
+++ b/src/patternfly/components/Content/examples/Content.md
@@ -17,6 +17,18 @@ cssPrefix: pf-v6-c-content
 {{/content}}
 ```
 
+### Long-form/editorial content
+```hbs
+{{> content--kitchen-sink content--element--IsEditorial=true}}
+```
+
+### Long-form/editorial content in content wrapper
+```hbs
+{{#> content content--IsEditorial=true}}
+  {{> content--kitchen-sink content--element--ExcludeClass=true}}
+{{/content}}
+```
+
 ## Documentation
 ### Overview
 When you can't use the CSS classes you want, or when you just want to directly use HTML tags, use `pf-v6-c-content` as container. It can handle almost any HTML tag:
@@ -37,3 +49,4 @@ This component is an exception to the variable system since we style type select
 | `.pf-v6-c-content` | `<div>`, `<section>`, or `<article>` | Generates vertical rhythm and typographic treatment to html elements. |
 | `.pf-m-visited` | `.pf-v6-c-content`, `<a>` | Modifies all links in a content block to include visited styles. Can also be applied to a single link in a content block. |
 | `.pf-m-plain` | `<ul>`, `<ol>` | Removes the list marker and indentation. |
+| `.pf-m-editorial` | `.pf-v6-c-content*` | Applies long-form, editorial content styles to a block of content or individual content elements. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6951

Adds `font-size/line-height/color` to all of the `.pf-v6-c-content--[element]` classes, since they were previously only set on `.pf-v6-c-content` before.
Adds `.pf-m-editorial` as a modifier that can go on on `.pf-v6-c-content` or `.pf-v6-c-content--[element]` and
* Changes the default font-size from `body--default` to `body--lg`
* Changes the `<small>` from `body--sm` to `body--default`