### PR TITLE
fix(table): fixed thead checkbox fitting

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -716,7 +716,7 @@
   --#{$table}--cell--MinWidth: 0;
   --#{$table}--cell--Width: 1%;
 
-  max-width: fit-content;
+  max-width: none;
 }
 // stylelint-enable
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -716,7 +716,7 @@
   --#{$table}--cell--MinWidth: 0;
   --#{$table}--cell--Width: 1%;
 
-  max-width: none;
+  max-width: fit-content;
 }
 // stylelint-enable
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -715,6 +715,8 @@
 .#{$table} .#{$table}__draggable {
   --#{$table}--cell--MinWidth: 0;
   --#{$table}--cell--Width: 1%;
+
+  max-width: none;
 }
 // stylelint-enable
 


### PR DESCRIPTION
closes #7132 

# TLDR:
`table__check` cells are supposed to be set as `max-width: none`. In this case, `max-width` is being overridden by [`.pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td)`](https://github.com/patternfly/patternfly/blob/main/src/patternfly/components/Table/table.scss#L322)


Convenience links:
https://patternfly-pr-7134.surge.sh/components/table/html-demos/loading-state-demo/
https://patternfly-pr-7134.surge.sh/components/table/html-demos/empty-state/
