### PR TITLE
fix(Page): fixes drawer grid area when sidebar is collapsed

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -475,10 +475,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   flex-shrink: 0;
 }
 
-.#{$page}__drawer {
-  grid-area: main;
-
-  > .#{$drawer} {
+.#{$page}__drawer > .#{$drawer} {
     flex: 1 0 auto;
-  }
 }


### PR DESCRIPTION
Fixes #7126 

Sidebar area did not collapse on a page with a full height drawer (i.e. notification drawer)

Backstop report for ["drawer"](https://drive.google.com/file/d/1cP67ZM66Rc2b9w9cdj9fb2v2YKIUYqTm/view?usp=sharing)