### PR TITLE
fix(toolbar): fix expanded content position in masthead

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -146,6 +146,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   //  - Toolbar static
   &.pf-m-static {
+    &,
     .#{$toolbar}__content {
       position: static;
     }
@@ -261,6 +262,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 .#{$toolbar}__expandable-content {
   position: absolute;
   inset-block-start: 100%;
+  inset-inline-start: 0;
   z-index: var(--#{$toolbar}__expandable-content--ZIndex);
   display: none;
   row-gap: var(--#{$toolbar}__expandable-content--RowGap);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6918

[BackstopJS Report.pdf](https://github.com/user-attachments/files/16641892/BackstopJS.Report.pdf) with `filter="toolbar|masthead"`

The 3 failures are the last 3 in the report, and seem to match the layout I see for these examples v5


