### PR TITLE
feat(Button): add notify modifier to button for microanimation

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -279,8 +279,8 @@
   --#{$button}__icon--MarginInlineEnd: 0;
   --#{$button}__icon--m-start--MarginInlineEnd: 0;
   --#{$button}__icon--m-end--MarginInlineStart: 0;
-  --#{$button}__icon--AnimationDuration--notify: var(--pf-t--global--duration--600);
-  --#{$button}__icon--AnimationTimingFunction--notify: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--m-notify__icon--AnimationDuration--notify: var(--pf-t--global--duration--600);
+  --#{$button}--m-notify__icon--AnimationTimingFunction--notify: var(--pf-t--global--motion--timing-function--default);
 
   // Progress
   --#{$button}__progress--width: calc(var(--pf-t--global--icon--size--lg) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
@@ -710,8 +710,8 @@
 
   &.pf-m-notify .#{$button}__icon {
     animation-name: #{$button}-icon-notify;
-    animation-duration: var(--#{$button}__icon--AnimationDuration--notify);
-    animation-timing-function: var(--#{$button}__icon--AnimationTimingFunction--notify);
+    animation-duration: var(--#{$button}--m-notify__icon--AnimationDuration--notify);
+    animation-timing-function: var(--#{$button}--m-notify__icon--AnimationTimingFunction--notify);
   }
 }
 
@@ -754,9 +754,5 @@
 
   66% {
     transform: rotate(-60deg);
-  }
-
-  100% {
-    transform: rotate(0);
   }
 }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -279,7 +279,7 @@
   --#{$button}__icon--MarginInlineEnd: 0;
   --#{$button}__icon--m-start--MarginInlineEnd: 0;
   --#{$button}__icon--m-end--MarginInlineStart: 0;
-  --#{$button}--m-notify__icon--AnimationDuration--notify: var(--pf-t--global--duration--600);
+  --#{$button}--m-notify__icon--AnimationDuration--notify: var(--pf-t--global--motion--duration--3xl);
   --#{$button}--m-notify__icon--AnimationTimingFunction--notify: var(--pf-t--global--motion--timing-function--default);
 
   // Progress

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -279,6 +279,8 @@
   --#{$button}__icon--MarginInlineEnd: 0;
   --#{$button}__icon--m-start--MarginInlineEnd: 0;
   --#{$button}__icon--m-end--MarginInlineStart: 0;
+  --#{$button}__icon--AnimationDuration--notify: var(--pf-t--global--duration--600);
+  --#{$button}__icon--AnimationTimingFunction--notify: var(--pf-t--global--motion--timing-function--default);
 
   // Progress
   --#{$button}__progress--width: calc(var(--pf-t--global--icon--size--lg) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
@@ -705,6 +707,12 @@
       }
     }
   }
+
+  &.pf-m-notify .#{$button}__icon {
+    animation-name: #{$button}-icon-notify;
+    animation-duration: var(--#{$button}__icon--AnimationDuration--notify);
+    animation-timing-function: var(--#{$button}__icon--AnimationTimingFunction--notify);
+  }
 }
 
 .#{$button}__icon {
@@ -737,4 +745,18 @@
 .#{$button}__count {
   display: inline-flex;
   align-items: center;
+}
+
+@keyframes #{$button}-icon-notify {
+  33% {
+    transform: rotate(30deg);
+  }
+
+  66% {
+    transform: rotate(-60deg);
+  }
+
+  100% {
+    transform: rotate(0);
+  }
 }


### PR DESCRIPTION
This is for the notification badge part of #6601 

A modifier `.pf-m-notify` gets added to a `.pf-m-button` in order to cause the icon portion of the button to have the ringing motion. 

https://github.com/patternfly/patternfly-react/issues/10624 will need to add the class, wait for the animation to complete, and then remove it, and also manage if a new notification arrives before the animation finishes from the previous notification.

This also requires React to update the notification badge to put the icon into the icon container rather than the text container, following core's structure.