### PR TITLE
fix(toolbar-group): let label groups wrap within the toolbar

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -232,6 +232,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   // - Toolbar label group
   &.pf-m-label-group {
     flex: 1;
+    flex-wrap: wrap;
     column-gap: var(--#{$toolbar}__group--m-label-group--ColumnGap);
   }
 


### PR DESCRIPTION
Allows label groups to wrap within the header rather than flexing them onto one line and having the labels within wrap down excessively.

Here are some examples of the new wrapping with longer label groups
Before:
<img width="895" alt="2024-08-19_09-09-25" src="https://github.com/user-attachments/assets/eaf0d396-1b72-43c2-b6de-a696860bb802">

After:
<img width="1241" alt="2024-08-19_08-58-34" src="https://github.com/user-attachments/assets/f1badd4e-ea49-4909-868a-3645c6cfd66a">

<img width="1085" alt="2024-08-19_08-58-54" src="https://github.com/user-attachments/assets/30a18c86-2d0c-4270-ac2f-4d48ba7b27a2">

<img width="892" alt="2024-08-19_08-59-12" src="https://github.com/user-attachments/assets/803ec296-e2c6-4de3-b037-e3e71ca96679">

fixes #6967 