### PR TITLE
fix(table): removed first/last child padding, added inset

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -5,11 +5,11 @@
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
   --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
-  --#{$button}--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--default);
+  --#{$button}--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -5,11 +5,11 @@
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
   --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
-  --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
-  --#{$button}--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--MinWidth: calc(1em * var(--#{$button}--LineHeight) + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
+  --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
+  --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -826,7 +826,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
   {{/table-tbody}}
 
-  {{#> table-tbody table-tr--index="2" table-tr--IsExpanded=true}}
+  {{#> table-tbody table-tr--index="2" table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr table-tr--IsExpanded=true}}
       {{> table-cell-toggle}}
       {{> table-cell-check}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -109,8 +109,8 @@
   --#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
 
   // * Table grid expandable row content
-  --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: 0;
-  --#{$table}__expandable-row-content--responsive--PaddingInlineStart: 0;
+  --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__expandable-row-content--responsive--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$table}__expandable-row-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // * Table check

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -30,18 +30,19 @@
     }
   }
 }
+// stylelint-enable
 
 // - Table grid
 @include pf-root($table, '[class*="pf-m-grid"]') {
   // ============================================================ //
   // Start non-conformant variables
-  //
   // these variables do not conform to guidelines as styling targets individual elements
   // this is purposeful and necessary to avoid adding selectors to each td/th
   // ============================================================ //
 
   // * Table responsive
   --#{$table}--responsive--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$table}--data-label--FontWeight: var(--pf-t--global--font--weight--heading);
 
   // * Table body
   --#{$table}__tbody--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);
@@ -95,26 +96,31 @@
   --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--responsive--PaddingInlineEnd: 0;
+  --#{$table}--cell--responsive--PaddingInlineStart: 0;
 
-  --#{$table}--cell--action--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--action--responsive--PaddingBlockEnd: 0;
+  // * Table compound expansion toggle
+  --#{$table}__compound-expansion-toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}__compound-expansion-toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__compound-expansion-toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$table}__compound-expansion-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
 
   // * Table grid compact table
   --#{$table}--m-compact__tr--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact__tr--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact__tr__td--responsive--PaddingBlockStart: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__tr__td--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$table}--m-compact__check--responsive--MarginBlockStart: #{pf-size-prem(7px)};
   --#{$table}--m-compact__action--responsive--MarginBlockStart: calc(var(--pf-t--global--spacer--xs) * -1);
   --#{$table}--m-compact__action--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
   --#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
+  --#{$table}--m-compact--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table grid expandable row content
   --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$table}__expandable-row-content--responsive--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$table}__expandable-row-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$table}__expandable-row--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
   // * Table check
   --#{$table}__check--responsive--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
@@ -122,11 +128,16 @@
 
   // * Table grid favorite
   --#{$table}--m-grid__check--favorite--MarginInlineStart: var(--pf-t--global--spacer--xl);
-
-  // * Table grid action
-  --#{$table}__action--responsive--MarginInlineStart: var(--pf-t--global--spacer--xl);
   --#{$table}--m-grid__favorite--action--MarginInlineStart: var(--pf-t--global--spacer--2xl);
   --#{$table}--m-grid__check--favorite--action--MarginInlineStart: calc(var(--#{$table}--m-grid__check--favorite--MarginInlineStart) + var(--#{$table}--m-grid__favorite--action--MarginInlineStart));
+  --#{$table}__action--responsive--MarginInlineStart: var(--pf-t--global--spacer--xl);
+
+  // * Table grid action
+  --#{$table}--cell--action--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+
+  // * Table grid action
+  --#{$table}--cell--clickable--responsive--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$table}--cell--clickable--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
 
   // * Table grid toggle icon
   --#{$table}__toggle__icon--Transition: .2s ease-in 0s;
@@ -149,6 +160,47 @@
   display: grid;
   border: none;
 
+  // * Table th, * Table td
+  .#{$table}__th, .#{$table}__td {
+    padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
+    padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
+
+    // - Table grid compound expansion toggle
+    &.#{$table}__compound-expansion-toggle {
+      --#{$table}__compound-expansion-toggle__button--before--BorderInlineEndWidth: 0;
+      --#{$table}__compound-expansion-toggle__button--before--BorderInlineStartWidth: 0;
+      --#{$table}__compound-expansion-toggle__button--after--InsetBlockStart: 100%;
+
+      padding-block-start: var(--#{$table}__compound-expansion-toggle--PaddingBlockStart);
+      padding-block-end: var(--#{$table}__compound-expansion-toggle--PaddingBlockEnd);
+      padding-inline-start: var(--#{$table}__compound-expansion-toggle--PaddingInlineStart);
+      padding-inline-end: var(--#{$table}__compound-expansion-toggle--PaddingInlineEnd);
+    }
+
+  }
+
+  &.#{$table} .#{$table}__th, .#{$table}__td {
+    &:is(&.#{$table}__action, .#{$table}__favorite, .#{$table}__inline-edit-action, .#{$table}__sort, .#{$table}__toggle, .#{$table}__draggable) {
+      padding-block-start: var(--#{$table}--cell--action--responsive--PaddingBlockStart);
+      padding-block-end: 0;
+    }
+  }
+
+  // - Table cell empty
+  .#{$table}__tbody {
+    .#{$table}__th, .#{$table}__td {
+      &.#{$table}__cell-empty {
+        padding: 0;
+      }
+    }
+  }
+
+  .#{$table}__tr.#{$table}__control-row {
+    border-block-end: 0;
+  }
+
   // reset cell modifications
   tr:where(.#{$table}__tr) > :where(th, td) {
     width: auto;
@@ -157,13 +209,23 @@
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
-  }
 
+    // Remove first child padding left
+    &:first-child {
+      --#{$table}--cell--PaddingInlineStart: 0;
+    }
+
+    // Remove last child padding right
+    &:last-child {
+      --#{$table}--cell--PaddingInlineEnd: 0;
+    }
+  }
 
   // - Table caption
   .#{$table}__caption {
     padding-inline-start: var(--#{$table}--m-grid__caption--PaddingInlineStart);
     padding-inline-end: var(--#{$table}--m-grid__caption--PaddingInlineEnd);
+    border-block-end: var(--#{$table}--BorderWidth) solid var(--#{$table}--BorderColor);
   }
 
   // apply modifications to text
@@ -182,77 +244,85 @@
     display: none;
   }
 
-  // - Table tbody
-  tbody:where(.#{$table}__tbody) {
-    display: block;
-
-    &:first-of-type {
-      border-block-start: var(--#{$table}__tbody--responsive--border-width--base) solid var(--#{$table}--responsive--BorderColor);
-    }
-  }
-
-  // Remove border on tr inside non-expanded tbody in of expandable tables
-  &.pf-m-expandable {
-    --#{$table}__tr--BorderBlockEndWidth: 0; // nested table rows have no border
-
-    .#{$table}__tbody,
-    .#{$table}__tbody.pf-m-expanded {
-      border-block-end: var(--#{$table}__tbody--responsive--m-expandable--BorderBlockEndWidth) solid var(--#{$table}--responsive--BorderColor);
-    }
-  }
-
   // - Table grid tr selected
   tr:where(.#{$table}__tr).pf-m-selected {
     --#{$table}__expandable-row--after--BorderInlineStartWidth: 0;
     --#{$table}__expandable-row--after--BorderColor: transparent;
+
+    border-block-end: 0;
+    border-block-end: var(--#{$table}__tr--BorderBlockEndWidth) solid var(--#{$table}__tr--BorderBlockEndColor);
+
+    &::after {
+      position: absolute;
+      inset-block-start: 0;
+      inset-block-end: 0;
+      inset-inline-start: 0;
+      width: var(--#{$table}__tr--m-selected--after--BorderInlineStartWidth);
+      content: '';
+      background-color: var(--#{$table}__tr--m-selected--after--BorderInlineStartColor);
+    }
   }
 
   // Standard table row (non-expandable)
   // exclude expandable rows
   // - Table grid tr not expandable row
-  tr:where(.#{$table}__tr):not(.#{$table}__expandable-row) {
+  .#{$table}__tr {
     display: grid;
     grid-template-columns: 1fr;
-    height: auto;
 
     // set subsequent auto column width to max-content
     grid-auto-columns: max-content;
     grid-column-gap: var(--#{$table}__tr--responsive--GridColumnGap);
+    height: auto;
 
     // set base variables to reset later
     padding-block-start: var(--#{$table}__tr--responsive--PaddingBlockStart);
-    padding-inline-end: var(--#{$table}__tr--responsive--PaddingInlineEnd);
     padding-block-end: var(--#{$table}__tr--responsive--PaddingBlockEnd);
     padding-inline-start: var(--#{$table}__tr--responsive--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}__tr--responsive--PaddingInlineEnd);
 
     // Reset td padding
     & > :where(th, td) {
       padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
-      padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
       padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
       padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
-    }
+      padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
 
-    .#{$table}__action,
-    .#{$table}__favorite,
-    .#{$table}__inline-edit-action,
-    .#{$table}__draggable,
-    .#{$table}__sort,
-    .#{$table}__toggle {
-      padding-block-start: var(--#{$table}--cell--action--responsive--PaddingBlockStart);
+      // remove padding from first child to align with kebab
+      &:first-child {
+        --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--cell--first-child--responsive--PaddingBlockStart);
+      }
     }
+  }
+
+  .#{$table}__tr.pf-m-clickable {
+    padding-block: 0;
+
+    .#{$table}__th, .#{$table}__td {
+      padding-block-start: var(--#{$table}--cell--clickable--responsive--PaddingBlockStart);
+      padding-block-end: var(--#{$table}--cell--clickable--responsive--PaddingBlockEnd);
+    }
+  }
+
+  .#{$table}__tr .#{$table}__expandable-row {
+    display: block;
   }
 
   // - Table grid compact
   &.pf-m-compact {
     --#{$table}__tr--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr--responsive--PaddingBlockStart);
     --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr--responsive--PaddingBlockEnd);
-    --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockStart);
-    --#{$table}--cell--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockEnd);
+    --#{$table}__check--responsive--MarginBlockStart: var(--#{$table}--m-compact__check--responsive--MarginBlockStart);
+    --#{$table}__check--input--MarginBlockStart: 0;
+
+    .#{$table}__th, .#{$table}__td {
+      padding-block-start: var(--#{$table}--m-compact--cell--responsive--PaddingBlockStart);
+      padding-block-end: var(--#{$table}--m-compact--cell--responsive--PaddingBlockEnd);
+    }
 
     .#{$table}__action {
       margin-block-start: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
-      margin-block-end: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
+      margin-block-end: var(--#{$table}--m-compact__action--responsive--MarginBlockEnd);
     }
 
     .#{$table}__toggle .#{$button} {
@@ -269,11 +339,10 @@
     // default pf-v6-hidden-visible() mixin is called in table.scss. redefining variable here
     --#{$table}--cell--hidden-visible--Display: var(--#{$table}--m-grid--cell--hidden-visible--Display);
 
-    grid-column: 1;
-    grid-column-gap: var(--#{$table}-td--responsive--GridColumnGap);
-
     // use minmax func to contain possible text modifier width
     grid-template-columns: 1fr minmax(0, 1.5fr);
+    grid-column: 1;
+    grid-column-gap: var(--#{$table}-td--responsive--GridColumnGap);
     align-items: start;
 
     // set contents of td to start at column two of td grid
@@ -283,21 +352,9 @@
 
     &::before {
       position: revert;
-      font-weight: bold;
+      font-weight: var(--#{$table}--data-label--FontWeight);
       text-align: start;
       content: attr(data-label);
-    }
-  }
-
-  tr:where(.#{$table}__tr) > :where(th, td) {
-    // Remove first child padding left
-    &:first-child {
-      --#{$table}--cell--PaddingInlineStart: 0;
-    }
-
-    // Remove last child padding right
-    &:last-child {
-      --#{$table}--cell--PaddingInlineEnd: 0;
     }
   }
 
@@ -311,17 +368,10 @@
     border: 0;
   }
 
-  // - Table grid compound expansion toggle
-  .#{$table}__compound-expansion-toggle {
-    --#{$table}__compound-expansion-toggle__button--before--BorderInlineEndWidth: 0;
-    --#{$table}__compound-expansion-toggle__button--before--BorderInlineStartWidth: 0;
-    --#{$table}__compound-expansion-toggle__button--after--InsetBlockStart: 100%;
-  }
-
-  // Compound expansion responsive
   // - Table grid tbody
   tbody:where(.#{$table}__tbody) {
     position: relative;
+    display: block;
 
     &::after {
       position: absolute;
@@ -350,12 +400,30 @@
     }
   }
 
+  // - Table expandable
+  &.pf-m-expandable {
+    &.#{$table} {
+      border-block-start: var(--#{$table}--BorderWidth) solid var(--#{$table}--BorderColor);
+    }
+
+    // .#{$table}__tbody,
+    .#{$table}__tbody.pf-m-expanded {
+      border-block-end: 0;
+      border-block-end: var(--#{$table}__tr--BorderBlockEndWidth) solid var(--#{$table}__tr--BorderBlockEndColor);
+    }
+
+    .#{$table}__tbody {
+      border-block-start: 0;
+      border-block-end: 0;
+    }
+  }
+
   // - Table grid expandable row
   .#{$table}__expandable-row {
-    --#{$table}--cell--responsive--PaddingBlockStart: 0;
-    --#{$table}--cell--responsive--PaddingInlineEnd: 0;
-    --#{$table}--cell--responsive--PaddingBlockEnd: 0;
-    --#{$table}--cell--responsive--PaddingInlineStart: 0;
+    --#{$table}__tr--responsive--PaddingBlockStart: 0;
+    --#{$table}__tr--responsive--PaddingInlineEnd: 0;
+    --#{$table}__tr--responsive--PaddingBlockEnd: 0;
+    --#{$table}__tr--responsive--PaddingInlineStart: 0;
     --#{$table}--cell--PaddingInlineEnd: 0;
     --#{$table}--cell--PaddingInlineStart: 0;
 
@@ -370,19 +438,17 @@
       display: block;
     }
 
-    // Modifier - expanded tr
-    &.pf-m-expanded {
-      border-block-start-color: var(--#{$table}--BorderColor);
-    }
-
     > :first-child:not(.#{$table}__check)::after {
       // Border treatment
       content: none;
     }
 
-    th:where(.#{$table}__th),
-    td:where(.#{$table}__td) {
+    .#{$table}__th, .#{$table}__td {
+      padding-block-end: var(--#{$table}__expandable-row--cell--responsive--PaddingBlockEnd);
+
       &.pf-m-no-padding {
+        padding: 0;
+
         .#{$table}__expandable-row-content {
           padding: 0;
         }
@@ -394,8 +460,8 @@
     }
 
     .#{$table}__expandable-row-content {
-      padding-inline-end: var(--#{$table}__expandable-row-content--responsive--PaddingInlineEnd);
       padding-inline-start: var(--#{$table}__expandable-row-content--responsive--PaddingInlineStart);
+      padding-inline-end: var(--#{$table}__expandable-row-content--responsive--PaddingInlineEnd);
     }
   }
 
@@ -410,12 +476,12 @@
     }
 
     > tr:where(.#{$table}__tr)::after {
-      content: '';
       position: absolute;
       inset-block-start: 0;
       inset-block-end: 0;
       inset-inline-start: 0;
       width: var(--#{$table}__tbody--after__tr--BorderInlineStartWidth);
+      content: '';
       background-color: var(--#{$table}__tbody--after__tr--BorderInlineStartColor);
     }
 
@@ -427,20 +493,6 @@
     &.pf-m-selected {
       --#{$table}__tbody--after__tr--BorderInlineStartWidth: var(--#{$table}__tbody--m-selected--after__tr--BorderInlineStartWidth);
       --#{$table}__tbody--after__tr--BorderInlineStartColor: var(--#{$table}__tbody--m-selected--after__tr--BorderInlineStartColor);
-    }
-  }
-
-
-  // - Table grid tr selected
-  tr:where(.#{$table}__tr).pf-m-selected {
-    &::after {
-      content: '';
-      position: absolute;
-      inset-block-start: 0;
-      inset-block-end: 0;
-      inset-inline-start: 0;
-      width: var(--#{$table}__tr--m-selected--after--BorderInlineStartWidth);
-      background-color: var(--#{$table}__tr--m-selected--after--BorderInlineStartColor);
     }
   }
 
@@ -485,8 +537,8 @@
 
   // - Table grid check
   .#{$table}__check {
-    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
     padding-block-start: var(--#{$table}__check--responsive--PaddingBlockStart);
+    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
     line-height: 1;
 
     ~ .#{$table}__favorite {
@@ -523,8 +575,8 @@
 
   // - Table grid inline edit action
   .#{$table}__inline-edit-action {
-    grid-column: 2;
     grid-row: 2;
+    grid-column: 2;
   }
 
   // - Table grid toggle icon
@@ -538,7 +590,6 @@
 
   // - Table grid nowrap - Table grid fit content - Table grid truncate - Table grid width
   :where(.#{$table}, .#{$table}__thead, .#{$table}__tbody, .#{$table}__tr, .#{$table}__th, .#{$table}__td, .#{$table}__text) {
-
     // No wrap
     &.pf-m-nowrap {
       --#{$table}--cell--Overflow: auto;
@@ -560,4 +611,3 @@
     --#{$table}--cell--Width: auto;
   }
 }
-// stylelint-enable

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -42,7 +42,7 @@
 
   // * Table responsive
   --#{$table}--responsive--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$table}--data-label--FontWeight: var(--pf-t--global--font--weight--heading);
+  --#{$table}--data-label--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // * Table body
   --#{$table}__tbody--responsive--border-width--base: var(--pf-t--global--border--width--divider--default);

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -87,34 +87,25 @@
   --#{$table}--m-grid--cell--hidden-visible--Display: grid;
 
   // * Table grid cell
-  --#{$table}--m-grid--cell--PaddingBlockStart: 0;
+  --#{$table}--m-grid--cell--GridColumnGap: var(--pf-t--global--spacer--md);
+  --#{$table}--m-grid--cell--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--m-grid--cell--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}--m-grid--cell--PaddingInlineEnd: 0;
-  --#{$table}--m-grid--cell--PaddingBlockEnd: 0;
   --#{$table}--m-grid--cell--PaddingInlineStart: 0;
-
-  // * Table td responsive
-  --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingInlineEnd: 0;
-  --#{$table}--cell--responsive--PaddingInlineStart: 0;
 
   // * Table compound expansion toggle
   --#{$table}__compound-expansion-toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}__compound-expansion-toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$table}__compound-expansion-toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$table}__compound-expansion-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__compound-expansion-toggle--PaddingInlineStart: 0;
+  --#{$table}__compound-expansion-toggle--PaddingInlineEnd: 0;
 
   // * Table grid compact table
   --#{$table}--m-compact__tr--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact__tr--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact__check--responsive--MarginBlockStart: #{pf-size-prem(7px)};
-  --#{$table}--m-compact__action--responsive--MarginBlockStart: calc(var(--pf-t--global--spacer--xs) * -1);
-  --#{$table}--m-compact__action--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
+  --#{$table}--m-compact__check--responsive--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
-  --#{$table}--m-compact--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}--m-compact--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact--m-grid--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--m-compact--m-grid--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table grid expandable row content
   --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -123,17 +114,14 @@
   --#{$table}__expandable-row--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
   // * Table check
-  --#{$table}__check--responsive--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
-  --#{$table}__check--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  --#{$table}--m-grid__check--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
+  --#{$table}--m-grid__check--PaddingBlockStart: var(--pf-t--global--spacer--sm);
 
   // * Table grid favorite
   --#{$table}--m-grid__check--favorite--MarginInlineStart: var(--pf-t--global--spacer--xl);
   --#{$table}--m-grid__favorite--action--MarginInlineStart: var(--pf-t--global--spacer--2xl);
   --#{$table}--m-grid__check--favorite--action--MarginInlineStart: calc(var(--#{$table}--m-grid__check--favorite--MarginInlineStart) + var(--#{$table}--m-grid__favorite--action--MarginInlineStart));
   --#{$table}__action--responsive--MarginInlineStart: var(--pf-t--global--spacer--xl);
-
-  // * Table grid action
-  --#{$table}--cell--action--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
 
   // * Table grid action
   --#{$table}--cell--clickable--responsive--PaddingBlockStart: var(--pf-t--global--spacer--lg);
@@ -146,26 +134,25 @@
 
 // - Table mobile layout
 @include pf-mobile-layout {
-  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-grid--cell--PaddingBlockStart);
-  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--m-grid--cell--PaddingInlineEnd);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-grid--cell--PaddingBlockEnd);
-  --#{$table}--cell--PaddingInlineStart: var(--#{$table}--m-grid--cell--PaddingInlineStart);
-
-  // - Table favorite
-  --#{$table}__favorite--c-button--MarginBlockStart: auto;
-  --#{$table}__favorite--c-button--MarginInlineEnd: auto;
-  --#{$table}__favorite--c-button--MarginBlockEnd: auto;
-  --#{$table}__favorite--c-button--MarginInlineStart: auto;
-
   display: grid;
   border: none;
 
   // * Table th, * Table td
   .#{$table}__th, .#{$table}__td {
-    padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
-    padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
-    padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
-    padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
+    padding-block-start: var(--#{$table}--m-grid--cell--PaddingBlockStart);
+    padding-block-end: var(--#{$table}--m-grid--cell--PaddingBlockEnd);
+    padding-inline-start: var(--#{$table}--m-grid--cell--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}--m-grid--cell--PaddingInlineEnd);
+
+    // stylelint-disable
+    // reset cell modifications
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    // stylelint-enable
 
     // - Table grid compound expansion toggle
     &.#{$table}__compound-expansion-toggle {
@@ -183,7 +170,7 @@
 
   &.#{$table} .#{$table}__th, .#{$table}__td {
     &:is(&.#{$table}__action, .#{$table}__favorite, .#{$table}__inline-edit-action, .#{$table}__sort, .#{$table}__toggle, .#{$table}__draggable) {
-      padding-block-start: var(--#{$table}--cell--action--responsive--PaddingBlockStart);
+      padding-block-start: calc(var(--#{$table}--m-grid--cell--PaddingBlockStart) / 2);
       padding-block-end: 0;
     }
   }
@@ -199,26 +186,6 @@
 
   .#{$table}__tr.#{$table}__control-row {
     border-block-end: 0;
-  }
-
-  // reset cell modifications
-  tr:where(.#{$table}__tr) > :where(th, td) {
-    width: auto;
-    min-width: 0;
-    max-width: none;
-    overflow: visible;
-    text-overflow: clip;
-    white-space: normal;
-
-    // Remove first child padding left
-    &:first-child {
-      --#{$table}--cell--PaddingInlineStart: 0;
-    }
-
-    // Remove last child padding right
-    &:last-child {
-      --#{$table}--cell--PaddingInlineEnd: 0;
-    }
   }
 
   // - Table caption
@@ -280,19 +247,6 @@
     padding-block-end: var(--#{$table}__tr--responsive--PaddingBlockEnd);
     padding-inline-start: var(--#{$table}__tr--responsive--PaddingInlineStart);
     padding-inline-end: var(--#{$table}__tr--responsive--PaddingInlineEnd);
-
-    // Reset td padding
-    & > :where(th, td) {
-      padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
-      padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
-      padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
-      padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
-
-      // remove padding from first child to align with kebab
-      &:first-child {
-        --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--cell--first-child--responsive--PaddingBlockStart);
-      }
-    }
   }
 
   .#{$table}__tr.pf-m-clickable {
@@ -301,33 +255,15 @@
     .#{$table}__th, .#{$table}__td {
       padding-block-start: var(--#{$table}--cell--clickable--responsive--PaddingBlockStart);
       padding-block-end: var(--#{$table}--cell--clickable--responsive--PaddingBlockEnd);
+
+      &:is(&.#{$table}__action, .#{$table}__favorite, .#{$table}__inline-edit-action, .#{$table}__sort, .#{$table}__toggle, .#{$table}__draggable) {
+        padding-block-start: calc(var(--#{$table}--cell--clickable--responsive--PaddingBlockStart) - var(--pf-t--global--spacer--control--vertical--default));
+      }
     }
   }
 
   .#{$table}__tr .#{$table}__expandable-row {
     display: block;
-  }
-
-  // - Table grid compact
-  &.pf-m-compact {
-    --#{$table}__tr--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr--responsive--PaddingBlockStart);
-    --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr--responsive--PaddingBlockEnd);
-    --#{$table}__check--responsive--MarginBlockStart: var(--#{$table}--m-compact__check--responsive--MarginBlockStart);
-    --#{$table}__check--input--MarginBlockStart: 0;
-
-    .#{$table}__th, .#{$table}__td {
-      padding-block-start: var(--#{$table}--m-compact--cell--responsive--PaddingBlockStart);
-      padding-block-end: var(--#{$table}--m-compact--cell--responsive--PaddingBlockEnd);
-    }
-
-    .#{$table}__action {
-      margin-block-start: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
-      margin-block-end: var(--#{$table}--m-compact__action--responsive--MarginBlockEnd);
-    }
-
-    .#{$table}__toggle .#{$button} {
-      margin-block-end: var(--#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd);
-    }
   }
 
   .#{$table}__icon > * {
@@ -342,7 +278,7 @@
     // use minmax func to contain possible text modifier width
     grid-template-columns: 1fr minmax(0, 1.5fr);
     grid-column: 1;
-    grid-column-gap: var(--#{$table}-td--responsive--GridColumnGap);
+    grid-column-gap: var(--#{$table}--m-grid--cell--GridColumnGap);
     align-items: start;
 
     // set contents of td to start at column two of td grid
@@ -366,6 +302,27 @@
     --#{$table}__tr--responsive--PaddingInlineStart: var(--#{$table}__tr--responsive--nested-table--PaddingInlineStart);
 
     border: 0;
+  }
+
+  // - Table grid compact
+  &.pf-m-compact,
+  .#{$table}.pf-m-compact {
+    --#{$table}__tr--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr--responsive--PaddingBlockStart);
+    --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr--responsive--PaddingBlockEnd);
+    --#{$table}__check--input--MarginBlockStart: 0;
+
+    .#{$table}__th, .#{$table}__td {
+      padding-block-start: var(--#{$table}--m-compact--m-grid--cell--PaddingBlockStart);
+      padding-block-end: var(--#{$table}--m-compact--m-grid--cell--PaddingBlockEnd);
+
+      &:is(&.#{$table}__action, .#{$table}__favorite, .#{$table}__inline-edit-action, .#{$table}__sort, .#{$table}__toggle, .#{$table}__draggable) {
+        padding-block-start: calc(var(--#{$table}--m-compact--m-grid--cell--PaddingBlockStart) / 2);
+      }
+    }
+
+    .#{$table}__toggle .#{$button} {
+      margin-block-end: var(--#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd);
+    }
   }
 
   // - Table grid tbody
@@ -519,14 +476,6 @@
     }
   }
 
-  // - Table grid button
-  .#{$table}__button {
-    --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-grid--cell--PaddingBlockStart);
-    --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--m-grid--cell--PaddingInlineEnd);
-    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-grid--cell--PaddingBlockEnd);
-    --#{$table}--cell--PaddingInlineStart: var(--#{$table}--m-grid--cell--PaddingInlineStart);
-  }
-
   // - Table grid check - Table grid favorite - Table grid action
   .#{$table}__check,
   .#{$table}__favorite,
@@ -537,10 +486,6 @@
 
   // - Table grid check
   .#{$table}__check {
-    padding-block-start: var(--#{$table}__check--responsive--PaddingBlockStart);
-    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
-    line-height: 1;
-
     ~ .#{$table}__favorite {
       margin-inline-start: var(--#{$table}--m-grid__check--favorite--MarginInlineStart);
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -94,9 +94,12 @@
   // * Table td responsive
   --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingInlineEnd: 0;
-  --#{$table}--cell--responsive--PaddingInlineStart: 0;
+  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--responsive--PaddingInlineStart: var(--pf-t--global--spacer--md);
+
+  --#{$table}--cell--action--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--action--responsive--PaddingBlockEnd: 0;
 
   // * Table grid compact table
   --#{$table}--m-compact__tr--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -154,11 +157,6 @@
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
-
-    &.#{$table}__check {
-      margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
-      padding-block-start: var(--#{$table}__check--responsive--PaddingBlockStart);
-    }
   }
 
 
@@ -233,6 +231,15 @@
       padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
       padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
       padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
+    }
+
+    .#{$table}__action,
+    .#{$table}__favorite,
+    .#{$table}__inline-edit-action,
+    .#{$table}__draggable,
+    .#{$table}__sort,
+    .#{$table}__toggle {
+      padding-block-start: var(--#{$table}--cell--action--responsive--PaddingBlockStart);
     }
   }
 
@@ -476,13 +483,10 @@
     grid-column-start: 2;
   }
 
-  .#{$table}__action,
-  .#{$table}__favorite {
-    margin-block-start: calc(var(--#{$table}--cell--action--PaddingBlockStart) * -1);
-  }
-
   // - Table grid check
   .#{$table}__check {
+    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
+    padding-block-start: var(--#{$table}__check--responsive--PaddingBlockStart);
     line-height: 1;
 
     ~ .#{$table}__favorite {

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -95,7 +95,6 @@
   --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  // --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--cell--responsive--PaddingInlineEnd: 0;
   --#{$table}--cell--responsive--PaddingInlineStart: 0;
 
@@ -117,7 +116,6 @@
   // * Table check
   --#{$table}__check--responsive--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
   --#{$table}__check--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  // --#{$table}__check--responsive--MarginBlockStart: #{pf-size-prem(14px)};
 
   // * Table grid favorite
   --#{$table}--m-grid__check--favorite--MarginInlineStart: var(--pf-t--global--spacer--xl);
@@ -502,8 +500,6 @@
 
   // - Table grid favorite
   .#{$table}__favorite {
-    // margin-block-start: var(--#{$table}--m-grid__favorite--MarginBlockStart);
-
     ~ .#{$table}__action {
       margin-inline-start: var(--#{$table}--m-grid__favorite--action--MarginInlineStart);
     }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -78,6 +78,10 @@
   --#{$table}__tbody--m-selected--after__tr--BorderInlineStartWidth: var(--#{$table}__expandable-row--after--border-width--base);
   --#{$table}__tbody--m-selected--after__tr--BorderInlineStartColor: var(--pf-t--global--border--color--clicked);
 
+  // * Table caption selected
+  --#{$table}--m-grid__caption--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}--m-grid__caption--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+
   // * Table grid cell
   --#{$table}--m-grid--cell--hidden-visible--Display: grid;
 
@@ -152,6 +156,12 @@
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
+  }
+
+  // - Table caption
+  .#{$table}__caption {
+    padding-inline-start: var(--#{$table}--m-grid__caption--PaddingInlineStart);
+    padding-inline-end: var(--#{$table}--m-grid__caption--PaddingInlineEnd);
   }
 
   // apply modifications to text

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -94,8 +94,8 @@
   // * Table td responsive
   --#{$table}-td--responsive--GridColumnGap: var(--pf-t--global--spacer--md);
   --#{$table}--cell--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--responsive--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  // --#{$table}--cell--first-child--responsive--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--cell--responsive--PaddingInlineEnd: 0;
   --#{$table}--cell--responsive--PaddingInlineStart: 0;
 
@@ -110,16 +110,16 @@
   --#{$table}--m-compact__toggle--c-button--responsive--MarginBlockEnd: calc(var(--pf-t--global--spacer--xs) * -1);
 
   // * Table grid expandable row content
-  --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
-  --#{$table}__expandable-row-content--responsive--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$table}__expandable-row-content--responsive--PaddingInlineEnd: 0;
+  --#{$table}__expandable-row-content--responsive--PaddingInlineStart: 0;
   --#{$table}__expandable-row-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // * Table check
   --#{$table}__check--responsive--MarginInlineStart: var(--#{$table}__tbody--responsive--border-width--base);
-  --#{$table}__check--responsive--MarginBlockStart: #{pf-size-prem(14px)};
+  --#{$table}__check--responsive--PaddingBlockStart: var(--pf-t--global--spacer--md);
+  // --#{$table}__check--responsive--MarginBlockStart: #{pf-size-prem(14px)};
 
   // * Table grid favorite
-  --#{$table}--m-grid__favorite--MarginBlockStart: #{pf-size-prem(8px)};
   --#{$table}--m-grid__check--favorite--MarginInlineStart: var(--pf-t--global--spacer--xl);
 
   // * Table grid action
@@ -156,7 +156,13 @@
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
+
+    &.#{$table}__check {
+      margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
+      padding-block-start: var(--#{$table}__check--responsive--PaddingBlockStart);
+    }
   }
+
 
   // - Table caption
   .#{$table}__caption {
@@ -229,11 +235,6 @@
       padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
       padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
       padding-inline-start: var(--#{$table}--cell--responsive--PaddingInlineStart);
-
-      // remove padding from first child to align with kebab
-      &:first-child {
-        --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--cell--first-child--responsive--PaddingBlockStart);
-      }
     }
   }
 
@@ -243,8 +244,6 @@
     --#{$table}__tr--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr--responsive--PaddingBlockEnd);
     --#{$table}--cell--responsive--PaddingBlockStart: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockStart);
     --#{$table}--cell--responsive--PaddingBlockEnd: var(--#{$table}--m-compact__tr__td--responsive--PaddingBlockEnd);
-    --#{$table}__check--responsive--MarginBlockStart: var(--#{$table}--m-compact__check--responsive--MarginBlockStart);
-    --#{$table}__check--input--MarginBlockStart: 0;
 
     .#{$table}__action {
       margin-block-start: var(--#{$table}--m-compact__action--responsive--MarginBlockStart);
@@ -447,7 +446,7 @@
     .#{$table}__favorite,
     .#{$table}__action {
       width: auto;
-      padding: 0;
+      padding-block-end: 0;
     }
   }
 
@@ -479,10 +478,13 @@
     grid-column-start: 2;
   }
 
+  .#{$table}__action,
+  .#{$table}__favorite {
+    margin-block-start: calc(var(--#{$table}--cell--action--PaddingBlockStart) * -1);
+  }
+
   // - Table grid check
   .#{$table}__check {
-    margin-block-start: var(--#{$table}__check--responsive--MarginBlockStart);
-    margin-inline-start: var(--#{$table}__check--responsive--MarginInlineStart);
     line-height: 1;
 
     ~ .#{$table}__favorite {
@@ -496,16 +498,11 @@
     ~ .#{$table}__action {
       margin-inline-start: var(--#{$table}__action--responsive--MarginInlineStart);
     }
-
-    label {
-      display: inline-block;
-      margin: 0;
-    }
   }
 
   // - Table grid favorite
   .#{$table}__favorite {
-    margin-block-start: var(--#{$table}--m-grid__favorite--MarginBlockStart);
+    // margin-block-start: var(--#{$table}--m-grid__favorite--MarginBlockStart);
 
     ~ .#{$table}__action {
       margin-inline-start: var(--#{$table}--m-grid__favorite--action--MarginInlineStart);

--- a/src/patternfly/components/Table/table-nested.hbs
+++ b/src/patternfly/components/Table/table-nested.hbs
@@ -1,5 +1,5 @@
 {{#> table newcontext table--id=(concat table--id '-' table-nested--id) table--attribute=(concat table-nested--attribute ' id="' table--id '" aria-label="Nested table"') table--modifier="pf-m-compact pf-m-no-border-rows" table--IsGrid=true}}
-  {{#> table-thead}}
+  {{#> table-thead table--IsCompact=true}}
     {{#> table-tr}}
       {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}Description{{/table-th}}
       {{#> table-th table-th--attribute='scope="col"'}}Date{{/table-th}}
@@ -7,7 +7,7 @@
       {{> table-cell-empty}}
     {{/table-tr}}
   {{/table-thead}}
-  {{#> table-tbody}}
+  {{#> table-tbody table--IsCompact=true}}
     {{#> table-tr table-tr--id="nested-tr1"}}
       {{#> table-th table-th--data-label="Description"}}Item one{{/table-th}}
       {{#> table-td table-td--data-label="Date"}}May 9, 2018{{/table-td}}

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -23,8 +23,8 @@
       {{ternary table-tr--IsHidden 'hidden' null}}
     {{/unless}}
   {{/if}}
-  {{ternary table--IsGrid 'role="row"' null}}
-  {{ternary table-tr--IsClickable 'tabindex="0"' null}}
+  {{{ternary table--IsGrid 'role="row"'}}}
+  {{{ternary table-tr--IsClickable 'tabindex="0"'}}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -23,8 +23,8 @@
       {{ternary table-tr--IsHidden 'hidden' null}}
     {{/unless}}
   {{/if}}
-  {{{ternary table--IsGrid 'role="row"'}}}
-  {{{ternary table-tr--IsClickable 'tabindex="0"'}}}
+  {{{ternary table--IsGrid 'role="row"' null}}}
+  {{{ternary table-tr--IsClickable 'tabindex="0"' null}}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -23,8 +23,8 @@
       {{ternary table-tr--IsHidden 'hidden' null}}
     {{/unless}}
   {{/if}}
-  {{ternary table--IsGrid 'role="row"'}}
-  {{ternary table-tr--IsClickable 'tabindex="0"'}}
+  {{ternary table--IsGrid 'role="row"' null}}
+  {{ternary table-tr--IsClickable 'tabindex="0"' null}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -7,9 +7,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}__tree-view-main--indent--base: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$table}__tree-view-icon--MinWidth)); // based off of the expected width of the toggle button
   --#{$table}__tree-view-main--nested-indent--base: calc(var(--#{$table}__tree-view-main--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it
 
-  // * Table tree view main button
-  --#{$table}__tree-view-main--c-button--MarginInlineEnd: var(--pf-t--global--spacer--sm);
-
   // * Table tree view main
   --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}__tree-view-main--indent--base);
   --#{$table}__tree-view-main--MarginInlineStart: calc(var(--#{$table}--cell--PaddingInlineStart) * -1);
@@ -62,7 +59,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 .#{$table}__tree-view-main {
   position: relative;
   display: flex;
-  align-items: baseline;
+  align-items: start;
   min-width: 0;
   padding-inline-start: var(--#{$table}__tree-view-main--PaddingInlineStart);
   margin-inline-start: var(--#{$table}__tree-view-main--MarginInlineStart);
@@ -78,6 +75,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     position: var(--#{$table}--m-tree-view__toggle--Position);
     inset-inline-start: var(--#{$table}--m-tree-view__toggle--InsetInlineStart);
+    padding-block-start: 0;
 
     .#{$table}__toggle-icon {
       min-width: var(--#{$table}--m-tree-view__toggle__toggle-icon--MinWidth);
@@ -85,10 +83,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     .#{$button} {
       margin-block-start: -50%;
-      margin-inline-end: var(--#{$table}__tree-view-main--c-button--MarginInlineEnd);
     }
   }
-
 
   > .#{$table}__check {
     margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
@@ -96,8 +92,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
   > .#{$table}__check label {
     padding-inline-end: var(--#{$table}__tree-view-main--c-table__check--PaddingInlineEnd);
-    margin-block-start: 0;
-    margin-block-end: 0;
     margin-inline-start: 0;
     margin-inline-end: calc(var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd) * -1);
   }
@@ -163,7 +157,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}--m-tree-view-grid--c-table__action--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}--m-tree-view-grid--c-table__action--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}--m-tree-view-grid--c-table__action--PaddingInlineStart: 0;
-  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart: var(--pf-t--global--spacer--lg);
 
   // details
   --#{$table}--m-tree-view-grid--m-tree-view-details-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
@@ -218,6 +212,10 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   tr:where(.#{$table}__tr)[aria-expanded] {
     .#{$table}__tree-view-title-cell {
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingBlockStart);
+    }
+
+    .#{$table}__action {
+      padding-block-start: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart);
     }
 
     .#{$table}__tree-view-title-cell ~ .#{$table}__action {
@@ -284,7 +282,16 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   // - Table tree view details toggle - Table tree view action
   .#{$table}__tree-view-details-toggle,
   .#{$table}__action {
+    display: revert;
+  }
+
+  .#{$table}__tree-view-details-toggle {
     display: inline-block;
+
+    .#{$button} {
+      margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
+      margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
+    }
   }
 
   // - Table tree view action
@@ -296,8 +303,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     grid-row: 1;
     grid-column: 2;
-    margin-block-start: var(--#{$table}--m-tree-view-grid__action--MarginBlockStart);
-    margin-block-end: var(--#{$table}--m-tree-view-grid__action--MarginBlockEnd);
   }
 
   // - Table tree view table check
@@ -308,11 +313,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   }
 
   // - Table tree view details toggle
-  .#{$table}__tree-view-details-toggle {
-    margin-block-start: var(--#{$table}__tree-view-details-toggle--MarginBlockStart);
-    margin-block-end: var(--#{$table}__tree-view-details-toggle--MarginBlockEnd);
-  }
-
   @for $i from 2 through $pf-v6-c-tree-view--MaxDepth {
     tr:where(.#{$table}__tr)[aria-level="#{$i}"] {
       --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: calc(var(--#{$table}__tree-view-main--nested-indent--base) * #{$i - 1} + var(--#{$table}__tree-view-main--indent--base)); // indent, plus indent level, plus

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -7,6 +7,9 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}__tree-view-main--indent--base: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$table}__tree-view-icon--MinWidth)); // based off of the expected width of the toggle button
   --#{$table}__tree-view-main--nested-indent--base: calc(var(--#{$table}__tree-view-main--indent--base) - var(--pf-t--global--spacer--md)); // nested spacing that removes the toggle button's left padding, so the icon aligns with text on the node above it
 
+  // * Table tree view main button
+  --#{$table}__tree-view-main--c-button--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+
   // * Table tree view main
   --#{$table}__tree-view-main--PaddingInlineStart: var(--#{$table}__tree-view-main--indent--base);
   --#{$table}__tree-view-main--MarginInlineStart: calc(var(--#{$table}--cell--PaddingInlineStart) * -1);
@@ -83,6 +86,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     .#{$button} {
       margin-block-start: -50%;
+      margin-inline-end: var(--#{$table}__tree-view-main--c-button--MarginInlineEnd);
     }
   }
 
@@ -92,6 +96,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
   > .#{$table}__check label {
     padding-inline-end: var(--#{$table}__tree-view-main--c-table__check--PaddingInlineEnd);
+    margin-block-start: 0;
+    margin-block-end: 0;
     margin-inline-start: 0;
     margin-inline-end: calc(var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd) * -1);
   }

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -90,6 +90,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     }
   }
 
+
   > .#{$table}__check {
     margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
   }

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -69,7 +69,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   text-align: start;
   cursor: pointer;
 
-  > .#{$table}__toggle {
+  > .#{$table}__th.#{$table}__toggle,
+  > .#{$table}__td.#{$table}__toggle {
     @include pf-v6-bidirectional-style (
       $prop: 'transform',
       $ltr-val: translateX(var(--#{$table}--m-tree-view__toggle--TranslateX)),
@@ -86,10 +87,10 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
     .#{$button} {
       margin-block-start: -50%;
+      margin-block-end: -50%;
       margin-inline-end: var(--#{$table}__tree-view-main--c-button--MarginInlineEnd);
     }
   }
-
 
   > .#{$table}__check {
     margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
@@ -155,8 +156,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   --#{$table}--m-tree-view-grid--tr--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
   // tbody cells
-  --#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: var(--#{$table}__tree-view-main--indent--base);
   --#{$table}--m-tree-view-grid__tbody--cell--GridColumnGap: var(--pf-t--global--spacer--sm);
 
@@ -181,10 +180,6 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
   // text
   --#{$table}__tree-view-text--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-
-  // tbody cells
-  --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockStart);
-  --#{$table}__tbody--cell--PaddingBlockEnd: var(--#{$table}--m-tree-view-grid__tbody--cell--PaddingBlockEnd);
 
   // toggle
   --#{$table}__tree-view-details-toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--plain) * -1);
@@ -289,24 +284,13 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   // - Table tree view details toggle - Table tree view action
   .#{$table}__tree-view-details-toggle,
   .#{$table}__action {
-    display: revert;
-  }
-
-  .#{$table}__tree-view-details-toggle {
     display: inline-block;
-
-    .#{$button} {
-      margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
-      margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
-    }
   }
 
   // - Table tree view action
   .#{$table}__action {
     --#{$table}--cell--Width: auto;
     --#{$table}--m-tree-view-grid__tbody--cell--PaddingInlineStart: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingInlineStart);
-    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingBlockStart);
-    --#{$table}--m-tree-view-grid__td--not--c-table__tree-view-title-cell--PaddingBlockEnd: var(--#{$table}--m-tree-view-grid--c-table__action--PaddingBlockEnd);
 
     grid-row: 1;
     grid-column: 2;
@@ -317,6 +301,12 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     order: var(--#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--Order);
     margin-inline-start: auto;
     margin-inline-end: var(--#{$table}--m-tree-view-mobile__tree-view-main--c-table__check--MarginInlineEnd);
+  }
+
+  // - Table tree view details toggle
+  .#{$table}__tree-view-details-toggle {
+    margin-block-start: var(--#{$table}__tree-view-details-toggle--MarginBlockStart);
+    margin-block-end: var(--#{$table}__tree-view-details-toggle--MarginBlockEnd);
   }
 
   // - Table tree view details toggle

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -93,6 +93,7 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   }
 
   > .#{$table}__check {
+    padding-inline-start: 0;
     margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
   }
 
@@ -216,12 +217,12 @@ $pf-v6-c-tree-view--MaxDepth: 10;
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--PaddingBlockStart);
     }
 
-    .#{$table}__action {
-      padding-block-start: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart);
-    }
-
-    .#{$table}__tree-view-title-cell ~ .#{$table}__action {
-      --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart);
+    .#{$table}__tree-view-title-cell ~ {
+      .#{$table}__th, .#{$table}__td {
+        &:is(&.#{$table}__action, .#{$table}__favorite, .#{$table}__inline-edit-action, .#{$table}__sort, .#{$table}__toggle, .#{$table}__draggable) {
+          padding-block-start: var(--#{$table}--m-tree-view-grid__tr--expanded__tree-view-title-cell--action--PaddingBlockStart);
+        }
+      }
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -12,9 +12,9 @@
   --#{$table}__caption--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__caption--Color: var(--pf-t--global--text--color--subtle);
   --#{$table}__caption--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // * Table thead cell
   --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--sm);
@@ -44,7 +44,10 @@
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$table}--cell--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
-  --#{$table}--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-last-child--PaddingInline--sm: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-last-child--PaddingInline--md: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-last-child--PaddingInline--lg: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-last-child--PaddingInline--xl: var(--pf-t--global--spacer--sm);
   --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
 
   // * Table cell - default variables
@@ -334,16 +337,6 @@
     text-overflow: var(--#{$table}--cell--TextOverflow);
     word-break: var(--#{$table}--cell--WordBreak);
     white-space: var(--#{$table}--cell--WhiteSpace);
-
-    // First child padding left
-    &:first-child {
-      padding-inline-start: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingInlineStart));
-    }
-
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: calc(var(--#{$table}--cell--first-last-child--PaddingInline) + var(--#{$table}--cell--PaddingInlineEnd));
-    }
 
     &.pf-m-center {
       text-align: center;
@@ -1098,6 +1091,57 @@
 
   > :not(:last-child) {
     margin-inline-end: var(--#{$table}__icon-inline--MarginInlineEnd);
+  }
+}
+
+.#{$table}__th,
+.#{$table}__td {
+  &.pf-m-inset-sm {
+    // First child padding left
+    &:first-child {
+      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--sm);
+    }
+
+    // Last child padding right
+    &:last-child {
+      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--sm);
+    }
+  }
+
+  &.pf-m-inset-md {
+    // First child padding left
+    &:first-child {
+      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--md);
+    }
+
+    // Last child padding right
+    &:last-child {
+      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--md);
+    }
+  }
+
+  &.pf-m-inset-lg {
+    // First child padding left
+    &:first-child {
+      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--lg);
+    }
+
+    // Last child padding right
+    &:last-child {
+      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--lg);
+    }
+  }
+
+  &.pf-m-inset-xl {
+    // First child padding left
+    &:first-child {
+      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--xl);
+    }
+
+    // Last child padding right
+    &:last-child {
+      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--xl);
+    }
   }
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -34,8 +34,8 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$table}--cell--PaddingBlock--base: calc(var(--pf-t--global--spacer--sm) * 2); // use spacer-sm * 2 to align with --pf-t--global--spacer--control--vertical--default
   --#{$table}--cell--PaddingInline--base: var(--pf-t--global--spacer--md);
   --#{$table}--cell--PaddingBlockStart: var(--#{$table}--cell--PaddingBlock--base);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--cell--PaddingBlock--base);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--cell--PaddingInline--base);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--cell--PaddingBlock--base);
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}--cell--PaddingInline--base);
   --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body--default);
@@ -43,12 +43,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
   --#{$table}--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--PaddingInline--base);
-
-  // * Table cell action
-  --#{$table}--cell--action--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--plain);
-  --#{$table}--cell--action--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--plain);
-  --#{$table}--cell--action--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
-  --#{$table}--cell--action--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
 
   // * Table cell - default variables
   --#{$table}--cell--MinWidth: 0;
@@ -104,6 +98,12 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   // * Table ghost row
   --#{$table}__tr--m-ghost-row--Opacity: .4;
   --#{$table}__tr--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+
+  // * Table cell action
+  --#{$table}--cell--action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--action--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table expandable row content
   --#{$table}__expandable-row-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -419,6 +419,17 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 
       color: var(--#{$table}__subhead--Color);
     }
+
+    // Table action - Table favorite - Table inline edit action - Table sort - Table toggle - Table draggable
+    .#{$table}__action,
+    .#{$table}__favorite,
+    .#{$table}__inline-edit-action,
+    .#{$table}__sort,
+    .#{$table}__toggle,
+    .#{$table}__draggable {
+      padding-block-start: 0;
+      padding-block-end: var(--#{$table}--cell--action--PaddingBlockEnd);
+    }
   }
 
   // - Table tbody
@@ -426,6 +437,17 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   tbody:where(.#{$table}__tbody) {
     > tr:where(.#{$table}__tr) > :where(th, td) {
       overflow-wrap: break-word;
+    }
+
+    // Table action - Table favorite - Table inline edit action - Table sort - Table toggle - Table draggable
+    .#{$table}__action,
+    .#{$table}__favorite,
+    .#{$table}__inline-edit-action,
+    .#{$table}__sort,
+    .#{$table}__toggle,
+    .#{$table}__draggable {
+      padding-block-start: var(--#{$table}--cell--action--PaddingBlockStart);
+      padding-block-end: 0;
     }
   }
   // stylelint-enable
@@ -696,7 +718,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   }
 }
 
-// stylelint-disable
 // - Table check - Table toggle - Table action - Table favorite - Table inline-edit-action - Table draggable
 .#{$table} .#{$table}__check,
 .#{$table} .#{$table}__toggle,
@@ -709,8 +730,8 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   padding-inline-start: var(--#{$table}--cell--action--PaddingInlineStart);
   padding-inline-end: var(--#{$table}--cell--action--PaddingInlineEnd);
 }
-// stylelint-enable
 
+// - Table favorite
 .#{$table} .#{$table}__favorite {
   --#{$table}--cell--MaxWidth: auto;
 }
@@ -774,14 +795,16 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 .#{$table}__action,
 .#{$table}__favorite,
 .#{$table}__inline-edit-action,
+.#{$table}__draggable,
 .#{$table}__sort,
-.#{$table}__toggle,
-.#{$table}__draggable {
+.#{$table}__toggle {
+  // set tbody actionable cells padding-block-start to zero, as negative margins impact row height
   .#{$table}__thead & {
     padding-block-start: 0;
     padding-block-end: var(--#{$table}--cell--action--PaddingBlockEnd);
   }
 
+  // set tbody actionable cells padding-block-start to zero, as negative margins impact row height
   .#{$table}__tbody & {
     padding-block-start: var(--#{$table}--cell--action--PaddingBlockStart);
     padding-block-end: 0;
@@ -967,6 +990,8 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 .#{$table}.pf-m-compact {
   --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact--cell--PaddingBlockStart);
   --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact--cell--PaddingBlockEnd);
+  --#{$table}--cell--action--PaddingBlockStart: var(--#{$table}--m-compact--cell--action--PaddingBlockStart);
+  --#{$table}--cell--action--PaddingBlockEnd: var(--#{$table}--m-compact--cell--action--PaddingBlockEnd);
 
   // - Table compact table tr
   tr:where(.#{$table}__tr) {
@@ -983,14 +1008,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__th--PaddingBlockStart);
       --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__th--PaddingBlockEnd);
     }
-  }
-
-  .#{$table}__action,
-  .#{$table}__favorite,
-  .#{$table}__toggle,
-  .#{$table}__draggable {
-    --#{$table}--cell--action--PaddingBlockStart: var(--#{$table}--m-compact--cell--action--PaddingBlockStart);
-    --#{$table}--cell--action--PaddingBlockEnd: var(--#{$table}--m-compact--cell--action--PaddingBlockEnd);
   }
 
   .#{$table}__icon {
@@ -1010,7 +1027,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 
   // - Table button
   .#{$table}__button {
-    margin-block-start: var(--#{$table}--cell--action--PaddingBlockStart); // this has no effect unless standard table are not present in the tr
+    margin-block-start: var(--#{$table}--cell--action--PaddingBlockStart); // this has no effect unless standard table cells are not present in the tr
   }
 
   // - Table nested column header button
@@ -1031,7 +1048,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 
   // - Table button
   .#{$table}__button {
-    margin-block-end: var(--#{$table}--cell--action--PaddingBlockEnd); // this has no effect unless standard table are not present in the tr
+    margin-block-end: var(--#{$table}--cell--action--PaddingBlockEnd); // this has no effect unless standard table cells are not present in the tr
   }
 
   // TODO: make this a class `compound expansion content`
@@ -1040,20 +1057,14 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   }
 }
 
-// - Table thead - Table tbody
-.#{$table} {
-  .#{$table}__thead,
-  .#{$table}__tbody {
-    line-height: var(--pf-v6-c-table--LineHeight);
-  }
-}
-
-.#{$table}__column-help-action {
-  .#{$button},
-  .#{$menu-toggle},
-  .#{$table}__button {
-    line-height: var(--pf-v6-c-table--LineHeight);
-  }
+// - Table - Table thead - Table tbody - Table column help action button - Table column help action menu-toggle - Table column help action table button
+.#{$table},
+.#{$table} .#{$table}__thead,
+.#{$table} .#{$table}__tbody,
+.#{$table}__column-help-action .#{$button},
+.#{$table}__column-help-action .#{$menu-toggle},
+.#{$table}__column-help-action .#{$table}__button {
+  line-height: var(--pf-v6-c-table--LineHeight);
 }
 
 // Table table tbody expandable

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -14,8 +14,8 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$table}__caption--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}__caption--Color: var(--pf-t--global--text--color--subtle);
   --#{$table}__caption--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // * Table thead cell
@@ -85,10 +85,10 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
   // * Table button
-  --#{$table}__button--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$table}__button--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$table}__button--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
-  --#{$table}__button--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$table}__button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__button--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$table}__button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$table}__button--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$table}__button--OutlineOffset: calc(var(--pf-t--global--border--width--strong) * -1);
@@ -327,6 +327,16 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     word-break: var(--#{$table}--cell--WordBreak);
     white-space: var(--#{$table}--cell--WhiteSpace);
 
+    // First child padding left
+    &:first-child {
+      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
+    }
+
+    // First child padding right
+    &:last-child {
+      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
+    }
+
     &.pf-m-center {
       text-align: center;
     }
@@ -413,8 +423,10 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 
   // - Table tbody
   // stylelint-disable
-  tbody:where(.#{$table}__tbody) > tr:where(.#{$table}__tr) > :where(th, td) {
-    overflow-wrap: break-word;
+  tbody:where(.#{$table}__tbody) {
+    > tr:where(.#{$table}__tr) > :where(th, td) {
+      overflow-wrap: break-word;
+    }
   }
   // stylelint-enable
 
@@ -711,6 +723,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     }
   }
 
+
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
 
@@ -738,10 +751,10 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   }
 
   &.pf-m-favorited .#{$button} {
-  --#{$button}--m-plain__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
+    --#{$button}--m-plain__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
 
-  &:is(:hover, :focus) {
-    --#{$button}--hover__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
+    &:is(:hover, :focus) {
+      --#{$button}--hover__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
     }
   }
 }
@@ -849,10 +862,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 // - Table column help action
 .#{$table}__column-help-action {
   margin-inline-start: var(--#{$table}__column-help--MarginInlineStart);
-
-  .#{$button}__icon {
-    display: flex;
-  }
 }
 
 // - Table sort
@@ -1096,16 +1105,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 // - Table th - Table td
 .#{$table}__th,
 .#{$table}__td {
-  // First child padding left
-  &:first-child {
-    padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
-  }
-
-  // First child padding right
-  &:last-child {
-    padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
-  }
-
   // - Table th inset - Table td inset
   @each $inset, $inset-value in $pf-v6-c-masthead--inset-map {
     &.pf-m-inset-#{$inset} {
@@ -1117,17 +1116,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
         padding-inline-end: #{$inset-value};
       }
     }
-  }
-}
-
-// - Table icon inline
-.#{$table}__icon-inline {
-  display: flex;
-  align-items: center;
-  margin-inline-end: var(--#{$table}__icon-inline--MarginInlineEnd);
-
-  &:last-child {
-    margin-inline-end: 0;
   }
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -45,9 +45,9 @@
   --#{$table}--cell--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
   --#{$table}--cell--first-last-child--PaddingInline--sm: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-last-child--PaddingInline--md: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-last-child--PaddingInline--lg: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-last-child--PaddingInline--xl: var(--pf-t--global--spacer--sm);
+  --#{$table}--cell--first-last-child--PaddingInline--md: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--first-last-child--PaddingInline--lg: var(--pf-t--global--spacer--lg);
+  --#{$table}--cell--first-last-child--PaddingInline--xl: var(--pf-t--global--spacer--xl);
   --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
 
   // * Table cell - default variables
@@ -116,8 +116,6 @@
   // * Table action
   --#{$table}__action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}__action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table expandable row content
   --#{$table}__expandable-row-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -499,9 +497,9 @@
       outline-offset: var(--#{$table}__tr--m-selected--OutlineOffset);
     }
 
-    &.pf-m-first-cell-offset-reset > :first-child {
-      padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart);
-    }
+    // &.pf-m-first-cell-offset-reset > :first-child {
+    //   padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart);
+    // }
   }
 
   // - Table tbody clickable
@@ -717,17 +715,11 @@
 
 // - Table toggle
 .#{$table}__toggle {
-  --#{$table}--cell--PaddingBlockStart: var(--#{$table}__toggle--PaddingBlockStart);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__toggle--PaddingBlockEnd);
-  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__toggle--PaddingInlineStart);
-  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__toggle--PaddingInlineEnd);
-
   .#{$button} {
     &.pf-m-expanded .#{$table}__toggle-icon {
       transform: rotate(var(--#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate));
     }
   }
-
 
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
@@ -743,9 +735,6 @@
 
 // - Table check
 .#{$table}__check {
-  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__check--PaddingInlineStart);
-  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__check--PaddingInlineEnd);
-
   vertical-align: top;
 
   .#{$check} {
@@ -806,8 +795,6 @@
 .#{$table}__draggable {
   --#{$table}--cell--PaddingBlockStart: var(--#{$table}__action--PaddingBlockStart);
   --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__action--PaddingBlockEnd);
-  --#{$table}--cell--PaddingInlineStart: var(--#{$table}__action--PaddingInlineStart);
-  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__action--PaddingInlineEnd);
 }
 
 // - Table action - Table inline edit action

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1,5 +1,7 @@
 @use '../../sass-utilities' as *;
 
+$pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
+
 // TODO: clean up unused variables
 // TODO: update grouping comments to // * Table {element}
 
@@ -13,20 +15,14 @@
   --#{$table}__caption--Color: var(--pf-t--global--text--color--subtle);
   --#{$table}__caption--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$table}__caption--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--md);
 
   // * Table thead cell
   --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
-
-  // * Table thead toggle
-  --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
-
-  // * Table body cell
-  --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
-  --#{$table}__tbody--cell--PaddingBlockEnd: var(--#{$table}--cell--Padding--base);
-  --#{$table}__tbody--cell--FontSize: var(--pf-t--global--font--size--body--default); // set this explicitly for input heights to calc properly
+  --#{$table}__thead--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm); // use spacer-sm to align with --pf-t--global--spacer--control--vertical--default
+  --#{$table}__thead--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm); // use spacer-sm to align with --pf-t--global--spacer--control--vertical--default
 
   // * Table tr
   --#{$table}__tr--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
@@ -35,20 +31,24 @@
   // TODO: update these in order of appearance in scss declarations
 
   // * Table cell
-  --#{$table}--cell--Padding--base: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--cell--Padding--base);
-  --#{$table}--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--PaddingBlock--base: calc(var(--pf-t--global--spacer--sm) * 2); // use spacer-sm * 2 to align with --pf-t--global--spacer--control--vertical--default
+  --#{$table}--cell--PaddingInline--base: var(--pf-t--global--spacer--md);
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--cell--PaddingBlock--base);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--cell--PaddingBlock--base);
+  --#{$table}--cell--PaddingInlineEnd: var(--#{$table}--cell--PaddingInline--base);
+  --#{$table}--cell--PaddingInlineStart: var(--#{$table}--cell--PaddingInline--base);
   --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$table}--cell--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
-  --#{$table}--cell--first-last-child--PaddingInline--sm: var(--pf-t--global--spacer--sm);
-  --#{$table}--cell--first-last-child--PaddingInline--md: var(--pf-t--global--spacer--md);
-  --#{$table}--cell--first-last-child--PaddingInline--lg: var(--pf-t--global--spacer--lg);
-  --#{$table}--cell--first-last-child--PaddingInline--xl: var(--pf-t--global--spacer--xl);
-  --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
+  --#{$table}--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--PaddingInline--base);
+
+  // * Table cell action
+  --#{$table}--cell--action--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--plain);
+  --#{$table}--cell--action--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--plain);
+  --#{$table}--cell--action--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
+  --#{$table}--cell--action--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
 
   // * Table cell - default variables
   --#{$table}--cell--MinWidth: 0;
@@ -79,30 +79,22 @@
   --#{$table}--cell--hidden-visible--Display: table-cell;
 
   // * Table toggle
-  --#{$table}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
   --#{$table}__toggle--c-button__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
   --#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
   // * Table button
-  --#{$table}__button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$table}__button--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$table}__button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$table}__button--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$table}__button--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$table}__button--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$table}__button--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$table}__button--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$table}__button--OutlineOffset: calc(var(--pf-t--global--border--width--strong) * -1);
   --#{$table}__button--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$table}__button--hover--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
-
-  // * Table check
-  --#{$table}__check--PaddingInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__check--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table favorite
   --#{$table}__favorite--c-button--FontSize: var(--pf-t--global--font--size--body--default);
@@ -112,10 +104,6 @@
   // * Table ghost row
   --#{$table}__tr--m-ghost-row--Opacity: .4;
   --#{$table}__tr--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-
-  // * Table action
-  --#{$table}__action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table expandable row content
   --#{$table}__expandable-row-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -171,16 +159,16 @@
   --#{$table}--compound-expansion--m-expanded--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
 
   // * Table compact th
-  --#{$table}--m-compact__th--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
+  --#{$table}--m-compact__th--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact__th--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table compact cell
   --#{$table}--m-compact--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
-  // * Table compact action
-  --#{$table}--m-compact__action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  // * Table compact cell action
+  --#{$table}--m-compact--cell--action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact--cell--action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // * Table expandable row expanded
   --#{$table}__expandable-row--m-expanded--BorderBlockEndColor: var(--pf-t--global--border--color--default);
@@ -223,6 +211,9 @@
   --#{$table}--m-sticky-header--cell--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$table}--m-sticky-header--ZIndex: calc(var(--pf-t--global--z-index--xs) + 1);
   --#{$table}--m-sticky-header--border--ZIndex: calc(var(--pf-t--global--z-index--xs) + 2);
+
+  // * Table line height
+  --#{$table}--LineHeight: calc(var(--#{$table}--cell--FontSize) * var(--#{$table}--cell--LineHeight)); // retain consistent line-height for all table cells / supports vertical alignment
 }
 
 // TODO: update grouping comments to // Table {element}
@@ -330,7 +321,7 @@
     overflow: var(--#{$table}--cell--Overflow);
     font-size: var(--#{$table}--cell--FontSize);
     font-weight: var(--#{$table}--cell--FontWeight);
-    line-height: var(--#{$table}--cell--LineHeight);
+    line-height: var(--#{$table}--LineHeight); // use consistent line height
     color: var(--#{$table}--cell--Color);
     text-overflow: var(--#{$table}--cell--TextOverflow);
     word-break: var(--#{$table}--cell--WordBreak);
@@ -422,14 +413,8 @@
 
   // - Table tbody
   // stylelint-disable
-  tbody:where(.#{$table}__tbody) {
-    --#{$table}--cell--PaddingBlockStart: var(--#{$table}__tbody--cell--PaddingBlockStart);
-    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__tbody--cell--PaddingBlockEnd);
-    --#{$table}--cell--FontSize: var(--#{$table}__tbody--cell--FontSize);
-
-    > tr:where(.#{$table}__tr) > :where(th, td) {
-      overflow-wrap: break-word;
-    }
+  tbody:where(.#{$table}__tbody) > tr:where(.#{$table}__tr) > :where(th, td) {
+    overflow-wrap: break-word;
   }
   // stylelint-enable
 
@@ -497,9 +482,9 @@
       outline-offset: var(--#{$table}__tr--m-selected--OutlineOffset);
     }
 
-    // &.pf-m-first-cell-offset-reset > :first-child {
-    //   padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart);
-    // }
+    &.pf-m-first-cell-offset-reset > :first-child {
+      padding-inline-start: var(--#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart);
+    }
   }
 
   // - Table tbody clickable
@@ -601,7 +586,7 @@
   min-width: var(--#{$table}--text--MinWidth);
   max-width: var(--#{$table}--cell--MaxWidth);
   overflow: var(--#{$table}--cell--Overflow);
-  line-height: var(--#{$table}--cell--LineHeight);
+  line-height: var(--#{$table}--LineHeight);
   text-overflow: var(--#{$table}--cell--TextOverflow);
   word-break: var(--#{$table}--cell--WordBreak);
   white-space: var(--#{$table}--cell--WhiteSpace);
@@ -626,8 +611,9 @@
   padding-block-end: var(--#{$table}__button--PaddingBlockEnd);
   padding-inline-start: var(--#{$table}__button--PaddingInlineStart);
   padding-inline-end: var(--#{$table}__button--PaddingInlineEnd);
-  margin-block-end: calc(var(--#{$table}__button--PaddingBlockEnd) * -1);
-  margin-inline-start: calc(var(--#{$table}__button--PaddingInlineStart) * -1);
+  margin-inline-start: calc(var(--#{$table}__button--PaddingInlineStart) * -1); // button needs to retain negative margin-inline-start
+
+  // margin-inline-end: omit as adjacent buttons could collide
   font-size: inherit;
   font-weight: inherit;
   color: var(--#{$table}__button--Color);
@@ -668,8 +654,9 @@
 .#{$table}__column-help {
   display: inline-grid;
   grid-template-columns: auto max-content;
-  align-items: baseline;
+  align-items: last baseline;
   justify-content: start;
+  line-height: inherit;
 
   .#{$table}__text {
     min-width: auto;
@@ -706,6 +693,9 @@
 .#{$table} .#{$table}__draggable {
   --#{$table}--cell--MinWidth: 0;
   --#{$table}--cell--Width: 1%;
+
+  padding-inline-start: var(--#{$table}--cell--action--PaddingInlineStart);
+  padding-inline-end: var(--#{$table}--cell--action--PaddingInlineEnd);
 }
 // stylelint-enable
 
@@ -735,30 +725,9 @@
 
 // - Table check
 .#{$table}__check {
-  vertical-align: top;
-
-  .#{$check} {
-    --#{$check}__label--FontSize: var(--#{$table}--cell--FontSize);
-    --#{$check}__label--LineHeight: var(--#{$table}--cell--LineHeight);
-  }
-
+  .#{$check},
   .#{$radio} {
-    --#{$radio}__label--FontSize: var(--#{$table}--cell--FontSize);
-    --#{$radio}__label--LineHeight: var(--#{$table}--cell--LineHeight);
-  }
-
-  thead & {
-    vertical-align: bottom;
-  }
-
-  .#{$check}.pf-m-standalone,
-  .#{$radio}.pf-m-standalone {
-    thead & {
-      display: table-cell;
-      height: auto;
-      line-height: 1;
-      vertical-align: baseline;
-    }
+    display: flex;
   }
 }
 
@@ -769,10 +738,10 @@
   }
 
   &.pf-m-favorited .#{$button} {
-    --#{$button}--m-plain__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
+  --#{$button}--m-plain__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
 
-    &:is(:hover, :focus) {
-      --#{$button}--hover__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
+  &:is(:hover, :focus) {
+    --#{$button}--hover__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
     }
   }
 }
@@ -788,13 +757,26 @@
   }
 }
 
-// - Table action - Table favorite - Table inline edit action - Table draggable
+// - Table action - Table favorite - Table inline edit action - Table draggable - Table sort - Table toggle
 .#{$table}__action,
 .#{$table}__favorite,
 .#{$table}__inline-edit-action,
+.#{$table}__sort,
+.#{$table}__toggle,
 .#{$table}__draggable {
-  --#{$table}--cell--PaddingBlockStart: var(--#{$table}__action--PaddingBlockStart);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__action--PaddingBlockEnd);
+  .#{$table}__thead & {
+    padding-block-start: 0;
+    padding-block-end: var(--#{$table}--cell--action--PaddingBlockEnd);
+  }
+
+  .#{$table}__tbody & {
+    padding-block-start: var(--#{$table}--cell--action--PaddingBlockStart);
+    padding-block-end: 0;
+  }
+}
+
+.#{$table}__compound-expansion-toggle .#{$table}__button {
+  --pf-v6-c-table--cell--action--PaddingBlockEnd: 0;
 }
 
 // - Table action - Table inline edit action
@@ -867,6 +849,10 @@
 // - Table column help action
 .#{$table}__column-help-action {
   margin-inline-start: var(--#{$table}__column-help--MarginInlineStart);
+
+  .#{$button}__icon {
+    display: flex;
+  }
 }
 
 // - Table sort
@@ -911,7 +897,6 @@
 // - Table sort indicator
 .#{$table}__sort-indicator {
   grid-column: 2;
-  align-self: end;
   margin-inline-start: var(--#{$table}__sort-indicator--MarginInlineStart); // TODO: update this to gap
   color: var(--#{$table}__sort-indicator--Color);
   pointer-events: none;
@@ -995,8 +980,8 @@
   .#{$table}__favorite,
   .#{$table}__toggle,
   .#{$table}__draggable {
-    --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
-    --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
+    --#{$table}--cell--action--PaddingBlockStart: var(--#{$table}--m-compact--cell--action--PaddingBlockStart);
+    --#{$table}--cell--action--PaddingBlockEnd: var(--#{$table}--m-compact--cell--action--PaddingBlockEnd);
   }
 
   .#{$table}__icon {
@@ -1011,7 +996,13 @@
   --#{$table}__tr--BorderBlockEndWidth: 0;
   --#{$table}__toggle--PaddingBlockEnd: var(--#{$table}__thead__toggle--PaddingBlockEnd);
 
+  font-size: var(--#{$table}__thead--cell--FontSize);
   vertical-align: bottom;
+
+  // - Table button
+  .#{$table}__button {
+    margin-block-start: var(--#{$table}--cell--action--PaddingBlockStart); // this has no effect unless standard table are not present in the tr
+  }
 
   // - Table nested column header button
   &.pf-m-nested-column-header {
@@ -1029,9 +1020,30 @@
 .#{$table}__tbody {
   vertical-align: top;
 
+  // - Table button
+  .#{$table}__button {
+    margin-block-end: var(--#{$table}--cell--action--PaddingBlockEnd); // this has no effect unless standard table are not present in the tr
+  }
+
   // TODO: make this a class `compound expansion content`
   .#{$table}__control-row ~ .#{$table}__expandable-row.pf-m-expanded {
     background-color: var(--#{$table}--compound-expansion--m-expanded--BackgroundColor);
+  }
+}
+
+// - Table thead - Table tbody
+.#{$table} {
+  .#{$table}__thead,
+  .#{$table}__tbody {
+    line-height: var(--pf-v6-c-table--LineHeight);
+  }
+}
+
+.#{$table}__column-help-action {
+  .#{$button},
+  .#{$menu-toggle},
+  .#{$table}__button {
+    line-height: var(--pf-v6-c-table--LineHeight);
   }
 }
 
@@ -1081,54 +1093,41 @@
   }
 }
 
+// - Table th - Table td
 .#{$table}__th,
 .#{$table}__td {
-  &.pf-m-inset-sm {
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--sm);
-    }
-
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--sm);
-    }
+  // First child padding left
+  &:first-child {
+    padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
   }
 
-  &.pf-m-inset-md {
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--md);
-    }
-
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--md);
-    }
+  // First child padding right
+  &:last-child {
+    padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
   }
 
-  &.pf-m-inset-lg {
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--lg);
-    }
+  // - Table th inset - Table td inset
+  @each $inset, $inset-value in $pf-v6-c-masthead--inset-map {
+    &.pf-m-inset-#{$inset} {
+      &:first-child {
+        padding-inline-start: #{$inset-value};
+      }
 
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--lg);
+      &:last-child {
+        padding-inline-end: #{$inset-value};
+      }
     }
   }
+}
 
-  &.pf-m-inset-xl {
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline--xl);
-    }
+// - Table icon inline
+.#{$table}__icon-inline {
+  display: flex;
+  align-items: center;
+  margin-inline-end: var(--#{$table}__icon-inline--MarginInlineEnd);
 
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline--xl);
-    }
+  &:last-child {
+    margin-inline-end: 0;
   }
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -8,6 +8,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 @include pf-root($table) {
   --#{$table}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$table}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$table}--BorderWidth: var(--pf-t--global--border--width--divider--default);
   --#{$table}--border-width--base: var(--pf-t--global--border--width--divider--default);
 
   // * Table caption
@@ -949,6 +950,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
       padding-block-start: 0;
       padding-inline-start: 0;
       padding-inline-end: 0;
+
       // padding-block-end: 0; // retain bottom padding
 
       .#{$table}__expandable-row-content {
@@ -1059,9 +1061,9 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 .#{$table},
 .#{$table} .#{$table}__thead,
 .#{$table} .#{$table}__tbody,
-.#{$table}__column-help-action .#{$button},
-.#{$table}__column-help-action .#{$menu-toggle},
-.#{$table}__column-help-action .#{$table}__button {
+.#{$table} .#{$button},
+.#{$table} .#{$menu-toggle},
+.#{$table} .#{$table}__button {
   line-height: var(--pf-v6-c-table--LineHeight);
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -21,8 +21,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   // * Table thead cell
   --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$table}__thead--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm); // use spacer-sm to align with --pf-t--global--spacer--control--vertical--default
-  --#{$table}__thead--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm); // use spacer-sm to align with --pf-t--global--spacer--control--vertical--default
 
   // * Table tr
   --#{$table}__tr--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
@@ -169,6 +167,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   // * Table compact cell action
   --#{$table}--m-compact--cell--action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$table}--m-compact--cell--action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--control--horizontal--spacious);
 
   // * Table expandable row expanded
   --#{$table}__expandable-row--m-expanded--BorderBlockEndColor: var(--pf-t--global--border--color--default);
@@ -304,6 +303,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     }
   }
 
+  // TODO: remove :where, target .#{$table}__th and .#{$table}__td
   // - Table th - Table td
   tr:where(.#{$table}__tr) > :where(th, td) {
     @include pf-v6-hidden-visible(var(--#{$table}--cell--hidden-visible--Display));
@@ -326,16 +326,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     text-overflow: var(--#{$table}--cell--TextOverflow);
     word-break: var(--#{$table}--cell--WordBreak);
     white-space: var(--#{$table}--cell--WhiteSpace);
-
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
-    }
-
-    // First child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
-    }
 
     &.pf-m-center {
       text-align: center;
@@ -563,9 +553,16 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
     }
   }
 
-  .#{$button} .#{$table}__sort-indicator {
-    --#{$table}__sort-indicator--MarginInlineStart: 0;
+  .#{$button} {
+    .#{$button}__icon {
+      line-height: inherit;
+    }
+
+    .#{$table}__sort-indicator {
+      --#{$table}__sort-indicator--MarginInlineStart: 0;
+    }
   }
+
 }
 
 // - Table truncate - Table wrap - Table nowrap - Table fit content - Table wrap - Table break word
@@ -950,9 +947,9 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   th:where(.#{$table}__th) {
     &.pf-m-no-padding {
       padding-block-start: 0;
-      padding-block-end: 0;
       padding-inline-start: 0;
       padding-inline-end: 0;
+      // padding-block-end: 0; // retain bottom padding
 
       .#{$table}__expandable-row-content {
         padding: 0;
@@ -992,6 +989,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact--cell--PaddingBlockEnd);
   --#{$table}--cell--action--PaddingBlockStart: var(--#{$table}--m-compact--cell--action--PaddingBlockStart);
   --#{$table}--cell--action--PaddingBlockEnd: var(--#{$table}--m-compact--cell--action--PaddingBlockEnd);
+  --#{$table}--cell--first-last-child--PaddingInline: var(--#{$table}--m-compact--cell--first-last-child--PaddingInline);
 
   // - Table compact table tr
   tr:where(.#{$table}__tr) {
@@ -1116,6 +1114,16 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 // - Table th - Table td
 .#{$table}__th,
 .#{$table}__td {
+  // first last child padding inline
+  &:first-child {
+    padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
+  }
+
+  // first last child padding inline
+  &:last-child {
+    padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
+  }
+
   // - Table th inset - Table td inset
   @each $inset, $inset-value in $pf-v6-c-masthead--inset-map {
     &.pf-m-inset-#{$inset} {


### PR DESCRIPTION
closes #7032  
closes [#11058](https://github.com/patternfly/patternfly/issues/7112)

Updated [Table Iso Backstop Report](https://drive.google.com/file/d/1aj7jx_rWbyy5eCK0738ZdcKh_AGa_bBx/view?usp=sharing)
Updated [Full Backstop Report](https://drive.google.com/file/d/1NKGM1Q2wz6V3Buyvj4w4Cx6BKRAuOf6R/view?usp=sharing)

Examples: https://patternfly-pr-7050.surge.sh/components/table

# TLDR:
Floating `:first/:last-child` pseudos result in a huge number of selector matching attempts. Attaching these pseudos to a selector results in a massive reduction in matching attempts. 

The cell padding and button fitting updates are the result of a somewhat hidden bug. `thead` row heights are affected erratically by using negative margining on `table__button` cells. See below:

**Before**

<img width="891" alt="Screenshot 2024-09-17 at 10 56 47 AM" src="https://github.com/user-attachments/assets/7cd2eb4c-4803-4ddf-9070-703a936eb6d6">

<img width="881" alt="Screenshot 2024-09-17 at 10 56 05 AM" src="https://github.com/user-attachments/assets/80da4f38-14b0-4068-a03e-418d8788a869">

<img width="899" alt="Screenshot 2024-09-17 at 10 53 34 AM" src="https://github.com/user-attachments/assets/562c8322-f654-42a7-94a5-cfbf2e3770d2">

<img width="894" alt="Screenshot 2024-09-17 at 10 52 39 AM" src="https://github.com/user-attachments/assets/ed504e45-4575-4944-8c11-1a35c2e6c4ef">

**After**

<img width="858" alt="Screenshot 2024-09-17 at 10 57 35 AM" src="https://github.com/user-attachments/assets/7810aed0-fcba-41b9-8203-480e79976a6e">

<img width="865" alt="Screenshot 2024-09-17 at 10 57 23 AM" src="https://github.com/user-attachments/assets/b15f673f-500b-4a30-a7bf-783ccc1e9afe">
<img width="857" alt="Screenshot 2024-09-17 at 10 57 10 AM" src="https://github.com/user-attachments/assets/f4ac94e5-1e95-4948-b8a9-3b7a29fdc483">
<img width="880" alt="Screenshot 2024-09-17 at 10 56 58 AM" src="https://github.com/user-attachments/assets/0dada0cb-a89b-476a-99b1-852e1611f269">



~~Table :first/:last-child css declarations are relics that should be standardized. As per a recent conversation w/ @lboehling, :first/:last-child th/td padding definitions can/should be simplified, while inset updates should be optional.~~

~~Also, toggles, checkboxes, radios, actions, etc do not need special spacing.~~

These need to be updated

## Performance impact

This PR 
* Reduces match attempts by **4,361,984**
* Improves performance by 2%
* Reduces blocking time by 50ms

**Before**

<img width="499" alt="Screenshot 2024-09-10 at 11 57 31 AM" src="https://github.com/user-attachments/assets/1b8add90-6a43-4b62-8ee6-555d2968a226">

**After**

<img width="798" alt="Screenshot 2024-09-10 at 11 49 02 AM" src="https://github.com/user-attachments/assets/4e092121-dd34-46e7-b9c1-f2ecb6ae443e">

**Before**

<img width="735" alt="Screenshot 2024-09-10 at 12 03 46 PM" src="https://github.com/user-attachments/assets/392346b5-e5e3-48b6-8421-225eb9aefd21">

**After**

<img width="735" alt="Screenshot 2024-09-10 at 12 05 26 PM" src="https://github.com/user-attachments/assets/a7b021ae-ae41-49f8-af34-29346ccca0c2">


[Backstop report](https://drive.google.com/file/d/1XSd0422s0tgllaC3dVdIir6kcamoFDiU/view)