### PR TITLE
feat(nav): animate expandable nav items

### DIFF
--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -37,6 +37,9 @@
     font-weight: var(--pf-t--global--font--weight--body--default);
     line-height: var(--pf-t--global--font--line-height--body);
     color: var(--pf-t--global--text--color--regular);
+    // stylelint-disable property-no-unknown
+    interpolate-size: allow-keywords; 
+    // stylelint-enable property-no-unknown
   }
 
   :where(

--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -37,9 +37,6 @@
     font-weight: var(--pf-t--global--font--weight--body--default);
     line-height: var(--pf-t--global--font--line-height--body);
     color: var(--pf-t--global--text--color--regular);
-    // stylelint-disable property-no-unknown
-    interpolate-size: allow-keywords; 
-    // stylelint-enable property-no-unknown
   }
 
   :where(

--- a/src/patternfly/components/Nav/nav-subnav.hbs
+++ b/src/patternfly/components/Nav/nav-subnav.hbs
@@ -1,6 +1,6 @@
 <section class="{{pfv}}nav__subnav{{#if nav-subnav--modifier}} {{nav-subnav--modifier}}{{/if}}"
   aria-labelledby="{{ternary nav-subnav--aria-labelledby nav-subnav--aria-labelledby nav-item--id}}"
-  {{ternary nav-item--IsExpanded '' 'hidden'}}
+  {{ternary nav-item--IsExpanded '' 'hidden inert'}}
   {{#if nav-subnav--attribute}}
     {{{nav-subnav--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -82,8 +82,8 @@
 
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
-  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__subnav--RowGap);
-  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__subnav--RowGap);
+  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
+  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
   --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
@@ -180,7 +180,7 @@
       .#{$menu}__list {
         row-gap: var(--#{$nav}__subnav--RowGap);
       }
-    
+
       .#{$menu}__list-item::before {
         border-radius: var(--#{$nav}__link--BorderRadius);
       }
@@ -233,7 +233,7 @@
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
-  transition-property: grid-template-rows, padding-block-start;
+  transition-property: grid-template-rows, padding-block-start, padding-block-end;
   
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
@@ -252,16 +252,11 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &.pf-m-expanded:is(:not(:only-child, :last-child)) {
-    + .#{$nav}__item > .#{$nav}__link::before {
-      inset-block-start: calc(var(--#{$nav}__item--RowGap) * -1 - var(--#{$nav}__list--RowGap));
-    }
+  &:is(:only-child, :last-child) {
+    --#{$nav}__subnav--PaddingBlockEnd: 0;
   }
 
   &.pf-m-expanded { 
-    --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
-    --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
-
     // duration for collapsing needs to set the property rather than the variable because of nested items
     transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap);
   }
@@ -305,11 +300,6 @@
   transition-timing-function: var(--#{$nav}__link--TransitionTimingFunction--background-color), var(--#{$nav}__link--m-current--TransitionTimingFunction--color);
   transition-duration: var(--#{$nav}__link--TransitionDuration--background-color), var(--#{$nav}__link--m-current--TransitionDuration--color);
   transition-property: background-color, color;
-
-  // increase height clickable area of expanded nav_links to account for
-  &[aria-expanded="true"]::before {
-    inset-block-end: calc(var(--#{$nav}__item--RowGap) * -1);
-  }
 
   // explicitly set background-color prop to avoid affecting child elements settings
   &:hover,

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,13 +30,13 @@
   --#{$nav}__item--ScrollSnapAlign: end;
 
   // Nav list animation variables
-  --#{$nav}__list--opacity--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$nav}__list--opacity--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__list--transform--TransitionDuration: 0s; // no slide by default
-  --#{$nav}__list--transform--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--TransitionDuration--transform: 0s; // no slide by default
+  --#{$nav}__list--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__list--transform--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__list--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav section title
@@ -80,11 +80,11 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
-  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -212,7 +212,7 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--opacity--TransitionDuration) var(--#{$nav}__list--opacity--TransitionTimingFunction), transform var(--#{$nav}__list--transform--TransitionDuration) var(--#{$nav}__list--transform--TransitionTimingFunction);
+  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
   transform: translateY(0); 
 
 }
@@ -225,7 +225,7 @@
   max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--max-height--TransitionDuration) var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
+  transition: max-height var(--#{$nav}__subnav--TransitionDuration--max-height) var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
 
   // transition-behavior: allow-discrete;
   // border: 1px solid blue;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,6 +29,16 @@
   --#{$nav}__list--ScrollSnapType: var(--#{$nav}__list--ScrollSnapTypeAxis) var(--#{$nav}__list--ScrollSnapTypeStrictness);
   --#{$nav}__item--ScrollSnapAlign: end;
 
+  // Nav list animation variables
+  --#{$nav}__list--opacity--Duration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--opacity--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--transform--Duration: 0s; // no slide by default
+  --#{$nav}__list--transform--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  @media ( prefers-reduced-motion: no-preference ) {
+    --#{$nav}__list--transform--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+  }
+
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
@@ -41,6 +51,7 @@
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
+  --#{$nav}__item__toggle-icon--Duration: var(--pf-t--global--motion--duration--icon--default);
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -54,6 +65,14 @@
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
 
+  // background color transition on hover
+  --#{$nav}__link--background-color--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__link--background-color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  // text color transition for current
+  --#{$nav}__link--m-current--color--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$nav}__link--m-current--color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  
   // * Nav link icon
   --#{$nav}__link-icon--Color: var(--pf-t--global--icon--color--subtle);
   --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -61,6 +80,12 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
+  --#{$nav}__subnav--max-height--Duration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  @media ( prefers-reduced-motion: no-preference ) {
+    --#{$nav}__subnav--max-height--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+  }
 
   // * Nav scroll button
   --#{$nav}__scroll-button--BorderColor: var(--pf-t--global--border--color--default);
@@ -96,6 +121,10 @@
   --#{$nav}--m-horizontal--m-subnav__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+
+  // horizontal - background color transition on hover
+  --#{$nav}__link--m-horizontal--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$nav}__link--m-horizontal--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 }
 
 // - Nav display - default to grid
@@ -158,7 +187,14 @@
 }
 
 [class^="#{$nav}"][hidden] {
-  display: none;
+  // display: none;
+  // border: 1px solid red;
+  max-height: 0;
+
+  & .#{$nav}__list {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
 }
 
 // Magic value calcs
@@ -175,13 +211,24 @@
 .#{$nav}__list {
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
+  opacity: 1;
+  transition: opacity var(--#{$nav}__list--opacity--Duration) var(--#{$nav}__list--opacity--TimingFunction), transform var(--#{$nav}__list--transform--Duration) var(--#{$nav}__list--transform--TimingFunction);
+  transform: translateY(0); 
+
 }
 
 // - Nav subnav
 .#{$nav}__subnav {
   --#{$nav}__list--RowGap: var(--#{$nav}__subnav--RowGap); // this value is passed to --#{$nav}__item--RowGap--row-offset and updates clickable area based on value passed
 
+  height: auto;
+  max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
+  overflow-y: clip;
+  transition: max-height var(--#{$nav}__subnav--max-height--Duration) var(--#{$nav}__subnav--max-height--TimingFunction);
+
+  // transition-behavior: allow-discrete;
+  // border: 1px solid blue;
 }
 
 // - Nav item
@@ -237,6 +284,9 @@
   background-color: var(--#{$nav}__link--BackgroundColor);
   border: none;
   border-radius: var(--#{$nav}__link--BorderRadius);
+  transition: 
+    background-color var(--#{$nav}__link--background-color--TransitionDuration) var(--#{$nav}__link--background-color--TransitionTimingFunction),
+    color var(--#{$nav}__link--m-current--color--TransitionDuration) var(--#{$nav}__link--m-current--color--TransitionTimingFunction);
 
   // increase height clickable area of expanded nav_links to account for
   &[aria-expanded="true"]::before {
@@ -278,6 +328,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
+  transition: transform var(--#{$nav}__item__toggle-icon--Duration);
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -39,7 +39,6 @@
 
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
-  --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
 
   // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
@@ -76,15 +75,13 @@
   --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap); // needed to keep focus outline on first item from being cut off
   --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap); // needed to keep focus outline on last item from being cut off
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
-  --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
-  --#{$nav}__subnav--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
-  --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__subnav--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--expansion: 0s; // no slide by default
+  --#{$nav}__subnav--hidden--TransitionDuration--expansion: 0;
+  --#{$nav}__subnav--TransitionTimingFunction--expansion: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
-    --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
+    --#{$nav}__subnav--TransitionDuration--expansion: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--hidden--TransitionDuration--expansion: var(--pf-t--global--motion--duration--slide-in--short);
   }
 
   // * Nav scroll button
@@ -215,15 +212,14 @@
   padding-block-end: var(--#{$nav}__subnav--PaddingBlockEnd);
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--opacity);
-  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--opacity);
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--expansion);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--expansion);
   transition-property: grid-template-rows, padding-block-start, padding-block-end, opacity;
   
   &[hidden] {
-    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
+    --#{$nav}__subnav--TransitionDuration--expansion: var(--#{$nav}__subnav--hidden--TransitionDuration--expansion);
     --#{$nav}__subnav--PaddingBlockStart: 0;
     --#{$nav}__subnav--PaddingBlockEnd: 0;
-    --#{$nav}__subnav--TransitionDuration--opacity: var(--#{$nav}__subnav--hidden--TransitionDuration--opacity);
 
     grid-template-rows: 0fr;
     opacity: 0;
@@ -242,11 +238,6 @@
     > .#{$nav}__subnav {
       margin-block-end: calc(var(--#{$nav}__subnav--PaddingBlockEnd) * -1); // offset bottom padding
     }
-  }
-
-  &.pf-m-expanded { 
-    // duration for collapsing needs to set the property rather than the variable because of nested items
-    transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -46,7 +46,7 @@
   --#{$nav}__item--TransitionDuration: 0;
   --#{$nav}__item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
-  @media ( prefers-reduced-motion: no-preference ) {
+  @media (prefers-reduced-motion: no-preference) {
     --#{$nav}__item--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
@@ -69,12 +69,12 @@
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
 
   // background color transition on hover
-  --#{$nav}__link--background-color--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$nav}__link--background-color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__link--TransitionTimingFunction--background-color: var(--pf-t--global--motion--timing-function--default);
 
   // text color transition for current
-  --#{$nav}__link--m-current--color--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
-  --#{$nav}__link--m-current--color--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__link--m-current--TransitionDuration--color: var(--pf-t--global--motion--duration--fade--short);
+  --#{$nav}__link--m-current--TransitionTimingFunction--color: var(--pf-t--global--motion--timing-function--default);
   
   // * Nav link icon
   --#{$nav}__link-icon--Color: var(--pf-t--global--icon--color--subtle);
@@ -84,11 +84,11 @@
   --#{$nav}__subnav--MaxHeight: fit-content;  
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
-  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -228,8 +228,8 @@
   min-height: 0;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
-  transition-duration: var(--#{$nav}__subnav--max-height--TransitionDuration);
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--max-height);
   transition-property: grid-template-rows, display;
   transition-behavior: allow-discrete; 
   
@@ -265,7 +265,7 @@
   }
 
   &.pf-m-expanded {
-    row-gap: var(--#{$nav}__item--RowGap); // no fallback here as this value is used to calc clickable offsets
+    row-gap: var(--#{$nav}__item--RowGap);
   }
 }
 
@@ -304,9 +304,9 @@
   background-color: var(--#{$nav}__link--BackgroundColor);
   border: none;
   border-radius: var(--#{$nav}__link--BorderRadius);
-  transition-timing-function: var(--#{$nav}__link--background-color--TransitionTimingFunction), var(--#{$nav}__link--m-current--color--TransitionTimingFunction);
-  transition-duration: var(--#{$nav}__link--background-color--TransitionDuration), var(--#{$nav}__link--m-current--color--TransitionDuration);
-  transition-property: background-color color;
+  transition-timing-function: var(--#{$nav}__link--TransitionTimingFunction--background-color), var(--#{$nav}__link--m-current--TransitionTimingFunction--color);
+  transition-duration: var(--#{$nav}__link--TransitionDuration--background-color), var(--#{$nav}__link--m-current--TransitionDuration--color);
+  transition-property: background-color, color;
 
   // increase height clickable area of expanded nav_links to account for
   &[aria-expanded="true"]::before {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -32,8 +32,8 @@
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
-  --#{$nav}__section-title--PaddingBlockStart: var(--#{$nav}__link--PaddingBlockStart);
-  --#{$nav}__section-title--PaddingBlockEnd: var(--#{$nav}__link--PaddingBlockEnd);
+  --#{$nav}__section-title--PaddingBlockStart: 0;
+  --#{$nav}__section-title--PaddingBlockEnd: 0;
   --#{$nav}__section-title--PaddingInlineStart: var(--#{$nav}__link--PaddingInlineStart);
   --#{$nav}__section-title--PaddingInlineEnd: var(--#{$nav}__link--PaddingInlineEnd);
 
@@ -73,8 +73,8 @@
 
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
-  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
-  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
+  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap); // needed to keep focus outline on first item from being cut off
+  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap); // needed to keep focus outline on last item from being cut off
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
   --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
@@ -238,8 +238,10 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &:last-child {
-    --#{$nav}__subnav--PaddingBlockEnd: 0;
+  &.pf-m-expanded:last-child {
+    > .#{$nav}__subnav {
+      margin-block-end: calc(var(--#{$nav}__subnav--PaddingBlockEnd) * -1); // offset bottom padding
+    }
   }
 
   &.pf-m-expanded { 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,13 +30,13 @@
   --#{$nav}__item--ScrollSnapAlign: end;
 
   // Nav list animation variables
-  --#{$nav}__list--opacity--Duration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$nav}__list--opacity--TimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__list--transform--Duration: 0s; // no slide by default
-  --#{$nav}__list--transform--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--opacity--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--opacity--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__list--transform--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__list--transform--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__list--transform--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__list--transform--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav section title
@@ -51,7 +51,7 @@
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
-  --#{$nav}__item__toggle-icon--Duration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$nav}__item__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -80,11 +80,11 @@
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--max-height--Duration: 0s; // no slide by default
-  --#{$nav}__subnav--max-height--TimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--max-height--Duration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -212,7 +212,7 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--opacity--Duration) var(--#{$nav}__list--opacity--TimingFunction), transform var(--#{$nav}__list--transform--Duration) var(--#{$nav}__list--transform--TimingFunction);
+  transition: opacity var(--#{$nav}__list--opacity--TransitionDuration) var(--#{$nav}__list--opacity--TransitionTimingFunction), transform var(--#{$nav}__list--transform--TransitionDuration) var(--#{$nav}__list--transform--TransitionTimingFunction);
   transform: translateY(0); 
 
 }
@@ -225,7 +225,7 @@
   max-height: 100dvh;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--max-height--Duration) var(--#{$nav}__subnav--max-height--TimingFunction);
+  transition: max-height var(--#{$nav}__subnav--max-height--TransitionDuration) var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
 
   // transition-behavior: allow-discrete;
   // border: 1px solid blue;
@@ -328,7 +328,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
-  transition: transform var(--#{$nav}__item__toggle-icon--Duration);
+  transition: transform var(--#{$nav}__item__toggle-icon--TransitionDuration);
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -30,7 +30,7 @@
   --#{$nav}__item--ScrollSnapAlign: end;
 
   // Nav list animation variables
-  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
   --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
 
   // * Nav section title
@@ -43,17 +43,17 @@
 
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
-  --#{$nav}__item--TransitionDuration: 0;
-  --#{$nav}__item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__item--TransitionDuration--row-gap: 0;
+  --#{$nav}__item--TransitionTimingFunction--row-gap: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__item--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__item--TransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
-  --#{$nav}__item__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$nav}__item__toggle-icon--TransitionDuration--transform: var(--pf-t--global--motion--duration--icon--default);
 
 
   // * Nav link
@@ -239,7 +239,7 @@
 
   [hidden] {
     --#{$nav}__list--RowGap: 0;
-
+    
     grid-template-rows: 0fr;
   }
 }
@@ -248,8 +248,8 @@
 .#{$nav}__item {
   row-gap: 0; // Only have row-gap when expanded and transition it
   scroll-snap-align: var(--#{$nav}__item--ScrollSnapAlign);
-  transition-timing-function: var(--#{$nav}__item--TransitionTimingFunction);
-  transition-duration: var(--#{$nav}__item--TransitionDuration);
+  transition-timing-function: var(--#{$nav}__item--TransitionTimingFunction--row-gap);
+  transition-duration: var(--#{$nav}__item--TransitionDuration--row-gap);
   transition-property: row-gap;
 
   > .#{$nav}__link[button] {
@@ -348,7 +348,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
-  transition-duration: var(--#{$nav}__item__toggle-icon--TransitionDuration);
+  transition-duration: var(--#{$nav}__item__toggle-icon--TransitionDuration--transform);
   transition-property: transform;
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -44,12 +44,9 @@
 
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
-  --#{$nav}__item--TransitionDuration--row-gap: 0;
   --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
-  --#{$nav}__item--TransitionTimingFunction--row-gap: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__item--TransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--short);
     --#{$nav}__item--m-expandedTransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
@@ -233,11 +230,13 @@
 
   grid-template-rows: 1fr;
   min-height: 0;
+  padding-block-start: 0;
+  padding-block-end: 0;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
-  transition-property: grid-template-rows;
+  transition-property: grid-template-rows, padding-block-start;
   transition-behavior: allow-discrete; 
   
   @starting-style {
@@ -245,7 +244,6 @@
   }
 
   &[hidden] {
-    --#{$nav}__list--RowGap: 0;
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
 
     grid-template-rows: 0fr;
@@ -254,29 +252,26 @@
 
 // - Nav item
 .#{$nav}__item {
-  row-gap: 0; // Only have row-gap when expanded and transition it
   scroll-snap-align: var(--#{$nav}__item--ScrollSnapAlign);
-  transition-timing-function: var(--#{$nav}__item--TransitionTimingFunction--row-gap);
-  transition-duration: var(--#{$nav}__item--TransitionDuration--row-gap);
-  transition-property: row-gap;
 
   > .#{$nav}__link[button] {
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
   &.pf-m-expanded:is(:not(:only-child, :last-child)) {
-    margin-block-end: var(--#{$nav}__item--m-expanded--MarginBlockEnd, var(--#{$nav}__item--RowGap)); // default to row gap if no custom value is set
-
     + .#{$nav}__item > .#{$nav}__link::before {
       inset-block-start: calc(var(--#{$nav}__item--RowGap) * -1 - var(--#{$nav}__list--RowGap));
     }
   }
 
   &.pf-m-expanded {
-    row-gap: var(--#{$nav}__item--RowGap);
-
     // duration for collapsing needs to set the property rather than the variable because of nested items
     transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap); 
+
+    & > .#{$nav}__subnav {
+      padding-block-start: var(--#{$nav}__item--RowGap);
+      padding-block-end: var(--#{$nav}__item--RowGap);
+    }
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -84,15 +84,14 @@
   --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Nav subnav
-  --#{$nav}__subnav--MaxHeight: fit-content;  
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
-  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--default);
-    --#{$nav}__subnav--hidden--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short);
+    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
   }
 
   // * Nav scroll button
@@ -236,8 +235,8 @@
   min-height: 0;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
-  transition-duration: var(--#{$nav}__subnav--TransitionDuration--max-height);
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
   transition-property: grid-template-rows;
   transition-behavior: allow-discrete; 
   
@@ -247,7 +246,7 @@
 
   &[hidden] {
     --#{$nav}__list--RowGap: 0;
-    --#{$nav}__subnav--TransitionDuration--max-height: var(--#{$nav}__subnav--hidden--TransitionDuration--max-height);
+    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
 
     grid-template-rows: 0fr;
   }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -32,12 +32,6 @@
   // Nav list animation variables
   --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--fade--default);
   --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__list--TransitionDuration--transform: 0s; // no slide by default
-  --#{$nav}__list--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--default);
-
-  @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__list--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
-  }
 
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
@@ -47,11 +41,20 @@
   --#{$nav}__section-title--PaddingInlineStart: var(--#{$nav}__link--PaddingInlineStart);
   --#{$nav}__section-title--PaddingInlineEnd: var(--#{$nav}__link--PaddingInlineEnd);
 
-  // * Nav toggle icon
+  // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
+  --#{$nav}__item--TransitionDuration: 0; // var(--pf-t--global--motion--duration--slide-in--default);
+  --#{$nav}__item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
+  @media ( prefers-reduced-motion: no-preference ) {
+    --#{$nav}__item--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
+  }
+
+  // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
   --#{$nav}__item__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -122,10 +125,6 @@
   --#{$nav}--m-horizontal--m-subnav__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}--m-horizontal--m-subnav__link--PaddingInlineEnd: var(--pf-t--global--spacer--md);
-
-  // horizontal - background color transition on hover
-  --#{$nav}__link--m-horizontal--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
-  --#{$nav}__link--m-horizontal--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 }
 
 // - Nav display - default to grid
@@ -189,11 +188,9 @@
 
 [class^="#{$nav}"][hidden] {
   display: none;
-  max-height: 0;
 
   & .#{$nav}__list {
     opacity: 0;
-    transform: translateY(-100%);
   }
 }
 
@@ -211,17 +208,15 @@
 .#{$nav}__list {
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
+  min-height: 0;
   opacity: 1;
-
-  // transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
-
-  // add display for the __list
-  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform), display var(--#{$nav}__list--TransitionDuration--opacity) allow-discrete;
-  transform: translateY(0);
+  transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
+  transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
+  transition-property: opacity, display;
+  transition-behavior: allow-discrete;
 
   @starting-style {
     opacity: 0;
-    transform: translateY(-100%);
   }
 }
 
@@ -229,23 +224,33 @@
 .#{$nav}__subnav {
   --#{$nav}__list--RowGap: var(--#{$nav}__subnav--RowGap); // this value is passed to --#{$nav}__item--RowGap--row-offset and updates clickable area based on value passed
 
-  max-height: var(--#{$nav}__subnav--MaxHeight, fit-content); // This can be set in React to the proper height until allow-discrete, i.e. transition to auto, is fully supported
+  grid-template-rows: 1fr;
+  min-height: 0;
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
   transition-duration: var(--#{$nav}__subnav--max-height--TransitionDuration);
-  transition-property: max-height, display;
-  transition-behavior: allow-discrete; // should allow transitions during show/hide 
+  transition-property: grid-template-rows, display;
+  transition-behavior: allow-discrete; 
   
   @starting-style {
-    max-height: 0;
+    grid-template-rows: 0fr;
+  }
+
+  [hidden] {
+    --#{$nav}__list--RowGap: 0;
+
+    grid-template-rows: 0fr;
   }
 }
 
 // - Nav item
 .#{$nav}__item {
-  row-gap: var(--#{$nav}__item--RowGap); // no fallback here as this value is used to calc clickable offsets
+  row-gap: 0; // Only have row-gap when expanded and transition it
   scroll-snap-align: var(--#{$nav}__item--ScrollSnapAlign);
+  transition-timing-function: var(--#{$nav}__item--TransitionTimingFunction);
+  transition-duration: var(--#{$nav}__item--TransitionDuration);
+  transition-property: row-gap;
 
   > .#{$nav}__link[button] {
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
@@ -257,6 +262,10 @@
     + .#{$nav}__item > .#{$nav}__link::before {
       inset-block-start: calc(var(--#{$nav}__item--RowGap) * -1 - var(--#{$nav}__list--RowGap));
     }
+  }
+
+  &.pf-m-expanded {
+    row-gap: var(--#{$nav}__item--RowGap); // no fallback here as this value is used to calc clickable offsets
   }
 }
 
@@ -295,9 +304,9 @@
   background-color: var(--#{$nav}__link--BackgroundColor);
   border: none;
   border-radius: var(--#{$nav}__link--BorderRadius);
-  transition: 
-    background-color var(--#{$nav}__link--background-color--TransitionDuration) var(--#{$nav}__link--background-color--TransitionTimingFunction),
-    color var(--#{$nav}__link--m-current--color--TransitionDuration) var(--#{$nav}__link--m-current--color--TransitionTimingFunction);
+  transition-timing-function: var(--#{$nav}__link--background-color--TransitionTimingFunction), var(--#{$nav}__link--m-current--color--TransitionTimingFunction);
+  transition-duration: var(--#{$nav}__link--background-color--TransitionDuration), var(--#{$nav}__link--m-current--color--TransitionDuration);
+  transition-property: background-color color;
 
   // increase height clickable area of expanded nav_links to account for
   &[aria-expanded="true"]::before {
@@ -339,7 +348,8 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
-  transition: transform var(--#{$nav}__item__toggle-icon--TransitionDuration);
+  transition-duration: var(--#{$nav}__item__toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -191,7 +191,7 @@
 }
 
 [class^="#{$nav}"][hidden] {
-  display: none;
+  visibility: hidden;
 
   & .#{$nav}__list {
     --#{$nav}__list--TransitionDuration--opacity: var(--#{$nav}__list--hidden--TransitionDuration--opacity);
@@ -208,6 +208,8 @@
   --#{$nav}__item--RowGap--row-offset: calc(var(--#{$nav}__list--RowGap) / 2 * -1); // row gap offset calcs 1/2 height of row gap
   --#{$nav}__link--clickable-inset--Block: var(--#{$nav}__item--RowGap--row-offset); // set link's clickable area offset based on 1/2 row gap
   --#{$nav}__button--RowGap--row-offset: calc(var(--#{$nav}__item--RowGap) * -1); // match extra bottom paddings applied to expanded nav_links
+
+  visibility: visible;
 }
 
 // - Nav list
@@ -218,7 +220,7 @@
   opacity: 1;
   transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
   transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
-  transition-property: opacity, display;
+  transition-property: opacity;
   transition-behavior: allow-discrete;
 
   @starting-style {
@@ -236,7 +238,7 @@
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--max-height);
-  transition-property: grid-template-rows, display;
+  transition-property: grid-template-rows;
   transition-behavior: allow-discrete; 
   
   @starting-style {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -238,7 +238,7 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &:is(:only-child, :last-child) {
+  &:last-child {
     --#{$nav}__subnav--PaddingBlockEnd: 0;
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,11 +29,6 @@
   --#{$nav}__list--ScrollSnapType: var(--#{$nav}__list--ScrollSnapTypeAxis) var(--#{$nav}__list--ScrollSnapTypeStrictness);
   --#{$nav}__item--ScrollSnapAlign: end;
 
-  // Nav list animation variables
-  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
-  --#{$nav}__list--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
-  --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
-
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
@@ -45,10 +40,6 @@
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
-
-  @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__item--m-expandedTransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
-  }
 
   // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
@@ -86,8 +77,11 @@
   --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
+  --#{$nav}__subnav--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
   --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
-  
+  --#{$nav}__subnav--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+
   @media (prefers-reduced-motion: no-preference) {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
     --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
@@ -190,12 +184,6 @@
 
 [class^="#{$nav}"][hidden] {
   visibility: hidden;
-
-  .#{$nav}__list {
-    --#{$nav}__list--TransitionDuration--opacity: var(--#{$nav}__list--hidden--TransitionDuration--opacity);
-
-    opacity: 0;
-  }
 }
 
 // Magic value calcs
@@ -215,10 +203,6 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   min-height: 0;
-  opacity: 1;
-  transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
-  transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
-  transition-property: opacity;
 }
 
 // - Nav subnav
@@ -231,16 +215,18 @@
   padding-block-end: var(--#{$nav}__subnav--PaddingBlockEnd);
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
-  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
-  transition-property: grid-template-rows, padding-block-start, padding-block-end;
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--opacity);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--opacity);
+  transition-property: grid-template-rows, padding-block-start, padding-block-end, opacity;
   
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
     --#{$nav}__subnav--PaddingBlockStart: 0;
     --#{$nav}__subnav--PaddingBlockEnd: 0;
+    --#{$nav}__subnav--TransitionDuration--opacity: var(--#{$nav}__subnav--hidden--TransitionDuration--opacity);
 
     grid-template-rows: 0fr;
+    opacity: 0;
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -43,7 +43,7 @@
 
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
-  --#{$nav}__item--TransitionDuration: 0; // var(--pf-t--global--motion--duration--slide-in--default);
+  --#{$nav}__item--TransitionDuration: 0;
   --#{$nav}__item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -54,7 +54,7 @@
   --#{$nav}__item__toggle-icon--Rotate: 0;
   --#{$nav}__item--m-expanded__toggle-icon--Rotate: 90deg;
   --#{$nav}__item__toggle-icon--TransitionDuration--transform: var(--pf-t--global--motion--duration--icon--default);
-
+  --#{$nav}__item__toggle-icon--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--default);
 
   // * Nav link
   --#{$nav}__link--ColumnGap: var(--pf-t--global--spacer--sm);
@@ -82,10 +82,12 @@
 
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
+  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__subnav--RowGap);
+  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__subnav--RowGap);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
   --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
-
+  
   @media (prefers-reduced-motion: no-preference) {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
     --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
@@ -189,7 +191,7 @@
 [class^="#{$nav}"][hidden] {
   visibility: hidden;
 
-  & .#{$nav}__list {
+  .#{$nav}__list {
     --#{$nav}__list--TransitionDuration--opacity: var(--#{$nav}__list--hidden--TransitionDuration--opacity);
 
     opacity: 0;
@@ -217,7 +219,6 @@
   transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
   transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
   transition-property: opacity;
-  transition-behavior: allow-discrete;
 
   @starting-style {
     opacity: 0;
@@ -230,14 +231,13 @@
 
   grid-template-rows: 1fr;
   min-height: 0;
-  padding-block-start: 0;
-  padding-block-end: 0;
+  padding-block-start: var(--#{$nav}__subnav--PaddingBlockStart);
+  padding-block-end: var(--#{$nav}__subnav--PaddingBlockEnd);
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
   transition-property: grid-template-rows, padding-block-start;
-  transition-behavior: allow-discrete; 
   
   @starting-style {
     grid-template-rows: 0fr;
@@ -245,6 +245,8 @@
 
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
+    --#{$nav}__subnav--PaddingBlockStart: 0;
+    --#{$nav}__subnav--PaddingBlockEnd: 0;
 
     grid-template-rows: 0fr;
   }
@@ -264,14 +266,12 @@
     }
   }
 
-  &.pf-m-expanded {
-    // duration for collapsing needs to set the property rather than the variable because of nested items
-    transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap); 
+  &.pf-m-expanded { 
+    --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
+    --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
 
-    & > .#{$nav}__subnav {
-      padding-block-start: var(--#{$nav}__item--RowGap);
-      padding-block-end: var(--#{$nav}__item--RowGap);
-    }
+    // duration for collapsing needs to set the property rather than the variable because of nested items
+    transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap);
   }
 }
 
@@ -354,6 +354,7 @@
 // - Nav toggle icon
 .#{$nav}__toggle-icon {
   display: inline-block;
+  transition-timing-function: var(--#{$nav}__item__toggle-icon--TransitionTimingFunction--transform);
   transition-duration: var(--#{$nav}__item__toggle-icon--TransitionDuration--transform);
   transition-property: transform;
   transform: rotate(var(--#{$nav}__item__toggle-icon--Rotate));

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -76,7 +76,7 @@
   --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap); // needed to keep focus outline on last item from being cut off
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--expansion: 0s; // no slide by default
-  --#{$nav}__subnav--hidden--TransitionDuration--expansion: 0;
+  --#{$nav}__subnav--hidden--TransitionDuration--expansion: 0s;
   --#{$nav}__subnav--TransitionTimingFunction--expansion: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -219,10 +219,6 @@
   transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
   transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
   transition-property: opacity;
-
-  @starting-style {
-    opacity: 0;
-  }
 }
 
 // - Nav subnav
@@ -239,10 +235,6 @@
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
   transition-property: grid-template-rows, padding-block-start;
   
-  @starting-style {
-    grid-template-rows: 0fr;
-  }
-
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
     --#{$nav}__subnav--PaddingBlockStart: 0;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -78,13 +78,14 @@
   --#{$nav}__link--m-current__link-icon--Color: var(--pf-t--global--icon--color--regular);
 
   // * Nav subnav
+  --#{$nav}__subnav--MaxHeight: fit-content;  
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
-  --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--max-height--TransitionDuration: 0s; // no slide by default
+  --#{$nav}__subnav--max-height--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
 
   @media ( prefers-reduced-motion: no-preference ) {
-    --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short); // TODO I think short might be better that having it the same as the list's slide var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--max-height--TransitionDuration: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav scroll button
@@ -187,8 +188,7 @@
 }
 
 [class^="#{$nav}"][hidden] {
-  // display: none;
-  // border: 1px solid red;
+  display: none;
   max-height: 0;
 
   & .#{$nav}__list {
@@ -212,23 +212,34 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   opacity: 1;
-  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
-  transform: translateY(0); 
 
+  // transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform);
+
+  // add display for the __list
+  transition: opacity var(--#{$nav}__list--TransitionDuration--opacity) var(--#{$nav}__list--TransitionTimingFunction--opacity), transform var(--#{$nav}__list--TransitionDuration--transform) var(--#{$nav}__list--TransitionTimingFunction--transform), display var(--#{$nav}__list--TransitionDuration--opacity) allow-discrete;
+  transform: translateY(0);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
 }
 
 // - Nav subnav
 .#{$nav}__subnav {
   --#{$nav}__list--RowGap: var(--#{$nav}__subnav--RowGap); // this value is passed to --#{$nav}__item--RowGap--row-offset and updates clickable area based on value passed
 
-  height: auto;
-  max-height: 100dvh;
+  max-height: var(--#{$nav}__subnav--MaxHeight, fit-content); // This can be set in React to the proper height until allow-discrete, i.e. transition to auto, is fully supported
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition: max-height var(--#{$nav}__subnav--TransitionDuration--max-height) var(--#{$nav}__subnav--TransitionTimingFunction--max-height);
-
-  // transition-behavior: allow-discrete;
-  // border: 1px solid blue;
+  transition-timing-function: var(--#{$nav}__subnav--max-height--TransitionTimingFunction);
+  transition-duration: var(--#{$nav}__subnav--max-height--TransitionDuration);
+  transition-property: max-height, display;
+  transition-behavior: allow-discrete; // should allow transitions during show/hide 
+  
+  @starting-style {
+    max-height: 0;
+  }
 }
 
 // - Nav item

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -237,7 +237,7 @@
     grid-template-rows: 0fr;
   }
 
-  [hidden] {
+  &[hidden] {
     --#{$nav}__list--RowGap: 0;
     
     grid-template-rows: 0fr;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -31,6 +31,7 @@
 
   // Nav list animation variables
   --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
+  --#{$nav}__list--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
   --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
 
   // * Nav section title
@@ -44,10 +45,12 @@
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item--TransitionDuration--row-gap: 0;
+  --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
   --#{$nav}__item--TransitionTimingFunction--row-gap: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__item--TransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__item--TransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--short);
+    --#{$nav}__item--m-expandedTransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
   }
 
   // * Nav item toggle icon
@@ -87,8 +90,9 @@
   --#{$nav}__subnav--TransitionDuration--max-height: 0s; // no slide by default
   --#{$nav}__subnav--TransitionTimingFunction--max-height: var(--pf-t--global--motion--timing-function--default);
 
-  @media ( prefers-reduced-motion: no-preference ) {
+  @media (prefers-reduced-motion: no-preference) {
     --#{$nav}__subnav--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--hidden--TransitionDuration--max-height: var(--pf-t--global--motion--duration--slide-in--short);
   }
 
   // * Nav scroll button
@@ -190,6 +194,8 @@
   display: none;
 
   & .#{$nav}__list {
+    --#{$nav}__list--TransitionDuration--opacity: var(--#{$nav}__list--hidden--TransitionDuration--opacity);
+
     opacity: 0;
   }
 }
@@ -239,7 +245,8 @@
 
   &[hidden] {
     --#{$nav}__list--RowGap: 0;
-    
+    --#{$nav}__subnav--TransitionDuration--max-height: var(--#{$nav}__subnav--hidden--TransitionDuration--max-height);
+
     grid-template-rows: 0fr;
   }
 }
@@ -266,6 +273,9 @@
 
   &.pf-m-expanded {
     row-gap: var(--#{$nav}__item--RowGap);
+
+    // duration for collapsing needs to set the property rather than the variable because of nested items
+    transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap); 
   }
 }
 


### PR DESCRIPTION
Fixes #6597 

Implements microanimations on the nav component:

- Hover on nav items transitions the background color
- Selected nav items transitions text color
- Expand/collapse slides the sub menu open/shut. In reduced motion, the menu fades but no slide.
- Expansion caret rotates when expanded
- Works cross browser

Figma reference: https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/UR1JfYwpZI6MP3rLj18iJ3/PatternFly-6%3A-Components?m=auto&node-id=3-35&t=PQCNAH226TGUdUfd-1

TIP - the site navigation will reflect the changes, rather than having to go to the examples and manually manipulate them.