### PR TITLE
fix(menu toggle): correct spacing for split menu-toggle__toggle-icon that contains svg for icon

### DIFF
--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -500,14 +500,6 @@
   flex-wrap: nowrap;
 }
 
-// - Menu toggle controls - Menu toggle icon
-.#{$menu-toggle}__controls,
-.#{$menu-toggle}__toggle-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
 
@@ -523,7 +515,10 @@
 
 // - Menu toggle controls
 .#{$menu-toggle}__controls {
+  display: flex;
   gap: var(--#{$menu-toggle}__controls--Gap);
+  align-items: center;
+  justify-content: center;
   margin-inline-start: auto; // TODO: possibly replace as part of one of the other TODOs at top of file
 }
 


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/7137
The react `MenuToggle` component uses an `<svg>` for the `menu toggle` icon, instead of an `<i>` used by core.
Removing `display: flex` from `pf-v6-c-menu-toggle__toggle-icon` because it causes a bug  where the `svg` `CaretDownIcon` is misaligned with the text and the button height to grow taller.

Before and after
![Screenshot 2024-11-12 at 1 42 43 PM](https://github.com/user-attachments/assets/9ab172b2-0b43-4364-a64e-49327e018639)


https://patternfly-pr-7213.surge.sh/components/menus/menu-toggle#split-toggle