### PR TITLE
docs(badge): poc typescript examples

### DIFF
--- a/src/patternfly/components/Badge/examples/Badge.md
+++ b/src/patternfly/components/Badge/examples/Badge.md
@@ -6,39 +6,67 @@ cssPrefix: pf-v6-c-badge
 
 ## Examples
 ### Read
-```hbs
-{{#> badge badge--modifier="pf-m-read"}}
-  7
-{{/badge}}
-{{#> badge badge--modifier="pf-m-read"}}
-  24
-{{/badge}}
-{{#> badge badge--modifier="pf-m-read"}}
-  240
-{{/badge}}
-{{#> badge badge--modifier="pf-m-read"}}
-  999+
-{{/badge}}
+```ts
+interface CoreBadgeProps {
+  className: string;
+  children: React.ReactNode;
+  screenReaderText: string;
+}
+
+const CoreBadge: React.FunctionComponent<CoreBadgeProps> = ({
+  className,
+  children,
+  screenReaderText
+}: CoreBadgeProps) => (
+  <span className={`pf-v6-c-badge ${className}`}>
+    {children}
+    {screenReaderText && <span className="pf-v6-screen-reader">{screenReaderText}</span>}
+  </span>
+);
+
+const readExample = () => {
+  const readValues = ['7', '21', '245', '999+'];
+  return (
+    <>
+      {readValues.map((value, index) => (
+        <CoreBadge className="pf-m-read" key={index}>{value}</CoreBadge>
+      ))}
+    </>
+  )
+}
 ```
 
 ### Unread
-```hbs
-{{#> badge badge--modifier="pf-m-unread"}}
-  7
-  {{#> screen-reader}}unread messages{{/screen-reader}}
-{{/badge}}
-{{#> badge badge--modifier="pf-m-unread"}}
-  24
-  {{#> screen-reader}}unread messages{{/screen-reader}}
-{{/badge}}
-{{#> badge badge--modifier="pf-m-unread"}}
-  240
-  {{#> screen-reader}}unread messages{{/screen-reader}}
-{{/badge}}
-{{#> badge badge--modifier="pf-m-unread"}}
-  999+
-  {{#> screen-reader}}unread messages{{/screen-reader}}
-{{/badge}}
+```ts
+interface CoreBadgeProps {
+  className: string;
+  children: React.ReactNode;
+  screenReaderText: string;
+}
+
+const CoreBadge: React.FunctionComponent<CoreBadgeProps> = ({
+  className,
+  children,
+  screenReaderText
+}: CoreBadgeProps) => (
+  <span className={`pf-v6-c-badge ${className}`}>
+    {children}
+    {screenReaderText && <span className="pf-v6-screen-reader">{screenReaderText}</span>}
+  </span>
+);
+
+const unreadExample = () => {
+  const unReadValues = ['7', '21', '245', '999+'];
+  return (
+    <>
+      {unReadValues.map((value, index) => (
+        <CoreBadge className="pf-m-unread" key={index} screenReaderText="unread messages">
+          {value}
+        </CoreBadge>
+      ))}
+    </>
+  )
+}
 ```
 
 ### Disabled


### PR DESCRIPTION
There is not currently any typescript compiling happening in the core workspace, so I cannot put the component definitions which could replace the handlebars into their own typescript files.

https://patternfly-pr-7309.surge.sh/components/badge (the first two examples are built using typescript, the last is still using handlebars.

ideally, the following snippet would live in a `CoreBadge.tsx` file which the markdown snippets could import and use over and over. 
```
interface CoreBadgeProps {
  className: string;
  children: React.ReactNode;
  screenReaderText: string;
}

const CoreBadge: React.FunctionComponent<CoreBadgeProps> = ({
  className,
  children,
  screenReaderText
}: CoreBadgeProps) => (
  <span className={`pf-v6-c-badge ${className}`}>
    {children}
    {screenReaderText && <span className="pf-v6-screen-reader">{screenReaderText}</span>}
  </span>
);
```

Then the `Read` badge example could only be the following:
```
const readExample = () => {
  const readValues = ['7', '21', '245', '999+'];
  return (
    <>
      {readValues.map((value, index) => (
        <CoreBadge className="pf-m-read" key={index}>{value}</CoreBadge>
      ))}
    </>
  )
}
```

some possible questions to answer, remaining hurdles:

- importing a `Badge` component will default to import PF-react's Badge component proper. That's why I named it `CoreBadge` in this case.
- In order to be able to reuse the typescript components, we would need to set up typescript compiling.
- the code editor is not displaying the html, because the documentation framework is not  expecting to turn typescript into html - it is handling the typescript example like it's coming from the react docs, so that'd require a tweak. We could update the `compileMD` gulp script to compile the typescript into html and possibly avoid a change to the docs-framework. That'd be probably the next thing to investigate.