### PR TITLE
fix(global): removed root selector from component vars, fix var refs

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -260,7 +260,7 @@
   --#{$button}__icon--m-end--MarginInlineStart: 0;
 
   // Progress
-  --#{$button}__progress--width: calc(var(--#{$spinner}--m-md--diameter) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
+  --#{$button}__progress--width: calc(var(--pf-t--global--icon--size--lg) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
   --#{$button}__progress--Opacity: 0;
   --#{$button}__progress--TranslateY: -50%;
   --#{$button}__progress--TranslateX: 0;
@@ -271,7 +271,7 @@
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}--m-in-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width));
-  --#{$button}--m-in-progress--m-plain--Color: var(--#{$spinner}--Color);
+  --#{$button}--m-in-progress--m-plain--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$button}--m-in-progress--m-plain__progress--InsetInlineStart: 50%;
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
 

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -3,7 +3,7 @@
 @include pf-root($check) {
   --#{$check}--GridGap: var(--pf-t--global--spacer--gap--group--vertical) var(--pf-t--global--spacer--gap--text-to-element--default);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
-  --#{$check}--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
+  --#{$check}--m-standalone--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
 
   // TODO: update to `--#{$check}--FontSize` `--#{$check}--LineHeight`
   --#{$check}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -33,7 +33,7 @@
   &.pf-m-standalone {
     display: inline-grid;
     grid-template-columns: auto;
-    min-height: var(--#{$check}--MinHeight);
+    min-height: var(--#{$check}--m-standalone--MinHeight);
 
     .#{$check}__input {
       align-self: center;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -49,11 +49,11 @@
   --#{$menu-toggle}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // * Menu toggle icon
-  --#{$menu-toggle}__icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
+  --#{$menu-toggle}__icon--MinHeight: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight));
   --#{$menu-toggle}__icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Menu toggle toggle icon
-  --#{$menu-toggle}__toggle-icon--MinHeight: calc(var(--#{$menu}__item--FontSize) * var(--#{$menu}__item--LineHeight));
+  --#{$menu-toggle}__toggle-icon--MinHeight: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight));
   --#{$menu-toggle}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Menu toggle primary

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -19,7 +19,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   // nav page select
   --#{$pagination}__nav-page-select--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$pagination}__nav-page-select--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$pagination}__nav-page-select--c-form-control--width-base: calc((var(--#{$form-control}--PaddingInlineEnd) + var(--#{$form-control}--PaddingInlineStart)) + (var(--#{$form-control}--before--BorderWidth) * 2));
+  --#{$pagination}__nav-page-select--c-form-control--width-base: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--border--width--control--default) * 2);
   --#{$pagination}__nav-page-select--c-form-control--width-chars: 2;
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
 

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -3,7 +3,7 @@
 @include pf-root($radio) {
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
-  --#{$radio}--Height: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
+  --#{$radio}--m-standalone--MinHeight: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
 
   // TODO: update to `--#{$radio}--FontSize` `--#{$radio}--LineHeight`
   --#{$radio}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -34,7 +34,7 @@
   &.pf-m-standalone {
     display: inline-grid;
     grid-template-columns: auto;
-    height: var(--#{$radio}--Height);
+    min-height: var(--#{$radio}--m-standalone--MinHeight);
 
     .#{$radio}__input {
       align-self: center;

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -34,7 +34,7 @@
   &.pf-m-standalone {
     display: inline-grid;
     grid-template-columns: auto;
-    height: var(--#{$check}--Height);
+    height: var(--#{$radio}--Height);
 
     .#{$radio}__input {
       align-self: center;

--- a/src/patternfly/components/Slider/slider.scss
+++ b/src/patternfly/components/Slider/slider.scss
@@ -59,7 +59,7 @@
 
   // value
   --#{$slider}__value--MarginInlineStart: var(--pf-t--global--spacer--md);
-  --#{$slider}__value--c-form-control--width-base: calc(var(--#{$form-control}--PaddingInlineStart) + var(--#{$form-control}--PaddingInlineEnd) + #{pf-size-prem(20px)}); // form control base width + number input spinner width
+  --#{$slider}__value--c-form-control--width-base: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--spacer--control--horizontal--default) + #{pf-size-prem(20px)}); // form control base width + number input spinner width
   --#{$slider}__value--c-form-control--width-chars: 3;
   --#{$slider}__value--c-form-control--Width: calc(var(--#{$slider}__value--c-form-control--width-base) + var(--#{$slider}__value--c-form-control--width-chars) * 1ch);
   --#{$slider}__value--m-floating--TranslateX: -50%;


### PR DESCRIPTION
As noted by @srambach, removing `:root` from the component var selectors drastically improves dev tools performance in Firefox. This PR makes that update, and fixes a handful of places we've cross-referenced component vars in other components since vars were previously available from the `:root` scope. 

Here is the backstop report - [backstop-remove-root.pdf](https://github.com/user-attachments/files/16971491/backstop-remove-root.pdf)

Everything is from `.pf-v6-c-radio.pf-m-standalone` now having a `min-height` because those were previously referencing `--#{$check}--Height` for their height, which didn't exist. They now reference `--#{$radio}--m-standalone--MinHeight`. It looks like the presence of a standalone check or radio is making a single line of regular content taller than it would be without it, which ideally that wouldn't happen. Here are a few examples to show that - https://codepen.io/mcoker/pen/bGPZyNB. That can be a follow-up IMO.

The last 3 screenshots in the backstop report are false positives from what I can tell. 

FWIW here is the quick and dirty script I put together to find instances of component vars referenced in stylesheets outside of the component the var is for. This returns more matches than we need to update, since most of these are used correctly.

```
for i in `find src/patternfly/components -name *.scss`; do
  echo "" && echo $i && COMPVAR=$(grep 'include pf-root' $i | sed -e 's/^.*\$//g' | sed -e 's/).*//g');
  grep -Eo '\-\-#\{\$[^}]+\}' $i | grep -vi "\$$COMPVAR";
done
```