### PR TITLE
fix(table): targeted control-row sort button margining

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -343,18 +343,20 @@
     // First child padding left
     &:first-child {
       padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
-
-      .#{$table}__button {
-        margin-inline-start: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineStart)) * -1);
-      }
     }
 
     // Last child padding right
     &:last-child {
       padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
+    }
 
-      .#{$table}__button {
-        margin-inline-end: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineend)) * -1);
+    &.#{$table}__sort {
+      &:first-child .#{$table}__button {
+        margin-inline-start: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineStart)) * -1);
+      }
+
+      &:last-child .#{$table}__button {
+        margin-inline-end: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineEnd)) * -1);
       }
     }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1057,6 +1057,7 @@
     margin-block-start: calc(var(--#{$table}__button--PaddingBlockStart) * -1);
     margin-block-end: 0;
   }
+
   // TODO: make this a class `compound expansion content`
   .#{$table}__control-row ~ .#{$table}__expandable-row.pf-m-expanded {
     background-color: var(--#{$table}--compound-expansion--m-expanded--BackgroundColor);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -767,28 +767,22 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__check--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__check--PaddingInlineEnd);
 
-  .#{$check} {
-    --#{$check}__label--FontSize: var(--#{$table}--cell--FontSize);
-    --#{$check}__label--LineHeight: var(--#{$table}--cell--LineHeight);
-  }
-
-  .#{$radio} {
-    --#{$radio}__label--FontSize: var(--#{$table}--cell--FontSize);
-    --#{$radio}__label--LineHeight: var(--#{$table}--cell--LineHeight);
-  }
-
-  thead & {
-    vertical-align: bottom;
-  }
-
   .#{$check}.pf-m-standalone,
   .#{$radio}.pf-m-standalone {
-    --#{$check}--m-standalone--MinHeight: var(--#{$table}--LineHeight);
+    min-height: var(--#{$table}--LineHeight);
+    line-height: 1;
 
-    vertical-align: top;
-
-    .#{$check}__input {
+    .#{$check}__input,
+    .#{$radio}__input {
       align-self: normal;
+    }
+
+    .#{$table}__thead & {
+      vertical-align: bottom;
+    }
+
+    .#{$table}__tbody & {
+      vertical-align: top;
     }
   }
 }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -4,6 +4,7 @@
 // TODO: update grouping comments to // * Table {element}
 
 @include pf-root($table) {
+  --#{$table}--LineHeight: calc(var(--pf-t--global--font--line-height--body) * var(--pf-t--global--font--size--body--default));
   --#{$table}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$table}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$table}--border-width--base: var(--pf-t--global--border--width--divider--default);
@@ -331,7 +332,7 @@
     overflow: var(--#{$table}--cell--Overflow);
     font-size: var(--#{$table}--cell--FontSize);
     font-weight: var(--#{$table}--cell--FontWeight);
-    line-height: var(--#{$table}--cell--LineHeight);
+    line-height: var(--#{$table}--LineHeight); // because standard buttons are allowed in table th/td cells, line-height must remain consistent with default values to ensure proper vertical alignment
     color: var(--#{$table}--cell--Color);
     text-overflow: var(--#{$table}--cell--TextOverflow);
     word-break: var(--#{$table}--cell--WordBreak);
@@ -636,7 +637,6 @@
   padding-block-end: var(--#{$table}__button--PaddingBlockEnd);
   padding-inline-start: var(--#{$table}__button--PaddingInlineStart);
   padding-inline-end: var(--#{$table}__button--PaddingInlineEnd);
-  margin-block-end: calc(var(--#{$table}__button--PaddingBlockEnd) * -1);
   margin-inline-start: calc(var(--#{$table}__button--PaddingInlineStart) * -1);
   font-size: inherit;
   font-weight: inherit;
@@ -649,9 +649,20 @@
   border-radius: var(--#{$table}__button--BorderRadius);
   outline-offset: var(--#{$table}__button--OutlineOffset);
 
+  // Table table table button
+  .#{$table} .#{$table} & {
+    margin-block-end: 0; // remove offset in nested tables
+  }
+
   &:is(:hover, :focus) {
     color: var(--#{$table}__button--hover--Color);
   }
+}
+
+// - Table sort - Table compound expansion toggle
+.#{$table} .#{$table}__sort {
+  padding-block-start: calc(var(--#{$table}--cell--PaddingBlockStart) / 2);
+  padding-block-end: calc(var(--#{$table}--cell--PaddingBlockEnd) / 2);
 }
 
 // - Table sort - Table compound expansion toggle
@@ -891,8 +902,6 @@
 
 // - Table sort
 .#{$table}__sort {
-  vertical-align: bottom;
-
   // - Table button
   .#{$table}__button {
     &:is(:hover, :focus) {
@@ -1014,7 +1023,8 @@
   .#{$table}__action,
   .#{$table}__favorite,
   .#{$table}__toggle,
-  .#{$table}__draggable {
+  .#{$table}__draggable,
+  .#{$table}__sort {
     --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
   }
@@ -1048,15 +1058,6 @@
 // - Table tbody
 .#{$table}__tbody {
   vertical-align: top;
-
-  .#{$table}__sort {
-    vertical-align: top;
-  }
-
-  .#{$table}__control-row .#{$table}__sort .#{$table}__button {
-    margin-block-start: calc(var(--#{$table}__button--PaddingBlockStart) * -1);
-    margin-block-end: 0;
-  }
 
   // TODO: make this a class `compound expansion content`
   .#{$table}__control-row ~ .#{$table}__expandable-row.pf-m-expanded {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -649,11 +649,6 @@
   border-radius: var(--#{$table}__button--BorderRadius);
   outline-offset: var(--#{$table}__button--OutlineOffset);
 
-  // Table table table button
-  .#{$table} .#{$table} & {
-    margin-block-end: 0; // remove offset in nested tables
-  }
-
   &:is(:hover, :focus) {
     color: var(--#{$table}__button--hover--Color);
   }
@@ -1054,6 +1049,14 @@
 .#{$table}__tbody {
   vertical-align: top;
 
+  .#{$table}__sort {
+    vertical-align: top;
+  }
+
+  .#{$table}__control-row .#{$table}__sort .#{$table}__button {
+    margin-block-start: calc(var(--#{$table}__button--PaddingBlockStart) * -1);
+    margin-block-end: 0;
+  }
   // TODO: make this a class `compound expansion content`
   .#{$table}__control-row ~ .#{$table}__expandable-row.pf-m-expanded {
     background-color: var(--#{$table}--compound-expansion--m-expanded--BackgroundColor);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -79,8 +79,6 @@
   --#{$table}--cell--hidden-visible--Display: table-cell;
 
   // * Table toggle
-  --#{$table}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
@@ -114,8 +112,12 @@
   --#{$table}__tr--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
 
   // * Table action
-  --#{$table}__action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}--action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}--action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+
+  // * Table action
+  --#{$table}__action--PaddingBlockStart: var(--#{$table}--action--PaddingBlockStart);
+  --#{$table}__action--PaddingBlockEnd: var(--#{$table}--action--PaddingBlockEnd);
   --#{$table}__action--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$table}__action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
@@ -341,11 +343,19 @@
     // First child padding left
     &:first-child {
       padding-inline-start: var(--#{$table}--cell--first-last-child--PaddingInline);
+
+      .#{$table}__button {
+        margin-inline-start: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineStart)) * -1);
+      }
     }
 
     // Last child padding right
     &:last-child {
       padding-inline-end: var(--#{$table}--cell--first-last-child--PaddingInline);
+
+      .#{$table}__button {
+        margin-inline-end: calc((var(--#{$table}--cell--first-last-child--PaddingInline) - var(--#{$table}--cell--PaddingInlineend)) * -1);
+      }
     }
 
     &.pf-m-center {
@@ -637,7 +647,7 @@
   padding-block-end: var(--#{$table}__button--PaddingBlockEnd);
   padding-inline-start: var(--#{$table}__button--PaddingInlineStart);
   padding-inline-end: var(--#{$table}__button--PaddingInlineEnd);
-  margin-inline-start: calc(var(--#{$table}__button--PaddingInlineStart) * -1);
+  margin-inline-start: calc((var(--#{$table}__button--PaddingInlineStart) - var(--#{$table}--cell--PaddingInlineStart)) * -1);
   font-size: inherit;
   font-weight: inherit;
   color: var(--#{$table}__button--Color);
@@ -657,12 +667,6 @@
   &:is(:hover, :focus) {
     color: var(--#{$table}__button--hover--Color);
   }
-}
-
-// - Table sort - Table compound expansion toggle
-.#{$table} .#{$table}__sort {
-  padding-block-start: calc(var(--#{$table}--cell--PaddingBlockStart) / 2);
-  padding-block-end: calc(var(--#{$table}--cell--PaddingBlockEnd) / 2);
 }
 
 // - Table sort - Table compound expansion toggle
@@ -763,8 +767,6 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__check--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__check--PaddingInlineEnd);
 
-  vertical-align: top;
-
   .#{$check} {
     --#{$check}__label--FontSize: var(--#{$table}--cell--FontSize);
     --#{$check}__label--LineHeight: var(--#{$table}--cell--LineHeight);
@@ -781,11 +783,12 @@
 
   .#{$check}.pf-m-standalone,
   .#{$radio}.pf-m-standalone {
-    thead & {
-      display: table-cell;
-      height: auto;
-      line-height: 1;
-      vertical-align: baseline;
+    --#{$check}--m-standalone--MinHeight: var(--#{$table}--LineHeight);
+
+    vertical-align: top;
+
+    .#{$check}__input {
+      align-self: normal;
     }
   }
 }
@@ -820,11 +823,20 @@
 .#{$table}__action,
 .#{$table}__favorite,
 .#{$table}__inline-edit-action,
-.#{$table}__draggable {
-  --#{$table}--cell--PaddingBlockStart: var(--#{$table}__action--PaddingBlockStart);
-  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}__action--PaddingBlockEnd);
+.#{$table}__draggable,
+.#{$table}__sort {
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__action--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__action--PaddingInlineEnd);
+}
+
+.#{$table}__action,
+.#{$table}__favorite,
+.#{$table}__inline-edit-action,
+.#{$table}__draggable,
+.#{$table}__toggle,
+.#{$table}__sort {
+  --#{$table}--cell--PaddingBlockStart: var(--#{$table}--action--PaddingBlockStart);
+  --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--action--PaddingBlockEnd);
 }
 
 // - Table action - Table inline edit action

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -43,7 +43,7 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
   --#{$table}--cell--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$table}--cell--FontWeight: var(--pf-t--global--font--weight--body--default);
-  --#{$table}--cell--LineHeight: var(--pf-t--global--font--line-height--body);
+  --#{$table}--cell--LineHeight: var(--#{$table}--LineHeight);
   --#{$table}--cell--Color: var(--pf-t--global--text--color--regular);
   --#{$table}--cell--first-last-child--PaddingInline: var(--pf-t--global--spacer--inset--page-chrome);
   --#{$table}__tr--m-first-cell-offset-reset--cell--PaddingInlineStart: var(--#{$table}--cell--Padding--base);
@@ -1014,6 +1014,8 @@
 .#{$table}.pf-m-compact {
   --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact--cell--PaddingBlockStart);
   --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact--cell--PaddingBlockEnd);
+  --#{$table}__button--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
+  --#{$table}__button--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
 
   // - Table compact table tr
   tr:where(.#{$table}__tr) {
@@ -1034,8 +1036,9 @@
 
   .#{$table}__action,
   .#{$table}__favorite,
-  .#{$table}__toggle,
+  .#{$table}__inline-edit-action,
   .#{$table}__draggable,
+  .#{$table}__toggle,
   .#{$table}__sort {
     --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);


### PR DESCRIPTION
closes #7220 

TLDR: Issue is being caused by table sort vertical alignment (should be `vertical-align: top`) in tbody and negative margining. 

[Backstop report](https://drive.google.com/file/d/1vVn1BdRJeiG6sThWNFXL42A-GS9PCUNj/view?usp=sharing)

Because tables may contain elements with varying `line-height`/`font-size`, all `th/td` cells, whether in `thead` or `tbody` require a consistent and explicit `line-height` to properly align vertically. 