### PR TITLE
feat(various): remove hardcoded namespace

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -144,7 +144,7 @@
       --#{$menu}--PaddingBlockEnd: 0;
       --#{$menu}--BackgroundColor: var(--#{$nav}--BackgroundColor);
       --#{$menu}--BoxShadow: none;
-      --#{$menu}__list-item--hover--BackgroundColor: var(--pf-v6-c-nav__link--hover--BackgroundColor);
+      --#{$menu}__list-item--hover--BackgroundColor: var(--#{$nav}__link--hover--BackgroundColor);
 
       .#{$menu}__list {
         row-gap: var(--#{$nav}__subnav--RowGap);

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -252,9 +252,9 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     @each $width-value in $pf-v6-c-sidebar__panel--list--width {
       .pf-v6-c-sidebar__panel.pf-m-width-#{$width-value}#{$breakpoint-name} {
         @if $width-value == "default" {
-          --pf-v6-c-sidebar__panel--FlexBasis: var(--pf-v6-c-sidebar__panel--FlexBasis--base);
+          --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--FlexBasis--base);
         } @else {
-          --pf-v6-c-sidebar__panel--FlexBasis: #{percentage(math.div($width-value, 100))};
+          --#{$sidebar}__panel--FlexBasis: #{percentage(math.div($width-value, 100))};
         }
       }
     }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -595,7 +595,7 @@
   }
 
   .#{$button} .#{$table}__sort-indicator {
-    --pf-v6-c-table__sort-indicator--MarginInlineStart: 0;
+    --#{$table}__sort-indicator--MarginInlineStart: 0;
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -19,9 +19,9 @@
 
   // Main
   --#{$text-input-group}__main--first-child--not--text-input--MarginInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--plain) / 2);
-  --#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
-  --#{$text-input-group}--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
-  --#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--sm) + var(--pf-v6-c-text-input-group__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
+  --#{$text-input-group}__main--m-icon__text-input--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$text-input-group}__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
+  --#{$text-input-group}--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$text-input-group}__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
+  --#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd: calc(var(--pf-t--global--spacer--sm) + var(--#{$text-input-group}__icon--FontSize) + var(--pf-t--global--spacer--gap--text-to-element--default));
   --#{$text-input-group}__main--RowGap: var(--pf-t--global--spacer--xs);
   --#{$text-input-group}__main--ColumnGap: var(--pf-t--global--spacer--xs);
 

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -195,34 +195,34 @@
 
 @mixin pf-v6-hidden-visible($val: "block") {
   // stylelint-disable-next-line
-  --pf-v6-hidden-visible--visible--Display: #{$val};
+  --#{$pf-prefix}hidden-visible--visible--Display: #{$val};
 
   // base value for visible display property is set to 'block' by default and passed in to
   // placeholder via `pf-v6-hidden-visible` mixin
 
   // set hidden var values
   // stylelint-disable custom-property-pattern
-  --pf-v6-hidden-visible--hidden--Display: none;
+  --#{$pf-prefix}hidden-visible--hidden--Display: none;
 
   // set visibile var values
-  --pf-v6-hidden-visible--Display: var(--pf-v6-hidden-visible--visible--Display);
+  --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--visible--Display);
 
   // set default state to visible
-  display: var(--pf-v6-hidden-visible--Display);
+  display: var(--#{$pf-prefix}hidden-visible--Display);
 
   // toggle values based on state
   &.pf-m-hidden {
-    --pf-v6-hidden-visible--Display: var(--pf-v6-hidden-visible--hidden--Display);
+    --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
   }
 
   @each $size, $bp in $pf-v6-global--breakpoint-name-map {
     @media screen and (min-width: $bp) {
       &.pf-m-hidden-on-#{$size} {
-        --pf-v6-hidden-visible--Display: var(--pf-v6-hidden-visible--hidden--Display);
+        --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
       }
 
       &.pf-m-visible-on-#{$size} {
-        --pf-v6-hidden-visible--Display: var(--pf-v6-hidden-visible--visible--Display);
+        --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--visible--Display);
       }
     }
   }

--- a/src/patternfly/utilities/Sizing/sizing.scss
+++ b/src/patternfly/utilities/Sizing/sizing.scss
@@ -47,44 +47,44 @@ $pf-v6-u-height-options: (
 @include pf-v6-utility-builder($pf-v6-u-height-options, $pf-v6-global--breakpoint-list);
 
 .#{$pf-prefix}u-min-width {
-  --pf-v6-u-min-width--MinWidth: 0;
+  --#{$pf-prefix}u-min-width--MinWidth: 0;
 
   @include pf-v6-build-css-variable-stack(
     "min-width",
-    "--pf-v6-u-min-width--MinWidth",
+    "--#{$pf-prefix}u-min-width--MinWidth",
     $pf-v6-u-sizing--min-max--breakpoint-map,
     $important: true
   );
 }
 
 .#{$pf-prefix}u-max-width {
-  --pf-v6-u-max-width--MaxWidth: auto;
+  --#{$pf-prefix}u-max-width--MaxWidth: auto;
 
   @include pf-v6-build-css-variable-stack(
     "max-width",
-    "--pf-v6-u-max-width--MaxWidth",
+    "--#{$pf-prefix}u-max-width--MaxWidth",
     $pf-v6-u-sizing--min-max--breakpoint-map,
     $important: true
   );
 }
 
 .#{$pf-prefix}u-min-height {
-  --pf-v6-u-min-height--MinHeight: 0;
+  --#{$pf-prefix}u-min-height--MinHeight: 0;
 
   @include pf-v6-build-css-variable-stack(
     "min-height",
-    "--pf-v6-u-min-height--MinHeight",
+    "--#{$pf-prefix}u-min-height--MinHeight",
     $pf-v6-u-sizing--min-max--breakpoint-map,
     $important: true
   );
 }
 
 .#{$pf-prefix}u-max-height {
-  --pf-v6-u-max-height--MaxHeight: auto;
+  --#{$pf-prefix}u-max-height--MaxHeight: auto;
 
   @include pf-v6-build-css-variable-stack(
     "max-height",
-    "--pf-v6-u-max-height--MaxHeight",
+    "--#{$pf-prefix}u-max-height--MaxHeight",
     $pf-v6-u-sizing--min-max--breakpoint-map,
     $important: true
   );

--- a/src/patternfly/utilities/Text/text.scss
+++ b/src/patternfly/utilities/Text/text.scss
@@ -34,7 +34,7 @@ $pf-v6-u-font-size-options: (
     font-size var(--pf-t--global--font--size--xl)
   ),
   font-size-2xl: (
-    font-size var(--pf-v6-global--FontSize--2xl)
+    font-size var(--pf-t-global--FontSize--2xl)
   ),
   font-size-3xl: (
     font-size var(--pf-t--global--font--size--3xl)

--- a/src/patternfly/utilities/Text/text.scss
+++ b/src/patternfly/utilities/Text/text.scss
@@ -34,7 +34,7 @@ $pf-v6-u-font-size-options: (
     font-size var(--pf-t--global--font--size--xl)
   ),
   font-size-2xl: (
-    font-size var(--pf-t-global--FontSize--2xl)
+    font-size var(--pf-t--global--font--size--2xl)
   ),
   font-size-3xl: (
     font-size var(--pf-t--global--font--size--3xl)


### PR DESCRIPTION
Fixes #6991 

Removes remaining hardcoded `--pf-v6-` instances and replaces them with the appropriate sass variable for the prefix.

Visual regression tests for nav, sidebar, table, utilities, and text show the same number of failures (9, 5, 15, 0, and 5 respectively) as when I ran it before changes, and all are indistinguishable.