### PR TITLE
refactor(progress-stepper): refactored progress stepper to prop: valu…

### DIFF
--- a/src/patternfly/components/ProgressStepper/_progress-stepper-layout.scss
+++ b/src/patternfly/components/ProgressStepper/_progress-stepper-layout.scss
@@ -1,0 +1,130 @@
+@use '../../sass-utilities' as *;
+
+// - Progress stepper vertical
+@mixin pf-v6-c-progress-stepper--m-vertical {
+  grid-auto-flow: row;
+
+  // - Progress stepper step
+  .#{$progress-stepper}__step {
+    grid-template-columns: max-content 1fr;
+  }
+
+  // - Progress stepper - Progress stepper compact
+  &,
+  &.pf-m-compact {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      // show first-child border -/ hide last child border
+      &:first-child .#{$progress-stepper}__step-connector::before { content: ""; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: none; }
+    }
+
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: var(--#{$progress-stepper}__step-icon--size);
+      inset-inline: calc(var(--#{$progress-stepper}__step-icon--size) / 2) 100%;
+      height: calc(100% + var(--#{$progress-stepper}--RowGap));
+    }
+  }
+
+  // - Progress stepper compact
+  &.pf-m-compact {
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector {
+      grid-row: auto;
+      grid-column: 1;
+    }
+
+    // - Progress stepper step connector before
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 0 -100%;
+      inset-inline: calc(var(--#{$progress-stepper}--m-compact__step-icon--size) / 2) 100%;
+      height: auto;
+    }
+  }
+
+  // - Progress stepper center
+  &.pf-m-center {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      grid-template-columns: 1fr;
+
+      // hide first-child border -/ shoe last child border
+      &:first-child .#{$progress-stepper}__step-connector::before { content: none; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: ""; }
+    }
+
+     // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: -100% 0;
+      inset-inline: 50%;
+      height: auto;
+    }
+  }
+
+  &.pf-m-compact.pf-m-center {
+    grid-template-columns: 1fr;
+  }
+}
+
+// - Progress stepper horizontal
+@mixin pf-v6-c-progress-stepper--m-horizontal {
+  grid-auto-flow: column;
+
+  // - Progress stepper step
+  .#{$progress-stepper}__step {
+    grid-template-columns: 1fr;
+  }
+
+  // - Progress stepper step connector
+  .#{$progress-stepper}__step-connector::before {
+    inset-inline: 0 calc(var(--#{$progress-stepper}--ColumnGap) * -1);
+  }
+
+  // - Progress stepper - Progress stepper center - Progress stepper compact
+  &,
+  &.pf-m-center,
+  &.pf-m-compact {
+    // - Progress stepper step
+    .#{$progress-stepper}__step {
+      // show first child / hide last child
+      &:first-child .#{$progress-stepper}__step-connector::before { content: ""; }
+      &:last-child .#{$progress-stepper}__step-connector::before { content: none; }
+    }
+
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      height: auto;
+    }
+  }
+
+  // - Progress stepper compact
+  &.pf-m-compact,
+  &.pf-m-compact.pf-m-center {
+    grid-template-columns: repeat(auto-fit, var(--#{$progress-stepper}--m-compact__step-icon--size));
+  }
+
+  &.pf-m-compact {
+    // - Progress stepper step connector
+    .#{$progress-stepper}__step-connector {
+      grid-row: 2;
+      grid-column: auto;
+    }
+
+    // connector positioning
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      inset-inline: 100% -100%;
+    }
+  }
+
+  // - Progress stepper center
+  &.pf-m-center {
+    // connector positioning
+    .#{$progress-stepper}__step-connector::before {
+      inset-block: 50%;
+      inset-inline: 50% -50%;
+    }
+  }
+}

--- a/src/patternfly/components/ProgressStepper/progress-stepper-layout-breakpoints.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper-layout-breakpoints.scss
@@ -1,0 +1,26 @@
+@use '../../sass-utilities' as *;
+@use './progress-stepper-layout';
+
+$pf-v6--include-progress-stepper-breakpoints: true !default;
+$pf-v6-c-progress-stepper--breakpoint-map: "base";
+
+@if $pf-v6--include-progress-stepper-breakpoints {
+  $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map('sm', 'md', 'lg', 'xl', '2xl');
+}
+
+// stylelint-disable
+.#{$progress-stepper} {
+  @each $breakpoint, $breakpoint-value in $pf-v6-c-progress-stepper--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-v6-apply-breakpoint($breakpoint) {
+      &.pf-m-horizontal#{$breakpoint-name} {
+        @include progress-stepper-layout.pf-v6-c-progress-stepper--m-horizontal;
+      }
+
+      &.pf-m-vertical#{$breakpoint-name} {
+        @include progress-stepper-layout.pf-v6-c-progress-stepper--m-vertical;
+      }
+    }
+  }
+}

--- a/src/patternfly/components/ProgressStepper/progress-stepper.scss
+++ b/src/patternfly/components/ProgressStepper/progress-stepper.scss
@@ -1,152 +1,46 @@
 @use '../../sass-utilities' as *;
+@use './progress-stepper-layout';
+@use './progress-stepper-layout-breakpoints';
 
-$pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
+@include pf-root($progress-stepper) {
+  // * Progress stepper
+  --#{$progress-stepper}--RowGap: var(--pf-t--global--spacer--xl);
+  --#{$progress-stepper}--ColumnGap: var(--pf-t--global--spacer--sm);
 
-// Default layout is vertical
-@mixin pf-v6-c-progress-stepper--m-vertical {
-  --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-vertical--GridAutoFlow);
-  --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-vertical--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--InsetBlockStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InsetBlockStart);
-  --#{$progress-stepper}__step-connector--before--InsetInlineStart: var(--#{$progress-stepper}--m-vertical__step-connector--before--InsetInlineStart);
-  --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-vertical__step-connector--before--Width);
-  --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-vertical__step-connector--before--Height);
-  --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth);
-  --#{$progress-stepper}__step-connector--before--BorderInlineEndColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndColor);
-  --#{$progress-stepper}__step-connector--before--BorderBlockEndWidth: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndWidth);
-  --#{$progress-stepper}__step-connector--before--BorderBlockEndColor: var(--#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndColor);
-  --#{$progress-stepper}__step-connector--before--Transform: var(--#{$progress-stepper}--m-vertical__step-connector--before--Transform);
-  --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-vertical__step-main--MarginBlockStart);
-  --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd);
-  --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-vertical__step-main--MarginBlockEnd);
-  --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical__step-main--MarginInlineStart);
+  // Progress stepper step
+  --#{$progress-stepper}__step--RowGap: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}__step--ColumnGap: var(--pf-t--global--spacer--sm);
 
-  // Compact vertical
-  --#{$progress-stepper}--m-compact--GridTemplateColumns: var(--#{$progress-stepper}--m-vertical--m-compact--GridTemplateColumns);
-  --#{$progress-stepper}--m-compact__step-connector--GridRow: var(--#{$progress-stepper}--m-vertical--m-compact__step-connector--GridRow);
-  --#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd: var(--#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBlockEnd);
+  // Progress stepper step main
+  --#{$progress-stepper}__step-main--RowGap: var(--pf-t--global--spacer--xs);
+  --#{$progress-stepper}__step-main--ColumnGap: var(--pf-t--global--spacer--sm);
 
-  // Center
-  --#{$progress-stepper}--m-center__step-connector--before--Content: none; // border swap
-  --#{$progress-stepper}--m-center__step-main--before--Content: ""; // border swap
-}
+  // * Progress stepper step title
+  --#{$progress-stepper}__step-title--FontSize: var(--pf-t--global--font--size--body--lg);
+  --#{$progress-stepper}__step-title--FontWeight: var(--pf-t--global--font--weight--body--default);
+  --#{$progress-stepper}__step-title--Color: var(--pf-t--global--text--color--regular);
 
-@mixin pf-v6-c-progress-stepper--m-horizontal {
-  --#{$progress-stepper}--GridAutoFlow: var(--#{$progress-stepper}--m-horizontal--GridAutoFlow);
-  --#{$progress-stepper}--GridTemplateColumns: var(--#{$progress-stepper}--m-horizontal--GridTemplateColumns);
-  --#{$progress-stepper}__step-connector--before--InsetBlockStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InsetBlockStart);
-  --#{$progress-stepper}__step-connector--before--InsetInlineStart: var(--#{$progress-stepper}--m-horizontal__step-connector--before--InsetInlineStart);
-  --#{$progress-stepper}__step-connector--before--Width: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Width);
-  --#{$progress-stepper}__step-connector--before--Height: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Height);
-  --#{$progress-stepper}__step-connector--before--BorderInlineEndWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth);
-  --#{$progress-stepper}__step-connector--before--BorderInlineEndColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndColor);
-  --#{$progress-stepper}__step-connector--before--BorderBlockEndWidth: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndWidth);
-  --#{$progress-stepper}__step-connector--before--BorderBlockEndColor: var(--#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndColor);
-  --#{$progress-stepper}__step-connector--before--Transform: var(--#{$progress-stepper}--m-horizontal__step-connector--before--Transform);
-  --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-horizontal__step-main--MarginBlockStart);
-  --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-horizontal__step-main--MarginInlineEnd);
-  --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-horizontal__step-main--MarginBlockEnd);
-  --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-horizontal__step-main--MarginInlineStart);
+  // * Progress stepper step description
+  --#{$progress-stepper}__step-description--FontSize: var(--pf-t--global--font--size--body--sm);
+  --#{$progress-stepper}__step-description--Color: var(--pf-t--global--text--color--subtle);
 
-  // Compact horizontal
-  --#{$progress-stepper}--m-compact--GridTemplateColumns: var(--#{$progress-stepper}--m-horizontal--m-compact--GridTemplateColumns);
-  --#{$progress-stepper}--m-compact__step-connector--GridRow: var(--#{$progress-stepper}--m-horizontal--m-compact__step-connector--GridRow);
-  --#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd: var(--#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBlockEnd);
-
-  // Center
-  --#{$progress-stepper}--m-center__step-connector--before--Content: ""; // border swap
-  --#{$progress-stepper}--m-center__step-main--before--Content: none; // border swap
-}
-
-// Progress stepper is vertically oriented by default
-:where(:root, .#{$progress-stepper}) {
-  // Vertical - these are the default settings
-  --#{$progress-stepper}--m-vertical--GridAutoFlow: row;
-  --#{$progress-stepper}--m-vertical--GridTemplateColumns: auto 1fr;
-  --#{$progress-stepper}--m-vertical__step-connector--before--InsetBlockStart: 0;
-  --#{$progress-stepper}--m-vertical__step-connector--before--InsetInlineStart: calc(var(--#{$progress-stepper}__step-icon--Width) / 2);
-  --#{$progress-stepper}--m-vertical__step-connector--before--Width: auto;
-  --#{$progress-stepper}--m-vertical__step-connector--before--Height: 100%;
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndWidth: var(--pf-t--global--border--width--box--default);
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndWidth: 0;
-  --#{$progress-stepper}--m-vertical__step-connector--before--BorderBlockEndColor: transparent;
-  --#{$progress-stepper}--m-vertical__step-connector--before--Transform: translateX(-50%);
-  --#{$progress-stepper}--m-vertical__step-main--MarginBlockStart: 0px; // needs px for calc
-  --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: 0;
-  --#{$progress-stepper}--m-vertical__step-main--MarginBlockEnd: var(--pf-t--global--spacer--xl);
-  --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--pf-t--global--spacer--sm);
-
-  // Compact, vertical
-  --#{$progress-stepper}--m-vertical--m-compact--GridTemplateColumns: 1fr;
-  --#{$progress-stepper}--m-vertical--m-compact__step-connector--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-vertical--m-compact__step-connector--GridRow: auto;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginBlockStart: 0;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineEnd: 0;
-  --#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineStart: 0;
-
-  // Center, vertical
-  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineEnd: 0;
-  --#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineStart: 0;
-
-  // Horizontal
-  --#{$progress-stepper}--m-horizontal--GridAutoFlow: column;
-  --#{$progress-stepper}--m-horizontal--GridTemplateColumns: initial;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--InsetBlockStart: calc(var(--#{$progress-stepper}__step-icon--Height) / 2);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--InsetInlineStart: 0;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--Width: 100%;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--Height: auto;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndWidth: 0;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderInlineEndColor: unset;
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--BorderBlockEndColor: var(--pf-t--global--border--color--default);
-  --#{$progress-stepper}--m-horizontal__step-connector--before--Transform: translateY(-50%);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-horizontal__step-main--MarginBlockEnd: 0;
-  --#{$progress-stepper}--m-horizontal__step-main--MarginInlineStart: 0;
-
-  // Compact, horizontal
-  --#{$progress-stepper}--m-horizontal--m-compact--GridTemplateColumns: repeat(auto-fill, #{pf-size-prem(28px)});
-  --#{$progress-stepper}--m-horizontal--m-compact__step-connector--PaddingBlockEnd: 0;
-  --#{$progress-stepper}--m-horizontal--m-compact__step-connector--GridRow: 2;
-
-  // Compact
-  --#{$progress-stepper}--m-compact--GridAutoFlow: row;
-  --#{$progress-stepper}--m-compact__step-main--MarginBlockStart: 0;
-  --#{$progress-stepper}--m-compact__step-main--MarginBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$progress-stepper}--m-compact__step-connector--MinWidth: #{pf-size-prem(28px)};
-  --#{$progress-stepper}--m-compact__step-icon--Width: #{pf-size-prem(18px)};
-  --#{$progress-stepper}--m-compact__step-icon--FontSize: var(--pf-t--global--icon--size--font--body--sm);
-  --#{$progress-stepper}--m-compact__step-title--FontSize: var(--pf-t--global--font--size--body--lg);
-  --#{$progress-stepper}--m-compact__step-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$progress-stepper}--m-compact__pficon--MarginBlockStart: 2px;
-  --#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginBlockStart: -3px;
-
-  // Center
-  --#{$progress-stepper}--m-center__step-connector--before--InsetInlineStart: 50%;
-  --#{$progress-stepper}--m-center--GridTemplateColumns: 1fr;
-  --#{$progress-stepper}--m-center__step-connector--JustifyContent: center;
-  --#{$progress-stepper}--m-center__step-main--MarginInlineEnd: var(--pf-t--global--spacer--xs);
-  --#{$progress-stepper}--m-center__step-main--MarginInlineStart: var(--pf-t--global--spacer--xs);
-  --#{$progress-stepper}--m-center__step-main--TextAlign: center;
-  --#{$progress-stepper}--m-center__step-description--MarginInlineEnd: 0;
-  --#{$progress-stepper}--m-center__step-description--MarginInlineStart: 0;
-
-  // Stepper variables
-  --#{$progress-stepper}--GridTemplateRows: auto 1fr;
-
-  // Step connector variables
-  --#{$progress-stepper}__step-connector--JustifyContent: flex-start;
-
-  // Step icon variables
+  // * Progress stepper step icon
+  --#{$progress-stepper}__step-icon--size: #{pf-size-prem(24px)};
   --#{$progress-stepper}__step-icon--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$progress-stepper}__step-icon--Width: #{pf-size-prem(24px)};
-  --#{$progress-stepper}__step-icon--Height: var(--#{$progress-stepper}__step-icon--Width);
   --#{$progress-stepper}__step-icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
   --#{$progress-stepper}__step-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$progress-stepper}__step-icon--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$progress-stepper}__step-icon--BorderWidth: var(--pf-t--global--border--width--box--default);
   --#{$progress-stepper}__step-icon--BorderColor: var(--pf-t--global--border--color--default);
+
+  // * Progress stepper step step title
+  --#{$progress-stepper}__step--m-danger__step-title--Color: var(--pf-t--global--text--color--status--danger--default);
+  --#{$progress-stepper}__step--m-pending__step-title--Color: var(--pf-t--global--text--color--subtle);
+  --#{$progress-stepper}__step--m-danger__step-title--m-help-text--hover--Color: var(--pf-t--global--text--color--status--danger--hover);
+
+  // * Progress stepper step current step title
+  --#{$progress-stepper}__step--m-current__step-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
+  --#{$progress-stepper}__step--m-current__step-title--Color: var(--pf-t--global--text--color--regular);
   --#{$progress-stepper}__step--m-current__step-icon--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$progress-stepper}__step--m-info__step-icon--Color: var(--pf-t--global--icon--color--status--info--default);
   --#{$progress-stepper}__step--m-success__step-icon--Color: var(--pf-t--global--icon--color--status--success--default);
@@ -154,21 +48,7 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}__step--m-danger__step-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
   --#{$progress-stepper}__step--m-custom__step-icon--Color: var(--pf-t--global--icon--color--status--custom--default);
 
-  // Icon adjustments to fix differences in alignment
-  --#{$progress-stepper}__pficon--MarginBlockStart: 3px;
-  --#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart: -2px;
-
-  // Step Title variables
-  --#{$progress-stepper}__step-title--Color: var(--pf-t--global--text--color--regular);
-  --#{$progress-stepper}__step-title--TextAlign: start;
-  --#{$progress-stepper}__step-title--FontSize: var(--pf-t--global--font--size--body--lg);
-  --#{$progress-stepper}__step-title--FontWeight: var(--pf-t--global--font--weight--body--default);
-  --#{$progress-stepper}__step--m-current__step-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$progress-stepper}__step--m-current__step-title--Color: var(--pf-t--global--text--color--regular);
-  --#{$progress-stepper}__step--m-pending__step-title--Color: var(--pf-t--global--text--color--subtle);
-  --#{$progress-stepper}__step--m-danger__step-title--Color: var(--pf-t--global--text--color--status--danger--default);
-
-  // Help text variables for the step title
+  // * Progress stepper step title help text
   --#{$progress-stepper}__step-title--m-help-text--PaddingInlineStart: 0;
   --#{$progress-stepper}__step-title--m-help-text--PaddingInlineEnd: 0;
   --#{$progress-stepper}__step-title--m-help-text--TextDecorationLine: var(--pf-t--global--text-decoration--help-text--line--default);
@@ -178,230 +58,147 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
   --#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--help-text--style--hover);
   --#{$progress-stepper}__step-title--m-help-text--hover--Color: var(--pf-t--global--text--color--brand--hover);
 
-  // Help text variables the step title for failure state
-  --#{$progress-stepper}__step--m-danger__step-title--m-help-text--hover--Color: var(--pf-t--global--text--color--status--danger--hover);
+  // * Progress stepper compact
+  --#{$progress-stepper}--m-compact--RowGap: var(--pf-t--global--spacer--sm);
+  --#{$progress-stepper}--m-compact--ColumnGap: var(--pf-t--global--spacer--sm);
 
-  // Step Description variables
-  --#{$progress-stepper}__step-description--MarginBlockStart: var(--pf-t--global--spacer--xs);
-  --#{$progress-stepper}__step-description--FontSize: var(--pf-t--global--font--size--body--sm);
-  --#{$progress-stepper}__step-description--Color: var(--pf-t--global--text--color--subtle);
-  --#{$progress-stepper}__step-description--TextAlign: start;
+  // * Progress stepper compact step icon
+  --#{$progress-stepper}--m-compact__step-icon--size: #{pf-size-prem(18px)};
+  --#{$progress-stepper}--m-compact__step-icon--FontSize: var(--pf-t--global--icon--size--font--body--sm);
+  --#{$progress-stepper}--m-compact__step-title--FontSize: var(--pf-t--global--font--size--body--lg);
 
-  // Vertical by default
-  @include pf-v6-c-progress-stepper--m-vertical;
-
-  // Horizontal at md breakpoint
-  @media screen and (min-width: $pf-v6-global--breakpoint--md) {
-    @include pf-v6-c-progress-stepper--m-horizontal;
-  }
+  // * Progress stepper step connector
+  --#{$progress-stepper}__step-connector--BorderWidth: var(--pf-t--global--border--width--divider--default);
+  --#{$progress-stepper}__step-connector--BorderColor: var(--pf-t--global--border--color--default);
 }
 
+// - Progress stepper
 .#{$progress-stepper} {
   position: relative;
   display: grid;
-  grid-template-rows: var(--#{$progress-stepper}--GridTemplateRows);
-  grid-template-columns: var(--#{$progress-stepper}--GridTemplateColumns);
-  grid-auto-columns: 1fr; // gives even spacing between steps
-  grid-auto-flow: var(--#{$progress-stepper}--GridAutoFlow);
+  grid-template-columns: 1fr;
+  grid-auto-columns: 1fr;
+  row-gap: var(--#{$progress-stepper}--RowGap);
+  column-gap: var(--#{$progress-stepper}--ColumnGap);
+  align-items: start;
+  list-style-type: none;
 
-  // Progress stepper Modifiers
-  &.pf-m-center {
-    --#{$progress-stepper}__step-connector--JustifyContent: var(--#{$progress-stepper}--m-center__step-connector--JustifyContent);
-    --#{$progress-stepper}__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-center__step-main--MarginInlineEnd);
-    --#{$progress-stepper}__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-center__step-main--MarginInlineStart);
-    --#{$progress-stepper}--step-main--TextAlign: var(--#{$progress-stepper}--m-center__step-main--TextAlign, auto);
-    --#{$progress-stepper}__step-title--TextAlign: var(--#{$progress-stepper}--m-center__step-title--TextAlign, auto);
-    --#{$progress-stepper}__step-description--MarginInlineEnd: var(--#{$progress-stepper}--m-center__step-description--MarginInlineEnd);
-    --#{$progress-stepper}__step-description--MarginInlineStart: var(--#{$progress-stepper}--m-center__step-description--MarginInlineStart);
-    --#{$progress-stepper}__step-description--TextAlign: var(--#{$progress-stepper}--m-center__step-description--TextAlign, auto);
-    --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineEnd);
-    --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical--m-center__step-main--MarginInlineStart);
+  // Progress stepper layout vertical
+  @include progress-stepper-layout.pf-v6-c-progress-stepper--m-vertical;
 
-    grid-template-columns: var(--#{$progress-stepper}--m-center--GridTemplateColumns);
-
-    .#{$progress-stepper}__step-main {
-      position: relative;
-    }
-
-    .#{$progress-stepper}__step:not(:last-of-type) > .#{$progress-stepper}__step-connector::before {
-     inset-inline-start: var(--#{$progress-stepper}--m-center__step-connector--before--InsetInlineStart);
-    }
-
-    // If not compact variant, swap borders from connector to main
-    &:not(.pf-m-compact) {
-      .#{$progress-stepper}__step:not(:last-of-type) > .#{$progress-stepper}__step-main::before {
-        content: var(--#{$progress-stepper}--m-center__step-main--before--Content);
-      }
-
-      .#{$progress-stepper}__step:not(:last-of-type) > .#{$progress-stepper}__step-connector::before {
-        content: var(--#{$progress-stepper}--m-center__step-connector--before--Content);
-      }
-    }
+  @media screen and (min-width: $pf-v6-global--breakpoint--md) {
+    @include progress-stepper-layout.pf-v6-c-progress-stepper--m-horizontal;
   }
 
-  &.pf-m-compact {
-    --#{$progress-stepper}__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockStart);
-    --#{$progress-stepper}__step-main--MarginBlockEnd: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockEnd);
-    --#{$progress-stepper}__step-icon--Width: var(--#{$progress-stepper}--m-compact__step-icon--Width);
-    --#{$progress-stepper}__step-icon--FontSize: var(--#{$progress-stepper}--m-compact__step-icon--FontSize);
-    --#{$progress-stepper}__step-title--FontSize: var(--#{$progress-stepper}--m-compact__step-title--FontSize);
-    --#{$progress-stepper}__step--m-current__step-title--FontWeight: var(--#{$progress-stepper}--m-compact__step-title--FontWeight);
-    --#{$progress-stepper}__pficon--MarginBlockStart: var(--#{$progress-stepper}--m-compact__pficon--MarginBlockStart);
-    --#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart: var(--#{$progress-stepper}--m-compact__fa-exclamation-triangle--MarginBlockStart);
-    --#{$progress-stepper}--m-vertical__step-main--MarginBlockStart: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginBlockStart);
-    --#{$progress-stepper}--m-vertical__step-main--MarginInlineEnd: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineEnd);
-    --#{$progress-stepper}--m-vertical__step-main--MarginInlineStart: var(--#{$progress-stepper}--m-vertical--m-compact__step-main--MarginInlineStart);
+  &.pf-m-horizontal {
+    @include progress-stepper-layout.pf-v6-c-progress-stepper--m-horizontal;
+  }
 
-    display: inline-grid;
-    grid-template-columns: var(--#{$progress-stepper}--m-compact--GridTemplateColumns);
-    grid-auto-flow: var(--#{$progress-stepper}--m-compact--GridAutoFlow);
-
-    .#{$progress-stepper}__step-connector {
-      grid-row: var(--#{$progress-stepper}--m-compact__step-connector--GridRow);
-      min-width: var(--#{$progress-stepper}--m-compact__step-connector--MinWidth);
-      padding-block-end: var(--#{$progress-stepper}--m-compact__step-connector--PaddingBlockEnd);
-    }
-
-    .#{$progress-stepper}__step-main {
-      margin-block-end: var(--#{$progress-stepper}--m-compact__step-main--MarginBlockEnd);
-    }
-
-    .#{$progress-stepper}__step:not(.pf-m-current) .#{$progress-stepper}__step-main {
-      @include pf-v6-u-screen-reader;
-    }
-
-    // For this compact variant only, move the main content for the current step to above the icons
-    .#{$progress-stepper}__step.pf-m-current .#{$progress-stepper}__step-main {
-        grid-row: 1/2;
-        grid-column: 1/-1;
-      }
-
-    .#{$progress-stepper}__step-description {
-      display: none;
-    }
+  &.pf-m-vertical {
+    @include progress-stepper-layout.pf-v6-c-progress-stepper--m-vertical;
   }
 }
 
-// Step
+// - Progress stepper center
+.#{$progress-stepper}.pf-m-center {
+  // - Progress stepper - Progress stepper main - Progress stepper title - Progress stepper description
+  // - set text alignment to start by default, update to center for centered layout
+  justify-items: center;
+  text-align: center;
+
+  // - Progress stepper connetor
+  .#{$progress-stepper}__step-connector {
+    justify-content: center;
+  }
+}
+
+// - Progress stepper compact
+.#{$progress-stepper}.pf-m-compact {
+  display: inline-grid;
+  row-gap: var(--#{$progress-stepper}--m-compact--RowGap);
+  column-gap: var(--#{$progress-stepper}--m-compact--ColumnGap);
+
+  // - Progress stepper step - Progress stepper step main
+  .#{$progress-stepper}__step,
+  .#{$progress-stepper}__step-main {
+    display: contents; // bypass progress stepper step and step main layout
+  }
+
+  // - Progress stepper step title
+  .#{$progress-stepper}__step-title {
+    grid-row: 1 / 2;
+    grid-column: 1 / -1;
+    font-size: var(--#{$progress-stepper}--m-compact__step-title--FontSize);
+  }
+
+  // Progress stepper step icon
+  .#{$progress-stepper}__step-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--#{$progress-stepper}--m-compact__step-icon--size);
+    height: var(--#{$progress-stepper}--m-compact__step-icon--size);
+    font-size: var(--#{$progress-stepper}--m-compact__step-icon--FontSize);
+    line-height: 1;
+  }
+
+  // Progress stepper step title - Progress stepper step description
+  .#{$progress-stepper}__step-title,
+  .#{$progress-stepper}__step-description {
+    @include pf-v6-u-screen-reader; // visually hide progress stepper step title and step description
+  }
+
+  // Progress stepper step current step title
+  .#{$progress-stepper}__step.pf-m-current .#{$progress-stepper}__step-title {
+    position: relative;
+    display: flex;
+    overflow: visible;
+    white-space: normal;
+  }
+}
+
+// - Progress stepper step
 .#{$progress-stepper}__step {
-  display: contents;
-
-  // Step Modifiers
-  &.pf-m-current {
-    --#{$progress-stepper}__step-title--FontWeight: var(--#{$progress-stepper}__step--m-current__step-title--FontWeight);
-    --#{$progress-stepper}__step-title--Color: var(--#{$progress-stepper}__step--m-current__step-title--Color);
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-current__step-icon--Color);
-  }
-
-  &.pf-m-pending {
-    --#{$progress-stepper}__step-title--Color: var(--#{$progress-stepper}__step--m-pending__step-title--Color);
-  }
-
-  &.pf-m-success {
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-success__step-icon--Color);
-  }
-
-  &.pf-m-danger {
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-danger__step-icon--Color);
-    --#{$progress-stepper}__step-title--Color: var(--#{$progress-stepper}__step--m-danger__step-title--Color);
-
-    // Help text variables for failure state
-    --#{$progress-stepper}__step-title--m-help-text--hover--Color: var(--#{$progress-stepper}__step--m-danger__step-title--m-help-text--hover--Color);
-  }
-
-  &.pf-m-warning {
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-warning__step-icon--Color);
-  }
-
-  &.pf-m-info {
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-info__step-icon--Color);
-  }
-
-  &.pf-m-custom {
-    --#{$progress-stepper}__step-icon--Color: var(--#{$progress-stepper}__step--m-custom__step-icon--Color);
-  }
-
-  &:last-child {
-    --#{$progress-stepper}__step-main--MarginBlockEnd: 0;
-  }
+  position: relative;
+  display: grid;
+  grid-column: auto;
+  row-gap: var(--#{$progress-stepper}__step--RowGap);
+  column-gap: var(--#{$progress-stepper}__step--ColumnGap);
+  width: 100%;
+  text-align: inherit;
 }
 
-// The step icon wrapper provides a container on which to use the before for the line connecting the steps
+// - Progress stepper step connector
 .#{$progress-stepper}__step-connector {
   position: relative;
-  display: flex;
-  justify-content: var(--#{$progress-stepper}__step-connector--JustifyContent);
-  width: 100%;
+  display: inline-flex;
 
-  .#{$progress-stepper}__step:not(:last-of-type) > &::before {
+  // - Progress stepper step connector -/ draws connector lines with ::before pseudo
+  &::before {
     position: absolute;
-    inset-block-start: var(--#{$progress-stepper}__step-connector--before--InsetBlockStart); // half the height
-    inset-inline-start: var(--#{$progress-stepper}__step-connector--before--InsetInlineStart);
-    width: var(--#{$progress-stepper}__step-connector--before--Width);
-    height: var(--#{$progress-stepper}__step-connector--before--Height);
+    inset-block: 0 calc(var(--#{$progress-stepper}--RowGap) * -1);
+    inset-inline: 0 calc(var(--#{$progress-stepper}__step-icon--size) / 2);
     content: "";
-    border-block-end: var(--#{$progress-stepper}__step-connector--before--BorderBlockEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderBlockEndColor);
-    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderInlineEndColor);
-    transform: var(--#{$progress-stepper}__step-connector--before--Transform);
+    border-block-end: var(--#{$progress-stepper}__step-connector--BorderWidth) solid var(--#{$progress-stepper}__step-connector--BorderColor);
+    border-inline-end: var(--#{$progress-stepper}__step-connector--BorderWidth) solid var(--#{$progress-stepper}__step-connector--BorderColor);
   }
 }
 
-// Step icon
-.#{$progress-stepper}__step-icon {
-  z-index: var(--#{$progress-stepper}__step-icon--ZIndex);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--#{$progress-stepper}__step-icon--Width);
-  height: var(--#{$progress-stepper}__step-icon--Height);
-  font-size: var(--#{$progress-stepper}__step-icon--FontSize);
-  color: var(--#{$progress-stepper}__step-icon--Color);
-  background-color: var(--#{$progress-stepper}__step-icon--BackgroundColor);
-  border: var(--#{$progress-stepper}__step-icon--BorderWidth) solid var(--#{$progress-stepper}__step-icon--BorderColor);
-  border-radius: 50%;
-
-  // Align pficons with the font awesome icons
-  // stylelint-disable
-  .pf-v6-pficon {
-    margin-block-start: var(--#{$progress-stepper}__pficon--MarginBlockStart);
-  }
-
-  // Push the triangle up to fit inside the circle
-  .fa-exclamation-triangle {
-    margin-block-start: var(--#{$progress-stepper}__fa-exclamation-triangle--MarginBlockStart);
-  }
-  // stylelint-enable
-}
-
-// Step main
+// - Progress stepper step main
 .#{$progress-stepper}__step-main {
-  min-width: 0;
-  margin-block-start: var(--#{$progress-stepper}__step-main--MarginBlockStart);
-  margin-block-end: var(--#{$progress-stepper}__step-main--MarginBlockEnd);
-  margin-inline-start: var(--#{$progress-stepper}__step-main--MarginInlineStart);
-  margin-inline-end: var(--#{$progress-stepper}__step-main--MarginInlineEnd);
-  text-align: var(--#{$progress-stepper}--step-main--TextAlign, auto);
-  overflow-wrap: anywhere;
-
-  // Draw a new border for vertical alignment using step main
-  .#{$progress-stepper}__step:not(:last-of-type) > &::before {
-    position: absolute;
-    inset-block-start: calc(100% + var(--#{$progress-stepper}__step-main--MarginBlockStart));
-    inset-inline-start: calc(50% - calc(var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) / 2));
-    width: auto;
-    height: calc(var(--#{$progress-stepper}__step-main--MarginBlockStart) + var(--#{$progress-stepper}__step-main--MarginBlockEnd));
-    border-inline-end: var(--#{$progress-stepper}__step-connector--before--BorderInlineEndWidth) solid var(--#{$progress-stepper}__step-connector--before--BorderInlineEndColor);
-  }
+  position: relative;
+  display: grid;
+  row-gap: var(--#{$progress-stepper}__step-main--RowGap);
+  column-gap: var(--#{$progress-stepper}__step-main--ColumnGap);
+  text-align: inherit;
 }
 
-// Step title
+
+// - Progress stepper step title
 .#{$progress-stepper}__step-title {
   font-size: var(--#{$progress-stepper}__step-title--FontSize);
   font-weight: var(--#{$progress-stepper}__step-title--FontWeight);
   color: var(--#{$progress-stepper}__step-title--Color);
-  text-align: var(--#{$progress-stepper}__step-title--TextAlign);
-  background: none;
-  border: 0;
 
   &.pf-m-help-text {
     padding-inline-start: var(--#{$progress-stepper}__step-title--m-help-text--PaddingInlineStart);
@@ -414,32 +211,110 @@ $pf-v6-c-progress-stepper--breakpoint-map: build-breakpoint-map();
       --#{$progress-stepper}__step-title--m-help-text--TextDecorationLine: var(--#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationLine);
       --#{$progress-stepper}__step-title--m-help-text--TextDecorationStyle: var(--#{$progress-stepper}__step-title--m-help-text--hover--TextDecorationStyle);
       --#{$progress-stepper}__step-title--Color: var(--#{$progress-stepper}__step-title--m-help-text--hover--Color);
+
+      cursor: pointer;
     }
   }
 }
 
-// Step description
+// - Progress stepper step icon
+.#{$progress-stepper}__step-icon {
+  z-index: var(--#{$progress-stepper}__step-icon--ZIndex);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--#{$progress-stepper}__step-icon--size);
+  height: var(--#{$progress-stepper}__step-icon--size);
+  font-size: var(--#{$progress-stepper}__step-icon--FontSize);
+  color: var(--#{$progress-stepper}__step-icon--Color);
+  background-color: var(--#{$progress-stepper}__step-icon--BackgroundColor);
+  border: var(--#{$progress-stepper}__step-icon--BorderWidth) solid var(--#{$progress-stepper}__step-icon--BorderColor);
+  border-radius: 50%;
+}
+
+// - Progress stepper step description
 .#{$progress-stepper}__step-description {
-  margin-block-start: var(--#{$progress-stepper}__step-description--MarginBlockStart);
   font-size: var(--#{$progress-stepper}__step-description--FontSize);
   color: var(--#{$progress-stepper}__step-description--Color);
-  text-align: var(--#{$progress-stepper}__step-description--TextAlign);
 }
 
-// stylelint-disable no-duplicate-selectors
-.#{$progress-stepper} {
-  @each $breakpoint, $breakpoint-value in $pf-v6-c-progress-stepper--breakpoint-map {
-    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-    @include pf-v6-apply-breakpoint($breakpoint) {
-      &.pf-m-horizontal#{$breakpoint-name} {
-        @include pf-v6-c-progress-stepper--m-horizontal;
-      }
+// - Progress stepper step current
+.#{$progress-stepper}__step.pf-m-current {
+  // - Progress stepper step current step icon
+  .#{$progress-stepper}__step-icon {
+    color: var(--#{$progress-stepper}__step--m-current__step-icon--Color);
+  }
 
-      &.pf-m-vertical#{$breakpoint-name} {
-        @include pf-v6-c-progress-stepper--m-vertical;
-      }
+  // - Progress stepper step current step title
+  .#{$progress-stepper}__step-title {
+    font-weight: var(--#{$progress-stepper}__step--m-current__step-title--FontWeight);
+    color: var(--#{$progress-stepper}__step--m-current__step-title--Color);
+  }
+}
+
+// - Progress stepper step danger
+.#{$progress-stepper}__step.pf-m-danger {
+  // - Progress stepper step danger step icon
+  .#{$progress-stepper}__step-icon {
+    color: var(--#{$progress-stepper}__step--m-danger__step-icon--Color);
+  }
+
+  // - Progress stepper step danger step title
+  .#{$progress-stepper}__step-title {
+    color: var(--#{$progress-stepper}__step--m-danger__step-title--Color);
+
+    &.pf-m-help-text:hover {
+      color: var(--#{$progress-stepper}__step--m-danger__step-title--m-help-text--hover--Color); // Help text variables for failure state
     }
   }
+}
+
+// - Progress stepper step pending
+.#{$progress-stepper}__step.pf-m-pending .#{$progress-stepper}__step-icon {
+  color: var(--#{$progress-stepper}__step--m-pending__step-title--Color);
+}
+
+// - Progress stepper step success
+.#{$progress-stepper}__step.pf-m-success .#{$progress-stepper}__step-icon {
+  color: var(--#{$progress-stepper}__step--m-success__step-icon--Color);
+}
+
+// - Progress stepper step warning
+.#{$progress-stepper}__step.pf-m-warning .#{$progress-stepper}__step-icon {
+  color: var(--#{$progress-stepper}__step--m-warning__step-icon--Color);
+}
+
+// - Progress stepper step info
+.#{$progress-stepper}__step.pf-m-info .#{$progress-stepper}__step-icon {
+  color: var(--#{$progress-stepper}__step--m-info__step-icon--Color);
+}
+
+// - Progress stepper step custom
+.#{$progress-stepper}__step.pf-m-custom .#{$progress-stepper}__step-icon {
+  color: var(--#{$progress-stepper}__step--m-custom__step-icon--Color);
+}
+
+// stylelint-disable
+.#{$progress-stepper} {
+  .fas,
+  .pf-v6-pficon,
+  .fa-exclamation-triangle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+}
+// stylelint-enable
+
+// stylelint-disable
+// Progress stepper step title button
+button.#{$progress-stepper}__step-title {
+  margin: 0;
+  padding: 0;
+  text-align: inherit;
+  background: none;
+  border: 0;
 }
 // stylelint-enable

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -416,3 +416,10 @@
 @mixin pf-v6-set-inverse($val: true) {
   --#{$pf-global}--inverse--multiplier: #{if($val, -1, 1)};
 }
+
+@mixin pf-root($selector) {
+  :root,
+  .#{$selector}-reset {
+    @content
+  }
+}


### PR DESCRIPTION
appllies to #6722

Progress stepper relies on chained css variables and as a result some of the intended values don't work as intended. Maintenance of css var chaining also makes this component difficult to maintain and confusing to interpret. 

[Backstop report](https://drive.google.com/file/d/1xC-OT2gf6BSfU8GhvFDLyZKnxiPObrGg/view?usp=sharing)

This error is due to an unrelated `text-input-group` update

<img width="513" alt="Screenshot 2024-08-20 at 3 00 50 PM" src="https://github.com/user-attachments/assets/6a68da7d-b7a4-4e14-8323-6227a8dea733">

This error looks to be a result of : https://github.com/patternfly/patternfly/commit/876119f2d03092a69b5a85cd2e88cfa6155188bc#diff-98e414994743ef6a80d6a54353a2d0df03e8af105f92236dd1ba848e28c8add7R145

<img width="1480" alt="Screenshot 2024-08-20 at 3 00 17 PM" src="https://github.com/user-attachments/assets/9f51e475-7b61-4e4f-8b3c-fd202d5a13ff">


This error is a result of css var chaining having no affecting the progress slider settings

<img width="1449" alt="Screenshot 2024-08-20 at 2 48 47 PM" src="https://github.com/user-attachments/assets/6ea8ca4a-691a-41c1-bcb9-67881bd282de">

`.pf-v6-c-progress-stepper__step-icon` positioning is resolved by this PR and reflected in BackStop report

<img width="1364" alt="Screenshot 2024-08-20 at 2 50 38 PM" src="https://github.com/user-attachments/assets/be5a5d3d-fecb-4604-ac4e-4c3c9734eb83">

Gap updates match Figma spec

<img width="1442" alt="Screenshot 2024-08-20 at 2 52 16 PM" src="https://github.com/user-attachments/assets/9283ecdd-e175-40a4-998b-1a3cb17c2cd7">

