### PR TITLE
fix(form): remove broken label selection pseudo style

### DIFF
--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -261,10 +261,6 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   font-size: var(--#{$form}__label--FontSize);
   line-height: var(--#{$form}__label--LineHeight);
 
-  &::selection {
-    background-color: none;
-  }
-
   &:not(.pf-m-disabled):hover {
     cursor: var(--#{$form}__label--hover--Cursor);
   }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7293

This rule has been in the stylesheet since the component was created. The comment when it was added was to hide the label selection on click, but I don't see that as an issue in any of the browsers we support, and we probably want the default behavior anyways.