### PR TITLE
feat(Table): add padding except for clickable expandable rows

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -567,6 +567,13 @@
       &.pf-m-expanded {
         --#{$table}__tbody--m-clickable--BackgroundColor: var(--#{$table}__tbody--m-clickable--m-expanded--BackgroundColor);
       }
+
+      .#{$table}__expandable-row { // - Table tr clickable and expandable
+        > .#{$table}__thead, 
+        > .#{$table}__td {
+          padding-block-start: 0;
+        }
+      }
     }
 
     // - Table tbody expanded
@@ -946,26 +953,19 @@
     transition: var(--#{$table}__expandable-row--Transition);
   }
 
-  // stylelint-disable
-  > td,
-  > th {
-    padding-block-start: 0;
-  }
-
   td:where(.#{$table}__td),
   th:where(.#{$table}__th) {
     &.pf-m-no-padding {
       padding-block-start: 0;
-      padding-inline-end: 0;
       padding-block-end: 0;
       padding-inline-start: 0;
+      padding-inline-end: 0;
 
       .#{$table}__expandable-row-content {
         padding: 0;
       }
     }
   }
-  // stylelint-enable
 
   // - Table expandable row content
   .#{$table}__expandable-row-content {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -567,13 +567,6 @@
       &.pf-m-expanded {
         --#{$table}__tbody--m-clickable--BackgroundColor: var(--#{$table}__tbody--m-clickable--m-expanded--BackgroundColor);
       }
-
-      .#{$table}__expandable-row { // - Table tr clickable and expandable
-        > .#{$table}__thead, 
-        > .#{$table}__td {
-          padding-block-start: 0;
-        }
-      }
     }
 
     // - Table tbody expanded
@@ -951,6 +944,13 @@
   &,
   td:where(.#{$table}__td):first-child::after {
     transition: var(--#{$table}__expandable-row--Transition);
+  }
+
+  @at-root :not(.#{$table}__control-row) ~ .#{$table}__expandable-row {
+    > .#{$table}__th, 
+    > .#{$table}__td {
+      padding-block-start: 0;
+    }
   }
 
   td:where(.#{$table}__td),


### PR DESCRIPTION
Closes #6782.

Adjusts padding so it applies padding-block-start to compound expandable rows (and still removes padding for all other types of expandable row).