### PR TITLE
chore(Alert): updated toggle and close styling per audit

### DIFF
--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -22,7 +22,7 @@
   --#{$alert}__toggle--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
   --#{$alert}__toggle--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
   --#{$alert}__toggle--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--action--horizontal--plain--default));
-  --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
+  --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Toggle icon
   --#{$alert}__toggle-icon--Rotate: 0;

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -21,8 +21,8 @@
   // Toggle
   --#{$alert}__toggle--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
   --#{$alert}__toggle--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
-  --#{$alert}__toggle--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--sm));
-  --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$alert}__toggle--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--action--horizontal--plain--default));
+  --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
 
   // Toggle icon
   --#{$alert}__toggle-icon--Rotate: 0;
@@ -227,7 +227,6 @@
   margin-block-start: var(--#{$alert}__action--MarginBlockStart);
   margin-block-end: var(--#{$alert}__action--MarginBlockEnd);
   margin-inline-end: var(--#{$alert}__action--MarginInlineEnd);
-  transform: translateY(var(--#{$alert}__action--TranslateY));
 }
 
 .#{$alert}__action-group {

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -193,9 +193,7 @@
 }
 
 .#{$alert}__icon {
-  display: flex;
   grid-area: icon;
-  margin-block-start: var(--#{$alert}__icon--MarginBlockStart);
   margin-inline-end: var(--#{$alert}__icon--MarginInlineEnd);
   font-size: var(--#{$alert}__icon--FontSize);
   color: var(--#{$alert}__icon--Color);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -21,6 +21,7 @@
   // Toggle
   --#{$alert}__toggle--MarginBlockStart: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
   --#{$alert}__toggle--MarginBlockEnd: calc(-1 * var(--pf-t--global--spacer--control--vertical--default));
+  --#{$alert}__toggle--MarginInlineStart: calc(-1 * var(--pf-t--global--spacer--sm));
   --#{$alert}__toggle--MarginInlineEnd: var(--pf-t--global--spacer--sm);
 
   // Toggle icon
@@ -179,6 +180,7 @@
 .#{$alert}__toggle {
   margin-block-start: var(--#{$alert}__toggle--MarginBlockStart);
   margin-block-end: var(--#{$alert}__toggle--MarginBlockEnd);
+  margin-inline-start: var(--#{$alert}__toggle--MarginInlineStart);
   margin-inline-end: var(--#{$alert}__toggle--MarginInlineEnd);
 }
 
@@ -226,10 +228,6 @@
   margin-block-end: var(--#{$alert}__action--MarginBlockEnd);
   margin-inline-end: var(--#{$alert}__action--MarginInlineEnd);
   transform: translateY(var(--#{$alert}__action--TranslateY));
-
-  > .#{$button} {
-    --#{$button}--LineHeight: 1;
-  }
 }
 
 .#{$alert}__action-group {


### PR DESCRIPTION
Closes #7054 

Toggle before update:
![Alert expand toggle currently shifted too far to the right](https://github.com/user-attachments/assets/08ee4e0c-3059-4a4b-bf21-fc834fb33d94)

Toggle after update:
![Alert expand toggle shifted to the left](https://github.com/user-attachments/assets/0b6f0117-51c7-4529-8e3e-891e202dff90)

Close button before update:
![Alert close button currently with smaller clickable area](https://github.com/user-attachments/assets/199a163f-fc83-4551-b623-2196f2bfe0b2)

Close button after update:
![Alert close button with a larger clickable area](https://github.com/user-attachments/assets/b60e5112-34c9-490c-970e-67ed0e8bca74)


Do we ever intend for consumers to ever be able to have multiple actions in an Alert, not just a close button? Wondering if having the action button be larger would cause issues if that's the case.