### PR TITLE
fix(force-reflow): removed `--Display` vars

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($button) {
-  --#{$button}--Display: inline-flex;
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
   --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
@@ -103,7 +102,6 @@
   --#{$button}--m-link--m-danger--m-clicked__icon--Color: var(--pf-t--global--text--color--status--danger--clicked);
 
   // Link inline
-  --#{$button}--m-link--m-inline--Display: inline-flex;
   --#{$button}--m-link--m-inline--JustifyContent: flex-start;
   --#{$button}--m-link--m-inline--FontSize: initial;
   --#{$button}--m-link--m-inline--LineHeight: initial;
@@ -120,7 +118,6 @@
   --#{$button}--m-link--m-inline--m-in-progress--PaddingInlineStart: calc(var(--#{$button}--m-link--m-inline__progress--InsetInlineStart) + 1rem + var(--pf-t--global--spacer--sm));
   --#{$button}--m-link--m-inline--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$button}--m-link--m-inline--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
-  --#{$button}--span--m-link--m-inline--Display: inline;
   --#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd: var(--pf-t--global--spacer--gap--text-to-element--default);
   --#{$button}--span--m-link--m-inline__icon--m-end--MarginInlineStart: var(--pf-t--global--spacer--gap--text-to-element--default);
 
@@ -279,13 +276,12 @@
   --#{$button}--m-primary__c-badge--BorderColor: var(--pf-t--global--border--color--default);
 
   // Block
-  --#{$button}--m-block--Display: flex;
   --#{$button}--m-block--Width: 100%;
 }
 
 .#{$button} {
   position: relative;
-  display: var(--#{$button}--Display);
+  display: inline-flex;
   gap: var(--#{$button}--Gap);
   align-items: var(--#{$button}--AlignItems);
   justify-content: var(--#{$button}--JustifyContent);
@@ -398,12 +394,12 @@
 
     &.pf-m-inline {
       @at-root span#{&} {
-        --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
         --#{$button}__icon--m-start--MarginInlineEnd: var(--#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd);
         --#{$button}__icon--m-end--MarginInlineStart: var(--#{$button}--span--m-link--m-inline__icon--m-end--MarginInlineStart);
+
+        display: inline;
       }
 
-      --#{$button}--Display: var(--#{$button}--m-link--m-inline--Display);
       --#{$button}--JustifyContent: var(--#{$button}--m-link--m-inline--JustifyContent);
       --#{$button}--FontSize: var(--#{$button}--m-link--m-inline--FontSize);
       --#{$button}--LineHeight: var(--#{$button}--m-link--m-inline--LineHeight);
@@ -572,8 +568,7 @@
   }
 
   &.pf-m-block {
-    --#{$button}--Display: var(--#{$button}--m-block--Display);
-
+    display: flex;
     width: var(--#{$button}--m-block--Width);
   }
 

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -91,8 +91,7 @@
   --#{$data-list}__check--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   --#{$data-list}__check--MarginBlockStart: #{pf-size-prem(-1px)}; // slightly offset input
 
-  // actions
-  --#{$data-list}__item-action--Display: flex;
+  // * Data list item action
   --#{$data-list}__item-action--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$data-list}__item-action--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$data-list}__item-action--MarginInlineStart: var(--pf-t--global--spacer--md);
@@ -316,7 +315,7 @@
 }
 
 .#{$data-list}__item-action {
-  @include pf-v6-hidden-visible(var(--#{$data-list}__item-action--Display));
+  @include pf-v6-hidden-visible('flex');
 
   gap: var(--#{$data-list}__item-action--Gap);
   align-content: flex-start;

--- a/src/patternfly/components/DescriptionList/description-list.scss
+++ b/src/patternfly/components/DescriptionList/description-list.scss
@@ -20,16 +20,10 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
   --#{$description-list}--m-compact--RowGap: var(--pf-t--global--spacer--md);
   --#{$description-list}--m-compact--ColumnGap: var(--pf-t--global--spacer--sm);
 
-  // term
-  --#{$description-list}__term--Display: inline;
-  --#{$description-list}__term--sm--Display: flex;
+  // * Description list term
   --#{$description-list}__term--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$description-list}__term--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$description-list}__term--LineHeight: var(--pf-t--global--font--line-height--body);
-
-  @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    --#{$description-list}__term--Display: var(--#{$description-list}__term--sm--Display);
-  }
 
   // icon
   --#{$description-list}__term-icon--MinWidth: var(--pf-t--global--font--size--body--sm);
@@ -154,10 +148,14 @@ $pf-v6-c-description-list--breakpoint-map: build-breakpoint-map("base", "sm", "m
 }
 
 .#{$description-list}__term {
-  display: var(--#{$description-list}__term--Display);
+  display: inline;
   font-size: var(--#{$description-list}__term--FontSize);
   font-weight: var(--#{$description-list}__term--FontWeight);
   line-height: var(--#{$description-list}__term--LineHeight);
+
+  @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
+    display: flex;
+  }
 
   .#{$description-list}__text {
     display: inline;

--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -19,7 +19,6 @@ $pf-v6-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
 
 @include pf-root($divider) {
   // * Divider
-  --#{$divider}--Display: flex;
   --#{$divider}--Color: var(--pf-t--global--border--color--default);
   --#{$divider}--Size: var(--pf-t--global--border--width--divider--default);
 
@@ -30,7 +29,7 @@ $pf-v6-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
 // - Divider
 .#{$divider} {
   @include pf-v6-c-divider--m-horizontal; // default, set to orientation to horizontal
-  @include pf-v6-hidden-visible(var(--#{$divider}--Display));
+  @include pf-v6-hidden-visible('flex');
 
   flex-shrink: 0;
   align-items: stretch;

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -4,7 +4,6 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
 @include pf-root($jump-links) {
   // list
-  --#{$jump-links}__list--Display: flex;
   --#{$jump-links}__list--PaddingBlockStart: 0;
   --#{$jump-links}__list--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$jump-links}__list--PaddingBlockEnd: 0;
@@ -53,12 +52,10 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   // label
   --#{$jump-links}__label--MarginBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$jump-links}__label--Display: block;
 
   // toggle
   --#{$jump-links}__toggle--MarginBlockEnd: 0;
   --#{$jump-links}--m-expanded__toggle--MarginBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$jump-links}__toggle--Display: none;
 
   // toggle icon
   --#{$jump-links}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -99,30 +96,49 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
     @include pf-v6-apply-breakpoint($breakpoint) {
       &.pf-m-expandable#{$breakpoint-name} {
-        --#{$jump-links}__list--Display: none;
-        --#{$jump-links}__toggle--Display: block;
-        --#{$jump-links}__label--Display: none;
+        .#{$jump-links}__list {
+          display: none;
+        }
+
+        .#{$jump-links}__toggle {
+          display: block;
+        }
+
+        .#{$jump-links}__label {
+          display: none;
+        }
       }
 
       &.pf-m-non-expandable#{$breakpoint-name} {
-        --#{$jump-links}__list--Display: flex;
-        --#{$jump-links}__toggle--Display: none;
-        --#{$jump-links}__label--Display: block;
+        .#{$jump-links}__list {
+          display: flex;
+        }
+
+        .#{$jump-links}__toggle {
+          display: none;
+        }
+
+        .#{$jump-links}__label {
+          display: block;
+        }
       }
     }
   }
 
   &.pf-m-expanded {
-    --#{$jump-links}__list--Display: flex;
     --#{$jump-links}__toggle--MarginBlockEnd: var(--#{$jump-links}--m-expanded__toggle--MarginBlockEnd);
     --#{$jump-links}__toggle-icon--Rotate: var(--#{$jump-links}--m-expanded__toggle-icon--Rotate);
     --#{$jump-links}__toggle-icon--Color: var(--#{$jump-links}--m-expanded__toggle-icon--Color);
+
+    .#{$jump-links}__list {
+      display: flex;
+    }
   }
 }
 
 .#{$jump-links}__list {
   position: relative;
-  display: var(--#{$jump-links}__list--Display);
+  display: flex;
   flex-direction: var(--#{$jump-links}__list--FlexDirection);
   padding-block-start: var(--#{$jump-links}__list--PaddingBlockStart);
   padding-block-end: var(--#{$jump-links}__list--PaddingBlockEnd);
@@ -199,7 +215,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 }
 
 .#{$jump-links}__label {
-  display: var(--#{$jump-links}__label--Display);
+  display: block;
   margin-block-end: var(--#{$jump-links}__label--MarginBlockEnd);
 }
 
@@ -209,7 +225,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 }
 
 .#{$jump-links}__toggle {
-  display: var(--#{$jump-links}__toggle--Display);
+  display: none;
   margin-block-end: var(--#{$jump-links}__toggle--MarginBlockEnd);
 }
 

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -37,22 +37,20 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$masthead}--m-display-stack__content--GridColumn: 1;
   --#{$masthead}--m-display-stack__content--Order: 1;
   --#{$masthead}--m-display-stack__main--toggle--content--GridColumn: 2;
-  --#{$masthead}--m-display-stack__main--Display: contents;
   --#{$masthead}--m-display-stack__main--ColumnGap: unset; // no column gap needed until it's flex display
 
   // * Masthead inline
   --#{$masthead}--m-display-inline--ColumnGap: 0;
   --#{$masthead}--m-display-inline--GridTemplateColumns: min-content 1fr;
   --#{$masthead}--m-display-inline--breakpoint--xl--GridTemplateColumns: subgrid;
-  --#{$masthead}--m-display-inline__brand--GridColumn: initial; 
+  --#{$masthead}--m-display-inline__brand--GridColumn: initial;
   --#{$masthead}--m-display-inline__brand--Order: initial;
   --#{$masthead}--m-display-inline__brand--PaddingBlockEnd: 0;
   --#{$masthead}--m-display-inline__brand--BorderBlockEnd: 0;
-  --#{$masthead}--m-display-inline__main--GridColumn: 1; 
+  --#{$masthead}--m-display-inline__main--GridColumn: 1;
   --#{$masthead}--m-display-inline__content--GridColumn: 2;
   --#{$masthead}--m-display-inline__content--Order: 0;
   --#{$masthead}--m-display-inline__main--toggle--content--GridColumn: 2;
-  --#{$masthead}--m-display-inline__main--Display: flex;
   --#{$masthead}--m-display-inline__main--ColumnGap: var(--pf-t--global--spacer--md);
 
   // * Masthead toolbar
@@ -76,8 +74,11 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$masthead}__content--GridColumn: var(--#{$masthead}--m-display-stack__content--GridColumn);
   --#{$masthead}__content--Order: var(--#{$masthead}--m-display-stack__content--Order);
   --#{$masthead}__main--toggle--content--GridColumn: var(--#{$masthead}--m-display-stack__main--toggle--content--GridColumn);
-  --#{$masthead}__main--Display: var(--#{$masthead}--m-display-stack__main--Display);
   --#{$masthead}__main--ColumnGap: var(--#{$masthead}--m-display-stack__main--ColumnGap);
+
+  .#{$masthead}__main {
+    display: contents;
+  }
 }
 
 // * Masthead display inline
@@ -92,8 +93,11 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$masthead}__content--GridColumn: var(--#{$masthead}--m-display-inline__content--GridColumn);
   --#{$masthead}__content--Order: var(--#{$masthead}--m-display-inline__content--Order);
   --#{$masthead}__main--toggle--content--GridColumn: var(--#{$masthead}--m-display-inline__main--toggle--content--GridColumn);
-  --#{$masthead}__main--Display: var(--#{$masthead}--m-display-inline__main--Display); 
   --#{$masthead}__main--ColumnGap: var(--#{$masthead}--m-display-inline__main--ColumnGap);
+
+  .#{$masthead}__main {
+    display: flex;
+  }
 }
 
 // - Masthead
@@ -161,7 +165,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 }
 
 .#{$masthead}__main {
-  display: var(--#{$masthead}__main--Display);
   grid-column: var(--#{$masthead}__main--GridColumn);
   column-gap: var(--#{$masthead}__main--ColumnGap);
   align-items: center;

--- a/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
+++ b/src/patternfly/components/MultipleFileUpload/multiple-file-upload.scss
@@ -22,7 +22,6 @@
   --#{$multiple-file-upload}__main--BorderRadius: var(--pf-t--global--border--radius--medium);
 
   // title
-  --#{$multiple-file-upload}__title--Display: grid;
   --#{$multiple-file-upload}__title--GridTemplateColumns: auto;
   --#{$multiple-file-upload}__title--Gap: var(--pf-t--global--spacer--lg);
 
@@ -37,7 +36,6 @@
   --#{$multiple-file-upload}__title-icon--FontSize: var(--pf-t--global--icon--size--xl);
 
   // title text separator
-  --#{$multiple-file-upload}__title-text-separator--Display: block;
   --#{$multiple-file-upload}__title-text-separator--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$multiple-file-upload}__title-text-separator--MarginBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$multiple-file-upload}__title-text-separator--Color: var(--pf-t--global--text--color--regular);
@@ -69,7 +67,6 @@
   // TODO replace with icon size token when available
   --#{$multiple-file-upload}--m-horizontal__title-icon--FontSize: var(--pf-t--global--font--size--heading--xs);
   --#{$multiple-file-upload}--m-horizontal__title-text--FontSize: var(--pf-t--global--font--size--heading--xs);
-  --#{$multiple-file-upload}--m-horizontal__title-text-separator--Display: inline;
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginBlockStart: 0;
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$multiple-file-upload}--m-horizontal__title-text-separator--FontSize: var(--pf-t--global--font--size--heading--xs);
@@ -128,11 +125,14 @@
     --#{$multiple-file-upload}__title-icon--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-icon--FontSize);
     --#{$multiple-file-upload}__title-text--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-text--FontSize);
     --#{$multiple-file-upload}__title-text-separator--FontFamily: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontFamily);
-    --#{$multiple-file-upload}__title-text-separator--Display: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--Display);
     --#{$multiple-file-upload}__title-text-separator--MarginBlockStart: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--MarginBlockStart);
     --#{$multiple-file-upload}__title-text-separator--FontSize: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontSize);
     --#{$multiple-file-upload}__title-text-separator--FontWeight: var(--#{$multiple-file-upload}--m-horizontal__title-text-separator--FontWeight);
     --#{$multiple-file-upload}__info--MarginBlockStart: var(--#{$multiple-file-upload}--m-horizontal__info--MarginBlockStart);
+
+    .#{$multiple-file-upload}__title-text-separator {
+      display: inline;
+    }
   }
 
   &.pf-m-drag-over {
@@ -158,7 +158,7 @@
 }
 
 .#{$multiple-file-upload}__title {
-  display: var(--#{$multiple-file-upload}__title--Display);
+  display: grid;
   grid-area: title;
   grid-template-columns: var(--#{$multiple-file-upload}__title--GridTemplateColumns);
   gap: var(--#{$multiple-file-upload}__title--Gap);
@@ -177,7 +177,7 @@
 }
 
 .#{$multiple-file-upload}__title-text-separator {
-  display: var(--#{$multiple-file-upload}__title-text-separator--Display);
+  display: block;
   margin-block-start: var(--#{$multiple-file-upload}__title-text-separator--MarginBlockStart);
   margin-block-end: var(--#{$multiple-file-upload}__title-text-separator--MarginBlockEnd);
   font-family: var(--#{$multiple-file-upload}__title-text-separator--FontFamily);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -10,10 +10,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   // Page insets
   --#{$pagination}--m-page-insets--inset: var(--pf-t--global--spacer--lg);
 
-  // nav
-  --#{$pagination}__nav--Display: none;
-  --#{$pagination}--m-display-summary__nav--Display: none;
-  --#{$pagination}--m-display-full__nav--Display: inline-flex;
+  // * Pagination nav
   --#{$pagination}__nav--ColumnGap: var(--pf-t--global--spacer--sm);
 
   // nav page select
@@ -22,11 +19,6 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}__nav-page-select--c-form-control--width-base: calc((var(--#{$form-control}--PaddingInlineEnd) + var(--#{$form-control}--PaddingInlineStart)) + (var(--#{$form-control}--before--BorderWidth) * 2));
   --#{$pagination}__nav-page-select--c-form-control--width-chars: 2;
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
-
-  // total items
-  --#{$pagination}__total-items--Display: block;
-  --#{$pagination}--m-display-summary__total-items--Display: block;
-  --#{$pagination}--m-display-full__total-items--Display: none;
 
   // top
   --#{$pagination}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -46,19 +38,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-bottom--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
 
-  // options menu
-  --#{$pagination}__page-menu--Display--base: block;
-  --#{$pagination}__page-menu--Display: none;
-  --#{$pagination}--m-display-summary__page-menu--Display: none;
-  --#{$pagination}--m-display-full__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
-  --#{$pagination}--m-bottom__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
-  --#{$pagination}__page-menu--md--Display: var(--#{$pagination}__page-menu--Display--base);
-
   @media screen and (min-width: $pf-v6-global--breakpoint--md) {
     --#{$pagination}--m-bottom--BoxShadow: none;
-    --#{$pagination}__page-menu--Display: var(--#{$pagination}__page-menu--md--Display);
-    --#{$pagination}__nav--Display: inline-flex;
-    --#{$pagination}__total-items--Display: none;
   }
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
@@ -66,6 +47,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   }
 }
 
+// - Pagination
 .#{$pagination} {
   display: flex;
   flex-wrap: wrap;
@@ -76,7 +58,25 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   padding-inline-end: var(--#{$pagination}--inset);
 
   .#{$pagination}__page-menu {
-    display: var(--#{$pagination}__page-menu--Display);
+    display: none;
+  }
+
+  .#{$pagination}__nav {
+    display: none;
+  }
+
+  @media screen and (min-width: $pf-v6-global--breakpoint--md) {
+    .#{$pagination}__page-menu {
+      display: block;
+    }
+
+    .#{$pagination}__nav {
+      display: inline-flex;
+    }
+
+    .#{$pagination}__total-items {
+      display: none;
+    }
   }
 
   &.pf-m-bottom {
@@ -107,7 +107,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
     .#{$pagination}__page-menu {
       position: absolute;
-      display: var(--#{$pagination}--m-bottom__page-menu--Display);
+      display: block;
     }
 
     .#{$pagination}__nav {
@@ -165,9 +165,9 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 }
 
 
-// nav
+// - Pagination nav
 .#{$pagination}__nav {
-  display: var(--#{$pagination}__nav--Display);
+  display: inline-flex;
   column-gap: var(--#{$pagination}__nav--ColumnGap);
   justify-content: flex-end;
 }
@@ -199,25 +199,41 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
 // display-summary element for total-items items
 .#{$pagination}__total-items {
-  display: var(--#{$pagination}__total-items--Display);
+  display: block;
 }
 
-// stylelint-disable no-duplicate-selectors
+// stylelint-disable
 .#{$pagination} {
   @each $breakpoint, $breakpoint-value in $pf-v6-c-pagination--breakpoint-map {
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
     @include pf-v6-apply-breakpoint($breakpoint) {
       &.pf-m-display-summary#{$breakpoint-name} {
-        --#{$pagination}__nav--Display: var(--#{$pagination}--m-display-summary__nav--Display);
-        --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-display-summary__page-menu--Display);
-        --#{$pagination}__total-items--Display: var(--#{$pagination}--m-display-summary__total-items--Display);
+        .#{$pagination}__nav {
+          display: none;
+        }
+
+        .#{$pagination}__page-menu {
+          display: none
+        }
+
+        .#{$pagination}__total-items {
+          display: block;
+        }
       }
 
       &.pf-m-display-full#{$breakpoint-name} {
-        --#{$pagination}__nav--Display: var(--#{$pagination}--m-display-full__nav--Display);
-        --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-display-full__page-menu--Display);
-        --#{$pagination}__total-items--Display: var(--#{$pagination}--m-display-full__total-items--Display);
+        .#{$pagination}__nav {
+          display: inline-flex
+        }
+
+        .#{$pagination}__page-menu {
+          display: block;
+        }
+
+        .#{$pagination}__total-items {
+          display: none;
+        }
       }
 
       @each $spacer, $spacer-value in $pf-v6-c-pagination--variable-map {

--- a/src/patternfly/components/Sidebar/sidebar.hbs
+++ b/src/patternfly/components/Sidebar/sidebar.hbs
@@ -1,4 +1,8 @@
-<div class="{{pfv}}sidebar{{#if sidebar--modifier}} {{sidebar--modifier}}{{/if}}"
+<div class="{{pfv}}sidebar
+  {{setModifiers
+    sidebar--HasBorder='pf-m-border'
+    sidebar--modifier=sidebar--modifier
+  }}"
   {{#if sidebar--attribute}}
     {{{sidebar--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -47,8 +47,6 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-gutter__main--Gap: var(--#{$sidebar}--inset);
 
   // Border
-  --#{$sidebar}__main--m-border--before--Display: none;
-  --#{$sidebar}__main--m-border--before--md--Display: block;
   --#{$sidebar}__main--m-border--before--BorderWidth: var(--#{$sidebar}--BorderWidth--base);
   --#{$sidebar}__main--m-border--before--BorderColor: var(--#{$sidebar}--BorderColor--base);
 
@@ -71,7 +69,6 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   --#{$sidebar}--m-split__panel--Position: static;
   --#{$sidebar}--m-split__panel--InsetBlockStart: auto;
   --#{$sidebar}--m-split--m-panel-right__panel--Order: 1;
-  --#{$sidebar}--m-split__main--m-border--before--Display: block;
 
   // Panel
   --#{$sidebar}__panel--FlexBasis--base: auto;
@@ -105,11 +102,14 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   @media (min-width: $pf-v6-global--breakpoint--md) {
     --#{$sidebar}__main--FlexDirection: var(--#{$sidebar}__main--md--FlexDirection);
     --#{$sidebar}__main--AlignItems: var(--#{$sidebar}__main--md--AlignItems);
-    --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}__main--m-border--before--md--Display); // show border starting at md breakpoint
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--md--FlexBasis);
     --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}__panel--md--InsetBlockStart);
     --#{$sidebar}__panel--Position: var(--#{$sidebar}__panel--md--Position);
+
+    .#{$sidebar}__main.m-border::before {
+      display: block;
+    }
   }
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
@@ -137,8 +137,11 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}--m-stack__panel--InsetBlockStart);
     --#{$sidebar}__panel--BoxShadow: var(--#{$sidebar}--m-stack__panel--BoxShadow);
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-stack--FlexBasis);
-    --#{$sidebar}__main--m-border--before--Display: none;
     --#{$sidebar}--m-panel-right__panel--Order: var(--#{$sidebar}--m-stack--m-panel-right__panel--Order);
+
+    .#{$sidebar}__main--m-border::before {
+      display: none;
+    }
   }
 
   &.pf-m-split {
@@ -148,8 +151,11 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__panel--InsetBlockStart: var(--#{$sidebar}--m-split__panel--InsetBlockStart);
     --#{$sidebar}__panel--BoxShadow: none;
     --#{$sidebar}__panel--FlexBasis: var(--#{$sidebar}__panel--m-split--FlexBasis);
-    --#{$sidebar}__main--m-border--before--Display: var(--#{$sidebar}--m-split__main--m-border--before--Display);
     --#{$sidebar}--m-panel-right__panel--Order: var(--#{$sidebar}--m-split--m-panel-right__panel--Order);
+
+    .#{$sidebar}__main--m-border::before {
+      display: block;
+    }
   }
 }
 
@@ -159,7 +165,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   align-items: var(--#{$sidebar}__main--AlignItems);
 
   &.pf-m-border::before {
-    display: var(--#{$sidebar}__main--m-border--before--Display);
+    display: block;
     flex: 0 0 var(--#{$sidebar}__main--m-border--before--BorderWidth);
     align-self: stretch;
     content: "";
@@ -233,6 +239,13 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   :where(&:first-child) {
     --#{$sidebar}__content--Order: -1;
+  }
+}
+
+// - Sidebar border
+.#{$sidebar}.pf-m-border {
+  .#{$sidebar}__panel {
+    box-shadow: none;
   }
 }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -79,9 +79,6 @@
   --#{$table}__tbody--m-selected--after__tr--BorderInlineStartColor: var(--pf-t--global--border--color--clicked);
 
   // * Table grid cell
-  --#{$table}--m-grid--cell--hidden-visible--Display: grid;
-
-  // * Table grid cell
   --#{$table}--m-grid--cell--PaddingBlockStart: 0;
   --#{$table}--m-grid--cell--PaddingInlineEnd: 0;
   --#{$table}--m-grid--cell--PaddingBlockEnd: 0;
@@ -252,8 +249,7 @@
 
   // - Table grid th td data label
   :where(.#{$table}__th, .#{$table}__td)[data-label] {
-    // default pf-v6-hidden-visible() mixin is called in table.scss. redefining variable here
-    --#{$table}--cell--hidden-visible--Display: var(--#{$table}--m-grid--cell--hidden-visible--Display);
+    @include pf-v6-hidden-visible('grid');
 
     grid-column: 1;
     grid-column-gap: var(--#{$table}-td--responsive--GridColumnGap);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -73,7 +73,7 @@
   --#{$table}--m-truncate__text--MinWidth: 5ch;
 
   // * Table cell hidden visible
-  --#{$table}--cell--hidden-visible--Display: table-cell;
+  // --#{$table}--cell--hidden-visible--Display: table-cell;
 
   // * Table toggle
   --#{$table}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -314,7 +314,7 @@
 
   // - Table th - Table td
   tr:where(.#{$table}__tr) > :where(th, td) {
-    @include pf-v6-hidden-visible(var(--#{$table}--cell--hidden-visible--Display));
+    @include pf-v6-hidden-visible('table-cell');
 
     position: relative;
     width: var(--#{$table}--cell--Width);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -14,10 +14,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--before--BorderInlineStartWidth: 0;
   --#{$tabs}--m-vertical--inset: var(--pf-t--global--spacer--sm);
 
-  // Tabs, Page insets modifier
+  // * Tabs page insets
   --#{$tabs}--m-page-insets--inset: var(--pf-t--global--spacer--md);
 
-  // Tabs, Vertical modifier
+  // * Tabs vertical
   --#{$tabs}--m-vertical--Width: 100%;
   --#{$tabs}--m-vertical--MaxWidth: #{pf-size-prem(250px)};
   --#{$tabs}--m-vertical--m-box--inset: var(--pf-t--global--spacer--md);
@@ -27,10 +27,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical__list--before--BorderBlockEndWidth: 0;
   --#{$tabs}--m-vertical__list--before--BorderInlineStartWidth: var(--#{$tabs}--before--border-width--base);
 
-  // Tabs List
-  --#{$tabs}__list--Display: flex;
-
-  // Tabs Item
+  // * Tabs item
   --#{$tabs}__item--BackgroundColor: transparent;
   --#{$tabs}__item--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__item--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
@@ -46,7 +43,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-box--m-secondary__item--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$tabs}__item--m-action--before--ZIndex: var(--pf-t--global--z-index--sm);
 
-  // Tabs link
+  // * Tabs link
   --#{$tabs}__link--Color: var(--pf-t--global--text--color--subtle);
   --#{$tabs}__link--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
@@ -75,7 +72,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-box--m-secondary__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
 
-  // Link before
+  // * Tabs link before
   --#{$tabs}__link--before--border-color--base: var(--pf-t--global--border--color--default);
   --#{$tabs}__link--before--border-width--base: var(--pf-t--global--border--width--regular);
   --#{$tabs}__link--before--BorderBlockStartColor: var(--#{$tabs}__link--before--border-color--base);
@@ -91,7 +88,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--disabled--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
   --#{$tabs}__link--disabled--before--BorderInlineStartWidth: 0;
 
-  // Link after
+  // * Tabs link after
   --#{$tabs}__link--after--InsetBlockStart: auto;
   --#{$tabs}__link--after--InsetInlineEnd: 0;
   --#{$tabs}__link--after--InsetBlockEnd: 0;
@@ -103,7 +100,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__item--m-current__link--after--BorderColor: var(--pf-t--global--border--color--clicked);
   --#{$tabs}__item--m-current__link--after--BorderWidth: var(--pf-t--global--border--width--extra-strong);
 
-  // Scroll buttons
+  // * Tabs scroll buttons
   --#{$tabs}__scroll-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__scroll-button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$tabs}__scroll-button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
@@ -113,22 +110,21 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__scroll-button--TransitionDuration--transform: .125s;
   --#{$tabs}__scroll-button--TransitionDuration--opacity: .125s;
 
-  // Scroll buttons before
+  // * Tabs scroll buttons before
   --#{$tabs}__scroll-button--before--BorderColor: var(--#{$tabs}--before--BorderColor);
   --#{$tabs}__scroll-button--before--border-width--base: var(--pf-t--global--border--width--regular);
   --#{$tabs}__scroll-button--before--BorderInlineEndWidth: 0;
   --#{$tabs}__scroll-button--before--BorderBlockEndWidth: var(--#{$tabs}__scroll-button--before--border-width--base);
   --#{$tabs}__scroll-button--before--BorderInlineStartWidth: 0;
 
-  // Scroll snap
+  // * Tabs scroll snap
   --#{$tabs}__list--ScrollSnapTypeAxis: x;
   --#{$tabs}__list--ScrollSnapTypeStrictness: proximity;
   --#{$tabs}__list--ScrollSnapType: var(--#{$tabs}__list--ScrollSnapTypeAxis) var(--#{$tabs}__list--ScrollSnapTypeStrictness);
   --#{$tabs}__item--ScrollSnapAlign: end;
   --#{$tabs}--m-vertical__list--ScrollSnapTypeAxis: y;
 
-  // Expandable
-  --#{$tabs}__toggle--Display: flex;
+  // * Tabs expandable
   --#{$tabs}__toggle-icon--Transition: all 250ms cubic-bezier(.42, 0, .58, 1);
   --#{$tabs}__toggle-icon--Rotate: 0;
   --#{$tabs}--m-expanded__toggle-icon--Rotate: 90deg;
@@ -138,12 +134,12 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-expandable--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$tabs}--m-expandable--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
-  // Item action
+  // * Tabs item action
   --#{$tabs}__item-action--c-button--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}--m-subtab__item-action--c-button--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}__item-action-icon--MarginBlockStart: #{pf-size-prem(2px)};
 
-  // Add button
+  // * Tabs add button
   --#{$tabs}__add--before--BorderColor: var(--#{$tabs}__link--before--border-color--base);
   --#{$tabs}__add--before--BorderInlineStartWidth: var(--#{$tabs}__link--before--border-width--base);
   --#{$tabs}__add--c-button--FontSize: var(--pf-t--global--font--size--sm);
@@ -153,7 +149,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__add--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__add--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
-  // Overflow menu toggle icon
+  // * Tabs overflow menu toggle icon
   --#{$tabs}__link-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$tabs}__link-toggle-icon--Transition: .2s ease-in 0s;
   --#{$tabs}__link-toggle-icon--Rotate: 0;
@@ -161,6 +157,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--m-expanded__toggle-icon--Rotate: 90deg;
 }
 
+// - Tabs
 .#{$tabs} {
   position: relative;
   display: flex;
@@ -205,7 +202,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
   }
 
-  // Scroll buttons enabled
+  // - Tabs scrollable
   &.pf-m-scrollable {
     .#{$tabs}__scroll-button {
       opacity: 1;
@@ -236,7 +233,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
   }
 
-  // Box
+  // - Tabs box
   &.pf-m-box {
     --#{$tabs}__item--BackgroundColor: var(--#{$tabs}--m-box__item--BackgroundColor);
     --#{$tabs}__item--m-current--BackgroundColor: var(--#{$tabs}--m-box__item--m-current--BackgroundColor);
@@ -294,7 +291,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
   }
 
-  // Vertical
+  // - Tabs vertical
   &.pf-m-vertical {
     --#{$tabs}--Width: var(--#{$tabs}--m-vertical--Width);
     --#{$tabs}--inset: var(--#{$tabs}--m-vertical--inset);
@@ -359,22 +356,40 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     @each $breakpoint, $breakpoint-value in $pf-v6-c-tabs--breakpoint-map {
       $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
+      // stylelint-disable
       @include pf-v6-apply-breakpoint($breakpoint) {
-        // stylelint-disable max-nesting-depth
         &.pf-m-expandable#{$breakpoint-name} {
-          --#{$tabs}__list--Display: none;
-          --#{$tabs}__toggle--Display: flex;
+          .#{$tabs}__list {
+            display: none;
+          }
+
+          .#{$tabs}__toggle {
+            display: flex;
+          }
         }
 
         &.pf-m-non-expandable#{$breakpoint-name} {
-          --#{$tabs}__list--Display: flex;
-          --#{$tabs}__toggle--Display: none;
+          .#{$tabs}__list {
+            display: flex;
+          }
+
+          .#{$tabs}__toggle {
+            display: none;
+          }
         }
-        // stylelint-enable
       }
+      // stylelint-enable
     }
 
     &.pf-m-expandable {
+      .#{$tabs}__list {
+        display: none;
+      }
+
+      .#{$tabs}__toggle {
+        display: flex;
+      }
+
       row-gap: var(--#{$tabs}--m-expandable--RowGap);
       padding-block-start: var(--#{$tabs}--m-expandable--PaddingBlockStart);
       padding-block-end: var(--#{$tabs}--m-expandable--PaddingBlockEnd);
@@ -383,12 +398,15 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     }
 
     &.pf-m-expanded {
-      --#{$tabs}__list--Display: flex;
       --#{$tabs}__toggle-icon--Rotate: var(--#{$tabs}--m-expanded__toggle-icon--Rotate);
+
+      .#{$tabs}__list {
+        display: flex;
+      }
     }
   }
 
-  // Box, vertical
+  // - Tabs box vertical
   &.pf-m-box.pf-m-vertical {
     --#{$tabs}--inset: var(--#{$tabs}--m-vertical--m-box--inset);
     --#{$tabs}--m-vertical__list--before--BorderInlineStartWidth: 0;
@@ -453,12 +471,13 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
-// Expandable toggle
+// - Tabs toggle
 .#{$tabs}__toggle {
-  display: var(--#{$tabs}__toggle--Display);
+  display: flex;
   align-items: center;
 }
 
+// - Tabs toggle button
 .#{$tabs}__toggle-button {
   .#{$button} {
     justify-content: start;
@@ -466,6 +485,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
+// - Tabs toggle icon
 .#{$tabs}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
@@ -474,12 +494,12 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   transform: rotate(var(--#{$tabs}__toggle-icon--Rotate));
 }
 
-// Tab list
+// - Tabs list
 .#{$tabs}__list {
   @include pf-v6-overflow-hide-scroll;
 
   position: relative;
-  display: var(--#{$tabs}__list--Display);
+  display: flex;
   max-width: 100%;
   overflow-x: auto;
   scroll-behavior: smooth;
@@ -487,7 +507,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   -webkit-overflow-scrolling: touch;
 }
 
-// Tabs item
+// - Tabs item
 .#{$tabs}__item {
   position: relative;
   display: flex;
@@ -609,7 +629,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   &:where(:hover, :focus) {
     --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__link--hover--BackgroundColor);
-      }
+  }
 
   &:disabled,
   &.pf-m-disabled {
@@ -644,6 +664,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
+// - Tabs link toggle icon
 .#{$tabs}__link-toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
@@ -654,6 +675,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   transform: rotate(var(--#{$tabs}__link-toggle-icon--Rotate));
 }
 
+// - Tabs item action
 .#{$tabs}__item-action {
   display: flex;
 
@@ -662,12 +684,13 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
+// - Tabs item action icon
 .#{$tabs}__item-action-icon {
   display: inline-block;
   margin-block-start: var(--#{$tabs}__item-action-icon--MarginBlockStart);
 }
 
-// Scroll buttons
+// - Tabs scroll button
 .#{$tabs}__scroll-button {
   padding-block-start: var(--#{$tabs}__scroll-button--PaddingBlockStart);
   padding-block-end: var(--#{$tabs}__scroll-button--PaddingBlockEnd);
@@ -699,6 +722,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
+// - Tabs add
 .#{$tabs}__add {
   position: relative;
   display: flex;
@@ -716,6 +740,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 }
 
+// - Tabs
 // stylelint-disable no-duplicate-selectors, max-nesting-depth
 .#{$tabs} {
   @each $breakpoint, $breakpoint-value in $pf-v6-c-tabs--breakpoint-map {

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -21,9 +21,6 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$tree-view}__node--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
 
-  // Container
-  --#{$tree-view}__node-container--Display: contents;
-
   // Node content
   --#{$tree-view}__node-content--RowGap: var(--pf-t--global--spacer--sm);
   --#{$tree-view}__node-content--Overflow: visible;
@@ -139,8 +136,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd: calc(var(--#{$tree-view}__node-toggle--PaddingInlineStart) * -.5);
   --#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart: calc(var(--#{$tree-view}__node-toggle--PaddingInlineStart) * -1.5);
 
-  // Node container
-  --#{$tree-view}--m-compact__node-container--Display: flex;
+  // * Node container
   --#{$tree-view}--m-compact__node-container--PaddingBlockEnd--base: var(--pf-t--global--spacer--lg);
   --#{$tree-view}--m-compact__node-container--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$tree-view}--m-compact__node-container--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -168,6 +164,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact--m-no-background__node--before--InsetBlockStart: calc(var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockStart) + var(--#{$tree-view}--m-compact__node--nested--PaddingBlockStart) + #{pf-size-prem(4px)});
 }
 
+// - Tree view
 .#{$tree-view} {
   &.pf-m-compact,
   &.pf-m-guides {
@@ -220,9 +217,16 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}__node--Color: var(--#{$tree-view}--m-compact__node--Color);
     --#{$tree-view}__node--PaddingBlockStart: var(--#{$tree-view}--m-compact__node--PaddingBlockStart);
     --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--PaddingBlockEnd);
-    --#{$tree-view}__node-container--Display: var(--#{$tree-view}--m-compact__node-container--Display);
     --#{$tree-view}__node--hover--BackgroundColor: transparent;
     --#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--InsetBlockStart);
+
+    .#{$tree-view}__node-container {
+      display: flex;
+      padding-block-start: var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart);
+      padding-block-end: var(--#{$tree-view}--m-compact__node-container--PaddingBlockEnd);
+      padding-inline-start: var(--#{$tree-view}--m-compact__node-container--PaddingInlineStart);
+      padding-inline-end: var(--#{$tree-view}--m-compact__node-container--PaddingInlineEnd);
+    }
 
     // Level 1
     .#{$tree-view}__list-item {
@@ -283,13 +287,6 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         }
         // stylelint-enable
       }
-    }
-
-    .#{$tree-view}__node-container {
-      padding-block-start: var(--#{$tree-view}--m-compact__node-container--PaddingBlockStart);
-      padding-block-end: var(--#{$tree-view}--m-compact__node-container--PaddingBlockEnd);
-      padding-inline-start: var(--#{$tree-view}--m-compact__node-container--PaddingInlineStart);
-      padding-inline-end: var(--#{$tree-view}--m-compact__node-container--PaddingInlineEnd);
     }
 
     // stylelint-disable selector-max-class, selector-max-compound-selectors
@@ -377,7 +374,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 }
 
 .#{$tree-view}__node-container {
-  display: var(--#{$tree-view}__node-container--Display);
+  display: contents;
   flex-grow: 1;
   border-radius: var(--#{$tree-view}--m-compact__node-container--BorderRadius);
 }

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -7,7 +7,6 @@ $pf-v6-l-flex--gap-map: build-spacer-map("base", "none", "xs", "sm", "md", "lg",
 $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $pf-v6-l-flex--spacer-map);
 
 @include pf-root($flex) {
-  --#{$flex}--Display: flex;
   --#{$flex}--FlexWrap: wrap;
   --#{$flex}--AlignItems: baseline;
   --#{$flex}--m-row--AlignItems: baseline;
@@ -27,7 +26,7 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
   // Emit spacer css variables that map to requested spacer values
   @include pf-v6-emit-properties($pf-v6-l-flex--variable-map);
 
-  display: var(--#{$flex}--Display);
+  display: flex;
   flex-wrap: var(--#{$flex}--FlexWrap);
   gap: var(--#{$flex}--RowGap) var(--#{$flex}--ColumnGap);
   align-items: var(--#{$flex}--AlignItems);
@@ -79,12 +78,12 @@ $pf-v6-l-flex--variable-map: build-variable-map("#{$pf-prefix}l-flex--spacer", $
     @include pf-v6-apply-breakpoint($breakpoint) {
       // display
       &.pf-m-flex#{$breakpoint-name} {
-        display: var(--#{$flex}--Display);
+        display: flex;
       }
 
       // inline flex
       &.pf-m-inline-flex#{$breakpoint-name} {
-        --#{$flex}--Display: inline-flex;
+        display: inline-flex;
       }
 
       // flex-direction

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -194,39 +194,24 @@
 }
 
 @mixin pf-v6-hidden-visible($val: "block") {
-  // stylelint-disable-next-line
-  --#{$pf-prefix}hidden-visible--visible--Display: #{$val};
-
-  // base value for visible display property is set to 'block' by default and passed in to
-  // placeholder via `pf-v6-hidden-visible` mixin
-
-  // set hidden var values
-  // stylelint-disable custom-property-pattern
-  --#{$pf-prefix}hidden-visible--hidden--Display: none;
-
-  // set visibile var values
-  --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--visible--Display);
-
-  // set default state to visible
-  display: var(--#{$pf-prefix}hidden-visible--Display);
+  display: #{$val};
 
   // toggle values based on state
   &.pf-m-hidden {
-    --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
+    display: none;
   }
 
   @each $size, $bp in $pf-v6-global--breakpoint-name-map {
     @media screen and (min-width: $bp) {
       &.pf-m-hidden-on-#{$size} {
-        --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
+        display: none;
       }
 
       &.pf-m-visible-on-#{$size} {
-        --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--visible--Display);
+        display: #{$val}
       }
     }
   }
-  // stylelint-enable
 }
 
 // Apply media query if value is passed


### PR DESCRIPTION
closes #7033

> TLDR:
>
> Redefining display props with CSS Variables causes [forced reflows](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing).
>
> Dependency Chains: If variables depend on other variables, it can create a complex web of dependencies. Changing one variable might have unintended consequences elsewhere in the stylesheet.

## What this PR does 
This PR converts `display` properties defined by `--Display` variables to standard [`display properties`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#syntax).

[Backstop report](https://drive.google.com/file/d/16pSbVdEhIvAu9X-jXdsJmAIcTG8gblh4/view?usp=sharing)

## Performance improvements

## Button

**Before**

<img width="674" alt="Screenshot 2024-09-09 at 5 53 36 AM" src="https://github.com/user-attachments/assets/bfb9b741-c5a7-40a3-956d-4d9bc51a0401">

**After**

<img width="691" alt="Screenshot 2024-09-09 at 5 52 53 AM" src="https://github.com/user-attachments/assets/8f5fb21f-b723-4db7-a747-a9c10dc3da11">

### Data List

**Before**

<img width="685" alt="Screenshot 2024-09-09 at 5 55 55 AM" src="https://github.com/user-attachments/assets/dc61cebc-fd7a-4d89-9e20-7c3ec1cbb0ab">

**After**

<img width="689" alt="Screenshot 2024-09-09 at 5 55 33 AM" src="https://github.com/user-attachments/assets/0e73852f-ecee-4a57-a8c5-cb21dd6e4b51">

### Description list

**Before**

<img width="685" alt="Screenshot 2024-09-09 at 6 01 39 AM" src="https://github.com/user-attachments/assets/4bbce640-8deb-4b79-afba-b2cd086dab1b">

**After**

<img width="687" alt="Screenshot 2024-09-09 at 6 00 53 AM" src="https://github.com/user-attachments/assets/ac108908-22be-4125-b8bb-70c5c9ed1c62">

### Divider

**Before**

<img width="714" alt="Screenshot 2024-09-09 at 6 02 58 AM" src="https://github.com/user-attachments/assets/74b66fc4-560b-4bbb-af89-cb9d97a7d09c">

**After**

<img width="676" alt="Screenshot 2024-09-09 at 6 03 23 AM" src="https://github.com/user-attachments/assets/a0ba8a2e-61a8-4048-9501-f01d57866115">

### Input group

**Before**

<img width="553" alt="Screenshot 2024-09-09 at 5 50 01 AM" src="https://github.com/user-attachments/assets/f63476f0-fe54-4392-ae24-34630caaf9a8">

**After**

<img width="646" alt="Screenshot 2024-09-09 at 5 50 10 AM" src="https://github.com/user-attachments/assets/2b3a5765-7a9e-47a6-81cb-b786441282ea">

### Jump links

**Before**

<img width="676" alt="Screenshot 2024-09-09 at 6 34 46 AM" src="https://github.com/user-attachments/assets/05a89c01-4a60-487a-8385-253aa08dc56f">

**After**

<img width="663" alt="Screenshot 2024-09-09 at 6 35 13 AM" src="https://github.com/user-attachments/assets/091ad722-9876-4342-9f52-c07ecd80ab6a">

### Masthead

**Before**

<img width="696" alt="Screenshot 2024-09-09 at 6 04 57 AM" src="https://github.com/user-attachments/assets/f11738d9-8825-47de-9c4c-bf9695bac2a6">

**After**

<img width="693" alt="Screenshot 2024-09-09 at 6 05 24 AM" src="https://github.com/user-attachments/assets/67ac172a-2171-445e-a086-2fa92a8a64d2">

### Multiple file upload

**Before**

<img width="673" alt="Screenshot 2024-09-09 at 6 07 22 AM" src="https://github.com/user-attachments/assets/394d7ddf-e047-4f58-99fa-ce0717142b9e">

**After**

<img width="695" alt="Screenshot 2024-09-09 at 6 08 08 AM" src="https://github.com/user-attachments/assets/2daf9f82-373b-4b05-8e76-f5ad2de4db1d">

### Pagination

**Before**

<img width="670" alt="Screenshot 2024-09-09 at 6 09 41 AM" src="https://github.com/user-attachments/assets/4fc9af99-33a8-428a-8372-138091048055">

**After**

<img width="664" alt="Screenshot 2024-09-09 at 6 09 59 AM" src="https://github.com/user-attachments/assets/62ec7f85-2f74-402c-993f-92ef503cbb29">

### Sidebar

**Before**

<img width="662" alt="Screenshot 2024-09-09 at 6 13 48 AM" src="https://github.com/user-attachments/assets/9ca2e6f5-07b5-4177-b718-0ea59c6eae0e">

**After**

<img width="682" alt="Screenshot 2024-09-09 at 6 13 15 AM" src="https://github.com/user-attachments/assets/ee989b44-7c4d-455e-92b1-55402c62be13">

### Table

**Before**

<img width="656" alt="Screenshot 2024-09-09 at 6 15 03 AM" src="https://github.com/user-attachments/assets/72db5f19-9301-4aa9-84d9-53950a916f13">

**After**

<img width="692" alt="Screenshot 2024-09-09 at 6 15 50 AM" src="https://github.com/user-attachments/assets/78ba6909-056f-41d9-a75c-447fe058df37">

### Tabs

**Before**

<img width="662" alt="Screenshot 2024-09-09 at 6 19 51 AM" src="https://github.com/user-attachments/assets/f83f19b2-7ee7-4615-9090-b4eac1f839c0">

**After**

<img width="669" alt="Screenshot 2024-09-09 at 6 20 57 AM" src="https://github.com/user-attachments/assets/114476a5-146a-41d8-92ce-56793b11369c">

### Tree view

**Before**

<img width="658" alt="Screenshot 2024-09-09 at 6 23 30 AM" src="https://github.com/user-attachments/assets/a3c69bae-4781-45e4-8c95-b10f3cbfc6a9">

**After**

<img width="698" alt="Screenshot 2024-09-09 at 6 22 18 AM" src="https://github.com/user-attachments/assets/6f73ef39-8e1c-43f4-9a72-4c326e42f865">

### Flex

**Before**

<img width="671" alt="Screenshot 2024-09-09 at 6 24 52 AM" src="https://github.com/user-attachments/assets/aaba42e5-9317-4158-9b22-b046985641d3">

**After**

<img width="683" alt="Screenshot 2024-09-09 at 6 24 35 AM" src="https://github.com/user-attachments/assets/e6f2bc90-49d7-40eb-9264-5173781ae9ed">
