### PR TITLE
feat(Button): add microanimation to favorites button

### DIFF
--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -21,6 +21,8 @@
     button--IsRead='pf-m-read'
     button--IsUnread='pf-m-unread'
     button--IsAttention='pf-m-attention'
+    button--IsFavorite='pf-m-favorite'
+    button--IsFavorited='pf-m-favorited'
     button--IsDisplayLg='pf-m-display-lg'
     button--IsBlock='pf-m-block'
     button--modifier=button--modifier

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -315,11 +315,6 @@
 }
 
 .#{$button} {
-  --#{$button}--m-favorite__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
-  --#{$button}--m-favorite__icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--m-favorited__icon--AnimationDuration: var(--pf-t--global--motion--duration--icon--long);
-  --#{$button}--m-favorited__icon--AnimationTimingFunction: var(--pf-t--global--motion--timing-function--default);
-
   position: relative;
   display: var(--#{$button}--Display);
   gap: var(--#{$button}--Gap);
@@ -792,6 +787,6 @@
 
 @keyframes #{$button}-icon-favorited {
   50% {
-    transform: scale(1.5); // make a variable
+    transform: scale(1.5);
   }
 }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -646,13 +646,6 @@
     --#{$button}--FontSize: var(--#{$button}--m-display-lg--FontSize);
   }
 
-  // Register the property type for the custom property to be animatable
-// @property --#{$button}__icon--Color {
-//   syntax: "<color>";
-//   inherits: false;
-//   initial-value: "red";
-// }
-
   // Favorite button icon will transition color
   &.pf-m-favorite .#{$button}__icon {
     transition-timing-function: var(--#{$button}--m-favorite__icon--TransitionTimingFunction);
@@ -660,13 +653,13 @@
     transition-property: color;
   }
 
-  // Favorite button when clicked
+  // Favorite button when favorited
   &.pf-m-favorited {
     --#{$button}__icon--Color: var(--#{$button}--m-favorited__icon--Color);
     --#{$button}--hover__icon--Color: var(--#{$button}--m-favorited--hover__icon--Color);
   }
 
-  // Favorite button will run an animation when clicked
+  // Favorite button will run an animation when favorited
   &.pf-m-favorited .#{$button}__icon {
     animation-name: #{$button}-icon-favorited;
     animation-duration: var(--#{$button}--m-favorited__icon--AnimationDuration);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -282,6 +282,14 @@
   --#{$button}--m-notify__icon--AnimationDuration--notify: var(--pf-t--global--motion--duration--3xl);
   --#{$button}--m-notify__icon--AnimationTimingFunction--notify: var(--pf-t--global--motion--timing-function--default);
 
+  // Favorite button
+  --#{$button}--m-favorite__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$button}--m-favorite__icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--m-favorited__icon--Color: var(--pf-t--global--color--favorite--default);
+  --#{$button}--m-favorited--hover__icon--Color: var(--pf-t--global--color--favorite--hover);
+  --#{$button}--m-favorited__icon--AnimationDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$button}--m-favorited__icon--AnimationTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
   // Progress
   --#{$button}__progress--width: calc(var(--pf-t--global--icon--size--lg) + var(--pf-t--global--spacer--sm)); // matches medium spinner diameter plus a spacer
   --#{$button}__progress--Opacity: 0;
@@ -307,6 +315,11 @@
 }
 
 .#{$button} {
+  --#{$button}--m-favorite__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$button}--m-favorite__icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--m-favorited__icon--AnimationDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$button}--m-favorited__icon--AnimationTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
   position: relative;
   display: var(--#{$button}--Display);
   gap: var(--#{$button}--Gap);
@@ -633,6 +646,33 @@
     --#{$button}--FontSize: var(--#{$button}--m-display-lg--FontSize);
   }
 
+  // Register the property type for the custom property to be animatable
+// @property --#{$button}__icon--Color {
+//   syntax: "<color>";
+//   inherits: false;
+//   initial-value: "red";
+// }
+
+  // Favorite button icon will transition color
+  &.pf-m-favorite .#{$button}__icon {
+    transition-timing-function: var(--#{$button}--m-favorite__icon--TransitionTimingFunction);
+    transition-duration: var(--#{$button}--m-favorite__icon--TransitionDuration);
+    transition-property: color;
+  }
+
+  // Favorite button when clicked
+  &.pf-m-favorited {
+    --#{$button}__icon--Color: var(--#{$button}--m-favorited__icon--Color);
+    --#{$button}--hover__icon--Color: var(--#{$button}--m-favorited--hover__icon--Color);
+  }
+
+  // Favorite button will run an animation when clicked
+  &.pf-m-favorited .#{$button}__icon {
+    animation-name: #{$button}-icon-favorited;
+    animation-duration: var(--#{$button}--m-favorited__icon--AnimationDuration);
+    animation-timing-function: var(--#{$button}--m-favorited__icon--AnimationTimingFunction);
+  }
+
   &:hover,
   &:focus {
     --#{$button}--Color: var(--#{$button}--hover--Color);
@@ -754,5 +794,11 @@
 
   66% {
     transform: rotate(-60deg);
+  }
+}
+
+@keyframes #{$button}-icon-favorited {
+  50% {
+    transform: scale(1.5); // make a variable
   }
 }

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -284,6 +284,6 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-progress` | `.pf-v6-c-button` | Indicates that the button supports the progress state. **Note:** Not used with the plain variation. |
 | `.pf-m-in-progress` | `.pf-v6-c-button` | Indicates that the button is in the in progress state. |
 | `.pf-m-stateful` | `.pf-v6-c-button` | Indicates that the button is used for one of read, unread, and attention states. **Note:** Always use with a modifier of `.pf-m-read`, `.pf-m-unread`, or `.pf-m-attention`. |
-| `.pf-m-notify` | `.pf-v6-c-button` | Indicates that the button should show the user notification of an event. **Note:** This is intended for use with a bell icon in the Notification Badge. |
+| `.pf-m-notify` | `.pf-v6-c-button` | Indicates that the button should show the user notification of an event. **Note:** This is intended for use with a bell icon in the notification badge. |
 | `.pf-m-favorite` | `.pf-v6-c-button .pf-m-plain` | Modifies a plain button to be a favorite button. **Note:** This is intended for use with a star icon. |
 | `.pf-m-favorited` | `.pf-v6-c-button .pf-m-plain .pf-m-favorite` | Modifies a favorite button to indicate that item is favorited.  |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -227,6 +227,15 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 {{/button}}
 ```
 
+### Favorite
+A favorite button should use a plain button with the star icon. Applying `.pf-m-favorited` to the button initiates a microanimation and indicates that the item is favorited.
+```hbs
+{{#> button button--icon="star" button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--aria-label="not starred"}}
+{{/button}}
+{{#> button button--icon="star" button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--IsFavorited=true button--aria-label="starred"}}
+{{/button}}
+```
+
 ## Documentation
 ### Overview
 Always add a modifier class to add color to the button.
@@ -275,3 +284,6 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-progress` | `.pf-v6-c-button` | Indicates that the button supports the progress state. **Note:** Not used with the plain variation. |
 | `.pf-m-in-progress` | `.pf-v6-c-button` | Indicates that the button is in the in progress state. |
 | `.pf-m-stateful` | `.pf-v6-c-button` | Indicates that the button is used for one of read, unread, and attention states. **Note:** Always use with a modifier of `.pf-m-read`, `.pf-m-unread`, or `.pf-m-attention`. |
+| `.pf-m-notify` | `.pf-v6-c-button` | Indicates that the button should show the user notification of an event. **Note:** This is intended for use with a bell icon in the Notification Badge. |
+| `.pf-m-favorite` | `.pf-v6-c-button .pf-m-plain` | Modifies a plain button to be a favorite button. **Note:** This is intended for use with a star icon. |
+| `.pf-m-favorited` | `.pf-v6-c-button .pf-m-plain .pf-m-favorite` | Modifies a favorite button to indicate that item is favorited.  |

--- a/src/patternfly/components/Menu/menu-item-action.hbs
+++ b/src/patternfly/components/Menu/menu-item-action.hbs
@@ -8,7 +8,7 @@
     {{{menu-item-action--attribute}}}
   {{/if}}>
   {{#> button button--role="menuitem" 
-  button--IsPlain=true button--IsIcon=true button--IsDisabled=menu-list-item--IsDisabled button--IsAriaDisabled=menu-list-item--IsAriaDisabled}}
+  button--IsPlain=true button--IsIcon=true button--IsDisabled=menu-list-item--IsDisabled button--IsAriaDisabled=menu-list-item--IsAriaDisabled button--IsFavorite=menu-item-action--IsFavorite button--IsFavorited=menu-item-action--IsFavorited}}
     {{#ifAny menu-item-action--IsFavorite menu-item-action--IsFavorited}}
       {{> button-icon button--icon="star"}}
     {{else if @partial-block}}

--- a/src/patternfly/components/Menu/menu-item-action.hbs
+++ b/src/patternfly/components/Menu/menu-item-action.hbs
@@ -1,7 +1,6 @@
 <div class="{{pfv}}menu__item-action
   {{setModifiers
     menu-list-item--IsAriaDisabled='pf-m-aria-disabled'
-    menu-item-action--IsFavorited='pf-m-favorited'
     menu-item-action--modifier=menu-item-action--modifier
   }}"
   {{#if menu-item-action--attribute}}

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -617,6 +617,7 @@
 
 // TODO: standardize icon fitting
 // - Menu item action
+// TODO in breaking change - remove button styling here that is taken care of by favorite button no
 .#{$menu}__item-toggle-icon,
 .#{$menu}__item-action {
   &.pf-m-favorited,

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -617,7 +617,7 @@
 
 // TODO: standardize icon fitting
 // - Menu item action
-// TODO in breaking change - remove button styling here that is taken care of by favorite button no
+// TODO in breaking change - remove button styling here that is taken care of by favorite button now
 .#{$menu}__item-toggle-icon,
 .#{$menu}__item-action {
   &.pf-m-favorited,

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -621,7 +621,7 @@
 .#{$menu}__item-action {
   &.pf-m-favorited,
   &.pf-m-favorited:hover,
-  &.pf-m-favorited .#{$button} {
+  &.pf-m-favorited .#{$button}:not(.pf-m-favorited) {
     --#{$button}--m-plain__icon--Color: var(--#{$menu}__item-action--m-favorited--Color);
     
     &:is(:hover, :focus) {

--- a/src/patternfly/components/Table/table-favorite-button.hbs
+++ b/src/patternfly/components/Table/table-favorite-button.hbs
@@ -2,5 +2,7 @@
   button--IsPlain=true
   button--icon="star"
   button--IsIcon=true
+  button--IsFavorite=true
+  button--IsFavorited=table-td--IsFavorited
   button--aria-label=(ternary table-td--IsFavorited "Starred" "Not starred")
   button--attribute=(concat 'id="' table--id '-favorite-button' table-tr--index '" aria-labelledby="' table--id '-node' table-tr--index ' ' table--id '-favorite-button' table-tr--index '"')}}

--- a/src/patternfly/components/Table/table-favorite-sort.hbs
+++ b/src/patternfly/components/Table/table-favorite-sort.hbs
@@ -1,6 +1,6 @@
 {{#> action-list action-list--modifier='pf-m-icons'}}
   {{#> action-list-item}}
-    {{> button button--IsPlain=true button--IsIcon=true button--icon="star" button--aria-label='Favorite all'}}
+    {{> button button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--icon="star" button--aria-label='Favorite all'}}
   {{/action-list-item}}
   {{#> action-list-item}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon-template="table-sort-indicator" button--aria-label='Sort favorites'}}

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -8,7 +8,6 @@
   {{#if table-td--IsStickyColumn}} {{pfv}}table__sticky-column{{/if}}
   {{#if table-td--IsFavorite}} {{pfv}}table__favorite{{/if}}
   {{#if table-td--IsDraggable}} {{pfv}}table__draggable{{/if}}
-  {{#if table-td--IsFavorited}} pf-m-favorited{{/if}}
   {{#if table--IsCompact}} pf-m-compact{{/if}}
   {{#if table-td--modifier}} {{table-td--modifier}}{{/if}}"
   {{#unless table-td--IsEmpty}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -789,12 +789,13 @@
 }
 
 // - Table favorite
+// TODO in breaking change - remove button styling here that is taken care of by favorite button now
 .#{$table}__favorite {
-  .#{$button} {
+  .#{$button}:not(.pf-m-favorite) {
     --#{$button}--FontSize: var(--#{$table}__favorite--c-button--FontSize);
   }
 
-  &.pf-m-favorited .#{$button} {
+  &.pf-m-favorited .#{$button}:not(.pf-m-favorited) {
     --#{$button}--m-plain__icon--Color: var(--#{$table}__favorite--m-favorited--c-button--Color);
 
     &:is(:hover, :focus) {


### PR DESCRIPTION
Fixes #6601 

`.pf-m-favorite` added to button, and then `.pf-m-favorited` to indicate that it's been marked as favorite.

I also snuck in a docs line for the `.pf-m-notify`
Separate commits to do the animation piece, then guard against the old way (in menu and table) and then update examples to use the new way.

Also, I think the table is using the wrong color for the favorite buttons - it uses `--pf-t--global--color--favorite--clicked` and I think it should be `--pf-t--global--color--favorite--default` (but I did not change this current behavior) So you'll see a difference in the icon color since I've switched the examples to use the new button variant.

Here's one on the table showing the hover, focused, and un- and then favorited states. You'll see the animation when the buttons is marked as `.pf-m-favorited`

https://github.com/user-attachments/assets/41ff911f-e799-4cd9-b3db-c1cbd78d30fc


