### PR TITLE
fix(table): reduce max-width breakpoints 1px

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -7,25 +7,25 @@
   }
 
   .pf-m-grid-md.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--md) {
+    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--md} - 1)) {
       @content;
     }
   }
 
   .pf-m-grid-lg.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--lg) {
+    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--lg} - 1)) {
       @content;
     }
   }
 
   .pf-m-grid-xl.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--xl) {
+    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--xl} - 1)) {
       @content;
     }
   }
 
   .pf-m-grid-2xl.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--2xl) {
+    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--2xl} - 1)) {
       @content;
     }
   }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -7,25 +7,25 @@
   }
 
   .pf-m-grid-md.#{$table} {
-    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--md} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--md)) {
       @content;
     }
   }
 
   .pf-m-grid-lg.#{$table} {
-    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--lg} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--lg)) {
       @content;
     }
   }
 
   .pf-m-grid-xl.#{$table} {
-    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--xl} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--xl)) {
       @content;
     }
   }
 
   .pf-m-grid-2xl.#{$table} {
-    @media screen and (max-width: calc(#{$pf-v6-global--breakpoint--2xl} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--2xl)) {
       @content;
     }
   }

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -126,25 +126,25 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   }
 
   .pf-m-tree-view-grid-md.#{$table} {
-    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--md} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--md)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-lg.#{$table} {
-    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--lg} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--lg)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-xl.#{$table} {
-    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--xl} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--xl)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-2xl.#{$table} {
-    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--2xl} - 1)) {
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--2xl)) {
       @content;
     }
   }

--- a/src/patternfly/components/Table/table-tree-view.scss
+++ b/src/patternfly/components/Table/table-tree-view.scss
@@ -126,25 +126,25 @@ $pf-v6-c-tree-view--MaxDepth: 10;
   }
 
   .pf-m-tree-view-grid-md.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--md) {
+    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--md} - 1)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-lg.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--lg) {
+    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--lg} - 1)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-xl.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--xl) {
+    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--xl} - 1)) {
       @content;
     }
   }
 
   .pf-m-tree-view-grid-2xl.#{$table} {
-    @media screen and (max-width: $pf-v6-global--breakpoint--2xl) {
+    @media screen and (width <= calc(#{$pf-v6-global--breakpoint--2xl} - 1)) {
       @content;
     }
   }

--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -21,6 +21,12 @@
   @return math.div(pf-strip-unit($pxval), $base) * 1rem;
 }
 
+// Return breakpoint for max-width
+// Used in combination with min-width avoids 1px overlap
+@function pf-v6-max-width-bp($breakpoint) {
+  @return calc($breakpoint - 1px);
+}
+
 // Return (width) breakpoint value if it exists
 @function pf-breakpoint-value($breakpoint, $breakpoint-map: $pf-v6-global--breakpoint-name-map) {
   $breakpoint-value: if(map-has-key($breakpoint-map, #{$breakpoint}), map-get($breakpoint-map, #{$breakpoint}), false);


### PR DESCRIPTION
Closes #7139 

This PR fixes the issue of `max-width` breakpoints (currently only used in Table component) overlapping the more standard `min-width` breakpoints by 1px at the very top of the width by creating a new function to subtract 1px from the max-width.

To test use [Hidden/visible breakpoint modifiers example](https://staging-v6.patternfly.org/components/table/html/hiddenvisible-breakpoint-modifiers-example/) and size screen width from 991 => 992 => 993px.

<details>
<summary>Current behavior - columns hide/show correctly at 992px layout does not update until 993px</summary>


https://github.com/user-attachments/assets/d5faef08-50eb-44de-b7e5-ed4da872f93e

</details>

<details>
<summary>Fixed behavior - columns continue to hide/show correctly but layout also updates at 992px (no changes at 993px)</summary>


https://github.com/user-attachments/assets/0e346b86-b5e5-4a27-8d3c-364f7942d74b

</details>