### PR TITLE
feat(progress): display progress measure as tabular numbers

### DIFF
--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -203,3 +203,7 @@
   grid-column: 1 / 3;
   margin-block-start: var(--#{$progress}__helper-text--MarginBlockStart);
 }
+
+.#{$progress}__measure {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
This should take care of the only issue not addressed in another issue on https://github.com/patternfly/patternfly/issues/5476

This PR changes the progress measure to be tabular numbers.
