### PR TITLE
fix(toolbar): reset toolbar bottom padding to 0

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -13,7 +13,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 @include pf-root($toolbar) {
   --#{$toolbar}--RowGap: var(--pf-t--global--spacer--md);
   --#{$toolbar}--PaddingBlockStart: 0;
-  --#{$toolbar}--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$toolbar}--PaddingBlockEnd: 0;
   --#{$toolbar}--PaddingInlineStart: 0;
   --#{$toolbar}--PaddingInlineEnd: 0;
   --#{$toolbar}--LineHeight: var(--pf-t--global--font--line-height--body);


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/7332
