### PR TITLE
fix(pagination): adjust block padding

### DIFF
--- a/src/patternfly/components/Pagination/pagination-menu-toggle.hbs
+++ b/src/patternfly/components/Pagination/pagination-menu-toggle.hbs
@@ -6,7 +6,8 @@
     menu-toggle--IsPlain=true
     menu-toggle--IsText=true
     menu-toggle--IsDisabled=pagination-menu-toggle--IsDisabled
-    menu-toggle--modifier=pagination-menu-toggle--modifier menu-toggle--id=pagination-menu-toggle--id}}
+    menu-toggle--modifier=pagination-menu-toggle--modifier
+    menu-toggle--id=pagination-menu-toggle--id}}
     {{#> menu-toggle-text}}
       <b>1 - 10</b>&nbsp;of&nbsp;<b>{{#if pagination--IsIndeterminate}}many{{else}}36{{/if}}</b>
     {{/menu-toggle-text}}

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -32,25 +32,27 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$pagination}--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
   --#{$pagination}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
-  --#{$pagination}--m-sticky--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$pagination}--m-sticky--PaddingInlineStart: var(--pf-t--global--spacer--lg);
-  --#{$pagination}--m-sticky--ZIndex: 100; // TODO: replace with z-index token
+  --#{$pagination}--m-sticky--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--m-sticky--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$pagination}--m-sticky--InsetBlockStart: 0;
 
   // bottom
   --#{$pagination}--m-bottom--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$pagination}--m-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
-  --#{$pagination}--m-bottom--InsetBlockEnd: 0;
-  --#{$pagination}--m-bottom--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
-  --#{$pagination}--m-bottom--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
-  --#{$pagination}--m-bottom--PaddingBlockStart: 0;
-  --#{$pagination}--m-bottom--m-sticky--PaddingBlockStart: 0;
-  --#{$pagination}--m-bottom--md--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
+  --#{$pagination}--m-bottom--InsetBlockEnd: 0;
+  --#{$pagination}--m-bottom--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$pagination}--m-bottom--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$pagination}--m-bottom--m-sticky--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$pagination}--m-bottom--m-sticky--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$pagination}--m-bottom--m-static--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
+  --#{$pagination}--m-bottom--m-static--PaddingBlockEnd: 0;
+  --#{$pagination}--m-bottom--m-static--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$pagination}--m-bottom--m-static--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
-  // options menu
+  // page menu
   --#{$pagination}__page-menu--Display--base: block;
   --#{$pagination}__page-menu--Display: none;
   --#{$pagination}--m-display-summary__page-menu--Display: none;
@@ -90,20 +92,12 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     position: sticky;
     inset-block-end: var(--#{$pagination}--m-bottom--InsetBlockEnd);
     justify-content: center;
-    padding-block-start: var(--#{$pagination}--m-bottom--PaddingBlockStart);
-    padding-inline-start: var(--#{$pagination}--m-bottom--PaddingInlineStart);
-    padding-inline-end: var(--#{$pagination}--m-bottom--PaddingInlineEnd);
+    padding-block-start: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockStart);
+    padding-block-end: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockEnd);
+    padding-inline-start: var(--#{$pagination}--m-bottom--m-sticky--PaddingInlineStart);
+    padding-inline-end: var(--#{$pagination}--m-bottom--m-sticky--PaddingInlineEnd);
     background-color: var(--#{$pagination}--m-bottom--BackgroundColor);
     box-shadow: var(--#{$pagination}--m-bottom--BoxShadow);
-
-    &.pf-m-static {
-      --#{$pagination}--m-bottom--MarginBlockStart: 0;
-      --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
-      --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--m-static--PaddingBlockStart);
-
-      position: relative;
-      box-shadow: none;
-    }
 
     .#{$pagination}__nav-control.pf-m-first,
     .#{$pagination}__nav-control.pf-m-last,
@@ -126,11 +120,14 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
       --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
       --#{$pagination}--m-bottom--MarginBlockStart: 0;
       --#{$pagination}--m-bottom--InsetBlockEnd: auto;
-      --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--md--PaddingBlockStart);
 
       position: relative;
       justify-content: flex-end;
-
+      padding-block-start: var(--#{$pagination}--m-bottom--m-static--PaddingBlockStart);
+      padding-block-end: var(--#{$pagination}--m-bottom--m-static--PaddingBlockEnd);
+      padding-inline-start: var(--#{$pagination}--m-bottom--m-static--PaddingInlineStart);
+      padding-inline-end: var(--#{$pagination}--m-bottom--m-static--PaddingInlineEnd);
+  
       .#{$pagination}__nav-control.pf-m-first,
       .#{$pagination}__nav-control.pf-m-last,
       .#{$pagination}__nav-page-select {
@@ -152,17 +149,25 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     }
   }
 
+  &.pf-m-static {
+    position: relative;
+    padding-block-start: var(--#{$pagination}--m-bottom--m-static--PaddingBlockStart);
+    padding-block-end: var(--#{$pagination}--m-bottom--m-static--PaddingBlockEnd);
+    padding-inline-start: var(--#{$pagination}--m-bottom--m-static--PaddingInlineStart);
+    padding-inline-end: var(--#{$pagination}--m-bottom--m-static--PaddingInlineEnd);
+    box-shadow: none;
+  }
+
   &.pf-m-sticky {
     --#{$pagination}--m-bottom--InsetBlockEnd: 0;
-    --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockStart);
 
     position: sticky;
     inset-block-start: var(--#{$pagination}--m-sticky--InsetBlockStart);
     z-index: var(--#{$pagination}--m-sticky--ZIndex);
-    padding-block-start: var(--#{$pagination}--m-sticky--PaddingBlockStart);
-    padding-block-end: var(--#{$pagination}--m-sticky--PaddingBlockEnd);
-    padding-inline-start: var(--#{$pagination}--m-sticky--PaddingInlineStart);
-    padding-inline-end: var(--#{$pagination}--m-sticky--PaddingInlineEnd);
+    padding-block-start: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockStart);
+    padding-block-end: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockEnd);
+    padding-inline-start: var(--#{$pagination}--m-bottom--m-sticky--PaddingInlineStart);
+    padding-inline-end: var(--#{$pagination}--m-bottom--m-sticky--PaddingInlineEnd);
     background-color: var(--#{$pagination}--m-sticky--BackgroundColor);
     box-shadow: var(--#{$pagination}--m-sticky--BoxShadow);
   }
@@ -171,7 +176,6 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     --#{$pagination}--inset: var(--#{$pagination}--m-page-insets--inset);
   }
 }
-
 
 // nav
 .#{$pagination}__nav {

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -6,7 +6,6 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 @include pf-root($pagination) {
   --#{$pagination}--inset: 0;
   --#{$pagination}--ColumnGap: var(--pf-t--global--spacer--lg);
-  --#{$pagination}--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
 
   // Page insets
   --#{$pagination}--m-page-insets--inset: var(--pf-t--global--spacer--lg);
@@ -46,6 +45,10 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-bottom--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$pagination}--m-bottom--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
+  --#{$pagination}--m-bottom--PaddingBlockStart: 0;
+  --#{$pagination}--m-bottom--m-sticky--PaddingBlockStart: 0;
+  --#{$pagination}--m-bottom--md--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
+  --#{$pagination}--m-bottom--m-static--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
 
   // options menu
   --#{$pagination}__page-menu--Display--base: block;
@@ -87,6 +90,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     position: sticky;
     inset-block-end: var(--#{$pagination}--m-bottom--InsetBlockEnd);
     justify-content: center;
+    padding-block-start: var(--#{$pagination}--m-bottom--PaddingBlockStart);
     padding-inline-start: var(--#{$pagination}--m-bottom--PaddingInlineStart);
     padding-inline-end: var(--#{$pagination}--m-bottom--PaddingInlineEnd);
     background-color: var(--#{$pagination}--m-bottom--BackgroundColor);
@@ -95,6 +99,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     &.pf-m-static {
       --#{$pagination}--m-bottom--MarginBlockStart: 0;
       --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
+      --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--m-static--PaddingBlockStart);
 
       position: relative;
       box-shadow: none;
@@ -121,6 +126,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
       --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
       --#{$pagination}--m-bottom--MarginBlockStart: 0;
       --#{$pagination}--m-bottom--InsetBlockEnd: auto;
+      --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--md--PaddingBlockStart);
 
       position: relative;
       justify-content: flex-end;
@@ -148,6 +154,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   &.pf-m-sticky {
     --#{$pagination}--m-bottom--InsetBlockEnd: 0;
+    --#{$pagination}--m-bottom--PaddingBlockStart: var(--#{$pagination}--m-bottom--m-sticky--PaddingBlockStart);
 
     position: sticky;
     inset-block-start: var(--#{$pagination}--m-sticky--InsetBlockStart);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -6,6 +6,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 @include pf-root($pagination) {
   --#{$pagination}--inset: 0;
   --#{$pagination}--ColumnGap: var(--pf-t--global--spacer--lg);
+  --#{$pagination}--PaddingBlockStart: var(--pf-t--global--spacer--gap--group--vertical);
 
   // Page insets
   --#{$pagination}--m-page-insets--inset: var(--pf-t--global--spacer--lg);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 @include pf-root($toolbar) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlockStart: 0;
-  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--gap--group--vertical);
   --#{$toolbar}--PaddingInlineStart: 0;
   --#{$toolbar}--PaddingInlineEnd: 0;
   --#{$toolbar}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 @include pf-root($toolbar) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlockStart: 0;
-  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--gap--group--vertical);
+  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingInlineStart: 0;
   --#{$toolbar}--PaddingInlineEnd: 0;
   --#{$toolbar}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/demos/Table/table-pagination-footer-static.hbs
+++ b/src/patternfly/demos/Table/table-pagination-footer-static.hbs
@@ -1,4 +1,4 @@
 {{#> pagination pagination--modifier="pf-m-bottom pf-m-static"}}
-  {{> pagination-menu-toggle pagination-menu-toggle--id="{{page--id}}-pagination-menu-toggle-bottom-example-static" pagination-menu-toggle--modifier="pf-m-top"}}
+  {{> pagination-menu-toggle pagination-menu-toggle--id=(concat page--id "-pagination-menu-toggle-bottom-example-static") pagination-menu-toggle--modifier="pf-m-top"}}
   {{> pagination-nav-content}}
 {{/pagination}}

--- a/src/patternfly/demos/Table/table-pagination-footer.hbs
+++ b/src/patternfly/demos/Table/table-pagination-footer.hbs
@@ -1,4 +1,4 @@
 {{#> pagination pagination--modifier="pf-m-bottom"}}
-  {{> pagination-menu-toggle pagination-menu-toggle--id="{{page--id}}-pagination-menu-toggle-bottom-example" pagination-menu-toggle--modifier="pf-m-top"}}
+  {{> pagination-menu-toggle pagination-menu-toggle--id=(concat page--id "-pagination-menu-toggle-bottom-example") pagination-menu-toggle--modifier="pf-m-top"}}
   {{> pagination-nav-content}}
 {{/pagination}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7057

Visual regression report - [backstop-toolbar-pagination-padding.pdf](https://github.com/user-attachments/files/16970719/backstop-toolbar-pagination-padding.pdf)

This updates both the toolbar's bottom padding and the bottom pagination's top padding to use `var(--pf-t--global--spacer--gap--group--vertical)`