### PR TITLE
fix(table-th-td): changed th, td target to table__th, table__td

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -146,13 +146,16 @@
   border: none;
 
   // reset cell modifications
-  tr:where(.#{$table}__tr) > :where(th, td) {
-    width: auto;
-    min-width: 0;
-    max-width: none;
-    overflow: visible;
-    text-overflow: clip;
-    white-space: normal;
+  .#{$table}__tr {
+    > .#{$table}__th,
+    > .#{$table}__td {
+      width: auto;
+      min-width: 0;
+      max-width: none;
+      overflow: visible;
+      text-overflow: clip;
+      white-space: normal;
+    }
   }
 
   // apply modifications to text
@@ -215,7 +218,8 @@
     padding-inline-start: var(--#{$table}__tr--responsive--PaddingInlineStart);
 
     // Reset td padding
-    & > :where(th, td) {
+    > .#{$table}__th,
+    > .#{$table}__td {
       padding-block-start: var(--#{$table}--cell--responsive--PaddingBlockStart);
       padding-inline-end: var(--#{$table}--cell--responsive--PaddingInlineEnd);
       padding-block-end: var(--#{$table}--cell--responsive--PaddingBlockEnd);
@@ -252,7 +256,8 @@
   }
 
   // - Table grid th td data label
-  :where(.#{$table}__th, .#{$table}__td)[data-label] {
+  .#{$table}__th[data-label],
+  .#{$table}__td[data-label] {
     // default pf-v6-hidden-visible() mixin is called in table.scss. redefining variable here
     --#{$table}--cell--hidden-visible--Display: var(--#{$table}--m-grid--cell--hidden-visible--Display);
 
@@ -276,15 +281,18 @@
     }
   }
 
-  tr:where(.#{$table}__tr) > :where(th, td) {
-    // Remove first child padding left
-    &:first-child {
-      --#{$table}--cell--PaddingInlineStart: 0;
-    }
+  .#{$table}__tr {
+    > .#{$table}__th,
+    > .#{$table}__td {
+      // Remove first child padding left
+      &:first-child {
+        --#{$table}--cell--PaddingInlineStart: 0;
+      }
 
-    // Remove last child padding right
-    &:last-child {
-      --#{$table}--cell--PaddingInlineEnd: 0;
+      // Remove last child padding right
+      &:last-child {
+        --#{$table}--cell--PaddingInlineEnd: 0;
+      }
     }
   }
 
@@ -352,7 +360,8 @@
     border-block-end: none;
 
     // cells
-    > :where(th, td) {
+    > .#{$table}__th,
+    > .#{$table}__td {
       position: static;
       display: block;
     }
@@ -367,8 +376,8 @@
       content: none;
     }
 
-    th:where(.#{$table}__th),
-    td:where(.#{$table}__td) {
+    .#{$table}__th,
+    .#{$table}__td {
       &.pf-m-no-padding {
         .#{$table}__expandable-row-content {
           padding: 0;

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -76,8 +76,10 @@ $pf-v6-c-tree-view--MaxDepth: 10;
       $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$table}--m-tree-view__toggle--TranslateX))})
     );
 
-    position: var(--#{$table}--m-tree-view__toggle--Position);
+    position: absolute;
     inset-inline-start: var(--#{$table}--m-tree-view__toggle--InsetInlineStart);
+    width: auto;
+    padding: 0;
 
     .#{$table}__toggle-icon {
       min-width: var(--#{$table}--m-tree-view__toggle__toggle-icon--MinWidth);
@@ -91,6 +93,10 @@ $pf-v6-c-tree-view--MaxDepth: 10;
 
 
   > .#{$table}__check {
+    width: auto;
+    min-width: auto;
+    padding-block: 0;
+    padding-inline: 0;
     margin-inline-end: var(--#{$table}__tree-view-main--c-table__check--MarginInlineEnd);
   }
 
@@ -236,11 +242,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     padding-inline-end: var(--#{$table}__tree-view-text--PaddingInlineEnd);
   }
 
-  thead:where(.#{$table}__thead) th:where(.#{$table}__th) {
-    display: none;
-  }
-
-  td:where(.#{$table}__td) {
+  .#{$table}__thead .#{$table}__th,
+  .#{$table}__thead .#{$table}__td {
     display: none;
   }
 
@@ -252,7 +255,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     align-items: start;
 
     // set contents of td to start at column two of td grid
-    > :where(th, td) {
+    > .#{$table}__th,
+    > .#{$table}__td {
       grid-column: 2;
     }
 
@@ -264,7 +268,8 @@ $pf-v6-c-tree-view--MaxDepth: 10;
     }
   }
 
-  .#{$table}__tr > :where(th, td).pf-m-border-right::before {
+  .#{$table}__tr > .#{$table}__th.pf-m-border-right::before,
+  .#{$table}__tr > .#{$table}__td.pf-m-border-right::before {
     border-inline-end: 0;
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -259,8 +259,9 @@
   &.pf-m-sticky-header {
     position: relative;
 
-    thead:where(.#{$table}__thead) tr:where(.#{$table}__tr) {
-      > :where(th, td) {
+    .#{$table}__thead .#{$table}__tr {
+      > .#{$table}__th,
+      > .#{$table}__td {
         z-index: var(--#{$table}--m-sticky-header--cell--ZIndex); // set z-index here to allow sticky column to override
       }
     }
@@ -279,8 +280,8 @@
       border-block-end: 0; // hard reset tr borders in nested headers
 
       // stylelint-disable max-nesting-depth
-      th:where(.#{$table}__th),
-      td:where(.#{$table}__td) {
+      .#{$table}__th,
+      .#{$table}__td {
         &:not([rowspan]) {
           --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd);
         }
@@ -312,77 +313,6 @@
     }
   }
 
-  // - Table th - Table td
-  tr:where(.#{$table}__tr) > :where(th, td) {
-    @include pf-v6-hidden-visible(var(--#{$table}--cell--hidden-visible--Display));
-
-    position: relative;
-    width: var(--#{$table}--cell--Width);
-    min-width: var(--#{$table}--cell--MinWidth);
-    max-width: var(--#{$table}--cell--MaxWidth);
-    padding-block-start: var(--#{$table}--cell--PaddingBlockStart);
-    padding-block-end: var(--#{$table}--cell--PaddingBlockEnd);
-    padding-inline-start: var(--#{$table}--cell--PaddingInlineStart);
-    padding-inline-end: var(--#{$table}--cell--PaddingInlineEnd);
-
-    // default settings
-    overflow: var(--#{$table}--cell--Overflow);
-    font-size: var(--#{$table}--cell--FontSize);
-    font-weight: var(--#{$table}--cell--FontWeight);
-    line-height: var(--#{$table}--cell--LineHeight);
-    color: var(--#{$table}--cell--Color);
-    text-overflow: var(--#{$table}--cell--TextOverflow);
-    word-break: var(--#{$table}--cell--WordBreak);
-    white-space: var(--#{$table}--cell--WhiteSpace);
-
-    // First child padding left
-    &:first-child {
-      padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
-    }
-
-    // Last child padding right
-    &:last-child {
-      padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
-    }
-
-    &.pf-m-center {
-      text-align: center;
-    }
-
-    &:is(:empty, .#{$table}__cell-empty) {
-      width: auto;
-      min-width: 0;
-      padding: 0;
-    }
-
-    &.pf-m-help {
-      --#{$table}--cell--MinWidth: var(--#{$table}--cell--m-help--MinWidth);
-    }
-
-    &.pf-m-favorite {
-      --#{$table}__button--Color: var(--#{$table}--cell--m-favorite--Color);
-      --#{$table}__sort--MinWidth: fit-content;
-      --#{$table}--cell--MaxWidth: fit-content;
-      --#{$table}--cell--Overflow: visible;
-    }
-
-    &.pf-m-border-right::before,
-    &.pf-m-border-left::before {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      content: "";
-    }
-
-    &.pf-m-border-right::before {
-      border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderInlineEndWidth) solid var(--#{$table}--cell--m-border-right--before--BorderInlineEndColor);
-    }
-
-    &.pf-m-border-left::before {
-      border-inline-start: var(--#{$table}--cell--m-border-left--before--BorderInlineStartWidth) solid var(--#{$table}--cell--m-border-left--before--BorderInlineStartColor);
-    }
-  }
-
   // - Table caption
   caption:where(.#{$table}__caption) {
     padding-block-start: var(--#{$table}__caption--PaddingBlockStart);
@@ -410,9 +340,9 @@
         outline-offset: var(--#{$table}__thead--m-nested-column-header--button--OutlineOffset);
       }
 
-      tr:where(.#{$table}__tr):not(:first-child) {
-        th:where(.#{$table}__th),
-        td:where(.#{$table}__td) {
+      .#{$table}__tr:not(:first-child) {
+        .#{$table}__th,
+        .#{$table}__td {
           &:not([rowspan]) {
             --#{$table}--cell--PaddingBlockStart: var(--#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart);
           }
@@ -436,7 +366,8 @@
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__tbody--cell--PaddingBlockEnd);
     --#{$table}--cell--FontSize: var(--#{$table}__tbody--cell--FontSize);
 
-    > tr:where(.#{$table}__tr) > :where(th, td) {
+    > .#{$table}__tr > .#{$table}__th,
+    > .#{$table}__tr > .#{$table}__td {
       overflow-wrap: break-word;
     }
   }
@@ -461,7 +392,8 @@
     min-width: var(--#{$table}__sort--MinWidth);
   }
 
-  :where(.#{$table}__th, .#{$table}__td) {
+  .#{$table}__th,
+  .#{$table}__td {
     &.pf-m-help {
       min-width: var(--#{$table}__th--m-help--MinWidth);
     }
@@ -600,6 +532,78 @@
   }
 }
 
+// - Table th - Table td
+.#{$table}__th,
+.#{$table}__td {
+  @include pf-v6-hidden-visible(var(--#{$table}--cell--hidden-visible--Display));
+
+  position: relative;
+  width: var(--#{$table}--cell--Width);
+  min-width: var(--#{$table}--cell--MinWidth);
+  max-width: var(--#{$table}--cell--MaxWidth);
+  padding-block-start: var(--#{$table}--cell--PaddingBlockStart);
+  padding-block-end: var(--#{$table}--cell--PaddingBlockEnd);
+  padding-inline-start: var(--#{$table}--cell--PaddingInlineStart);
+  padding-inline-end: var(--#{$table}--cell--PaddingInlineEnd);
+
+  // default settings
+  overflow: var(--#{$table}--cell--Overflow);
+  font-size: var(--#{$table}--cell--FontSize);
+  font-weight: var(--#{$table}--cell--FontWeight);
+  line-height: var(--#{$table}--cell--LineHeight);
+  color: var(--#{$table}--cell--Color);
+  text-overflow: var(--#{$table}--cell--TextOverflow);
+  word-break: var(--#{$table}--cell--WordBreak);
+  white-space: var(--#{$table}--cell--WhiteSpace);
+
+  // First child padding left
+  &:first-child {
+    padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
+  }
+
+  // Last child padding right
+  &:last-child {
+    padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
+  }
+
+  &.pf-m-center {
+    text-align: center;
+  }
+
+  &:is(:empty, .#{$table}__cell-empty) {
+    width: auto;
+    min-width: 0;
+    padding: 0;
+  }
+
+  &.pf-m-help {
+    --#{$table}--cell--MinWidth: var(--#{$table}--cell--m-help--MinWidth);
+  }
+
+  &.pf-m-favorite {
+    --#{$table}__button--Color: var(--#{$table}--cell--m-favorite--Color);
+    --#{$table}__sort--MinWidth: fit-content;
+    --#{$table}--cell--MaxWidth: fit-content;
+    --#{$table}--cell--Overflow: visible;
+  }
+
+  &.pf-m-border-right::before,
+  &.pf-m-border-left::before {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+  }
+
+  &.pf-m-border-right::before {
+    border-inline-end: var(--#{$table}--cell--m-border-right--before--BorderInlineEndWidth) solid var(--#{$table}--cell--m-border-right--before--BorderInlineEndColor);
+  }
+
+  &.pf-m-border-left::before {
+    border-inline-start: var(--#{$table}--cell--m-border-left--before--BorderInlineStartWidth) solid var(--#{$table}--cell--m-border-left--before--BorderInlineStartColor);
+  }
+}
+
 // - Table text
 .#{$table}__text {
   --#{$table}--cell--MaxWidth: 100%;
@@ -620,7 +624,8 @@
     --#{$table}--cell--MinWidth: 100%;
     --#{$table}--text--MinWidth: var(--#{$table}--m-truncate__text--MinWidth);
 
-    > :where(th, td) {
+    > .#{$table}__th,
+    > .#{$table}__td {
       overflow: var(--#{$table}--cell--Overflow);
       text-overflow: var(--#{$table}--cell--TextOverflow);
       white-space: var(--#{$table}--cell--WhiteSpace);
@@ -686,22 +691,22 @@
 
   .#{$table} thead:where(.#{$table}__thead).pf-m-nowrap &,
   .#{$table} tr:where(.#{$table}__tr).pf-m-nowrap &,
-  .#{$table} th:where(.#{$table}__th).pf-m-nowrap & {
+  .#{$table} .#{$table}__th.pf-m-nowrap & {
     grid-template-columns: min-content max-content;
   }
 
   .#{$table} thead:where(.#{$table}__thead).pf-m-fit-content &,
   .#{$table} tr:where(.#{$table}__tr).pf-m-fit-content &,
-  .#{$table} th:where(.#{$table}__th).pf-m-fit-content & {
+  .#{$table} .#{$table}__th.pf-m-fit-content & {
     grid-template-columns: fit-content max-content;
   }
 
   .#{$table} thead:where(.#{$table}__thead).pf-m-wrap &,
   .#{$table} tr:where(.#{$table}__tr).pf-m-wrap &,
-  .#{$table} th:where(.#{$table}__th).pf-m-wrap &,
+  .#{$table} .#{$table}__th.pf-m-wrap &,
   .#{$table} thead:where(.#{$table}__thead).pf-m-truncate &,
   .#{$table} tr:where(.#{$table}__tr).pf-m-truncate &,
-  .#{$table} th:where(.#{$table}__th).pf-m-truncate & {
+  .#{$table} .#{$table}__th.pf-m-truncate & {
     grid-template-columns: auto max-content;
   }
 }
@@ -831,7 +836,6 @@
   --#{$table}__button--hover--Color: var(--#{$table}__compound-expansion-toggle__button--hover--Color);
 
   position: relative;
-  padding: 0;
   background-color: var(--#{$table}__compound-expansion-toggle__button--BackgroundColor);
 
   // show left border, use __text to truncate content
@@ -950,8 +954,8 @@
     }
   }
 
-  td:where(.#{$table}__td),
-  th:where(.#{$table}__th) {
+  .#{$table}__td,
+  .#{$table}__th {
     &.pf-m-no-padding {
       padding-block-start: 0;
       padding-block-end: 0;
@@ -1005,7 +1009,7 @@
 
   // - Table compact thead
   thead:where(.#{$table}__thead) {
-    th:where(.#{$table}__th),
+    .#{$table}__th,
     .#{$table}__toggle {
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__th--PaddingBlockStart);
       --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__th--PaddingBlockEnd);


### PR DESCRIPTION
fixes #7146 

# TLDR
This PR updates references to `(th, td)` and `:where(th, td)`. 


 
Performance improvements:
Overall match attempt reduction of ~ 930k

**Before:**

<img width="969" alt="Screenshot 2024-10-15 at 12 39 26 PM" src="https://github.com/user-attachments/assets/82ecd49d-d0a7-4176-8d4c-bf586e06447f">

**After:**

<img width="948" alt="Screenshot 2024-10-15 at 12 43 38 PM" src="https://github.com/user-attachments/assets/8b098963-0e1f-4714-b83c-e65e87210da9">

Backstop reports are clean. 

**Table backstop report** 
[BackstopJS Report - table-only.pdf](https://github.com/user-attachments/files/17381742/BackstopJS.Report.-.table-only.pdf)

**Full backstop report**
[BackstopJS Report - table full.pdf](https://github.com/user-attachments/files/17381743/BackstopJS.Report.-.table.full.pdf)