### PR TITLE
fix(menu-toggle): split button alignment/spacing

### DIFF
--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -115,7 +115,7 @@
   // Split button, controls, check
   --#{$menu-toggle}__button--BackgroundColor: transparent;
   --#{$menu-toggle}__button--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
-  --#{$menu-toggle}__button--AlignSelf: baseline;
+  --#{$menu-toggle}__button--AlignSelf: center;
   --#{$menu-toggle}__button--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--plain);
   --#{$menu-toggle}__button--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--plain);
   --#{$menu-toggle}__button--MinWidth: calc(var(--#{$menu-toggle}--FontSize) * var(--#{$menu-toggle}--LineHeight) + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
@@ -411,7 +411,7 @@
   &.pf-m-primary,
   &.pf-m-secondary {
     // Reduce the padding before/after the border unless it's an icon/check-only element
-    .#{$menu-toggle}__button:not(:has(.#{$menu-toggle}__toggle-icon:only-child)),
+    .#{$menu-toggle}__button:not(:has(.#{$menu-toggle}__controls:only-child)),
     .#{$check}:not(.pf-m-standalone) {
       &:first-child {
         padding-inline-end: var(--#{$menu-toggle}--m-split-button--pill--child--PaddingInlineEnd--offset);
@@ -479,7 +479,7 @@
 
   &.pf-m-text {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
   }
 
   @at-root .#{$menu-toggle}.pf-m-split-button > .#{$check}.pf-m-standalone,


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7137

Ran regression tests against menu-toggle, toolbar, table, and data-list and everything passed except the split button toggle in the toolbar in this example is misaligned now - https://patternfly-pr-7138.surge.sh/components/data-list/html-demos/expandable-demo/

Looks like it's misaligned when the toolbar items are in a toolbar__group, which uses baseline alignment. If the items are not in a toolbar__group, alignment is fine since the parent is toolbar__content-section which uses "start" alignment.

I'd say we hold off on this until post-v6 and spend some time cleaning it up.