### PR TITLE
fix(CodeEditor): set explicit 100% or 90% heights on divs

### DIFF
--- a/src/patternfly/components/CodeEditor/code-editor-code.hbs
+++ b/src/patternfly/components/CodeEditor/code-editor-code.hbs
@@ -1,6 +1,6 @@
-<code dir="ltr" class="{{pfv}}code-editor__code{{#if code-editor-code--modifier}} {{code-editor-code--modifier}}{{/if}}"
+<div dir="ltr" class="{{pfv}}code-editor__code{{#if code-editor-code--modifier}} {{code-editor-code--modifier}}{{/if}}"
   {{#if code-editor-code--attribute}}
     {{{code-editor-code--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</code>
+</div>

--- a/src/patternfly/components/CodeEditor/code-editor-container.hbs
+++ b/src/patternfly/components/CodeEditor/code-editor-container.hbs
@@ -1,0 +1,3 @@
+<div role="presentation" tabIndex="0" class="{{pfv}}code-editor-container">
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/CodeEditor/code-editor-container.hbs
+++ b/src/patternfly/components/CodeEditor/code-editor-container.hbs
@@ -1,3 +1,3 @@
-<div role="presentation" tabIndex="0" class="{{pfv}}code-editor-container">
+<div role="presentation" tabindex="0" class="{{pfv}}code-editor__container">
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -83,6 +83,12 @@
   }
 }
 
+.#{$code-editor}__container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 .#{$code-editor}__header {
   position: relative;
   display: flex;

--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -71,8 +71,15 @@
 }
 
 .#{$code-editor} {
+  display: flex;
+  flex-direction: column;
+
   &.pf-m-read-only {
     --#{$code-editor}__main--BackgroundColor: var(--#{$code-editor}--m-read-only__main--BackgroundColor);
+  }
+
+  &.pf-m-full-height {
+    height: 100%;
   }
 }
 
@@ -144,7 +151,8 @@
 }
 
 .#{$code-editor}__main {
-  position: relative;
+  position: relative; 
+  flex-grow: 1;
   color: var(--#{$code-editor}__main--Color, inherit);
   background-color: var(--#{$code-editor}__main--BackgroundColor);
   border: var(--#{$code-editor}__main--BorderWidth) solid;
@@ -170,6 +178,7 @@
 
 .#{$code-editor}__code {
   position: relative;
+  height: 100%;
   padding-block-start: var(--#{$code-editor}__code--PaddingBlockStart);
   padding-block-end: var(--#{$code-editor}__code--PaddingBlockEnd);
   padding-inline-start: var(--#{$code-editor}__code--PaddingInlineStart);

--- a/src/patternfly/components/CodeEditor/examples/CodeEditor.css
+++ b/src/patternfly/components/CodeEditor/examples/CodeEditor.css
@@ -1,0 +1,3 @@
+#ws-core-c-code-editor-with-full-height-modifier .ws-preview-html {
+  height: 400px;
+}

--- a/src/patternfly/components/CodeEditor/examples/CodeEditor.md
+++ b/src/patternfly/components/CodeEditor/examples/CodeEditor.md
@@ -113,6 +113,64 @@ cssPrefix: pf-v6-c-code-editor
 {{/code-editor}}
 ```
 
+
+### With optional code editor container 
+This is an extra container used in React to prevent event propagation if upload is enabled or there is a provided empty state.
+
+```hbs 
+{{#> code-editor}}
+  {{#> code-editor-container}}
+  {{#> code-editor-header}}
+    {{#> code-editor-header-content}}
+      {{#> code-editor-controls}}
+        {{> code-editor-controls--buttons}}
+      {{/code-editor-controls}}
+    {{/code-editor-header-content}}
+    {{#> code-editor-tab}}
+      {{#> code-editor-tab-icon}}
+        <i class="fas fa-code"></i>
+      {{/code-editor-tab-icon}}
+      {{#> code-editor-tab-text}}
+        HTML
+      {{/code-editor-tab-text}}
+    {{/code-editor-tab}}
+  {{/code-editor-header}}
+  {{#> code-editor-main}}
+    {{#> code-editor-upload}}
+      {{#> empty-state}}
+        {{#> empty-state-header}}
+          {{> empty-state-icon empty-state-icon--type="code"}}
+          {{#> empty-state-title}}
+            {{#> empty-state-title-text}}
+              Start editing
+            {{/empty-state-title-text}}
+          {{/empty-state-title}}
+        {{/empty-state-header}}
+
+        {{#> empty-state-body}}
+          Drag a file here or browse to upload.
+        {{/empty-state-body}}
+
+        {{#> empty-state-footer}}
+          {{#> empty-state-actions}}
+            {{#> button button--IsPrimary=true}}
+              Browse
+            {{/button}}
+          {{/empty-state-actions}}
+          {{#> empty-state-actions}}
+            {{#> button button--IsLink=true}}
+              Start from scratch
+            {{/button}}
+          {{/empty-state-actions}}
+        {{/empty-state-footer}}
+      {{/empty-state}}
+    {{/code-editor-upload}}
+  {{/code-editor-main}}
+  {{/code-editor-container}}
+{{/code-editor}}
+```
+
+
 ### With full height modifiers
 
 ```hbs

--- a/src/patternfly/components/CodeEditor/examples/CodeEditor.md
+++ b/src/patternfly/components/CodeEditor/examples/CodeEditor.md
@@ -226,3 +226,6 @@ This is an extra container used in React to prevent event propagation if upload 
 | `.pf-v6-c-code-editor__tab-text`           | `<span>`   | Initiates the code editor tab text.                                                           |
 | `.pf-v6-c-code-editor__tab-icon`           | `<span>`   | Initiates the code editor tab icon.                                                           |
 | `.pf-v6-c-code-editor__upload`             | `<div>`    | Initiates the code editor upload border.                                                      |
+| `.pf-v6-c-code-editor__container`             | `<div>`    | Initiates the container used inside `.pf-v6-c-code-editor` in PatternFly React. This is used in PatternFly React to prevent event propagation if upload is enabled or there is a provided empty state.                                                      |
+| `.pf-m-full-height`             | `.pf-v6-c-code-editor`    | Modifies for full-height style.                                                   |
+

--- a/src/patternfly/components/CodeEditor/examples/CodeEditor.md
+++ b/src/patternfly/components/CodeEditor/examples/CodeEditor.md
@@ -4,6 +4,8 @@ section: components
 cssPrefix: pf-v6-c-code-editor
 ---
 
+import './CodeEditor.css';
+
 ## Examples
 
 ### Default
@@ -171,7 +173,7 @@ This is an extra container used in React to prevent event propagation if upload 
 ```
 
 
-### With full height modifiers
+### With full height modifier
 
 ```hbs
 {{#> code-editor code-editor--modifier="pf-m-full-height"}}

--- a/src/patternfly/components/CodeEditor/examples/CodeEditor.md
+++ b/src/patternfly/components/CodeEditor/examples/CodeEditor.md
@@ -113,6 +113,41 @@ cssPrefix: pf-v6-c-code-editor
 {{/code-editor}}
 ```
 
+### With full height modifiers
+
+```hbs
+{{#> code-editor code-editor--modifier="pf-m-full-height"}}
+  {{#> code-editor-header}}
+    {{#> code-editor-header-content}}
+      {{#> code-editor-controls}}
+        {{> code-editor-controls--buttons}}
+      {{/code-editor-controls}}
+      {{> code-editor-header-main code-editor-header-main--text="Header main content"}}
+      {{#> code-editor-keyboard-shortcuts}}
+        {{#> button button--IsLink=true button--icon="question-circle"}}
+          View shortcuts
+        {{/button}}
+      {{/code-editor-keyboard-shortcuts}}
+    {{/code-editor-header-content}}
+    {{#> code-editor-tab}}
+      {{#> code-editor-tab-icon}}
+        <i class="fas fa-code"></i>
+      {{/code-editor-tab-icon}}
+      {{#> code-editor-tab-text}}
+        HTML
+      {{/code-editor-tab-text}}
+    {{/code-editor-tab}}
+  {{/code-editor-header}}
+  {{#> code-editor-main}}
+    {{#> code-editor-code}}
+      {{#> code-editor-code-pre}}
+        code goes here
+      {{/code-editor-code-pre}}
+    {{/code-editor-code}}
+  {{/code-editor-main}}
+{{/code-editor}}
+```
+
 ## Documentation
 
 ### Usage


### PR DESCRIPTION
We're using a third-party dependency for the PF React CodeEditor. This dependency states that by default, it will be 100% of the parent. Unfortunately, this is not what happens in PF React. The docs say the default is 100%. However, in PF React, you have to set a fixed height or rely on the height of the code. 

You can see this issue if you go to https://patternfly-react-v6.surge.sh/components/code-editor and remove `height="400px"` from the first demo.

It appears the third-party dependency by itself still defaults to 100%: https://codesandbox.io/p/sandbox/competent-jepsen-gz9dzf?workspaceId=f5599198-6a68-44b3-85bd-1caed5609909. I had a go at trying to replicate this in PatternFly React and I was able to get it to work locally if I removed the default `height: ''` prop in React and set these heights as `style={{}}` attributes. I don't think PF React will let me merge anything with `style={{}}` attributes, so I'm hoping I can make the change directly here.

The 90% height takes into account the header we place on top of the editor. If we use 100%, the CodeEditor always overflows the parent since the third-party Monaco Editor tries to take the full 100%. This way it is 100% of 90% of 100%. 🪦 

We're trying to place the CodeEditor in a modal in virtual-assistant, and it would be a huge help if we could rely on getting a default height. 

This is related to https://github.com/patternfly/patternfly-react/issues/11013.

Fixes https://github.com/patternfly/patternfly/issues/7195