### PR TITLE
fix(slider): adjust styles

### DIFF
--- a/src/patternfly/base/tokens/tokens-charts-dark.scss
+++ b/src/patternfly/base/tokens/tokens-charts-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 18 Jul 2024 22:27:54 GMT
+// Generated on Thu, 15 Aug 2024 00:08:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-charts.scss
+++ b/src/patternfly/base/tokens/tokens-charts.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 18 Jul 2024 22:27:54 GMT
+// Generated on Thu, 15 Aug 2024 00:08:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--chart--global--BorderWidth--lg: 8;

--- a/src/patternfly/base/tokens/tokens-dark.scss
+++ b/src/patternfly/base/tokens/tokens-dark.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 18 Jul 2024 22:27:54 GMT
+// Generated on Thu, 15 Aug 2024 00:08:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);
@@ -32,9 +32,9 @@
   --pf-t--global--dark--color--nonstatus--blue--100: var(--pf-t--color--blue--30);
   --pf-t--global--dark--color--nonstatus--blue--200: var(--pf-t--color--blue--20);
   --pf-t--global--dark--color--nonstatus--blue--300: var(--pf-t--color--blue--10);
-  --pf-t--global--dark--color--nonstatus--gray--100: var(--pf-t--color--gray--30);
-  --pf-t--global--dark--color--nonstatus--gray--200: var(--pf-t--color--gray--20);
-  --pf-t--global--dark--color--nonstatus--gray--300: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--color--nonstatus--gray--100: var(--pf-t--color--gray--60);
+  --pf-t--global--dark--color--nonstatus--gray--200: var(--pf-t--color--gray--50);
+  --pf-t--global--dark--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
   --pf-t--global--dark--color--nonstatus--green--100: var(--pf-t--color--green--30);
   --pf-t--global--dark--color--nonstatus--green--200: var(--pf-t--color--green--20);
   --pf-t--global--dark--color--nonstatus--green--300: var(--pf-t--color--green--10);
@@ -77,7 +77,7 @@
   --pf-t--global--dark--icon--color--100: var(--pf-t--color--gray--10);
   --pf-t--global--dark--icon--color--200: var(--pf-t--color--gray--40);
   --pf-t--global--dark--icon--color--300: var(--pf-t--color--gray--90);
-  --pf-t--global--dark--text--color--100: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--text--color--100: var(--pf-t--color--white);
   --pf-t--global--dark--text--color--200: var(--pf-t--color--gray--30);
   --pf-t--global--dark--text--color--300: var(--pf-t--color--gray--90);
   --pf-t--global--dark--text--color--400: var(--pf-t--color--red-orange--30);
@@ -107,9 +107,9 @@
   --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--dark--color--nonstatus--blue--200);
   --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--dark--color--nonstatus--blue--100);
   --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--dark--color--nonstatus--blue--200);
-  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--200);
-  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--100);
-  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--300);
   --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--dark--color--nonstatus--green--200);
   --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--dark--color--nonstatus--green--100);
   --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--dark--color--nonstatus--green--200);
@@ -243,9 +243,9 @@
   --pf-t--global--icon--color--nonstatus--on-blue--clicked: var(--pf-t--global--icon--color--inverse);
   --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--inverse);
   --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--inverse);
-  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--inverse);
-  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--inverse);
-  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--regular);
   --pf-t--global--icon--color--nonstatus--on-green--clicked: var(--pf-t--global--icon--color--inverse);
   --pf-t--global--icon--color--nonstatus--on-green--default: var(--pf-t--global--icon--color--inverse);
   --pf-t--global--icon--color--nonstatus--on-green--hover: var(--pf-t--global--icon--color--inverse);
@@ -309,9 +309,9 @@
   --pf-t--global--text--color--nonstatus--on-blue--clicked: var(--pf-t--global--text--color--inverse);
   --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--inverse);
   --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--inverse);
-  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--inverse);
-  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--inverse);
-  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--regular);
   --pf-t--global--text--color--nonstatus--on-green--clicked: var(--pf-t--global--text--color--inverse);
   --pf-t--global--text--color--nonstatus--on-green--default: var(--pf-t--global--text--color--inverse);
   --pf-t--global--text--color--nonstatus--on-green--hover: var(--pf-t--global--text--color--inverse);

--- a/src/patternfly/base/tokens/tokens-default.scss
+++ b/src/patternfly/base/tokens/tokens-default.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 18 Jul 2024 22:27:54 GMT
+// Generated on Thu, 15 Aug 2024 00:08:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--global--background--color--500: rgba(21, 21, 21, 0.2000);

--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 18 Jul 2024 22:27:54 GMT
+// Generated on Thu, 15 Aug 2024 00:08:40 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--color--black: #000000;

--- a/src/patternfly/components/Slider/examples/Slider.md
+++ b/src/patternfly/components/Slider/examples/Slider.md
@@ -194,6 +194,7 @@ cssPrefix: pf-v6-c-slider
 <br><br>
 
 {{#> slider
+  slider--IsDisabled="true"
   slider--value-min="0"
   slider--value-max="100"
   slider--value-now="50"

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -8,7 +8,7 @@
   --#{$slider}__rail--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$slider}__rail--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$slider}__rail-track--Height: #{pf-size-prem(4px)};
-  --#{$slider}__rail-track--before--base--BackgroundColor: var(--pf-t--global--border--color--default);
+  --#{$slider}__rail-track--before--base--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--default);
   --#{$slider}__rail-track--before--fill--BackgroundColor: var(--pf-t--global--border--color--hover);
   --#{$slider}__rail-track--before--BorderRadius: var(--pf-t--global--border--radius--tiny);
   --#{$slider}__rail-track--before--fill--BackgroundColor--gradient-stop: var(--#{$slider}--value);
@@ -19,12 +19,12 @@
 
   // step tick
   --#{$slider}__step-tick--InsetBlockStart: var(--pf-t--global--spacer--md);
-  --#{$slider}__step-tick--Width: #{pf-size-prem(4px)};
+  --#{$slider}__step-tick--Width: 0.15rem;
   --#{$slider}__step-tick--Height: #{pf-size-prem(4px)};
-  --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--subtle);
+  --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--on-disabled);
   --#{$slider}__step-tick--TranslateX: -50%;
-  --#{$slider}__step-tick--BorderRadius: var(--pf-t--global--border--radius--large);
-  --#{$slider}__step--m-active__slider-tick--BackgroundColor: var(--pf-t--global--icon--color--brand--clicked);
+  --#{$slider}__step-tick--BorderRadius: var(--pf-t--global--border--radius--sharp);
+  --#{$slider}__step--m-active__slider-tick--BackgroundColor: var(--pf-t--global--icon--color--on-brand--default);
   --#{$slider}__step--first-child__step-tick--TranslateX: 0;
   --#{$slider}__step--last-child__step-tick--TranslateX: -100%;
 

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -21,7 +21,7 @@
   --#{$slider}__step-tick--InsetBlockStart: var(--pf-t--global--spacer--md);
   --#{$slider}__step-tick--Width: 0.15rem;
   --#{$slider}__step-tick--Height: #{pf-size-prem(4px)};
-  --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--on-disabled);
+  --#{$slider}__step-tick--BackgroundColor: var(--pf-t--global--icon--color--nonstatus--on-gray--default);
   --#{$slider}__step-tick--TranslateX: -50%;
   --#{$slider}__step-tick--BorderRadius: var(--pf-t--global--border--radius--sharp);
   --#{$slider}__step--m-active__slider-tick--BackgroundColor: var(--pf-t--global--icon--color--on-brand--default);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6977 and pulls in the latest tokens from https://github.com/patternfly/design-tokens/pull/82

@lboehling  the only difference I see in the between what's in the PR and in the referenced issue is the disabled/unfilled tick color (updated to `--pf-t--global--icon--color--on-disabled`). In the design screenshot, the tick color is lighter than the background, but `--pf-t--global--icon--color--on-disabled` is a darker color. Not sure if anything needs to be updated there?