### PR TITLE
fix(table): isolated sort button negative margins to thead

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -406,6 +406,10 @@
     --#{$table}--cell--TextOverflow: ellipsis;
     --#{$table}--cell--WhiteSpace: nowrap;
 
+    .#{$table}__sort .#{$table}__button {
+      margin-block-end: calc(var(--#{$table}__button--PaddingBlockEnd) * -1);
+    }
+
     // stylelint-disable
     &.pf-m-nested-column-header {
       button:where(.#{$button}) {


### PR DESCRIPTION
Closes #7220 

Quick fix for table sort buttons in nested tables. Eventually we'll need to address the issues detailed in #7244 and #7050, but this will solve our immediate issue. 