### PR TITLE
fix(Page): limit width on section and example cleanup

### DIFF
--- a/src/patternfly/components/Page/examples/Page.css
+++ b/src/patternfly/components/Page/examples/Page.css
@@ -1,5 +1,5 @@
 /* Because the page component has height:100dvh, override it just for the embedded examples */
-.ws-mdx-content-content [id^=ws-core-c-page-] .pf-v6-c-page {
+.ws-preview-html .pf-v6-c-page {
   height: min-content;
   min-height: 30em;
 }

--- a/src/patternfly/components/Page/examples/Page.css
+++ b/src/patternfly/components/Page/examples/Page.css
@@ -1,5 +1,5 @@
 /* Because the page component has height:100dvh, override it just for the embedded examples */
-.ws-preview-html .pf-v6-c-page {
+[id^=ws-core-c-page-] .ws-preview-html .pf-v6-c-page {
   height: min-content;
   min-height: 30em;
 }

--- a/src/patternfly/components/Page/examples/Page.css
+++ b/src/patternfly/components/Page/examples/Page.css
@@ -1,5 +1,5 @@
 /* Because the page component has height:100dvh, override it just for the embedded examples */
-[id^=ws-core-c-page-] .ws-preview-html .pf-v6-c-page {
+#ws-page-main [id^=ws-core-c-page-] .pf-v6-c-page {
   height: min-content;
   min-height: 30em;
 }

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -97,10 +97,13 @@ import './Page.css'
     {{#> page-sidebar-body}}
       Navigation
     {{/page-sidebar-body}}
-    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-fill pf-m-page-insets"}}
+    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-fill"}}
       inset content
     {{/page-sidebar-body}}
-    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-page-insets"}}
+    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-fill pf-m-inset-none"}}
+      content that is not inset
+    {{/page-sidebar-body}}
+    {{#> page-sidebar-body page-sidebar-body--modifier="pf-m-no-fill"}}
       footer content
     {{/page-sidebar-body}}
   {{/page-sidebar}}
@@ -125,15 +128,15 @@ import './Page.css'
     {{/masthead-main}}
     {{> masthead-content}}
   {{/masthead}}
-  {{#> page-main}}
+  {{#> page-main page-main-container--IsFilled="true"}}
     {{#> page-main-section}}
       A regular page section.
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-fill"}}
-      This section uses <code>.pf-m-fill</code> to fill the available space.
+      This section uses <code>.pf-m-fill</code> to fill the available space. The <code>.pf-v6-c-page__main-container</code> must also have <code>.pf-m-fill</code> in order for the section to have space to stretch to full height.
     {{/page-main-section}}
     {{#> page-main-section page-main-section--modifier="pf-m-no-fill"}}
-      This section uses <code>.pf-m-no-fill</code> not to fill the available space.
+      This section uses <code>.pf-m-no-fill</code> and will not fill the available space.
     {{/page-main-section}}
   {{/page-main}}
 {{/page}}
@@ -272,7 +275,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-inset-none` | `.pf-v6-c-page__sidebar-body` | Removes a sidebar body left/right inset. |
 | `.pf-m-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Modifies the main page section to add padding back in at an optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). Should be used with pf-m-no-padding. |
 | `.pf-m-no-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Removes padding from the main page section at an optional [breakpoint](/developer-resources/global-css-variables#breakpoint-variables-and-class-suffixes). |
-| `.pf-m-fill` | `.pf-v6-c-page__main-container`, `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element to grow to fill the available space. |
+| `.pf-m-fill` | `.pf-v6-c-page__main-container`, `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element to grow to fill the available space. Note that `.pf-v6-c-page__main-container` must also have `.pf-m-fill` applied in order for the section to have space to stretch to full height.|
 | `.pf-m-no-fill` | `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element not to grow to fill the available vertical space. |
 | `.pf-m-limit-width` | `.pf-v6-c-page__main-section` | Modifies a page section to limit the `max-width` of the content inside. |
 | `.pf-m-align-center` | `.pf-v6-c-page__main-section.pf-m-limit-width` | Modifies a page section body to align center. |

--- a/src/patternfly/components/Page/page-main-container.hbs
+++ b/src/patternfly/components/Page/page-main-container.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}page__main-container{{#if page-main-container--modifier}}{{page-main-container--modifier}}{{/if}}{{#if page-main-container--IsFilled}} pf-m-fill{{/if}}" tabindex="-1"
+<div class="{{pfv}}page__main-container{{#if page-main-container--modifier}} {{page-main-container--modifier}}{{/if}}{{#if page-main-container--IsFilled}} pf-m-fill{{/if}}" tabindex="-1"
   {{#if page-main-container--attribute}}
     {{{page-main-container--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Page/page-main-container.hbs
+++ b/src/patternfly/components/Page/page-main-container.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}page__main-container{{#if page-main-container--modifier}} {{page-main-container--modifier}}{{/if}}" tabindex="-1"
+<div class="{{pfv}}page__main-container{{#if page-main-container--modifier}}{{page-main-container--modifier}}{{/if}}{{#if page-main-container--IsFilled}} pf-m-fill{{/if}}" tabindex="-1"
   {{#if page-main-container--attribute}}
     {{{page-main-container--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -80,6 +80,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Limit width
   --#{$page}--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--#{$page}__sidebar--Width));
+  --#{$page}--section--m-limit-width--xl--MaxWidth: #{pf-size-prem(1710px)}; // 2000px - 290px because at xl breakpoint, the sidebar width goes to auto and can't be used in a calc
   
   // Sticky
   --#{$page}--section--m-sticky-top--ZIndex: var(--pf-t--global--z-index--md);
@@ -137,6 +138,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
     --#{$page}__sidebar--Width: var(--#{$page}__sidebar--xl--Width);
+    --#{$page}--section--m-limit-width--MaxWidth: var(--#{$page}--section--m-limit-width--xl--MaxWidth);
 
     grid-template-areas:
       "header header"
@@ -247,6 +249,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   }
 }
 
+.#{$page}__main-subnav,
 .#{$page}__main-breadcrumb,
 .#{$page}__main-tabs,
 .#{$page}__main-section,

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -15,7 +15,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   // Sidebar
   --#{$page}__sidebar--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$page}__sidebar--Width: #{pf-size-prem(290px)};
-  --#{$page}__sidebar--xl--Width: auto;
+  --#{$page}__sidebar--xl--Width: #{pf-size-prem(290px)}; // TODO Can remove at breaking change
   --#{$page}__sidebar--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$page}__sidebar--BoxShadow: none;
 
@@ -80,7 +80,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Limit width
   --#{$page}--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--#{$page}__sidebar--Width));
-  --#{$page}--section--m-limit-width--xl--MaxWidth: #{pf-size-prem(1710px)}; // 2000px - 290px because at xl breakpoint, the sidebar width goes to auto and can't be used in a calc
   
   // Sticky
   --#{$page}--section--m-sticky-top--ZIndex: var(--pf-t--global--z-index--md);
@@ -137,8 +136,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   background-color: var(--#{$page}--BackgroundColor);
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {
-    --#{$page}__sidebar--Width: var(--#{$page}__sidebar--xl--Width);
-    --#{$page}--section--m-limit-width--MaxWidth: var(--#{$page}--section--m-limit-width--xl--MaxWidth);
+    --#{$page}__sidebar--Width: var(--#{$page}__sidebar--xl--Width); // TODO can remove at breaking change
 
     grid-template-areas:
       "header header"


### PR DESCRIPTION
`.pf-m-limit-width` was not working at XL viewport because there was a calc() involving `auto`. Instead of a calc, I manually set the max-width value for the XL breakpoint. EDIT: in light of #7216, I kept the calc but changed `auto` to be the same width for XL as it was for the other breakpoints. This means the sidebar no longer stretches, and so the items will now wrap properly.

Added the main-subnav page section to the sections that can be width limited.

The `.pf-m-fill` example wasn't showing the effect because `.pf-m-fill` wasn't added to the page main container, so this has been fixed and documented.

The sidebar example didn't have the correct modifier for insets/no inset and the footer section was preventing the fill section from filling.

Changed the selector in the local css to catch the in-page examples that are inline and limit their height so that the examples page isn't super tall.

[Page examples](https://patternfly-pr-7224.surge.sh/components/page)

Fixes #6801 
Fixes #7216
