### PR TITLE
fix(menu-toggle): added support for placeholder, fixed disabled icon color

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -665,6 +665,18 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 {{> menu-toggle menu-toggle--IsDanger=true menu-toggle--text="Danger"}}
 ```
 
+### Placeholder
+```hbs
+{{#> menu-toggle menu-toggle--IsPlaceholder=true}}
+  {{#> menu-toggle-text}}
+    Placeholder text
+  {{/menu-toggle-text}}
+  {{#> menu-toggle-controls}}
+    {{> menu-toggle-toggle-icon}}
+  {{/menu-toggle-controls}}
+{{/menu-toggle}}
+```
+
 ## Documentation
 
 ### Accessibility
@@ -700,3 +712,4 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 | `.pf-m-success` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the success state. |
 | `.pf-m-warning` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the warning state. |
 | `.pf-m-danger` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the danger state. |
+| `.pf-m-placeholder` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle text for placeholder styles. |

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -43,6 +43,9 @@
   {{#if menu-toggle--IsDanger}}
     pf-m-danger
   {{/if}}
+  {{#if menu-toggle--IsPlaceholder}}
+    pf-m-placeholder
+  {{/if}}
   {{#if menu-toggle--modifier}} {{menu-toggle--modifier}}{{/if}}"
   {{#unless (concat menu-toggle--IsDiv menu-toggle--IsSplitButton)}}
     type="button"

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -43,6 +43,8 @@
 
   // * Menu toggle disabled
   --#{$menu-toggle}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
+  --#{$menu-toggle}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
+  --#{$menu-toggle}--disabled__status-icon--Color: var(--pf-t--global--icon--color--on-disabled);
   --#{$menu-toggle}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // * Menu toggle icon
@@ -157,6 +159,9 @@
   // Danger
   --#{$menu-toggle}--m-danger--BorderColor: var(--pf-t--global--border--color--status--danger--default);
   --#{$menu-toggle}--m-danger__status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
+
+  // Placeholder
+  --#{$menu-toggle}--m-placeholder--Color: var(--pf-t--global--text--color--placeholder);
 }
 
 .#{$menu-toggle} {
@@ -277,16 +282,6 @@
     --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--expanded__toggle-icon--Color);
   }
 
-  &:is(:disabled, .pf-m-disabled) {
-    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--disabled--Color);
-    --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--disabled--BackgroundColor);
-
-    &,
-    .#{$button} {
-      pointer-events: none;
-    }
-  }
-
   &.pf-m-primary,
   &:is(:disabled, .pf-m-disabled) {
     &::before {
@@ -319,6 +314,22 @@
   &.pf-m-danger {
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-danger--BorderColor);
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--m-danger__status-icon--Color);
+  }
+
+  &.pf-m-placeholder {
+    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--m-placeholder--Color);
+  }
+
+  &:is(:disabled, .pf-m-disabled) {
+    --#{$menu-toggle}--Color: var(--#{$menu-toggle}--disabled--Color);
+    --#{$menu-toggle}__icon--Color: var(--#{$menu-toggle}--disabled__icon--Color);
+    --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--disabled__status-icon--Color);
+    --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--disabled--BackgroundColor);
+
+    &,
+    .#{$button} {
+      pointer-events: none;
+    }
   }
 }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -44,14 +44,17 @@
   // * Menu toggle disabled
   --#{$menu-toggle}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$menu-toggle}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
+  --#{$menu-toggle}--disabled__toggle-icon--Color: var(--pf-t--global--icon--color--on-disabled);
   --#{$menu-toggle}--disabled__status-icon--Color: var(--pf-t--global--icon--color--on-disabled);
   --#{$menu-toggle}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // * Menu toggle icon
   --#{$menu-toggle}__icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
+  --#{$menu-toggle}__icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Menu toggle toggle icon
   --#{$menu-toggle}__toggle-icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
+  --#{$menu-toggle}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // TODO: add pf-m-button modifier here
   // * Menu toggle button
@@ -76,7 +79,6 @@
   --#{$menu-toggle}--m-primary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--hover);
   --#{$menu-toggle}--m-primary--expanded__toggle-icon--Color: var(--pf-t--global--icon--color--on-brand--clicked);
 
-
   // * Menu toggle secondary
   --#{$menu-toggle}--m-secondary--PaddingInlineStart: var(--#{$menu-toggle}--m-button--PaddingInlineStart);
   --#{$menu-toggle}--m-secondary--PaddingInlineEnd: var(--#{$menu-toggle}--m-button--PaddingInlineEnd);
@@ -90,7 +92,7 @@
   --#{$menu-toggle}--m-secondary--expanded--BorderWidth: var(--pf-t--global--border--width--action--clicked);
   --#{$menu-toggle}--m-secondary--expanded--BorderColor: var(--pf-t--global--border--color--brand--clicked);
   --#{$menu-toggle}--m-secondary__toggle-icon--Color: var(--pf-t--global--icon--color--brand--default);
-  --#{$menu-toggle}--m-secondary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--brand--clicked);
+  --#{$menu-toggle}--m-secondary--hover__toggle-icon--Color: var(--pf-t--global--icon--color--brand--hover);
   --#{$menu-toggle}--m-secondary--expanded__toggle-icon--Color: var(--pf-t--global--icon--color--brand--clicked);
 
   // Controls
@@ -147,6 +149,7 @@
 
   // Status icon
   --#{$menu-toggle}__status-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // Success
   --#{$menu-toggle}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -220,6 +223,7 @@
     --#{$menu-toggle}--expanded--BorderColor: var(--#{$menu-toggle}--m-primary--expanded--BorderColor);
     --#{$menu-toggle}--hover__toggle-icon--Color: var(--#{$menu-toggle}--m-primary--hover__toggle-icon--Color);
     --#{$menu-toggle}--expanded__toggle-icon--Color: var(--#{$menu-toggle}--m-primary--expanded__toggle-icon--Color);
+    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--m-primary__toggle-icon--Color);
   }
 
   &.pf-m-secondary {
@@ -236,6 +240,7 @@
     --#{$menu-toggle}--expanded--BorderWidth: var(--#{$menu-toggle}--m-secondary--expanded--BorderWidth);
     --#{$menu-toggle}--hover__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary--hover__toggle-icon--Color);
     --#{$menu-toggle}--expanded__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary--expanded__toggle-icon--Color);
+    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--m-secondary__toggle-icon--Color);
   }
 
   &.pf-m-full-height {
@@ -323,6 +328,7 @@
   &:is(:disabled, .pf-m-disabled) {
     --#{$menu-toggle}--Color: var(--#{$menu-toggle}--disabled--Color);
     --#{$menu-toggle}__icon--Color: var(--#{$menu-toggle}--disabled__icon--Color);
+    --#{$menu-toggle}__toggle-icon--Color: var(--#{$menu-toggle}--disabled__toggle-icon--Color);
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--disabled__status-icon--Color);
     --#{$menu-toggle}--BackgroundColor: var(--#{$menu-toggle}--disabled--BackgroundColor);
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6962

* adds `.pf-m-placeholder` on the menu toggle, which changes the text color to the placeholder color token
* Icon colors were mostly set to `inherit` (matched text color), so this wires up/fixes vars to use icon color tokens 

Backstop report has no failures other than this random one, which looks like a viewport size/timing glitch
[BackstopJS Report.pdf](https://github.com/user-attachments/files/16606725/BackstopJS.Report.pdf)
