### PR TITLE
fix(menu): enable pointer-events on aria-disabled items

### DIFF
--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -175,11 +175,21 @@
   &:is(.pf-m-disabled, :disabled, .pf-m-aria-disabled, [aria-disabled="true"]) {
     --#{$menu}__item--Color: var(--#{$menu}__item--m-disabled--Color);
     --#{$menu}__item-toggle-icon--Color: var(--#{$menu}--icon--disabled--Color);
-    --#{$menu}__item-external-icon--Color: var(--#{$menu}--icon--disabled--Color);
+    --#{$menu}__item-external--Color: transparent;
+    --#{$menu}__item-select-icon--Color: transparent;
     --#{$menu}__item-description--Color: var(--#{$menu}--icon--disabled--Color);
     --#{$menu}__list-item--BackgroundColor: transparent;
+    --#{$menu}__list-item--hover--BackgroundColor: transparent;
+  }
 
+  &:is(.pf-m-disabled, :disabled) {
     pointer-events: none;
+  }
+
+  &.pf-m-aria-disabled {
+    .#{$menu}__item {
+      cursor: default;
+    }
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7253

A couple of notes

* This keeps the background from showing up on focus for an aria-disabled item. This is different than v5, but the hover background with disabled text was more readable in v5 than it is in v6. This also now matches lack of background change on aria-disabled buttons.
* Updates the external icon var in a disabled item to 1) fix the var name since it was incorrect, and 2) change the color to transparent so the icon doesn't show on hover/focus for an aria-disabled item. The color change to transparent also applies to the select/check icon.