### PR TITLE
feat(Nav): animation on nav

### DIFF
--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -37,6 +37,9 @@
     font-weight: var(--pf-t--global--font--weight--body--default);
     line-height: var(--pf-t--global--font--line-height--body);
     color: var(--pf-t--global--text--color--regular);
+    // stylelint-disable property-no-unknown
+    interpolate-size: allow-keywords; 
+    // stylelint-enable property-no-unknown
   }
 
   :where(

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,13 +30,13 @@
   --#{$nav}__item--ScrollSnapAlign: end;
 
   // Nav list animation variables
-  --#{$nav}__list--opacity--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$nav}__list--opacity--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__list--transform--TransitionDuration: 0s; // no slide by default
-  --#{$nav}__list--transform--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--TransitionDuration--transform: 0s; // no slide by default
+  --#{$nav}__list--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__list--transform--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__list--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav section title
@@ -80,11 +80,11 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
-  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -212,7 +212,7 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--opacity--TransitionDuration) var(--#{$nav}__list--opacity--TransitionTimingFunction), transform var(--#{$nav}__list--transform--TransitionDuration) var(--#{$nav}__list--transform--TransitionTimingFunction);
+  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
   transform: translateY(0); 
 
 }
@@ -225,7 +225,7 @@
   max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--max-height--TransitionDuration) var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
+  transition: max-height var(--#{$nav}__subnav--TransitionDuration--max-height) var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
 
   // transition-behavior: allow-discrete;
   // border: 1px solid blue;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,6 +29,16 @@
   --#{$nav}__list--ScrollSnapType: var(--#{$nav}__list--ScrollSnapTypeAxis) var(--#{$nav}__list--ScrollSnapTypeStrictness);
   --#{$nav}__item--ScrollSnapAlign: end;
 
+  // Nav list animation variables
+  --#{$nav}__list--opacity--Duration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--opacity--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--transform--Duration: 0s; // no slide by default
+  --#{$nav}__list--transform--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  @media ( prefers-reduced-motion: no-preference ) {
+    --#{$nav}__list--transform--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+  }
+
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
@@ -41,6 +51,7 @@
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
+  --#{$nav}__item__toggle-icon--Duration: var(--pf-t--global--motion--duration--icon--default);
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -54,6 +65,14 @@
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
 
+  // background color transition on hover
+  --#{$nav}__link--background-color--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__link--background-color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  // text color transition for current
+  --#{$nav}__link--m-current--color--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$nav}__link--m-current--color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  
   // * Nav link icon
   --#{$nav}__link-icon--Color: var(--pf-t--global--icon--color--subtle);
   --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -61,6 +80,12 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$nav}__subnav--max-height--Duration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  @media ( prefers-reduced-motion: no-preference ) {
+    --#{$nav}__subnav--max-height--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+  }
 
   // * Nav scroll button
   --#{$nav}__scroll-button--BorderColor: var(--pf-t--global--border--color--default);
@@ -96,6 +121,10 @@
   --#{$nav}--m-horizontal--m-subnav__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+
+  // horizontal - background color transition on hover
+  --#{$nav}__link--m-horizontal--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$nav}__link--m-horizontal--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 }
 
 // - Nav display - default to grid
@@ -158,7 +187,14 @@
 }
 
 [class^="#{$nav}"][hidden] {
-  display: none;
+  // display: none;
+  // border: 1px solid red;
+  max-height: 0;
+
+  & .#{$nav}__list {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
 }
 
 // Magic value calcs
@@ -175,13 +211,24 @@
 .#{$nav}__list {
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
+  opacity: 1;
+  transition: opacity var(--#{$nav}__list--opacity--Duration) var(--#{$nav}__list--opacity--TimingFunction), transform var(--#{$nav}__list--transform--Duration) var(--#{$nav}__list--transform--TimingFunction);
+  transform: translateY(0); 
+
 }
 
 // - Nav subnav
 .#{$nav}__subnav {
   --#{$nav}__list--RowGap: var(--#{$nav}__subnav--RowGap); // this value is passed to --#{$nav}__item--RowGap--row-offset and updates clickable area based on value passed
 
+  height: auto;
+  max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
+  overflow-y: clip;
+  transition: max-height var(--#{$nav}__subnav--max-height--Duration) var(--#{$nav}__subnav--max-height--TimingFunction);
+
+  // transition-behavior: allow-discrete;
+  // border: 1px solid blue;
 }
 
 // - Nav item
@@ -237,6 +284,9 @@
   background-color: var(--#{$nav}__link--BackgroundColor);
   border: none;
   border-radius: var(--#{$nav}__link--BorderRadius);
+  transition: 
+    background-color var(--#{$nav}__link--background-color--TransitionDuration) var(--#{$nav}__link--background-color--TransitionTimingFunction),
+    color var(--#{$nav}__link--m-current--color--TransitionDuration) var(--#{$nav}__link--m-current--color--TransitionTimingFunction);
 
   // increase height clickable area of expanded nav_links to account for
   &[aria-expanded="true"]::before {
@@ -278,6 +328,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
+  transition: transform var(--#{$nav}__item__toggle-icon--Duration);
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,13 +30,13 @@
   --#{$nav}__item--ScrollSnapAlign: end;
 
   // Nav list animation variables
-  --#{$nav}__list--opacity--Duration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$nav}__list--opacity--TimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__list--transform--Duration: 0s; // no slide by default
-  --#{$nav}__list--transform--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--opacity--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--opacity--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--transform--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__list--transform--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__list--transform--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__list--transform--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav section title
@@ -51,7 +51,7 @@
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
-  --#{$nav}__item__toggle-icon--Duration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$nav}__item__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -80,11 +80,11 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--max-height--Duration: 0s; // no slide by default
-  --#{$nav}__subnav--max-height--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--max-height--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -212,7 +212,7 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--opacity--Duration) var(--#{$nav}__list--opacity--TimingFunction), transform var(--#{$nav}__list--transform--Duration) var(--#{$nav}__list--transform--TimingFunction);
+  transition: opacity var(--#{$nav}__list--opacity--TransitionDuration) var(--#{$nav}__list--opacity--TransitionTimingFunction), transform var(--#{$nav}__list--transform--TransitionDuration) var(--#{$nav}__list--transform--TransitionTimingFunction);
   transform: translateY(0); 
 
 }
@@ -225,7 +225,7 @@
   max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--max-height--Duration) var(--#{$nav}__subnav--max-height--TimingFunction);
+  transition: max-height var(--#{$nav}__subnav--max-height--TransitionDuration) var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
 
   // transition-behavior: allow-discrete;
   // border: 1px solid blue;
@@ -328,7 +328,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
-  transition: transform var(--#{$nav}__item__toggle-icon--Duration);
+  transition: transform var(--#{$nav}__item__toggle-icon--TransitionDuration);
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -78,13 +78,14 @@
   --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Nav subnav
+  --#{$nav}__subnav--MaxHeight: fit-content;  
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
-  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -187,8 +188,7 @@
 }
 
 [class^="#{$nav}"][hidden] {
-  // display: none;
-  // border: 1px solid red;
+  display: none;
   max-height: 0;
 
   & .#{$nav}__list {
@@ -212,23 +212,34 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
-  transform: translateY(0); 
 
+  // transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
+
+  // add display for the __list
+  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform), display var(--#{$nav}__list--TransitionDuration--opacity) allow-discrete;
+  transform: translateY(0);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
 }
 
 // - Nav subnav
 .#{$nav}__subnav {
   --#{$nav}__list--RowGap: var(--#{$nav}__subnav--RowGap); // this value is passed to --#{$nav}__item--RowGap--row-offset and updates clickable area based on value passed
 
-  height: auto;
-  max-height: 100dvh;
+  max-height: var(--#{$nav}__subnav--MaxHeight, fit-content); // This can be set in React to the proper height until allow-discrete, i.e. transition to auto, is fully supported
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--TransitionDuration--max-height) var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
-
-  // transition-behavior: allow-discrete;
-  // border: 1px solid blue;
+  transition-timing-function: var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
+  transition-duration: var(--#{$nav}__subnav--max-height--TransitionDuration);
+  transition-property: max-height, display;
+  transition-behavior: allow-discrete; // should allow transitions during show/hide 
+  
+  @starting-style {
+    max-height: 0;
+  }
 }
 
 // - Nav item


### PR DESCRIPTION
Initial animation including:
- hover on nav items transitions background color
- select nav items transitions text color
- expand/collapse slide the sub menu (with reduced motion just fades it)
- caret rotates

Not yet: drill down menus

Figma reference: https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/UR1JfYwpZI6MP3rLj18iJ3/PatternFly-6%3A-Components?m=auto&node-id=3-35&t=PQCNAH226TGUdUfd-1