### PR TITLE
fix(button): add min-width

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -5,6 +5,7 @@
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
   --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
+  --#{$button}--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
   --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
@@ -131,7 +132,6 @@
   --#{$button}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain__icon--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$button}--m-plain--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--m-plain--hover--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$button}--m-plain--m-clicked--Color: var(--pf-t--global--icon--color--regular);
@@ -289,6 +289,7 @@
   gap: var(--#{$button}--Gap);
   align-items: var(--#{$button}--AlignItems);
   justify-content: var(--#{$button}--JustifyContent);
+  min-width: var(--#{$button}--MinWidth);
   padding-block-start: var(--#{$button}--PaddingBlockStart);
   padding-block-end: var(--#{$button}--PaddingBlockEnd);
   padding-inline-start: var(--#{$button}--PaddingInlineStart);
@@ -567,8 +568,6 @@
 
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
     }
-
-    min-width: var(--#{$button}--m-plain--MinWidth);
   }
 
   &.pf-m-block {

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -62,10 +62,6 @@
 .#{$clipboard-copy}__group {
   display: flex;
   gap: var(--#{$clipboard-copy}__group--Gap);
-
-  > * + * {
-    margin-inline-start: -1px;
-  }
 }
 
 .#{$clipboard-copy}__toggle-icon {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7034

[backstop-button-min-width.pdf](https://github.com/user-attachments/files/16882480/backstop-button-min-width.pdf)

There is a sub-pixel size difference with the clipboard copy buttons for some reason when adding the `min-width`. Not sure why, but not concerned about it either 🐸