### PR TITLE
fix(jumplinks): fixed outdated hbs for jump link toggle in demo

### DIFF
--- a/src/patternfly/components/JumpLinks/jump-links-header.hbs
+++ b/src/patternfly/components/JumpLinks/jump-links-header.hbs
@@ -4,15 +4,9 @@
   {{/if}}>
   {{#if jump-links--IsExpandable}}
     {{#> jump-links-toggle}}
-      {{#if jump-links--IsExpanded}}
-        {{#> button button--IsPlain=true button--icon-template="jump-links-toggle-icon" button--attribute=(concat 'aria-label="Toggle jump links" aria-expanded="true"')}}
-          Jump to section
-        {{/button}}
-      {{else}}
-        {{#> button button--IsPlain=true button--icon-template="jump-links-toggle-icon" button--attribute=(concat 'aria-label="Toggle jump links" aria-expanded="false"')}}
-          Jump to section
-        {{/button}}
-      {{/if}}
+      {{#> button button--IsPlain=true button--icon-template="jump-links-toggle-icon" button--aria-label="Toggle jump links" button--IsAriaExpanded=jump-links--IsExpanded}}
+        Jump to section
+      {{/button}}
     {{/jump-links-toggle}}
   {{/if}}
   {{#unless jump-links--HasNoLabel}}

--- a/src/patternfly/demos/Drawer/examples/drawer-jump-links.hbs
+++ b/src/patternfly/demos/Drawer/examples/drawer-jump-links.hbs
@@ -8,9 +8,7 @@
           {{#> sidebar-panel sidebar-panel--modifier="pf-m-sticky pf-m-gutter"}}
             {{#> page-main-section}}
               {{#> jump-links jump-links--IsExpandable="true" jump-links--modifier="pf-m-vertical pf-m-non-expandable-on-md"}}
-                {{#> jump-links-label}}
-                  Jump to section
-                {{/jump-links-label}}
+                {{> jump-links-header}}
                 {{> jump-links-template-list}}
               {{/jump-links}}
             {{/page-main-section}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7021

Convenience link from the issue - https://patternfly-pr-7024.surge.sh/components/drawer/html-demos/collapsed-drawer-with-jump-links/
* The expandable toggle is now visible on small screens
