### PR TITLE
feat(menu-toggle): menu toggle with danger status animation

### DIFF
--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -16,6 +16,8 @@
   --#{$helper-text}__item-text--m-success--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$helper-text}__item-icon--m-error--Color: var(--pf-t--global--icon--color--status--danger--default);
   --#{$helper-text}__item-text--m-error--FontWeight: var(--pf-t--global--font--weight--body--bold);
+  --#{$helper-text}__item-icon--m-error--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$helper-text}__item-icon--m-error--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
 
   // dynamic
   --#{$helper-text}--m-dynamic__item-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -71,6 +73,15 @@
     --#{$helper-text}__item-text--FontWeight: var(--#{$helper-text}__item-text--m-error--FontWeight);
     --#{$helper-text}__item-icon--Color: var(--#{$helper-text}__item-icon--m-error--Color);
     --#{$helper-text}--m-dynamic__item-icon--Color: var(--#{$helper-text}--m-dynamic--m-error__item-icon--Color);
+
+    transition:
+      opacity 
+        var(--#{$helper-text}__item-icon--m-error--TransitionDuration--Opacity)
+        var(--#{$helper-text}__item-icon--m-error--TransitionTimingFunction--Opacity);
+    
+    @starting-style {
+      opacity: 0;
+    }
   }
 
   &.pf-m-dynamic {

--- a/src/patternfly/components/HelperText/helper-text.scss
+++ b/src/patternfly/components/HelperText/helper-text.scss
@@ -16,8 +16,8 @@
   --#{$helper-text}__item-text--m-success--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$helper-text}__item-icon--m-error--Color: var(--pf-t--global--icon--color--status--danger--default);
   --#{$helper-text}__item-text--m-error--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$helper-text}__item-icon--m-error--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
-  --#{$helper-text}__item-icon--m-error--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$helper-text}__item--m-error--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$helper-text}__item--m-error--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
 
   // dynamic
   --#{$helper-text}--m-dynamic__item-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -74,13 +74,18 @@
     --#{$helper-text}__item-icon--Color: var(--#{$helper-text}__item-icon--m-error--Color);
     --#{$helper-text}--m-dynamic__item-icon--Color: var(--#{$helper-text}--m-dynamic--m-error__item-icon--Color);
 
-    transition:
-      opacity 
-        var(--#{$helper-text}__item-icon--m-error--TransitionDuration--Opacity)
-        var(--#{$helper-text}__item-icon--m-error--TransitionTimingFunction--Opacity);
+    animation-name: --#{$helper-text}-item-fade-in;
+    animation-duration: var(--#{$helper-text}__item--m-error--TransitionDuration--Opacity);
+    animation-timing-function: var(--#{$helper-text}__item--m-error--TransitionTimingFunction--Opacity); 
     
-    @starting-style {
-      opacity: 0;
+    @keyframes --#{$helper-text}-item-fade-in {
+      from {
+        opacity: 0;
+      }
+
+      to {
+        opacity: 1;
+      }
     }
   }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -152,6 +152,8 @@
 
   // Status icon
   --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
+  --#{$menu-toggle}__status-icon--m--danger--Opacity: var(--pf-t--global--motion--duration--icon--default);
+  --#{$menu-toggle}__status-icon--m--danger--TransitionTimingFunction: var(--pf-t--global--motion--duration--icon--default);
 
   // Success
   --#{$menu-toggle}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -164,6 +166,8 @@
   // Danger
   --#{$menu-toggle}--m-danger--BorderColor: var(--pf-t--global--border--color--status--danger--default);
   --#{$menu-toggle}--m-danger__status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
+  --#{$menu-toggle}--m-danger--TransitionDuration--Transform: var(--pf-t--global--motion--duration--md);
+  --#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
 
   // Placeholder
   --#{$menu-toggle}--m-placeholder--Color: var(--pf-t--global--text--color--placeholder);
@@ -337,6 +341,24 @@
   &.pf-m-danger {
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-danger--BorderColor);
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--m-danger__status-icon--Color);
+    
+    transform: translate3d(0, 0, 0);
+    animation-name: menu-toggle-m-danger-motion;
+    animation-duration: var(--#{$menu-toggle}--m-danger--TransitionDuration--Transform);
+    animation-timing-function: var(--#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform);
+    animation-fill-mode: both;
+
+    .#{$menu-toggle}__status-icon {
+      color: var(--#{$menu-toggle}__status-icon--Color, inherit);
+      transition: 
+        opacity
+          var(--#{$menu-toggle}__status-icon--m--danger--Opacity)
+          var(--#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform);
+      
+      @starting-style  {
+        opacity: 0;
+      }
+    }
   }
 
   &.pf-m-placeholder {
@@ -353,6 +375,18 @@
     &,
     .#{$button} {
       pointer-events: none;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes menu-toggle-m-danger-motion {
+    33% {
+      transform: translate3d(-2px, 0, 0);
+    }
+
+    66% {
+      transform: translate3d(3px, 0, 0);
     }
   }
 }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -152,8 +152,8 @@
 
   // Status icon
   --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$menu-toggle}__status-icon--m--danger--Opacity: var(--pf-t--global--motion--duration--icon--default);
-  --#{$menu-toggle}__status-icon--m--danger--TransitionTimingFunction: var(--pf-t--global--motion--duration--icon--default);
+  --#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--icon--default);
+  --#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--timing-function--default);
 
   // Success
   --#{$menu-toggle}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -166,8 +166,8 @@
   // Danger
   --#{$menu-toggle}--m-danger--BorderColor: var(--pf-t--global--border--color--status--danger--default);
   --#{$menu-toggle}--m-danger__status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
-  --#{$menu-toggle}--m-danger--TransitionDuration--Transform: var(--pf-t--global--motion--duration--md);
-  --#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
+  --#{$menu-toggle}--m-danger--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
+  --#{$menu-toggle}--m-danger--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
 
   // Placeholder
   --#{$menu-toggle}--m-placeholder--Color: var(--pf-t--global--text--color--placeholder);
@@ -341,22 +341,26 @@
   &.pf-m-danger {
     --#{$menu-toggle}--BorderColor: var(--#{$menu-toggle}--m-danger--BorderColor);
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--m-danger__status-icon--Color);
-    
-    transform: translate3d(0, 0, 0);
-    animation-name: menu-toggle-m-danger-motion;
-    animation-duration: var(--#{$menu-toggle}--m-danger--TransitionDuration--Transform);
-    animation-timing-function: var(--#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform);
-    animation-fill-mode: both;
 
-    .#{$menu-toggle}__status-icon {
-      color: var(--#{$menu-toggle}__status-icon--Color, inherit);
-      transition: 
-        opacity
-          var(--#{$menu-toggle}__status-icon--m--danger--Opacity)
-          var(--#{$menu-toggle}--m-danger--TransitionTimingFunction--Transform);
+    @media screen and (prefers-reduced-motion: no-preference) {
+      transform: translate3d(0, 0, 0);
+      animation-name: menu-toggle-m-danger-motion;
+      animation-duration: var(--#{$menu-toggle}--m-danger--AnimationDuration--Transform);
+      animation-timing-function: var(--#{$menu-toggle}--m-danger--AnimationTimingFunction--Transform);
+      animation-fill-mode: both;
       
-      @starting-style  {
-        opacity: 0;
+      .#{$menu-toggle}__status-icon {
+        color: var(--#{$menu-toggle}__status-icon--Color, inherit);
+        opacity: 1;
+        transition: 
+          opacity 
+            var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity)
+            var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity);
+        // stylelint-disable max-nesting-depth
+        @starting-style {
+          opacity: 0;
+        }
+        // stylelint-enable
       }
     }
   }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -348,25 +348,24 @@
       animation-duration: var(--#{$menu-toggle}--m-danger--AnimationDuration--Transform);
       animation-timing-function: var(--#{$menu-toggle}--m-danger--AnimationTimingFunction--Transform);
       animation-fill-mode: both;
-      
-      .#{$menu-toggle}__status-icon {
-        color: var(--#{$menu-toggle}__status-icon--Color, inherit);
-        animation-name: #{$menu-toggle}-status-icon-fade-in;
-        animation-duration: var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity);
-        animation-timing-function: var(--#{$menu-toggle}__status-icon--m-danger--TransitionTimingFunction--Opacity);
-        
-        // stylelint-disable max-nesting-depth
-        @keyframes #{$menu-toggle}-status-icon-fade-in {
-          from {
-            opacity: 0;
-          }
+    }
 
-          to {
-            opacity: 1;
-          }
+    .#{$menu-toggle}__status-icon {
+      animation-name: #{$menu-toggle}-status-icon-fade-in;
+      animation-duration: var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity);
+      animation-timing-function: var(--#{$menu-toggle}__status-icon--m-danger--TransitionTimingFunction--Opacity);
+      
+      // stylelint-disable max-nesting-depth
+      @keyframes #{$menu-toggle}-status-icon-fade-in {
+        from {
+          opacity: 0;
         }
-        // stylelint-enable
+
+        to {
+          opacity: 1;
+        }
       }
+      // stylelint-enable
     }
   }
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -153,7 +153,7 @@
   // Status icon
   --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--icon--default);
-  --#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$menu-toggle}__status-icon--m-danger--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
 
   // Success
   --#{$menu-toggle}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
@@ -343,22 +343,27 @@
     --#{$menu-toggle}__status-icon--Color: var(--#{$menu-toggle}--m-danger__status-icon--Color);
 
     @media screen and (prefers-reduced-motion: no-preference) {
-      transform: translate3d(0, 0, 0);
-      animation-name: menu-toggle-m-danger-motion;
+      transform: translateX(var(--#{$menu-toggle}--m-danger--TranslateX, 0));
+      animation-name: #{$menu-toggle}-m-danger-motion;
       animation-duration: var(--#{$menu-toggle}--m-danger--AnimationDuration--Transform);
       animation-timing-function: var(--#{$menu-toggle}--m-danger--AnimationTimingFunction--Transform);
       animation-fill-mode: both;
       
       .#{$menu-toggle}__status-icon {
         color: var(--#{$menu-toggle}__status-icon--Color, inherit);
-        opacity: 1;
-        transition: 
-          opacity 
-            var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity)
-            var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity);
+        animation-name: #{$menu-toggle}-status-icon-fade-in;
+        animation-duration: var(--#{$menu-toggle}__status-icon--m-danger--TransitionDuration--Opacity);
+        animation-timing-function: var(--#{$menu-toggle}__status-icon--m-danger--TransitionTimingFunction--Opacity);
+        
         // stylelint-disable max-nesting-depth
-        @starting-style {
-          opacity: 0;
+        @keyframes #{$menu-toggle}-status-icon-fade-in {
+          from {
+            opacity: 0;
+          }
+
+          to {
+            opacity: 1;
+          }
         }
         // stylelint-enable
       }
@@ -383,14 +388,21 @@
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  @keyframes menu-toggle-m-danger-motion {
-    33% {
-      transform: translate3d(-2px, 0, 0);
-    }
+// Register the property type for the custom property to be animatable
+@property --#{$menu-toggle}--m-danger--TranslateX {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
 
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes #{$menu-toggle}-m-danger-motion {
+    33% {
+      --#{$menu-toggle}--m-danger--TranslateX: -2px;
+    }
+    
     66% {
-      transform: translate3d(3px, 0, 0);
+      --#{$menu-toggle}--m-danger--TranslateX: 3px;
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/6591

[Codesandbox](https://codesandbox.io/p/sandbox/awesome-cdn-flsfyv) showing behavior.

Note this [design prototype](https://www.figma.com/proto/VMEX8Xg2nzhBX8rfBx53jp/branch/J0HlG83xKgYoT2pMpCl4SY/PatternFly-6%3A-Components?type=design&node-id=23118-27297&t=NUaOc6etggp2gIAn-0&scaling=min-zoom&page-id=3%3A16) includes the `HelperText` component which fades in with the menu-toggle danger selection. That helper-text fade in transition code changes aren't currently included in these changes. I didn't know if it should be or if it would be a follow on. Because in my sandbox demo I only applied an css opacity transition that keys off of `pf-v6-c-helper-text__item.pf-m-error` which would imply all helper-text with the error class would transition, even if it's not associated with a `menu-toggle`


Update: 
These changes now include additions to fade in the helper text for `pf-m-error` status