### PR TITLE
fix(page): apply bottom padding to page breadcrumb and horizontal subnav elements

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -99,6 +99,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-subnav--PaddingBlockEnd: 0;
   --#{$page}__main-subnav--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth));
   --#{$page}__main-subnav--PaddingInlineEnd: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth));
+  --#{$page}__main-subnav--m-sticky-top--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
   // Main section breadcrumb
   --#{$page}__main-breadcrumb--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -106,6 +107,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-breadcrumb--PaddingBlockEnd: 0;
   --#{$page}__main-breadcrumb--PaddingInlineStart: calc(var(--pf-t--global--spacer--lg) - var(--#{$page}__main-container--BorderWidth)); // subtract the border of the main section
   --#{$page}__main-breadcrumb--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$page}__main-breadcrumb--m-sticky-top--PaddingBlockEnd: var(--pf-t--global--spacer--md);
 
   // Main section tabs
   --#{$page}__main-tabs--PaddingBlockStart: 0;
@@ -374,6 +376,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   padding-inline-start: var(--#{$page}__main-subnav--PaddingInlineStart);
   padding-inline-end: var(--#{$page}__main-subnav--PaddingInlineEnd);
   background-color: var(--#{$page}__main-subnav--BackgroundColor);
+
+  &.pf-m-sticky-top {
+    padding-block-end: var(--#{$page}__main-subnav--m-sticky-top--PaddingBlockEnd);
+  }
 }
 
 .#{$page}__main-breadcrumb {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7145

Convenience links:
* [sticky breadcrumb](https://patternfly-pr-7152.surge.sh/components/page/html-demos/sticky-breadcrumb/)
* [sticky horizontal subnav](https://patternfly-pr-7152.surge.sh/components/page/html-demos/sticky-horizontal-subnav/)

**After**
![Screenshot 2024-10-17 at 3 04 05 PM](https://github.com/user-attachments/assets/ebf5a4b8-7671-4465-8eb6-cb0436110f99)

![Screenshot 2024-10-17 at 3 05 00 PM](https://github.com/user-attachments/assets/188fe465-fa27-4b39-8b67-4ded9969fbe4)
