### PR TITLE
feat(FormControl): refine textarea styles

### DIFF
--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -119,43 +119,43 @@ cssPrefix: pf-v6-c-form-control
 
 ### Textarea
 ```hbs
-{{#> form-control controlType="textarea" form-control--attribute='name="textarea-standard" id="textarea-standard" aria-label="Standard textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-standard" id="textarea-standard" aria-label="Standard textarea example"'}}
 Standard
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly" id="textarea-readonly" aria-label="Readonly textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly" id="textarea-readonly" aria-label="Readonly textarea example"'}}
 Readonly
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsPlain='true' form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly-plain" id="textarea-readonly-plain" aria-label="Readonly plain textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsPlain='true' form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly-plain" id="textarea-readonly-plain" aria-label="Readonly plain textarea example"'}}
 Readonly plain
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsDisabled="true" form-control--attribute='name="textarea-disabled" id="textarea-disabled" aria-label="Disabled textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsDisabled="true" form-control--attribute='name="textarea-disabled" id="textarea-disabled" aria-label="Disabled textarea example"'}}
 Disabled
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsSuccess="true" form-control--attribute='name="textarea-success" id="textarea-success" aria-label="Success state textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsSuccess="true" form-control--attribute='name="textarea-success" id="textarea-success" aria-label="Success state textarea example"'}}
 Success
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsWarning="true" form-control--attribute='name="textarea-warning" id="textarea-warning" aria-label="Warning state textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsWarning="true" form-control--attribute='name="textarea-warning" id="textarea-warning" aria-label="Warning state textarea example"'}}
 Warning
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsError="true" form-control--attribute='required name="textarea-error" id="textarea-error" aria-label="Error state textarea example" aria-invalid="true"'}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsError="true" form-control--attribute='required name="textarea-error" id="textarea-error" aria-label="Error state textarea example" aria-invalid="true"'}}
 Error
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-vertical" id="textarea-resize-vertical" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-vertical" id="textarea-resize-vertical" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
 Resizes vertically
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-horizontal" id="textarea-resize-horizontal" aria-label="Resize horizontal textarea example"' form-control--modifier="pf-m-resize-horizontal"}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-horizontal" id="textarea-resize-horizontal" aria-label="Resize horizontal textarea example"' form-control--modifier="pf-m-resize-horizontal"}}
 Resizes horizontally
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-both" id="textarea-resize-both" aria-label="Resize both textarea example"' form-control--modifier="pf-m-resize-both"}}
+{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-both" id="textarea-resize-both" aria-label="Resize both textarea example"' form-control--modifier="pf-m-resize-both"}}
 Resizes in both directions
 {{/form-control}}
 ```

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -119,43 +119,43 @@ cssPrefix: pf-v6-c-form-control
 
 ### Textarea
 ```hbs
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-standard" id="textarea-standard" aria-label="Standard textarea example"'}}
+{{#> form-control controlType="textarea" form-control--attribute='name="textarea-standard" id="textarea-standard" aria-label="Standard textarea example"'}}
 Standard
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly" id="textarea-readonly" aria-label="Readonly textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly" id="textarea-readonly" aria-label="Readonly textarea example"'}}
 Readonly
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsPlain='true' form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly-plain" id="textarea-readonly-plain" aria-label="Readonly plain textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsPlain='true' form-control--IsReadonly="true" form-control--attribute='name="textarea-readonly-plain" id="textarea-readonly-plain" aria-label="Readonly plain textarea example"'}}
 Readonly plain
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsDisabled="true" form-control--attribute='name="textarea-disabled" id="textarea-disabled" aria-label="Disabled textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsDisabled="true" form-control--attribute='name="textarea-disabled" id="textarea-disabled" aria-label="Disabled textarea example"'}}
 Disabled
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsSuccess="true" form-control--attribute='name="textarea-success" id="textarea-success" aria-label="Success state textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsSuccess="true" form-control--attribute='name="textarea-success" id="textarea-success" aria-label="Success state textarea example"'}}
 Success
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsWarning="true" form-control--attribute='name="textarea-warning" id="textarea-warning" aria-label="Warning state textarea example"'}}
+{{#> form-control controlType="textarea" form-control--IsWarning="true" form-control--attribute='name="textarea-warning" id="textarea-warning" aria-label="Warning state textarea example"'}}
 Warning
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--IsError="true" form-control--attribute='required name="textarea-error" id="textarea-error" aria-label="Error state textarea example" aria-invalid="true"'}}
+{{#> form-control controlType="textarea" form-control--IsError="true" form-control--attribute='required name="textarea-error" id="textarea-error" aria-label="Error state textarea example" aria-invalid="true"'}}
 Error
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-vertical" id="textarea-resize-vertical" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
+{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-vertical" id="textarea-resize-vertical" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
 Resizes vertically
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-horizontal" id="textarea-resize-horizontal" aria-label="Resize horizontal textarea example"' form-control--modifier="pf-m-resize-horizontal"}}
+{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-horizontal" id="textarea-resize-horizontal" aria-label="Resize horizontal textarea example"' form-control--modifier="pf-m-resize-horizontal"}}
 Resizes horizontally
 {{/form-control}}
 <br>
-{{#> form-control controlType="textarea" form-control--IsTextarea="true" form-control--attribute='name="textarea-resize-both" id="textarea-resize-both" aria-label="Resize both textarea example"' form-control--modifier="pf-m-resize-both"}}
+{{#> form-control controlType="textarea" form-control--attribute='name="textarea-resize-both" id="textarea-resize-both" aria-label="Resize both textarea example"' form-control--modifier="pf-m-resize-both"}}
 Resizes in both directions
 {{/form-control}}
 ```

--- a/src/patternfly/components/FormControl/form-control.hbs
+++ b/src/patternfly/components/FormControl/form-control.hbs
@@ -9,6 +9,7 @@
   {{#if form-control--IsWarning}} pf-m-warning{{/if}}
   {{#if form-control--IsError}} pf-m-error{{/if}}
   {{#if form-control--HasIcon}} pf-m-icon{{/if}}
+  {{#if form-control--IsTextarea}} pf-m-textarea{{/if}}
   {{#if form-control--modifier}} {{form-control--modifier}}{{/if}}
 ">
   {{#ifEquals controlType "select"}}

--- a/src/patternfly/components/FormControl/form-control.hbs
+++ b/src/patternfly/components/FormControl/form-control.hbs
@@ -9,7 +9,7 @@
   {{#if form-control--IsWarning}} pf-m-warning{{/if}}
   {{#if form-control--IsError}} pf-m-error{{/if}}
   {{#if form-control--HasIcon}} pf-m-icon{{/if}}
-  {{#if form-control--IsTextarea}} pf-m-textarea{{/if}}
+  {{#ifEquals controlType "textarea"}} pf-m-textarea{{/ifEquals}}
   {{#if form-control--modifier}} {{form-control--modifier}}{{/if}}
 ">
   {{#ifEquals controlType "select"}}

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -90,11 +90,10 @@
   // Textarea
   --#{$form-control}--textarea--Width: var(--#{$form-control}--Width);
   --#{$form-control}--textarea--Height: auto;
-  --#{$form-control}--textarea--Padding: calc(-1 * var(--#{$form-control}--OutlineOffset));
-  --#{$form-control}--textarea--PaddingBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--Padding));
-  --#{$form-control}--textarea--PaddingBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--Padding));
-  --#{$form-control}--textarea--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--Padding));
-  --#{$form-control}--textarea--PaddingInlineStart: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--Padding));
+  --#{$form-control}--textarea--PaddingBlockStart: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingBlockEnd: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingInlineEnd: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingInlineStart: calc(-1 * var(--#{$form-control}--OutlineOffset));
 
   // Form control icon
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
@@ -177,14 +176,24 @@
   }
 
   &.pf-m-textarea {
-    padding: var(--#{$form-control}--textarea--Padding);
+    padding-block-start: var(--#{$form-control}--textarea--PaddingBlockStart);
+    padding-block-end: var(--#{$form-control}--textarea--PaddingBlockEnd);
+    padding-inline-start: var(--#{$form-control}--textarea--PaddingInlineStart);
+    padding-inline-end: var(--#{$form-control}--textarea--PaddingInlineEnd);
+   
+    &.pf-m-success,
+    &.pf-m-warning,
+    &.pf-m-error {
+      --#{$form-control}--m-status--PaddingInlineEnd--offset: calc(var(--#{$form-control}__icon--FontSize) + var(--#{$form-control}--ColumnGap)); 
+    }
 
-    > :is(textarea) {
-      padding-block-start: var(--#{$form-control}--textarea--PaddingBlockStart);
-      padding-block-end: var(--#{$form-control}--textarea--PaddingBlockEnd);
-      padding-inline-start: var(--#{$form-control}--textarea--PaddingInlineStart);
-      padding-inline-end: var(--#{$form-control}--textarea--PaddingInlineEnd);
+    > textarea {
+      padding-block-start: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--PaddingBlockStart));
+      padding-block-end: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--PaddingBlockEnd));
+      padding-inline-start: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--PaddingInlineStart));
+      padding-inline-end: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--PaddingInlineEnd) + var(--#{$form-control}--m-status--PaddingInlineEnd--offset, 0));  
       outline-offset: 0;
+      scrollbar-gutter: stable;
     }
   }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -90,10 +90,10 @@
   // Textarea
   --#{$form-control}--textarea--Width: var(--#{$form-control}--Width);
   --#{$form-control}--textarea--Height: auto;
-  --#{$form-control}--textarea--PaddingBlockStart: calc(-1 * var(--#{$form-control}--OutlineOffset));
-  --#{$form-control}--textarea--PaddingBlockEnd: calc(-1 * var(--#{$form-control}--OutlineOffset));
-  --#{$form-control}--textarea--PaddingInlineEnd: calc(-1 * var(--#{$form-control}--OutlineOffset));
-  --#{$form-control}--textarea--PaddingInlineStart: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingBlockStart--offset: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingBlockEnd--offset: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingInlineEnd--offset: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingInlineStart--offset: calc(-1 * var(--#{$form-control}--OutlineOffset));
 
   // Form control icon
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
@@ -176,10 +176,10 @@
   }
 
   &.pf-m-textarea {
-    padding-block-start: var(--#{$form-control}--textarea--PaddingBlockStart);
-    padding-block-end: var(--#{$form-control}--textarea--PaddingBlockEnd);
-    padding-inline-start: var(--#{$form-control}--textarea--PaddingInlineStart);
-    padding-inline-end: var(--#{$form-control}--textarea--PaddingInlineEnd);
+    padding-block-start: var(--#{$form-control}--textarea--PaddingBlockStart--offset);
+    padding-block-end: var(--#{$form-control}--textarea--PaddingBlockEnd--offset);
+    padding-inline-start: var(--#{$form-control}--textarea--PaddingInlineStart--offset);
+    padding-inline-end: var(--#{$form-control}--textarea--PaddingInlineEnd--offset);
    
     &.pf-m-success,
     &.pf-m-warning,
@@ -188,10 +188,10 @@
     }
 
     > textarea {
-      padding-block-start: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--PaddingBlockStart));
-      padding-block-end: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--PaddingBlockEnd));
-      padding-inline-start: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--PaddingInlineStart));
-      padding-inline-end: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--PaddingInlineEnd) + var(--#{$form-control}--m-status--PaddingInlineEnd--offset, 0));  
+      padding-block-start: calc(var(--#{$form-control}--PaddingBlockStart) - var(--#{$form-control}--textarea--PaddingBlockStart--offset));
+      padding-block-end: calc(var(--#{$form-control}--PaddingBlockEnd) - var(--#{$form-control}--textarea--PaddingBlockEnd--offset));
+      padding-inline-start: calc(var(--#{$form-control}--PaddingInlineStart) - var(--#{$form-control}--textarea--PaddingInlineStart--offset));
+      padding-inline-end: calc(var(--#{$form-control}--PaddingInlineEnd) - var(--#{$form-control}--textarea--PaddingInlineEnd--offset) + var(--#{$form-control}--m-status--PaddingInlineEnd--offset, 0));  
       outline-offset: 0;
       scrollbar-gutter: stable;
     }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -7,7 +7,6 @@
   --#{$form-control}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$form-control}--Resize: none;
   --#{$form-control}--OutlineOffset: -6px;
-  --#{$form-control}--OutlinePadding: calc(-1 * var(--#{$form-control}--OutlineOffset));
   --#{$form-control}--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$form-control}--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--before--BorderColor: var(--pf-t--global--border--color--default);
@@ -24,10 +23,6 @@
   --#{$form-control}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
   --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--inset--base);
   --#{$form-control}--PaddingInlineStart: var(--#{$form-control}--inset--base);
-  --#{$form-control}--TextArea--PaddingBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--OutlinePadding));
-  --#{$form-control}--TextArea--PaddingBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--OutlinePadding));
-  --#{$form-control}--TextArea--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--OutlinePadding));
-  --#{$form-control}--TextArea--PaddingInlineStart: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--OutlinePadding));
 
   // hover
   --#{$form-control}--hover--after--BorderWidth: var(--pf-t--global--border--width--control--hover);
@@ -95,6 +90,11 @@
   // Textarea
   --#{$form-control}--textarea--Width: var(--#{$form-control}--Width);
   --#{$form-control}--textarea--Height: auto;
+  --#{$form-control}--textarea--Padding: calc(-1 * var(--#{$form-control}--OutlineOffset));
+  --#{$form-control}--textarea--PaddingBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--Padding));
+  --#{$form-control}--textarea--PaddingBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--textarea--Padding));
+  --#{$form-control}--textarea--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--Padding));
+  --#{$form-control}--textarea--PaddingInlineStart: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--textarea--Padding));
 
   // Form control icon
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
@@ -177,13 +177,13 @@
   }
 
   &.pf-m-textarea {
-    padding: var(--#{$form-control}--OutlinePadding);
+    padding: var(--#{$form-control}--textarea--Padding);
 
     > :is(textarea) {
-      padding-block-start: var(--#{$form-control}--TextArea--PaddingBlockStart);
-      padding-block-end: var(--#{$form-control}--TextArea--PaddingBlockEnd);
-      padding-inline-start: var(--#{$form-control}--TextArea--PaddingInlineStart);
-      padding-inline-end: var(--#{$form-control}--TextArea--PaddingInlineEnd);
+      padding-block-start: var(--#{$form-control}--textarea--PaddingBlockStart);
+      padding-block-end: var(--#{$form-control}--textarea--PaddingBlockEnd);
+      padding-inline-start: var(--#{$form-control}--textarea--PaddingInlineStart);
+      padding-inline-end: var(--#{$form-control}--textarea--PaddingInlineEnd);
       outline-offset: 0;
     }
   }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -7,6 +7,7 @@
   --#{$form-control}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$form-control}--Resize: none;
   --#{$form-control}--OutlineOffset: -6px;
+  --#{$form-control}--OutlinePadding: calc(-1 * var(--#{$form-control}--OutlineOffset));
   --#{$form-control}--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$form-control}--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--before--BorderColor: var(--pf-t--global--border--color--default);
@@ -23,6 +24,10 @@
   --#{$form-control}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
   --#{$form-control}--PaddingInlineEnd: var(--#{$form-control}--inset--base);
   --#{$form-control}--PaddingInlineStart: var(--#{$form-control}--inset--base);
+  --#{$form-control}--TextArea--PaddingBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--OutlinePadding));
+  --#{$form-control}--TextArea--PaddingBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) - var(--#{$form-control}--OutlinePadding));
+  --#{$form-control}--TextArea--PaddingInlineEnd: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--OutlinePadding));
+  --#{$form-control}--TextArea--PaddingInlineStart: calc(var(--#{$form-control}--inset--base) - var(--#{$form-control}--OutlinePadding));
 
   // hover
   --#{$form-control}--hover--after--BorderWidth: var(--pf-t--global--border--width--control--hover);
@@ -155,15 +160,12 @@
     background-color: transparent;
     border: none;
     border-radius: var(--#{$form-control}--BorderRadius);
+    outline-offset: var(--#{$form-control}--OutlineOffset);
 
     // stylelint-disable
     -moz-appearance: none;
     -webkit-appearance: none;
     // stylelint-enable
-
-    &:focus {
-      outline-offset: var(--#{$form-control}--OutlineOffset);
-    }
   }
 
   > ::placeholder {
@@ -172,6 +174,18 @@
 
   > :is(input, select) {
     text-overflow: ellipsis;
+  }
+
+  &.pf-m-textarea {
+    padding: var(--#{$form-control}--OutlinePadding);
+
+    > :is(textarea) {
+      padding-block-start: var(--#{$form-control}--TextArea--PaddingBlockStart);
+      padding-block-end: var(--#{$form-control}--TextArea--PaddingBlockEnd);
+      padding-inline-start: var(--#{$form-control}--TextArea--PaddingInlineStart);
+      padding-inline-end: var(--#{$form-control}--TextArea--PaddingInlineEnd);
+      outline-offset: 0;
+    }
   }
 
   &.pf-m-readonly {


### PR DESCRIPTION
Closes #7013

Overrides padding styles for formcontrol textareas, to account for the outline offset. I put the new values into variables, but they could be calc'd inline in the modifier as well, so LMK which place would be preferred.