### PR TITLE
fix(menu-toggle): fixed alignment, remove display: flex from __icon

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -566,7 +566,7 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 ### With avatar and text
 ```hbs
 {{#> menu-toggle}}
-  {{#> menu-toggle-icon}}
+  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -580,7 +580,7 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--IsExpanded="true"}}
-  {{#> menu-toggle-icon}}
+  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -594,7 +594,7 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 &nbsp;
 
 {{#> menu-toggle menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-icon}}
+  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -713,3 +713,4 @@ To add a label to a split toggle that will be linked to the toggle button, pass 
 | `.pf-m-warning` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the warning state. |
 | `.pf-m-danger` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the danger state. |
 | `.pf-m-placeholder` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle text for placeholder styles. |
+| `.pf-m-avatar` | `.pf-v6-c-menu-toggle__icon` | Modifies the menu toggle icon for avatar styles. |

--- a/src/patternfly/components/MenuToggle/menu-toggle-icon.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-icon.hbs
@@ -1,4 +1,8 @@
-<span class="{{pfv}}menu-toggle__icon{{#if menu-toggle-icon--modifier}} {{menu-toggle-icon--modifier}}{{/if}}"
+<span class="{{pfv}}menu-toggle__icon
+  {{setModifiers
+    menu-toggle-icon--HasAvatar='pf-m-avatar'
+    menu-toggle-icon--modifier=menu-toggle-icon--modifier
+  }}"
   {{#if menu-toggle-icon--attribute}}
     {{{menu-toggle-icon--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -496,7 +496,6 @@
 }
 
 // - Menu toggle controls - Menu toggle icon
-.#{$menu-toggle}__icon,
 .#{$menu-toggle}__controls,
 .#{$menu-toggle}__toggle-icon {
   display: flex;
@@ -507,10 +506,9 @@
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
 
-  &.pf-m-avatar {
-    align-items: center;
-    margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) / 2 * -1);
-    margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) / 2 * -1);
+  .#{$avatar} {
+    margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) * -1);
+    margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) * -1);
   }
 }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -496,6 +496,7 @@
 }
 
 // - Menu toggle controls - Menu toggle icon
+.#{$menu-toggle}__icon,
 .#{$menu-toggle}__controls,
 .#{$menu-toggle}__toggle-icon {
   display: flex;
@@ -505,7 +506,12 @@
 
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
-  min-height: var(--#{$menu-toggle}__icon--MinHeight);
+
+  &.pf-m-avatar {
+    align-items: center;
+    margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) / 2 * -1);
+    margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) / 2 * -1);
+  }
 }
 
 // - Menu toggle controls

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -184,7 +184,7 @@
   transition-timing-function: var(--#{$menu-toggle}--TransitionTimingFunction);
   transition-duration: var(--#{$menu-toggle}--TransitionDuration);
   transition-property: var(--#{$menu-toggle}--TransitionProperty);
-  
+
   &,
   &::before {
     border-radius: var(--#{$menu-toggle}--BorderRadius);
@@ -496,7 +496,6 @@
 }
 
 // - Menu toggle controls - Menu toggle icon
-.#{$menu-toggle}__icon,
 .#{$menu-toggle}__controls,
 .#{$menu-toggle}__toggle-icon {
   display: flex;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -506,9 +506,13 @@
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
 
-  .#{$avatar} {
-    margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) * -1);
-    margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) * -1);
+  &.pf-m-avatar {
+    .#{$avatar},
+    img,
+    svg {
+      margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) * -1);
+      margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) * -1);
+    }
   }
 }
 


### PR DESCRIPTION
closes #6975 

# TLDR:
`.#{$menu-toggle}__icon` should not be `display: flex`. 