### PR TITLE
feat(title/content): add page title variation

### DIFF
--- a/src/patternfly/components/Content/content--element.hbs
+++ b/src/patternfly/components/Content/content--element.hbs
@@ -1,7 +1,10 @@
 <{{content--element--type}} class="{{#unless content--element--ExcludeClass}}{{pfv}}content--{{content--element--type}}{{/unless}}
-  {{~#if content--element--IsEditorial}} pf-m-editorial{{/if}}
-  {{~#if content--element--IsPlain}} pf-m-plain{{/if}}
-  {{~#if content--element--modifier}} {{content--element--modifier}}{{/if}}"
+  {{setModifiers
+    content--element--IsEditorial="pf-m-editorial"
+    content--element--IsPlain="pf-m-plain"
+    content--element--IsPageTitle="pf-m-page-title"
+    content--element--modifier=content--element--modifier
+  }}"
   {{#if content--element--attribute}}
     {{{content--element--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Content/content--kitchen-sink.hbs
+++ b/src/patternfly/components/Content/content--kitchen-sink.hbs
@@ -1,4 +1,4 @@
-{{#> content--element content--element--type="h1"}}Hello world{{/content--element}}
+{{#> content--element content--element--type="h1" content--element--IsPageTitle=true}}Hello world{{/content--element}}
 {{#> content--element content--element--type="p"}}Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla accumsan, metus ultrices eleifend gravida, nulla nunc varius lectus, nec rutrum justo nibh eu lectus. Ut vulputate semper dui. Fusce erat odio, sollicitudin vel erat vel, interdum mattis neque. Sub works as well!{{/content--element}}
 {{#> content--element content--element--type="h2"}}Second level{{/content--element}}
 {{#> content--element content--element--type="p"}}Curabitur accumsan turpis pharetra <strong>augue tincidunt</strong> blandit. Quisque condimentum maximus mi, sit amet commodo arcu rutrum id. Proin pretium urna vel cursus venenatis. Suspendisse potenti. Etiam mattis sem rhoncus lacus dapibus facilisis. Donec at dignissim dui. Ut et neque nisl.{{/content--element}}

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -56,6 +56,9 @@
   --#{$content}--h6--FontSize: var(--pf-t--global--font--size--heading--h6);
   --#{$content}--h6--FontWeight: var(--pf-t--global--font--weight--heading--default);
 
+  // Page title
+  --#{$content}--heading--m-page-title--FontWeight: var(--pf-t--global--font--weight--heading--bold);
+
   // Small text
   --#{$content}--small--MarginBlockEnd: var(--pf-t--global--spacer--md);
   --#{$content}--small--LineHeight: var(--pf-t--global--font--line-height--body);
@@ -193,6 +196,10 @@
 
     &:last-child {
       margin-block-end: 0;
+    }
+
+    &.pf-m-page-title {
+      font-weight: var(--#{$content}--heading--m-page-title--FontWeight);
     }
   }
 

--- a/src/patternfly/components/Content/examples/Content.md
+++ b/src/patternfly/components/Content/examples/Content.md
@@ -29,6 +29,15 @@ cssPrefix: pf-v6-c-content
 {{/content}}
 ```
 
+### Page title
+```hbs
+{{#> content}}
+  {{#> content--element content--element--type="h1" content--element--IsPageTitle=true content--element--ExcludeClass=true}}H1 page title in content wrapper{{/content--element}}
+{{/content}}
+
+{{#> content--element content--element--type="h1" content--element--IsPageTitle=true}}H1 page title{{/content--element}}
+```
+
 ## Documentation
 ### Overview
 When you can't use the CSS classes you want, or when you just want to directly use HTML tags, use `pf-v6-c-content` as container. It can handle almost any HTML tag:
@@ -50,3 +59,4 @@ This component is an exception to the variable system since we style type select
 | `.pf-m-visited` | `.pf-v6-c-content`, `<a>` | Modifies all links in a content block to include visited styles. Can also be applied to a single link in a content block. |
 | `.pf-m-plain` | `<ul>`, `<ol>` | Removes the list marker and indentation. |
 | `.pf-m-editorial` | `.pf-v6-c-content*` | Applies long-form, editorial content styles to a block of content or individual content elements. |
+| `.pf-m-page-title` | `.pf-v6-c-content--[h1, h2, h3, h4, h5, h6]`, `.pf-v6-c-content [h1, h2, h3, h4, h5, h6]` | Applies page title styles. **Note:** `.pf-m-page-title` should only apply to the heading that serves as the title for the current page. |

--- a/src/patternfly/components/Content/examples/Content.md
+++ b/src/patternfly/components/Content/examples/Content.md
@@ -29,15 +29,6 @@ cssPrefix: pf-v6-c-content
 {{/content}}
 ```
 
-### Page title
-```hbs
-{{#> content}}
-  {{#> content--element content--element--type="h1" content--element--IsPageTitle=true content--element--ExcludeClass=true}}H1 page title in content wrapper{{/content--element}}
-{{/content}}
-
-{{#> content--element content--element--type="h1" content--element--IsPageTitle=true}}H1 page title{{/content--element}}
-```
-
 ## Documentation
 ### Overview
 When you can't use the CSS classes you want, or when you just want to directly use HTML tags, use `pf-v6-c-content` as container. It can handle almost any HTML tag:

--- a/src/patternfly/components/Title/examples/Title.md
+++ b/src/patternfly/components/Title/examples/Title.md
@@ -8,44 +8,55 @@ cssPrefix: pf-v6-c-title
 ### Size modifiers
 ```hbs
 {{#> title titleType="h1" title--modifier="pf-m-4xl"}}
-    4xl title
+  4xl title
 {{/title}}
 {{#> title titleType="h1" title--modifier="pf-m-3xl"}}
-    3xl title
+  3xl title
 {{/title}}
 {{#> title titleType="h1" title--modifier="pf-m-2xl"}}
-    2xl title
+  2xl title
 {{/title}}
 {{#> title titleType="h1" title--modifier="pf-m-xl"}}
-    xl title
+  xl title
 {{/title}}
 {{#> title titleType="h1" title--modifier="pf-m-lg"}}
-    lg title
+  lg title
 {{/title}}
 {{#> title titleType="h1" title--modifier="pf-m-md"}}
-    md title
+  md title
 {{/title}}
 ```
 
 ### Heading level modifiers
 ```hbs
 {{#> title titleType="div" title--modifier="pf-m-h1"}}
-    H1-styled title
+  H1-styled title
 {{/title}}
 {{#> title titleType="div" title--modifier="pf-m-h2"}}
-    H2-styled title
+  H2-styled title
 {{/title}}
 {{#> title titleType="div" title--modifier="pf-m-h3"}}
-    H3-styled title
+  H3-styled title
 {{/title}}
 {{#> title titleType="div" title--modifier="pf-m-h4"}}
-    H4-styled title
+  H4-styled title
 {{/title}}
 {{#> title titleType="div" title--modifier="pf-m-h5"}}
-    H5-styled title
+  H5-styled title
 {{/title}}
 {{#> title titleType="div" title--modifier="pf-m-h6"}}
-    H6-styled title
+  H6-styled title
+{{/title}}
+```
+
+### Page title
+```hbs
+{{#> title titleType="h1" title--modifier="pf-m-2xl" title--IsPageTitle=true}}
+  2xl page title
+{{/title}}
+
+{{#> title titleType="div" title--modifier="pf-m-h1" title--IsPageTitle=true}}
+  H1 page title
 {{/title}}
 ```
 
@@ -80,3 +91,4 @@ The content component defines margin on headers. To regain the same spacing use,
 | `.pf-m-h4` | `.pf-v6-c-title` | Modifies for default h4 size |
 | `.pf-m-h5` | `.pf-v6-c-title` | Modifies for default h5 size |
 | `.pf-m-h6` | `.pf-v6-c-title` | Modifies for default h6 size |
+| `.pf-m-page-title` | `.pf-v6-c-title` | Applies page title styles. **Note:** `.pf-m-page-title` should only apply to the heading that serves as the title for the current page. |

--- a/src/patternfly/components/Title/title.hbs
+++ b/src/patternfly/components/Title/title.hbs
@@ -1,4 +1,8 @@
-<{{#if titleType}}{{titleType}}{{else}}h1{{/if}} class="{{pfv}}title{{#if title--modifier}} {{title--modifier}}{{/if}}"
+<{{#if titleType}}{{titleType}}{{else}}h1{{/if}} class="{{pfv}}title
+  {{setModifiers
+    title--IsPageTitle='pf-m-page-title'
+    title--modifier=title--modifier
+  }}"
 	{{#if title--attribute}}
     {{{title--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -64,6 +64,9 @@
   --#{$title}--m-h6--LineHeight: var(--pf-t--global--font--line-height--heading);
   --#{$title}--m-h6--FontSize: var(--pf-t--global--font--size--heading--h6);
   --#{$title}--m-h6--FontWeight: var(--pf-t--global--font--weight--heading--default);
+
+  // Page title
+  --#{$title}--m-page-title--FontWeight: var(--pf-t--global--font--weight--heading--bold);
 }
 
 .#{$title} {
@@ -140,5 +143,9 @@
     font-size: var(--#{$title}--m-h6--FontSize);
     font-weight: var(--#{$title}--m-h6--FontWeight);
     line-height: var(--#{$title}--m-h6--LineHeight);
+  }
+
+  &.pf-m-page-title {
+    font-weight: var(--#{$title}--m-page-title--FontWeight);
   }
 }

--- a/src/patternfly/demos/Page/page-template-title.hbs
+++ b/src/patternfly/demos/Page/page-template-title.hbs
@@ -1,18 +1,16 @@
 {{#> page-main-section page-main-section--IsLimitWidth="true" page-main-section--modifier=page-template-title--modifier}}
-  {{#> content}}
-    <h1>
-      {{~#if page-template-title--title}}
-        {{page-template-title--title}}
-      {{else}}
-        Main title
-      {{/if}}
-    </h1>
-    <p>
-      {{~#if page-template-title--description}}
-        {{page-template-title--description}}
-      {{else}}
-        This is a full page demo.
-      {{/if}}
-    </p>
-  {{/content}}
+  {{#> content--element content--element--type="h1" content--element--IsPageTitle=true}}
+    {{~#if page-template-title--title}}
+      {{page-template-title--title}}
+    {{else}}
+      Main title
+    {{/if}}
+  {{/content--element}}
+  {{#> content--element content--element--type="p"}}
+    {{~#if page-template-title--description}}
+      {{page-template-title--description}}
+    {{else}}
+      This is a full page demo.
+    {{/if}}
+  {{/content--element}}
 {{/page-main-section}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7072

* Adds `.pf-m-page-title` to the content component and title component
* Can be applied to any heading level/size and it will override the font-weight
* Updates our standard full-page demo template to add the page title modifier to the main heading
  * Some demos may not use that template and would need to be updated manually
  * We could add the page-title modifier to the "Hello world" heading in main content component examples - wdyt @lboehling @andrew-ronaldson?

Links:
https://patternfly-pr-7212.surge.sh/components/content
https://patternfly-pr-7212.surge.sh/components/title#page-title
https://patternfly-pr-7212.surge.sh/components/page/html-demos/basic/
https://patternfly-pr-7212.surge.sh/components/data-list/html-demos/basic/

