### PR TITLE
fix(popover): break long strings in title text

### DIFF
--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -247,9 +247,11 @@
 }
 
 .#{$popover}__title-text {
+  min-width: 0;
   font-size: var(--#{$popover}__title-text--FontSize);
   font-weight: var(--#{$popover}__title-text--FontWeight);
   color: var(--#{$popover}__title-text--Color);
+  overflow-wrap: break-word;
 }
 
 // Body


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7340