### PR TITLE
fix(masthead): center align content

### DIFF
--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -199,7 +199,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   grid-column-end: -1; // force content to right edge or full available width
   row-gap: var(--#{$masthead}__content-RowGap, var(--#{$masthead}--RowGap));
   column-gap: var(--#{$masthead}__content--ColumnGap, var(--#{$masthead}--ColumnGap));
-  align-self: stretch;
+  align-self: center;
   order: var(--#{$masthead}__content--Order);
   min-width: #{pf-size-prem(4ch)}; // allow flex containers to shrink to fit possible overflow
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7320

Confirmed with @lboehling that the masthead content should be centered by default.

I tried to run the visual regressions but am having issues running the full report. But attaching masthead, page, and navigation. Nothing out of the ordinary.

[navigation.pdf](https://github.com/user-attachments/files/19019966/navigation.pdf)
[page.pdf](https://github.com/user-attachments/files/19019967/page.pdf)
[masthead.pdf](https://github.com/user-attachments/files/19019968/masthead.pdf)
