### PR TITLE
fix(expandable-section): use link button, update styles

### DIFF
--- a/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
+++ b/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
@@ -112,19 +112,18 @@ cssPrefix: pf-v6-c-expandable-section
 ### Accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `aria-expanded="true"` | `.pf-v6-c-expandable-section__toggle` | Indicates that the expandable section content is visible. **Required** |
-| `aria-expanded="false"` | `.pf-v6-c-expandable-section__toggle` | Indicates the the expandable section content is hidden. **Required** |
+| `aria-expanded="true"` | `.pf-v6-c-expandable-section__toggle .pf-v6-c-button` | Indicates that the expandable section content is visible. **Required** |
+| `aria-expanded="false"` | `.pf-v6-c-expandable-section__toggle .pf-v6-c-button` | Indicates the the expandable section content is hidden. **Required** |
 | `hidden` | `.pf-v6-c-expandable-section__content` | Indicates that the expandable section content element is hidden. Use with `aria-expanded="false"` **Required** |
 | `aria-hidden="true"` | `.pf-v6-c-expandable-section__toggle-icon` | Hides the icon from screen readers. **Required** |
-| `aria-controls="[id of content element]"` | `.pf-v6-c-expandable-section.pf-m-detached .pf-v6-c-expandable-section__toggle` | Identifies the element controlled by the toggle button. **Required** |
-| `id` | `.pf-v6-c-expandable-section.pf-m-detached .pf-v6-c-expandable-section__content` | Gives the content an `id` for use with `aria-controls` on `.pf-v6-c-expandable-section__toggle`. **Required** |
+| `aria-controls="[id of content element]"` | `.pf-v6-c-expandable-section.pf-m-detached .pf-v6-c-expandable-section__toggle .pf-v6-c-button` | Identifies the element controlled by the toggle button. **Required** |
+| `id` | `.pf-v6-c-expandable-section.pf-m-detached .pf-v6-c-expandable-section__content` | Gives the content an `id` for use with `aria-controls` on `.pf-v6-c-expandable-section__toggle .pf-v6-c-button`. **Required** |
 
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-v6-c-expandable-section` | `<div>` | Initiates the expandable section component. **Required** |
-| `.pf-v6-c-expandable-section__toggle` | `<button>` | Initiates the expandable section toggle. **Required** |
-| `.pf-v6-c-expandable-section__toggle-text` | `<span>` | Initiates the expandable toggle text. **Required** |
+| `.pf-v6-c-expandable-section__toggle` | `<div>` | Initiates the expandable toggle wrapper. **Required** |
 | `.pf-v6-c-expandable-section__toggle-icon` | `<span>` | Initiates the expandable toggle icon. **Required** |
 | `.pf-v6-c-expandable-section__content` | `<div>` | Initiates the expandable section content. **Required** |
 | `.pf-m-expanded` | `.pf-v6-c-expandable-section` | Modifies the component for the expanded state. |

--- a/src/patternfly/components/ExpandableSection/expandable-section-toggle-text.hbs
+++ b/src/patternfly/components/ExpandableSection/expandable-section-toggle-text.hbs
@@ -1,6 +1,0 @@
-<span class="{{pfv}}expandable-section__toggle-text{{#if expandable-section-toggle-text--modifier}} {{expandable-section-toggle-text--modifier}}{{/if}}"
-  {{#if expandable-section-toggle-text--attribute}}
-    {{{expandable-section-toggle-text--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</span>

--- a/src/patternfly/components/ExpandableSection/expandable-section-toggle.hbs
+++ b/src/patternfly/components/ExpandableSection/expandable-section-toggle.hbs
@@ -1,19 +1,13 @@
-<button type="button" class="{{pfv}}expandable-section__toggle{{#if expandable-section-toggle--modifier}} {{expandable-section-toggle--modifier}}{{/if}}"
+<div class="{{pfv}}expandable-section__toggle{{#if expandable-section-toggle--modifier}} {{expandable-section-toggle--modifier}}{{/if}}"
   {{#if expandable-section-toggle--attribute}}
     {{{expandable-section-toggle--attribute}}}
-  {{/if}}
-  {{#if expandable-section--IsExpanded}}
-    aria-expanded="true"
-  {{else}}
-    aria-expanded="false"
-  {{/if}}
-  {{#if expandable-section--IsDetached}}
-    aria-controls="{{expandable-section--id}}-content"
   {{/if}}>
-  {{#unless expandable-section--IsTruncate}}
-    {{> expandable-section-toggle-icon}}
-  {{/unless}}
-  {{#> expandable-section-toggle-text}}
+  {{#> button
+    button--IsLink=true
+    button--IsInline=expandable-section--IsTruncate
+    button--IsAriaExpanded=expandable-section--IsExpanded
+    button--aria-controls=(ternary expandable-section--IsDetached (concat expandable-section--id '-content') null)
+    button--icon-template=(ternary expandable-section--IsTruncate null "expandable-section-toggle-icon")}}
     {{#if @partial-block}}
       {{> @partial-block}}
     {{else if expandable-section--IsExpanded}}
@@ -21,5 +15,5 @@
     {{else}}
       Show more
     {{/if}}
-  {{/expandable-section-toggle-text}}
-</button>
+  {{/button}}
+</div>

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -1,13 +1,7 @@
 @use '../../sass-utilities' as *;
 
 :where(:root, .#{$expandable-section}) {
-  // Toggle
-  --#{$expandable-section}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__toggle--BackgroundColor: transparent;
-  --#{$expandable-section}__toggle--ColumnGap: calc(var(--pf-t--global--spacer--xs) + var(--pf-t--global--spacer--sm));
+  --#{$expandable-section}--Gap: var(--pf-t--global--spacer--sm);
 
   // Toggle icon
   --#{$expandable-section}__toggle-icon--MinWidth: 1em;
@@ -18,60 +12,41 @@
   --#{$expandable-section}--m-expanded__toggle-icon--Rotate: 90deg;
   --#{$expandable-section}--m-expanded__toggle-icon--m-expand-top--Rotate: -90deg;
 
-  // Toggle text
-  --#{$expandable-section}__toggle-text--Color: var(--pf-t--global--color--brand--default);
-  --#{$expandable-section}__toggle-text--hover--Color: var(--pf-t--global--color--brand--hover);
-  --#{$expandable-section}--m-expanded__toggle-text--Color: var(--pf-t--global--color--brand--hover);
-
   // Content
-  --#{$expandable-section}__content--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}__content--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}__content--MaxWidth: auto;
 
   // Limit Width
   --#{$expandable-section}--m-limit-width__content--MaxWidth: #{pf-size-prem(750px)};
 
   // Large / Disclosure
+  --#{$expandable-section}--m-display-lg--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}--m-display-lg--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$expandable-section}--m-display-lg--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-display-lg--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$expandable-section}--m-display-lg--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$expandable-section}--m-display-lg--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$expandable-section}--m-display-lg--BorderWidth: var(--pf-t--global--border--width--box--default);
   --#{$expandable-section}--m-display-lg--BorderColor: var(--pf-t--global--border--color--default);
   --#{$expandable-section}--m-display-lg--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__toggle--PaddingInlineStart: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-display-lg__toggle--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$expandable-section}--m-display-lg__toggle--Width: 100%;
-  --#{$expandable-section}--m-display-lg__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
-  --#{$expandable-section}--m-display-lg__toggle--active--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
-  --#{$expandable-section}--m-display-lg__toggle--focus--BackgroundColor: var(--pf-t--global--background--color--secondary--hover);
-  --#{$expandable-section}--m-display-lg__content--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-display-lg__content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-display-lg__content--PaddingInlineStart: var(--pf-t--global--spacer--lg);
-  --#{$expandable-section}--m-expanded--m-display-lg__toggle--BorderRadius: var(--pf-t--global--border--radius--medium) var(--pf-t--global--border--radius--medium) 0 0;
 
   // Indented
-  --#{$expandable-section}--m-indented__content--PaddingInlineStart--base: calc(var(--#{$expandable-section}__toggle--ColumnGap) + var(--#{$expandable-section}__toggle-icon--MinWidth));
-  --#{$expandable-section}--m-indented__content--PaddingInlineStart: calc(var(--#{$expandable-section}--m-indented__content--PaddingInlineStart--base) + var(--#{$expandable-section}__toggle--PaddingInlineStart));
-  --#{$expandable-section}--m-display-lg--m-indented__content--PaddingInlineStart: calc(var(--#{$expandable-section}--m-indented__content--PaddingInlineStart--base) + var(--#{$expandable-section}--m-display-lg__content--PaddingInlineStart));
+  --#{$expandable-section}--m-indented__content--PaddingInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) + var(--pf-t--global--spacer--gap--text-to-element--default) + var(--#{$expandable-section}__toggle-icon--MinWidth));
 
   // Truncate
-  --#{$expandable-section}--m-truncate--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}--m-truncate--PaddingInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-truncate--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$expandable-section}--m-truncate--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$expandable-section}--m-truncate__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$expandable-section}--m-truncate__content--LineClamp: 3;
+  --#{$expandable-section}--m-truncate--Gap: var(--pf-t--global--spacer--xs);
 }
 
 .#{$expandable-section} {
+  display: flex;
+  flex-direction: column;
+  gap: var(--#{$expandable-section}--Gap);
+  align-items: start;
+
   &.pf-m-expanded {
-    --#{$expandable-section}__toggle-text--Color: var(--#{$expandable-section}--m-expanded__toggle-text--Color);
     --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}--m-expanded__toggle-icon--Rotate);
     --#{$expandable-section}__toggle-icon--m-expand-top--Rotate: var(--#{$expandable-section}--m-expanded__toggle-icon--m-expand-top--Rotate);
-    --#{$expandable-section}--m-display-lg--after--BackgroundColor: var(--#{$expandable-section}--m-display-lg--m-expanded--after--BackgroundColor);
-    --#{$expandable-section}--m-display-lg__toggle--BorderRadius: var(--#{$expandable-section}--m-expanded--m-display-lg__toggle--BorderRadius);
+    --#{$expandable-section}--m-display-lg--PaddingBlockEnd: var(--#{$expandable-section}--m-display-lg--m-expanded--PaddingBlockEnd);
   }
 
   &.pf-m-limit-width {
@@ -79,22 +54,12 @@
   }
 
   &.pf-m-display-lg {
-    --#{$expandable-section}__toggle--PaddingBlockStart: var(--#{$expandable-section}--m-display-lg__toggle--PaddingBlockStart);
-    --#{$expandable-section}__toggle--PaddingInlineEnd: var(--#{$expandable-section}--m-display-lg__toggle--PaddingInlineEnd);
-    --#{$expandable-section}__toggle--PaddingBlockEnd: var(--#{$expandable-section}--m-display-lg__toggle--PaddingBlockEnd);
-    --#{$expandable-section}__toggle--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg__toggle--PaddingInlineStart);
-    --#{$expandable-section}__toggle--hover--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--hover--BackgroundColor);
-    --#{$expandable-section}__toggle--active--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--active--BackgroundColor);
-    --#{$expandable-section}__toggle--focus--BackgroundColor: var(--#{$expandable-section}--m-display-lg__toggle--focus--BackgroundColor);
-    --#{$expandable-section}__toggle--BorderRadius: var(--#{$expandable-section}--m-display-lg__toggle--BorderRadius);
-    --#{$expandable-section}__toggle--Width: var(--#{$expandable-section}--m-display-lg__toggle--Width);
-    --#{$expandable-section}__content--PaddingInlineEnd: var(--#{$expandable-section}--m-display-lg__content--PaddingInlineEnd);
-    --#{$expandable-section}__content--PaddingBlockEnd: var(--#{$expandable-section}--m-display-lg__content--PaddingBlockEnd);
-    --#{$expandable-section}__content--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg__content--PaddingInlineStart);
-    --#{$expandable-section}--m-indented__content--PaddingInlineStart: var(--#{$expandable-section}--m-display-lg--m-indented__content--PaddingInlineStart);
-
+    padding-block-start: var(--#{$expandable-section}--m-display-lg--PaddingBlockStart);
+    padding-block-end: var(--#{$expandable-section}--m-display-lg--PaddingBlockEnd);
+    padding-inline-start: var(--#{$expandable-section}--m-display-lg--PaddingInlineStart);
+    padding-inline-end: var(--#{$expandable-section}--m-display-lg--PaddingInlineEnd);
     background-color: var(--#{$expandable-section}--m-display-lg--BackgroundColor);
-    border: solid 1px var(--#{$expandable-section}--m-display-lg--BorderColor);
+    border: var(--#{$expandable-section}--m-display-lg--BorderWidth) solid var(--#{$expandable-section}--m-display-lg--BorderColor);
     border-radius: var(--#{$expandable-section}--m-display-lg--BorderRadius);
   }
 
@@ -103,15 +68,7 @@
   }
 
   &.pf-m-truncate {
-    --#{$expandable-section}__toggle--PaddingBlockStart: 0;
-    --#{$expandable-section}__toggle--PaddingInlineEnd: 0;
-    --#{$expandable-section}__toggle--PaddingBlockEnd: var(--#{$expandable-section}--m-truncate__toggle--PaddingBlockEnd);
-    --#{$expandable-section}__toggle--PaddingInlineStart: 0;
-    --#{$expandable-section}__content--PaddingBlockStart: 0;
-    --#{$expandable-section}__content--PaddingInlineEnd: 0;
-    --#{$expandable-section}__content--PaddingBlockEnd: 0;
-    --#{$expandable-section}__content--PaddingInlineStart: 0;
-
+    --#{$expandable-section}--Gap: var(--#{$expandable-section}--m-truncate--Gap);
     &:not(.pf-m-expanded) .#{$expandable-section}__content {
       // stylelint-disable
       display: -webkit-box;
@@ -123,27 +80,10 @@
   }
 }
 
-.#{$expandable-section}__toggle {
-  display: flex;
-  column-gap: var(--#{$expandable-section}__toggle--ColumnGap);
-  width: var(--#{$expandable-section}__toggle--Width, initial);
-  padding-block-start: var(--#{$expandable-section}__toggle--PaddingBlockStart);
-  padding-block-end: var(--#{$expandable-section}__toggle--PaddingBlockEnd);
-  padding-inline-start: var(--#{$expandable-section}__toggle--PaddingInlineStart);
-  padding-inline-end: var(--#{$expandable-section}__toggle--PaddingInlineEnd);
-  background-color: var(--#{$expandable-section}__toggle--BackgroundColor);
-  border: none;
-  border-radius: var(--#{$expandable-section}__toggle--BorderRadius, 0);
-
-  &:is(:hover, :focus) {
-    --#{$expandable-section}__toggle-text--Color: var(--#{$expandable-section}__toggle-text--hover--Color);
-    --#{$expandable-section}__toggle--BackgroundColor: var(--#{$expandable-section}__toggle--hover--BackgroundColor, initial);
-  }
-}
-
 .#{$expandable-section}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
+  display: inline-block;
   min-width: var(--#{$expandable-section}__toggle-icon--MinWidth);
   color: var(--#{$expandable-section}__toggle-icon--Color);
   transition: var(--#{$expandable-section}__toggle-icon--Transition);
@@ -154,14 +94,8 @@
   }
 }
 
-.#{$expandable-section}__toggle-text {
-  color: var(--#{$expandable-section}__toggle-text--Color);
-}
-
 .#{$expandable-section}__content {
   max-width: var(--#{$expandable-section}__content--MaxWidth);
-  padding-block-start: var(--#{$expandable-section}__content--PaddingBlockStart);
-  padding-block-end: var(--#{$expandable-section}__content--PaddingBlockEnd);
-  padding-inline-start: var(--#{$expandable-section}__content--PaddingInlineStart);
-  padding-inline-end: var(--#{$expandable-section}__content--PaddingInlineEnd);
+  padding-block-end: var(--#{$expandable-section}__content--PaddingBlockEnd, 0);
+  padding-inline-start: var(--#{$expandable-section}__content--PaddingInlineStart, 0);
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6998

Visual regression report - [expandable-section.pdf](https://github.com/user-attachments/files/16702893/expandable-section.pdf)


Just a draft to see if it's something we want to get in this sprint. Cleans up some styles, too.

The react changes would be:
* Make `__toggle` a `<div>` instead of a custom button
* Use a link `<Button>` in `__toggle` and update old `__toggle` logic to apply to the `<Button>` instead