### PR TITLE
fix(data-list): add spacing to compact data-list buttons

### DIFF
--- a/src/patternfly/components/DataList/data-list-item-action.hbs
+++ b/src/patternfly/components/DataList/data-list-item-action.hbs
@@ -6,6 +6,7 @@
     {{> @partial-block}}
   {{else}}
     {{> menu-toggle
+      menu-toggle--IsSmall=data-list--IsCompact
       menu-toggle--IsPlain=true
       menu-toggle--HasKebab=true
       menu-toggle--id=(dasherize data-list--id data-list-item--id 'menu-toggle')

--- a/src/patternfly/components/DataList/data-list.hbs
+++ b/src/patternfly/components/DataList/data-list.hbs
@@ -1,4 +1,6 @@
-<ul class="{{pfv}}data-list{{#if data-list--modifier}} {{data-list--modifier}}{{/if}}"
+<ul class="{{pfv}}data-list
+  {{#if data-list--IsCompact}} pf-m-compact{{/if}}
+  {{#if data-list--modifier}} {{data-list--modifier}}{{/if}}"
   role="list"
   {{#if data-list--attribute}}
     {{{data-list--attribute}}}

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -132,6 +132,8 @@
   --#{$data-list}--m-compact__item-control--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$data-list}--m-compact__item-action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$data-list}--m-compact__item-action--PaddingBlockStart--offset: var(--pf-t--global--spacer--control--vertical--compact);
+  --#{$data-list}--m-compact__item-action--PaddingBlockEnd--offset: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$data-list}--m-compact__item-action--MarginInlineStart: var(--pf-t--global--spacer--md);
   --#{$data-list}--m-compact__item-content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1);
@@ -174,6 +176,11 @@
 
     .#{$data-list}__check {
       font-size: var(--#{$data-list}--m-compact__check--FontSize);
+    }
+
+    .#{$data-list}__item-action {
+      padding-block-start: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockStart) - var(--#{$data-list}--m-compact__item-action--PaddingBlockStart--offset));
+      padding-block-end: calc(var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd) - var(--#{$data-list}--m-compact__item-action--PaddingBlockEnd--offset));
     }
   }
 

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -292,7 +292,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ### Expandable compact
 ```hbs
-{{#> data-list data-list--modifier="pf-m-compact" data-list--id="data-list-expandable-compact" data-list--attribute='aria-label="Expandable data list example"'}}
+{{#> data-list data-list--IsCompact=true data-list--id="data-list-expandable-compact" data-list--attribute='aria-label="Expandable data list example"'}}
   {{#> data-list-item data-list-item--expanded="true" data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
@@ -523,7 +523,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ### Compact
 ```hbs
-{{#> data-list data-list--id="data-list-compact" data-list--attribute='aria-label="Compact data list example"' data-list--modifier="pf-m-compact pf-m-grid-sm"}}
+{{#> data-list data-list--id="data-list-compact" data-list--attribute='aria-label="Compact data list example"' data-list--modifier=" pf-m-grid-sm" data-list--IsCompact=true}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
@@ -565,10 +565,10 @@ When a list item includes more than one block of content, it can be difficult fo
       {{/data-list-item-content}}
       {{> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-lg"}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-lg"}}
-        {{#> button button--IsPrimary=true}}
+        {{#> button button--IsPrimary=true button--IsSmall=true}}
             Primary
         {{/button}}
-        {{#> button button--IsSecondary=true}}
+        {{#> button button--IsSecondary=true button--IsSmall=true}}
             Secondary
         {{/button}}
       {{/data-list-item-action}}
@@ -590,16 +590,16 @@ When a list item includes more than one block of content, it can be difficult fo
       {{/data-list-item-content}}
       {{> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-xl"}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-xl"}}
-        {{#> button button--IsPrimary=true}}
+        {{#> button button--IsPrimary=true button--IsSmall=true}}
             Primary
         {{/button}}
-        {{#> button button--IsSecondary=true}}
+        {{#> button button--IsSecondary=true button--IsSmall=true}}
             Secondary
         {{/button}}
-        {{#> button button--IsSecondary=true}}
+        {{#> button button--IsSecondary=true button--IsSmall=true}}
             Secondary
         {{/button}}
-        {{#> button button--IsSecondary=true}}
+        {{#> button button--IsSecondary=true button--IsSmall=true}}
             Secondary
         {{/button}}
       {{/data-list-item-action}}
@@ -871,7 +871,7 @@ When a list item includes more than one block of content, it can be difficult fo
 <div id="draggable-help">
   Activate the reorder button and use the arrow keys to reorder the list or use your mouse to drag/reorder. Press escape to cancel the reordering.
 </div>
-{{#> data-list data-list--modifier="pf-m-compact" data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
+{{#> data-list data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}

--- a/src/patternfly/demos/Table/table-manage-cols-data-list.hbs
+++ b/src/patternfly/demos/Table/table-manage-cols-data-list.hbs
@@ -1,4 +1,4 @@
-{{#> data-list data-list--modifier="pf-m-compact" data-list-item--modifier="pf-m-draggable" data-list--id="table-manage-columns-data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
+{{#> data-list data-list--IsCompact=true data-list-item--modifier="pf-m-draggable" data-list--id="table-manage-columns-data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7105

- Update DataList compact examples to use small buttons
- Add top and bottom padding to small buttons

Backstop tests
https://drive.google.com/drive/folders/1aKh3N42bPbMjsfkTTbGOrQr8zUO_YHYn?usp=sharing

**Before**
![Screenshot 2024-11-01 at 6 13 52 PM](https://github.com/user-attachments/assets/608a52d8-7949-4cbb-b979-6cd09fcad754)


**After**
![Screenshot 2024-11-01 at 6 13 32 PM](https://github.com/user-attachments/assets/46ca9436-0f76-4bb1-bcbe-c9fadb021c36)


**Before**
![Screenshot 2024-11-01 at 6 51 25 PM](https://github.com/user-attachments/assets/ed9bc22e-dabb-431e-a024-f2328680d83a)


**After**
![Screenshot 2024-11-01 at 6 50 01 PM](https://github.com/user-attachments/assets/8da673cf-41be-42d9-914b-c3fec150f448)

