### PR TITLE
fix(table-text): updated truncate value

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3391,25 +3391,16 @@ For sticky columns to function correctly, the parent table's width must be contr
         {{#> table-th table-th--attribute='scope="col" colspan="2"' table-th--modifier="pf-m-border-right"}}
           Ports
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Protocol
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Flow rate
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Traffic
-        {{/table-th}}
         {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-fit-content"}}
           Packets
         {{/table-th}}
       {{/table-tr}}
 
       {{#> table-tr}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-wrap"}}
           Source
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-wrap"}}
           Destination
         {{/table-th}}
         {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-fit-content pf-m-border-right"}}
@@ -3452,25 +3443,16 @@ For sticky columns to function correctly, the parent table's width must be contr
         {{#> table-th table-th--attribute='scope="col" colspan="2"' table-th--modifier="pf-m-border-right"}}
           Ports
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Protocol
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Flow rate
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-border-right pf-m-fit-content"}}
-          Traffic
-        {{/table-th}}
         {{#> table-th table-th--attribute='scope="col" rowspan="2"' table-th--IsSortable=true table-th--modifier="pf-m-fit-content"}}
           Packets
         {{/table-th}}
       {{/table-tr}}
 
       {{#> table-tr}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-wrap"}}
           Source
         {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead"}}
+        {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-wrap"}}
           Destination
         {{/table-th}}
         {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--modifier="pf-v6-c-table__subhead pf-m-fit-content pf-m-border-right"}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -618,7 +618,8 @@
   // Only apply these settings if specifically modified
   &.pf-m-truncate {
     --#{$table}--cell--MinWidth: 100%;
-    --#{$table}--text--MinWidth: var(--#{$table}--m-truncate__text--MinWidth);
+
+    min-width: max(var(--#{$table}--m-truncate__text--MinWidth), var(--#{$table}--m-truncate--cell--MaxWidth));
 
     > :where(th, td) {
       overflow: var(--#{$table}--cell--Overflow);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -48,7 +48,7 @@
   --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
 
   // * Table cell - default variables
-  --#{$table}--cell--MinWidth: 0;
+  --#{$table}--cell--MinWidth: calc(var(--#{$table}--cell--PaddingInlineEnd) + var(--#{$table}--cell--PaddingInlineEnd));
   --#{$table}--cell--MaxWidth: none;
   --#{$table}--cell--Width: auto;
   --#{$table}--cell--Overflow: visible;
@@ -70,6 +70,8 @@
   --#{$table}--m-truncate--cell--MinWidth: calc(5ch + var(--#{$table}--cell--PaddingInlineEnd) + var(--#{$table}--cell--PaddingInlineStart));
 
   // * Table truncate
+  --#{$table}__text--MinWidth: 100%;
+  --#{$table}__text--m-truncate--MinWidth: 5ch;
   --#{$table}--m-truncate__text--MinWidth: 5ch;
 
   // * Table cell hidden visible
@@ -602,12 +604,10 @@
 
 // - Table text
 .#{$table}__text {
-  --#{$table}--cell--MaxWidth: 100%;
-
   position: relative;
   display: block;
   width: var(--#{$table}--cell--Width);
-  min-width: var(--#{$table}--text--MinWidth);
+  min-width: var(--#{$table}__text--MinWidth);
   max-width: var(--#{$table}--cell--MaxWidth);
   overflow: var(--#{$table}--cell--Overflow);
   line-height: var(--#{$table}--cell--LineHeight);
@@ -619,7 +619,7 @@
   &.pf-m-truncate {
     --#{$table}--cell--MinWidth: 100%;
 
-    min-width: max(var(--#{$table}--m-truncate__text--MinWidth), var(--#{$table}--m-truncate--cell--MaxWidth));
+    min-width: max(var(--#{$table}__text--m-truncate--MinWidth), var(--#{$table}__text--MinWidth));
 
     > :where(th, td) {
       overflow: var(--#{$table}--cell--Overflow);
@@ -683,6 +683,7 @@
 
   .#{$table}__text {
     min-width: auto;
+    max-width: 100%;
   }
 
   .#{$table} thead:where(.#{$table}__thead).pf-m-nowrap &,

--- a/src/patternfly/components/Table/templates/table-tr--nested-column-header.hbs
+++ b/src/patternfly/components/Table/templates/table-tr--nested-column-header.hbs
@@ -41,15 +41,6 @@
       <span class="{{pfv 'u'}}color-200">(smtp)</span>
     {{/stack}}
   {{/table-td}}
-  {{#> table-td table-td--data-label="Protocol"}}
-    TCP
-  {{/table-td}}
-  {{#> table-td table-td--data-label="Flow rate"}}
-    1.9 Kbps
-  {{/table-td}}
-  {{#> table-td table-td--data-label="Traffic"}}
-    2.1 KB
-  {{/table-td}}
   {{#> table-td table-td--data-label="Packets"}}
     3
   {{/table-td}}


### PR DESCRIPTION
fixes #7172 

# TLDR:
`max(var(--#{$table}--m-truncate__text--MinWidth), var(--#{$table}--m-truncate--cell--MaxWidth));` sets `table__text.m-truncate` to accept larger of the two values, assuring that truncated text is always at least `5ch` long and at max `100%`. 

Link: https://patternfly-pr-7175.surge.sh/components/table

[BackstopJS Report table text.pdf](https://github.com/user-attachments/files/17510300/BackstopJS.Report.table.text.pdf)
