### PR TITLE
fix(content): actually remove root, update content selector

### DIFF
--- a/src/patternfly/components/Content/content--element.hbs
+++ b/src/patternfly/components/Content/content--element.hbs
@@ -1,11 +1,12 @@
 <{{content--element--type}} class="{{#unless content--element--ExcludeClass}}{{pfv}}content--{{content--element--type}}{{/unless}}
   {{~#if content--element--IsEditorial}} pf-m-editorial{{/if}}
+  {{~#if content--element--IsPlain}} pf-m-plain{{/if}}
   {{~#if content--element--modifier}} {{content--element--modifier}}{{/if}}"
   {{#if content--element--attribute}}
     {{{content--element--attribute}}}
   {{/if}}>
   {{#if @partial-block}}
-    {{> @partial-block newcontext}}
+    {{> @partial-block content--element--IsPlain=reset}}
   {{/if}}
 {{#unlessIfEquals content--element--type "hr"}}
   </{{content--element--type}}>

--- a/src/patternfly/components/Content/content--kitchen-sink.hbs
+++ b/src/patternfly/components/Content/content--kitchen-sink.hbs
@@ -47,7 +47,7 @@
 {{#> content--element content--element--type="p"}}Quisque at semper enim, eu hendrerit odio. Etiam auctor nisl et <em>justo sodales</em> elementum. Maecenas ultrices lacus quis neque consectetur, et lobortis nisi molestie.{{/content--element}}
 {{> content--element content--element--type="hr"}}
 {{#> content--element content--element--type="h3"}}Plain list example{{/content--element}}
-{{#> content--element content--element--type="ol" content--element--modifier="pf-m-plain"}}
+{{#> content--element content--element--type="ol" content--element--IsPlain=true}}
   {{#> content--element content--element--type="li"}}Donec blandit a lorem id convallis.{{/content--element}}
   {{#> content--element content--element--type="li"}}Cras gravida arcu at diam gravida gravida.{{/content--element}}
   {{#> content--element content--element--type="li"}}Integer in volutpat libero.{{/content--element}}
@@ -58,7 +58,7 @@
       {{#> content--element content--element--type="li"}}Donec blandit a lorem id convallis.{{/content--element}}
       {{#> content--element content--element--type="li"}}Cras gravida arcu at diam gravida gravida.{{/content--element}}
       {{#> content--element content--element--type="li"}}Integer in volutpat libero.
-        {{#> content--element content--element--type="ol" content--element--modifier="pf-m-plain"}}
+        {{#> content--element content--element--type="ol" content--element--IsPlain=true}}
           {{#> content--element content--element--type="li"}}Nested plain list{{/content--element}}
           {{#> content--element content--element--type="li"}}Donec blandit a lorem id convallis.{{/content--element}}
           {{#> content--element content--element--type="li"}}Cras gravida arcu at diam gravida gravida.{{/content--element}}
@@ -73,7 +73,7 @@
 {{> content--element content--element--type="hr"}}
 {{#> content--element content--element--type="h3"}}Visited link example{{/content--element}}
 {{#> content--element content--element--type="p"}}
-  {{#> content--element content--element--type="a" content--element--attribute='href' content--element--modifier="pf-m-plain"}}Visited link{{/content--element}}
+  {{#> content--element content--element--type="a" content--element--attribute='href' content--element--IsPlain=true}}Visited link{{/content--element}}
 {{/content--element}}
 {{> content--element content--element--type="hr"}}
 {{#> content--element content--element--type="p"}}Sed sagittis enim ac tortor maximus rutrum. Nulla facilisi. Donec mattis vulputate risus in luctus. Maecenas vestibulum interdum

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-@include pf-root($content) {
+@include pf-root('[class*="#{$content}"]', false) {
   // Body
   --#{$content}--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -1,6 +1,6 @@
 @use '../../sass-utilities' as *;
 
-@include pf-root('[class*="#{$content}"]', false) {
+@include pf-root(':root', false) {
   // Body
   --#{$content}--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -417,9 +417,9 @@
   --#{$pf-global}--inverse--multiplier: #{if($val, -1, 1)};
 }
 
-@mixin pf-root($selector, $mods: null) {
-  :root,
-  .#{$selector} {
+@mixin pf-root($selector, $isClass: true) {
+  $selector: if($isClass, "." + $selector, $selector);
+  #{$selector} {
     @content
   }
 }


### PR DESCRIPTION
Looks like I forgot to commit removing `:root` in https://github.com/patternfly/patternfly/pull/7060 🤦‍♂️ And there was an update to the content component I was still working out, so made that, too. 

Here's the [backstop report](https://github.com/user-attachments/files/16987350/BackstopJS.Report.pdf). From what I can tell, everything is a false positive or related to previous updates.