### PR TITLE
chore(multiple): make icon rotation expansion transitions consistent

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -31,7 +31,8 @@
   --#{$accordion}--m-display-lg__toggle--m-expanded__toggle-text--FontWeight: var(--pf-t--global--font--weight--heading--default);
 
   // accordion toggle icon
-  --#{$accordion}__toggle-icon--Transition: .2s ease-in 0s;
+  --#{$accordion}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$accordion}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$accordion}__toggle--m-expanded__toggle-icon--Rotate: 90deg;
 
   // accordion expandable content
@@ -151,7 +152,9 @@
 .#{$accordion}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  transition: var(--#{$accordion}__toggle-icon--Transition);
+  transition-timing-function: var(--#{$accordion}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$accordion}__toggle-icon--TransitionDuration);
+  transition-property: transform;
 }
 
 .#{$accordion}__expandable-content {

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -33,6 +33,7 @@
   // accordion toggle icon
   --#{$accordion}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$accordion}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$accordion}__toggle-icon--Transition: transform var(--#{$accordion}__toggle-icon--TransitionDuration) var(--#{$accordion}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$accordion}__toggle--m-expanded__toggle-icon--Rotate: 90deg;
 
   // accordion expandable content
@@ -152,9 +153,7 @@
 .#{$accordion}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  transition-timing-function: var(--#{$accordion}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$accordion}__toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$accordion}__toggle-icon--Transition); // TODO remove shorthand property in breaking change
 }
 
 .#{$accordion}__expandable-content {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -33,6 +33,7 @@
   --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$card}__header-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$card}__header-toggle-icon--Transition: transform var(--#{$card}__header-toggle-icon--TransitionDuration) var(--#{$card}__header-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
   // Selectable/Clickable
@@ -283,9 +284,7 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition-timing-function: var(--#{$card}__header-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$card}__header-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$card}__header-toggle-icon--Transition); // TODO remove shorthand in breaking change
 }
 
 .#{$card}__title-text {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -33,7 +33,6 @@
   --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$card}__header-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
-  --#{$card}__header-toggle-icon--Transition: transform var(--#{$card}__header-toggle-icon--TransitionDuration) var(--#{$card}__header-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
   // Selectable/Clickable
@@ -284,7 +283,9 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition: var(--#{$card}__header-toggle-icon--Transition); // TODO remove shorthand in breaking change
+  transition-timing-function: var(--#{$card}__header-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$card}__header-toggle-icon--TransitionDuration);
+  transition-property: transform;
 }
 
 .#{$card}__title-text {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -32,7 +32,7 @@
   --#{$card}__header-toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$card}__header-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$card}__header-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
   // Selectable/Clickable
@@ -283,7 +283,9 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition: transform var(--#{$card}__header-toggle-icon--TransitionDuration) var(--#{$card}__header-toggle-icon--TransitionTimingFunction);
+  transition-timing-function: var(--#{$card}__header-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$card}__header-toggle-icon--TransitionDuration);
+  transition-property: transform;
 }
 
 .#{$card}__title-text {

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -4,6 +4,7 @@
   // Toggle icon
   --#{$clipboard-copy}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$clipboard-copy}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$clipboard-copy}__toggle-icon--Transition: transform var(--#{$clipboard-copy}__toggle-icon--TransitionDuration) var(--#{$clipboard-copy}__toggle-icon--TransitionTimingFunction); // TODO Remove in breaking change along with shorthand property
   --#{$clipboard-copy}--m-expanded__toggle-icon--Rotate: 90deg;
 
   // Clipboard copy expanded content
@@ -68,9 +69,7 @@
 .#{$clipboard-copy}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  transition-timing-function: var(--#{$clipboard-copy}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$clipboard-copy}__toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$clipboard-copy}__toggle-icon--Transition); // TODO remove shorthand in breaking change
 }
 
 .#{$clipboard-copy}__expandable-content {

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -2,7 +2,8 @@
 
 @include pf-root($clipboard-copy) {
   // Toggle icon
-  --#{$clipboard-copy}__toggle-icon--Transition: .2s ease-in 0s;
+  --#{$clipboard-copy}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$clipboard-copy}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$clipboard-copy}--m-expanded__toggle-icon--Rotate: 90deg;
 
   // Clipboard copy expanded content
@@ -67,7 +68,9 @@
 .#{$clipboard-copy}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 
-  transition: var(--#{$clipboard-copy}__toggle-icon--Transition);
+  transition-timing-function: var(--#{$clipboard-copy}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$clipboard-copy}__toggle-icon--TransitionDuration);
+  transition-property: transform;
 }
 
 .#{$clipboard-copy}__expandable-content {

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -60,7 +60,8 @@
   --#{$data-list}__toggle--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$data-list}__toggle--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--default) * -1);
   --#{$data-list}__toggle-icon--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
-  --#{$data-list}__toggle-icon--Transition: .2s ease-in 0s;
+  --#{$data-list}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$data-list}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$data-list}__toggle-icon--Rotate: 0;
   --#{$data-list}__item--m-expanded__toggle-icon--Rotate: 90deg;
 
@@ -342,7 +343,9 @@
 
   height: var(--#{$data-list}__toggle-icon--Height);
   pointer-events: none;
-  transition: var(--#{$data-list}__toggle-icon--Transition);
+  transition-timing-function: var(--#{$data-list}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$data-list}__toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$data-list}__toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -62,6 +62,7 @@
   --#{$data-list}__toggle-icon--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
   --#{$data-list}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$data-list}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$data-list}__toggle-icon--Transition: transform var(--#{$data-list}__toggle-icon--TransitionDuration) var(--#{$data-list}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$data-list}__toggle-icon--Rotate: 0;
   --#{$data-list}__item--m-expanded__toggle-icon--Rotate: 90deg;
 
@@ -343,9 +344,7 @@
 
   height: var(--#{$data-list}__toggle-icon--Height);
   pointer-events: none;
-  transition-timing-function: var(--#{$data-list}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$data-list}__toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$data-list}__toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$data-list}__toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -86,6 +86,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item--m-expanded__item-toggle-icon--Rotate: 90deg;
   --#{$dual-list-selector}__item-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$dual-list-selector}__item-toggle-icon--Transition: transform var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration) var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$dual-list-selector}__item-toggle-icon--MinWidth: var(--#{$dual-list-selector}__list-item-row--FontSize);
   --#{$dual-list-selector}__list-item--m-disabled__item-toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 }
@@ -339,9 +340,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   min-width: var(--#{$dual-list-selector}__item-toggle-icon--MinWidth);
   color: var(--#{$dual-list-selector}__item-toggle-icon--Color, inherit);
   text-align: center;
-  transition-timing-function: var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$dual-list-selector}__item-toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$dual-list-selector}__item-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -84,7 +84,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   // Icon
   --#{$dual-list-selector}__item-toggle-icon--Rotate: 0;
   --#{$dual-list-selector}__list-item--m-expanded__item-toggle-icon--Rotate: 90deg;
-  --#{$dual-list-selector}__item-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$dual-list-selector}__item-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$dual-list-selector}__item-toggle-icon--MinWidth: var(--#{$dual-list-selector}__list-item-row--FontSize);
   --#{$dual-list-selector}__list-item--m-disabled__item-toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
@@ -339,7 +339,9 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   min-width: var(--#{$dual-list-selector}__item-toggle-icon--MinWidth);
   color: var(--#{$dual-list-selector}__item-toggle-icon--Color, inherit);
   text-align: center;
-  transition: transform var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration) var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction);
+  transition-timing-function: var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$dual-list-selector}__item-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -86,7 +86,6 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item--m-expanded__item-toggle-icon--Rotate: 90deg;
   --#{$dual-list-selector}__item-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$dual-list-selector}__item-toggle-icon--Transition: transform var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration) var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$dual-list-selector}__item-toggle-icon--MinWidth: var(--#{$dual-list-selector}__list-item-row--FontSize);
   --#{$dual-list-selector}__list-item--m-disabled__item-toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 }
@@ -340,7 +339,9 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   min-width: var(--#{$dual-list-selector}__item-toggle-icon--MinWidth);
   color: var(--#{$dual-list-selector}__item-toggle-icon--Color, inherit);
   text-align: center;
-  transition: var(--#{$dual-list-selector}__item-toggle-icon--Transition); // TODO remove shorthand in breaking change
+  transition-timing-function: var(--#{$dual-list-selector}__item-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$dual-list-selector}__item-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$dual-list-selector}__item-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -6,7 +6,8 @@
   // Toggle icon
   --#{$expandable-section}__toggle-icon--MinWidth: 1em;
   --#{$expandable-section}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$expandable-section}__toggle-icon--Transition: .2s ease-in 0s;
+  --#{$expandable-section}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$expandable-section}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$expandable-section}__toggle-icon--Rotate: 0;
   --#{$expandable-section}__toggle-icon--m-expand-top--Rotate: 0;
   --#{$expandable-section}--m-expanded__toggle-icon--Rotate: 90deg;
@@ -85,7 +86,8 @@
   display: inline-block;
   min-width: var(--#{$expandable-section}__toggle-icon--MinWidth);
   color: var(--#{$expandable-section}__toggle-icon--Color);
-  transition: var(--#{$expandable-section}__toggle-icon--Transition);
+  transition-timing-function: var(--#{$expandable-section}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$expandable-section}__toggle-icon--TransitionDuration);
   transform: rotate(var(--#{$expandable-section}__toggle-icon--Rotate));
 
   &.pf-m-expand-top {

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -8,6 +8,7 @@
   --#{$expandable-section}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$expandable-section}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$expandable-section}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$expandable-section}__toggle-icon--Transition: transform var(--#{$expandable-section}__toggle-icon--TransitionDuration) var(--#{$expandable-section}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$expandable-section}__toggle-icon--Rotate: 0;
   --#{$expandable-section}__toggle-icon--m-expand-top--Rotate: 0;
   --#{$expandable-section}--m-expanded__toggle-icon--Rotate: 90deg;
@@ -86,8 +87,7 @@
   display: inline-block;
   min-width: var(--#{$expandable-section}__toggle-icon--MinWidth);
   color: var(--#{$expandable-section}__toggle-icon--Color);
-  transition-timing-function: var(--#{$expandable-section}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$expandable-section}__toggle-icon--TransitionDuration);
+  transition: var(--#{$expandable-section}__toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$expandable-section}__toggle-icon--Rotate));
 
   &.pf-m-expand-top {

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -135,6 +135,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   --#{$form}__field-group-toggle-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--plain) * -1);
   --#{$form}__field-group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$form}__field-group-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$form}__field-group-toggle-icon--Transition: transform var(---#{$form}__field-group-toggle-icon--TransitionDuration) var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$form}__field-group-toggle-icon--MinWidth: var(--pf-t--global--font--size--body--default);
   --#{$form}__field-group-toggle-icon--Rotate: 0;
   --#{$form}__field-group--m-expanded__toggle-icon--Rotate: 90deg;
@@ -408,9 +409,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   display: inline-block;
   min-width: var(--#{$form}__field-group-toggle-icon--MinWidth);
   text-align: center;
-  transition-timing-function: var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$form}__field-group-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$form}__field-group-toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$form}__field-group-toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -133,7 +133,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   --#{$form}__field-group__field-group--field-group__field-group-toggle--after--BorderBlockStartWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
   --#{$form}__field-group-toggle-button--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--plain) * -1);
   --#{$form}__field-group-toggle-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--plain) * -1);
-  --#{$form}__field-group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$form}__field-group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$form}__field-group-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$form}__field-group-toggle-icon--MinWidth: var(--pf-t--global--font--size--body--default);
   --#{$form}__field-group-toggle-icon--Rotate: 0;
@@ -408,7 +408,9 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   display: inline-block;
   min-width: var(--#{$form}__field-group-toggle-icon--MinWidth);
   text-align: center;
-  transition: transform var(--#{$form}__field-group-toggle-icon--TransitionDuration) var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction);
+  transition-timing-function: var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$form}__field-group-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$form}__field-group-toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -135,7 +135,6 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   --#{$form}__field-group-toggle-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--plain) * -1);
   --#{$form}__field-group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$form}__field-group-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$form}__field-group-toggle-icon--Transition: transform var(---#{$form}__field-group-toggle-icon--TransitionDuration) var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$form}__field-group-toggle-icon--MinWidth: var(--pf-t--global--font--size--body--default);
   --#{$form}__field-group-toggle-icon--Rotate: 0;
   --#{$form}__field-group--m-expanded__toggle-icon--Rotate: 90deg;
@@ -409,7 +408,9 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   display: inline-block;
   min-width: var(--#{$form}__field-group-toggle-icon--MinWidth);
   text-align: center;
-  transition: var(--#{$form}__field-group-toggle-icon--Transition); // TODO remove shorthand in breaking change
+  transition-timing-function: var(--#{$form}__field-group-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$form}__field-group-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$form}__field-group-toggle-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl;

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -64,7 +64,6 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$jump-links}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$jump-links}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$jump-links}__toggle-icon--Transition: tranform var(--#{$jump-links}__toggle-icon--TransitionDuration) var(--#{$jump-links}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$jump-links}__toggle-icon--Rotate: 0;
   --#{$jump-links}--m-expanded__toggle-icon--Rotate: 90deg;
 }
@@ -219,6 +218,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   display: inline-block;
   color: var(--#{$jump-links}__toggle-icon--Color);
-  transition: var(--#{$jump-links}__toggle-icon--Transition); // TODO remove shorthand property in breaking change
+  transition-timing-function: var(--#{$jump-links}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$jump-links}__toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$jump-links}__toggle-icon--Rotate));
 }

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -64,6 +64,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$jump-links}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$jump-links}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$jump-links}__toggle-icon--Transition: tranform var(--#{$jump-links}__toggle-icon--TransitionDuration) var(--#{$jump-links}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$jump-links}__toggle-icon--Rotate: 0;
   --#{$jump-links}--m-expanded__toggle-icon--Rotate: 90deg;
 }
@@ -218,8 +219,6 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   display: inline-block;
   color: var(--#{$jump-links}__toggle-icon--Color);
-  transition-timing-function: var(--#{$jump-links}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$jump-links}__toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$jump-links}__toggle-icon--Transition); // TODO remove shorthand property in breaking change
   transform: rotate(var(--#{$jump-links}__toggle-icon--Rotate));
 }

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -62,7 +62,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   // toggle icon
   --#{$jump-links}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$jump-links}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$jump-links}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$jump-links}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$jump-links}__toggle-icon--Rotate: 0;
   --#{$jump-links}--m-expanded__toggle-icon--Rotate: 90deg;
@@ -218,6 +218,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
 
   display: inline-block;
   color: var(--#{$jump-links}__toggle-icon--Color);
-  transition: transform var(--#{$jump-links}__toggle-icon--TransitionDuration) var(--#{$jump-links}__toggle-icon--TransitionTimingFunction);
+  transition-timing-function: var(--#{$jump-links}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$jump-links}__toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$jump-links}__toggle-icon--Rotate));
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -101,7 +101,8 @@
   // Group toggle icon
   --#{$notification-drawer}__group-toggle-icon--MarginInlineEnd: var(--pf-t--global--spacer--md);
   --#{$notification-drawer}__group-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$notification-drawer}__group-toggle-icon--Transition: .2s ease-in 0s;
+  --#{$notification-drawer}__group-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$notification-drawer}__group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate: 90deg;
 }
 
@@ -308,7 +309,9 @@
 
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginInlineEnd);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);
-  transition: var(--#{$notification-drawer}__group-toggle-icon--Transition);
+  transition-timing-function: var(--#{$notification-drawer}__group-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$notification-drawer}__group-toggle-icon--TransitionDuration);
+  transition-property: transform;
 
   .#{$notification-drawer}__group.pf-m-expanded & {
     transform: rotate(var(--#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate));

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -103,6 +103,7 @@
   --#{$notification-drawer}__group-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$notification-drawer}__group-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$notification-drawer}__group-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$notification-drawer}__group-toggle-icon--Transition: transform var(--#{$notification-drawer}__group-toggle-icon--TransitionDuration) var(--#{$notification-drawer}__group-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate: 90deg;
 }
 
@@ -309,9 +310,7 @@
 
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-icon--MarginInlineEnd);
   color: var(--#{$notification-drawer}__group-toggle-icon--Color);
-  transition-timing-function: var(--#{$notification-drawer}__group-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$notification-drawer}__group-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$notification-drawer}__group-toggle-icon--Transition); // TODO remove shorthand in breaking change
 
   .#{$notification-drawer}__group.pf-m-expanded & {
     transform: rotate(var(--#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate));

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -126,6 +126,7 @@
   // * Table grid toggle icon
   --#{$table}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$table}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}__toggle-icon--Transition: transform var(--#{$table}__toggle-icon--TransitionDuration) var(--#{$table}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$table}__toggle--m-expanded__icon--Rotate: 180deg;
 }
 
@@ -524,9 +525,7 @@
 
   // - Table grid toggle icon
   .#{$table}__toggle-icon {
-    transition-timing-function: var(--#{$table}__toggle-icon--TransitionTimingFunction);
-    transition-duration: var(--#{$table}__toggle-icon--TransitionDuration);
-    transition-property: transform;
+    transition: var(--#{$table}__toggle-icon--Transition); // TODO remove shorthand in breaking change
 
     .#{$button}.pf-m-expanded > & {
       transform: rotate(var(--#{$table}__toggle--m-expanded__icon--Rotate));

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -124,7 +124,8 @@
   --#{$table}--m-grid__check--favorite--action--MarginInlineStart: calc(var(--#{$table}--m-grid__check--favorite--MarginInlineStart) + var(--#{$table}--m-grid__favorite--action--MarginInlineStart));
 
   // * Table grid toggle icon
-  --#{$table}__toggle__icon--Transition: .2s ease-in 0s;
+  --#{$table}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$table}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$table}__toggle--m-expanded__icon--Rotate: 180deg;
 }
 
@@ -523,7 +524,9 @@
 
   // - Table grid toggle icon
   .#{$table}__toggle-icon {
-    transition: var(--#{$table}__toggle__icon--Transition);
+    transition-timing-function: var(--#{$table}__toggle-icon--TransitionTimingFunction);
+    transition-duration: var(--#{$table}__toggle-icon--TransitionDuration);
+    transition-property: transform;
 
     .#{$button}.pf-m-expanded > & {
       transform: rotate(var(--#{$table}__toggle--m-expanded__icon--Rotate));

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -124,9 +124,9 @@
   --#{$table}--m-grid__check--favorite--action--MarginInlineStart: calc(var(--#{$table}--m-grid__check--favorite--MarginInlineStart) + var(--#{$table}--m-grid__favorite--action--MarginInlineStart));
 
   // * Table grid toggle icon
-  --#{$table}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
-  --#{$table}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$table}__toggle-icon--Transition: transform var(--#{$table}__toggle-icon--TransitionDuration) var(--#{$table}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
+  --#{$table}__toggle__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$table}__toggle__icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}__toggle__icon--Transition: transform var(--#{$table}__toggle__icon--TransitionDuration) var(--#{$table}__toggle__icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$table}__toggle--m-expanded__icon--Rotate: 180deg;
 }
 
@@ -525,7 +525,7 @@
 
   // - Table grid toggle icon
   .#{$table}__toggle-icon {
-    transition: var(--#{$table}__toggle-icon--Transition); // TODO remove shorthand in breaking change
+    transition: var(--#{$table}__toggle__icon--Transition); // TODO remove shorthand in breaking change
 
     .#{$button}.pf-m-expanded > & {
       transform: rotate(var(--#{$table}__toggle--m-expanded__icon--Rotate));

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -83,7 +83,7 @@
   --#{$table}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
-  --#{$table}__toggle--c-button__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$table}__toggle--c-button__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
@@ -747,7 +747,9 @@
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
 
-    transition: transform var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration) var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction);
+    transition-timing-function: var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction);
+    transition-duration: var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration);
+    transition-property: transform;
     transform: rotate(var(--#{$table}__toggle--c-button__toggle-icon--Rotate));
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -85,7 +85,6 @@
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
   --#{$table}__toggle--c-button__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$table}__toggle--c-button__toggle-icon--Transition: transform var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration) var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
   // * Table button
@@ -748,7 +747,10 @@
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
 
-    transition: var(--#{$table}__toggle--c-button__toggle-icon--Transition); // TODO remove in breaking change
+    transition-timing-function: var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction);
+    transition-duration: var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration);
+    transition-property: transform;
+    transform: rotate(var(--#{$table}__toggle--c-button__toggle-icon--Rotate));
   }
 
   svg {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -85,6 +85,7 @@
   --#{$table}__toggle--c-button__toggle-icon--Rotate: 270deg;
   --#{$table}__toggle--c-button__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}__toggle--c-button__toggle-icon--Transition: transform var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration) var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate: 360deg;
 
   // * Table button
@@ -747,10 +748,8 @@
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
 
-    transition-timing-function: var(--#{$table}__toggle--c-button__toggle-icon--TransitionTimingFunction);
-    transition-duration: var(--#{$table}__toggle--c-button__toggle-icon--TransitionDuration);
+    transition: var(--#{$table}__toggle--c-button__toggle-icon--Transition); // TODO remove in breaking change
     transition-property: transform;
-    transform: rotate(var(--#{$table}__toggle--c-button__toggle-icon--Rotate));
   }
 
   svg {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -749,7 +749,6 @@
     @include pf-v6-mirror-inline-on-rtl;
 
     transition: var(--#{$table}__toggle--c-button__toggle-icon--Transition); // TODO remove in breaking change
-    transition-property: transform;
   }
 
   svg {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -129,7 +129,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   // Expandable
   --#{$tabs}__toggle--Display: flex;
-  --#{$tabs}__toggle-icon--Transition: all 250ms cubic-bezier(.42, 0, .58, 1);
+  --#{$tabs}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$tabs}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$tabs}__toggle-icon--Rotate: 0;
   --#{$tabs}--m-expanded__toggle-icon--Rotate: 90deg;
   --#{$tabs}--m-expandable--RowGap: var(--pf-t--global--spacer--sm);
@@ -155,7 +156,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   // Overflow menu toggle icon
   --#{$tabs}__link-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
-  --#{$tabs}__link-toggle-icon--Transition: .2s ease-in 0s;
+  --#{$tabs}__link-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$tabs}__link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$tabs}__link-toggle-icon--Rotate: 0;
   --#{$tabs}__link-toggle-icon--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--m-expanded__toggle-icon--Rotate: 90deg;
@@ -470,7 +472,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition: var(--#{$tabs}__toggle-icon--Transition);
+  transition-timing-function: var(--#{$tabs}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$tabs}__toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$tabs}__toggle-icon--Rotate));
 }
 
@@ -650,7 +654,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   align-self: end;
   font-size: var(--#{$tabs}__link-toggle-icon--FontSize);
   color: var(--#{$tabs}__link-toggle-icon--Color);
-  transition: var(--#{$tabs}__link-toggle-icon--Transition);
+  transition-timing-function: var(--#{$tabs}__link-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$tabs}__link-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$tabs}__link-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -159,6 +159,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link-toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$tabs}__link-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$tabs}__link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$tabs}__link-toggle-icon--Transition: transform var(--#{$tabs}__link-toggle-icon--TransitionDuration) var(--#{$tabs}__link-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$tabs}__link-toggle-icon--Rotate: 0;
   --#{$tabs}__link-toggle-icon--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--m-expanded__toggle-icon--Rotate: 90deg;
@@ -653,9 +654,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   align-self: end;
   font-size: var(--#{$tabs}__link-toggle-icon--FontSize);
   color: var(--#{$tabs}__link-toggle-icon--Color);
-  transition-timing-function: var(--#{$tabs}__link-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$tabs}__link-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$tabs}__link-toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$tabs}__link-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -131,6 +131,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__toggle--Display: flex;
   --#{$tabs}__toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$tabs}__toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
+  --#{$tabs}__toggle-icon--Transition: transform var(--#{$tabs}__toggle-icon--TransitionDuration) var(--#{$tabs}__toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$tabs}__toggle-icon--Rotate: 0;
   --#{$tabs}--m-expanded__toggle-icon--Rotate: 90deg;
   --#{$tabs}--m-expandable--RowGap: var(--pf-t--global--spacer--sm);
@@ -472,9 +473,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition-timing-function: var(--#{$tabs}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$tabs}__toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$tabs}__toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$tabs}__toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -67,7 +67,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // * Toolbar expand all
   --#{$toolbar}__expand-all-icon--Rotate: 0;
-  --#{$toolbar}__expand-all-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$toolbar}__expand-all-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$toolbar}__expand-all-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$toolbar}__item--m-expand-all--m-expanded__expand-all-icon--Rotate: 90deg;
 
@@ -300,7 +300,9 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 // - Toolbar expand all
 .#{$toolbar}__expand-all-icon {
   display: inline-flex;
-  transition: transform var(--#{$toolbar}__expand-all-icon--TransitionDuration) var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction);
+  transition-timing-function: var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$toolbar}__expand-all-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$toolbar}__expand-all-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl; // - TODO: mirror this icon in breaking change

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -69,6 +69,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}__expand-all-icon--Rotate: 0;
   --#{$toolbar}__expand-all-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$toolbar}__expand-all-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$toolbar}__expand-all-icon--Transition:  transform var(--#{$toolbar}__expand-all-icon--TransitionDuration) var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$toolbar}__item--m-expand-all--m-expanded__expand-all-icon--Rotate: 90deg;
 
   // * Toolbar filter group
@@ -300,9 +301,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 // - Toolbar expand all
 .#{$toolbar}__expand-all-icon {
   display: inline-flex;
-  transition-timing-function: var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$toolbar}__expand-all-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$toolbar}__expand-all-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$toolbar}__expand-all-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl; // - TODO: mirror this icon in breaking change

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -69,7 +69,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}__expand-all-icon--Rotate: 0;
   --#{$toolbar}__expand-all-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$toolbar}__expand-all-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$toolbar}__expand-all-icon--Transition:  transform var(--#{$toolbar}__expand-all-icon--TransitionDuration) var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$toolbar}__item--m-expand-all--m-expanded__expand-all-icon--Rotate: 90deg;
 
   // * Toolbar filter group
@@ -301,7 +300,9 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 // - Toolbar expand all
 .#{$toolbar}__expand-all-icon {
   display: inline-flex;
-  transition: var(--#{$toolbar}__expand-all-icon--Transition); // TODO remove shorthand in breaking change
+  transition-timing-function: var(--#{$toolbar}__expand-all-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$toolbar}__expand-all-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$toolbar}__expand-all-icon--Rotate));
 
   @include pf-v6-mirror-inline-on-rtl; // - TODO: mirror this icon in breaking change

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -65,6 +65,7 @@
   --#{$wizard}__nav-link-toggle--Color: var(--pf-t--global--icon--color--regular);
   --#{$wizard}__nav-link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$wizard}__nav-link-toggle-icon--Transition: transform var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration) var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$wizard}__nav-link-toggle-icon--Rotate: 0;
   --#{$wizard}__nav-item--m-expanded__link-toggle-icon--Rotate: 90deg;
 
@@ -547,9 +548,7 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition-timing-function:  var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration);
-  transition-property: transform;
+  transition: var(--#{$wizard}__nav-link-toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$wizard}__nav-link-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -65,7 +65,6 @@
   --#{$wizard}__nav-link-toggle--Color: var(--pf-t--global--icon--color--regular);
   --#{$wizard}__nav-link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$wizard}__nav-link-toggle-icon--Transition: transform var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration) var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction); // TODO remove in breaking change along with shorthand property
   --#{$wizard}__nav-link-toggle-icon--Rotate: 0;
   --#{$wizard}__nav-item--m-expanded__link-toggle-icon--Rotate: 90deg;
 
@@ -548,7 +547,9 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition: var(--#{$wizard}__nav-link-toggle-icon--Transition); // TODO remove shorthand in breaking change
+  transition-timing-function: var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$wizard}__nav-link-toggle-icon--Rotate));
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -63,7 +63,7 @@
   --#{$wizard}__nav-link-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-toggle--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-toggle--Color: var(--pf-t--global--icon--color--regular);
-  --#{$wizard}__nav-link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
+  --#{$wizard}__nav-link-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
   --#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$wizard}__nav-link-toggle-icon--Rotate: 0;
   --#{$wizard}__nav-item--m-expanded__link-toggle-icon--Rotate: 90deg;
@@ -547,7 +547,9 @@
   @include pf-v6-mirror-inline-on-rtl;
 
   display: inline-block;
-  transition: transform var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration) var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction);
+  transition-timing-function:  var(--#{$wizard}__nav-link-toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$wizard}__nav-link-toggle-icon--TransitionDuration);
+  transition-property: transform;
   transform: rotate(var(--#{$wizard}__nav-link-toggle-icon--Rotate));
 }
 


### PR DESCRIPTION
Fixes #6959 

Puts tokens and vars where transitions were hard coded.
Breaks apart shorthand transition into separate properties.
Where the --long duration token was used for the expansion toggle rotation, it was changed to --default (per design team on slack)
