### PR TITLE
fix(expandable section): updated white-space when using truncate with and expandable section

### DIFF
--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -76,6 +76,11 @@
       // stylelint-enable
       overflow: hidden;
     }
+
+    .#{$truncate}__start,
+    .#{$truncate}__end {
+      white-space: nowrap;
+    }
   }
 }
 


### PR DESCRIPTION
fixes: https://github.com/patternfly/patternfly/issues/7181

Examples using ` <Truncate content={content} style={{ maxWidth: '30ch' }} />`

Related pr https://github.com/patternfly/patternfly/pull/6737 sets `.#{$truncate}__start, .#{$truncate}__end`  to have `white-space: pre`

**Before**
![Screenshot 2024-11-05 at 9 41 12 AM](https://github.com/user-attachments/assets/0402ae87-7e99-44e8-87b0-3524bc45bfb8)


**After**
![Screenshot 2024-11-05 at 9 36 29 AM](https://github.com/user-attachments/assets/2f285260-8d7a-436c-9a1d-e3a6860b3684)
