### PR TITLE
fix: address early a11y issues + clean up

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -685,7 +685,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
-      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -712,7 +712,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -738,7 +738,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -764,7 +764,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Expandable row content has no padding.
         {{/table-expandable-row-content}}
@@ -814,7 +814,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
       {{#> table-td table-td--attribute='colspan="4"'}}
@@ -843,7 +843,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
       {{#> table-td table-td--attribute='colspan="2"'}}
@@ -877,7 +877,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-expandable-row-content}}
           <b>Span all</b>&nbsp;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -903,7 +903,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{#> table-td table-td--attribute='colspan="3"'}}
         {{#> table-expandable-row-content}}
           Span one, two, and three
@@ -963,7 +963,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           {{#> table newcontext table--id=(concat table--id "-table-basic") table--IsGrid=true table--IsCompact=true table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a simple table"'}}
             {{#> table-thead}}
@@ -1083,7 +1083,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1109,7 +1109,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1135,7 +1135,7 @@ Note: Table column widths will respond automatically when toggling expanded rows
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Expandable row content has no padding.
         {{/table-expandable-row-content}}
@@ -1519,7 +1519,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
-      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content-' table-tr--index '"')}}
         <div class="pf-v6-c-table__expandable-row-content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
@@ -1546,7 +1546,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1572,7 +1572,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1598,7 +1598,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           This content has no padding.
         {{/table-expandable-row-content}}
@@ -1624,7 +1624,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1649,7 +1649,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
       {{#> table-td table-td--attribute='colspan="2"'}}
@@ -1685,7 +1685,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -1710,7 +1710,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content' table-tr--index '"')}}
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true table-tr--attribute=(concat 'id="' table--id '-content-' table-tr--index '"')}}
       {{#> table-td table-td--attribute='colspan="4"'}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -1743,7 +1743,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -2187,7 +2187,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
-      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -2214,7 +2214,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -2241,7 +2241,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -2267,7 +2267,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Expandable row content has no padding.
         {{/table-expandable-row-content}}
@@ -3299,7 +3299,7 @@ For sticky columns to function correctly, the parent table's width must be contr
       {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
         {{> table-cell-empty}}
         {{> table-cell-empty}}
-        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content1"'}}
+        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content-1"'}}
           {{#> table-expandable-row-content}}
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
           {{/table-expandable-row-content}}
@@ -3333,7 +3333,7 @@ For sticky columns to function correctly, the parent table's width must be contr
       {{#> table-tr table-tr--IsExpandable=true}}
         {{> table-cell-empty}}
         {{> table-cell-empty}}
-        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content2"'}}
+        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content-2"'}}
           {{#> table-expandable-row-content}}
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
           {{/table-expandable-row-content}}
@@ -3367,7 +3367,7 @@ For sticky columns to function correctly, the parent table's width must be contr
       {{#> table-tr table-tr--IsExpandable=true}}
         {{> table-cell-empty}}
         {{> table-cell-empty}}
-        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content3"'}}
+        {{#> table-td table-td--attribute='colspan="5" id="nested-columns-expandable-example-content-3"'}}
           {{#> table-expandable-row-content}}
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
           {{/table-expandable-row-content}}
@@ -4045,7 +4045,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
       {{> table-cell-empty}}
       {{> table-cell-empty}}
-      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -4072,7 +4072,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -4098,7 +4098,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         {{/table-expandable-row-content}}
@@ -4124,7 +4124,7 @@ Basic striped table rows are supported on tables with a single `<tbody>` element
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content' table-tr--index '"')}}
+      {{#> table-td table-td--modifier="pf-m-no-padding" table-td--attribute=(concat 'colspan="7" id="' table--id '-content-' table-tr--index '"')}}
         {{#> table-expandable-row-content}}
           Expandable row content has no padding.
         {{/table-expandable-row-content}}

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -23,8 +23,8 @@
       {{ternary table-tr--IsHidden 'hidden' null}}
     {{/unless}}
   {{/if}}
-  {{ternary table--IsGrid 'role="row"'}}
-  {{ternary table-tr--IsClickable 'tabindex="0"'}}
+  role="row"
+  {{ternary table-tr--IsClickable 'tabindex="0"' null}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/templates/table-tbody--expandable.hbs
+++ b/src/patternfly/components/Table/templates/table-tbody--expandable.hbs
@@ -27,7 +27,7 @@
   {{#> table-tr table-tr--IsExpandable=true}}
     {{> table-cell-empty}}
     {{> table-cell-empty}}
-    {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content' table-tbody--expandable--index '"')}}
+    {{#> table-td table-td--attribute=(concat 'colspan="4" id="' table--id '-content-' table-tbody--expandable--index '"')}}
       {{#> table-expandable-row-content}}
         Expandable content
       {{/table-expandable-row-content}}

--- a/src/patternfly/demos/Card/examples/Card.css
+++ b/src/patternfly/demos/Card/examples/Card.css
@@ -21,6 +21,10 @@
   --pf-v6-c-table--m-compact--cell--first-last-child--PaddingInlineStart: var(--pf-v6-global--spacer--sm);
 }
 
+#ws-html-demos-c-card-status-card-expanded-with-popover .pf-v6-c-card {
+  overflow: initial;
+}
+
 .ws-chart {
   display: flex;
   max-width: 100%;

--- a/src/patternfly/demos/Card/templates/card-demo--popover-table.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--popover-table.hbs
@@ -27,7 +27,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content1"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content-1"')}}
         <div class="{{pfv}}table__expandable-row-content">
           {{#> alert alert--modifier="pf-m-danger pf-m-inline" alert--attribute='aria-label="Inline danger alert"'}}
             {{#> alert-icon alert-icon--type="exclamation-circle"}}
@@ -59,7 +59,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content2"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content-2"')}}
         <div class="{{pfv}}table__expandable-row-content">
           This is message
         </div>
@@ -84,7 +84,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content3"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content-3"')}}
         <div class="{{pfv}}table__expandable-row-content">
           This is the message
         </div>
@@ -109,7 +109,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content4"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="3" id="' table--id '-content-4"')}}
         <div class="{{pfv}}table__expandable-row-content">
           This is the message
         </div>


### PR DESCRIPTION
addresses following a11y issues flagged by patternfly-a11y upgrade:

- card demo has invalid aria-controls values (the aria-controls on a table's expandable row toggle does not match the id of the expandable content)
- multiple table examples have invalid aria-controls values (the aria-controls on a table's expandable row toggle does not match the id of the expandable content)

Also cleans up:

- the styles on the card demo - status card expanded with popover example
- `role="row"` always being rendered (rather than only conditionally rendered), preventing a lot of `[Object, object]` appearing in the rendered html markup in table examples.