### PR TITLE
fix(global): banner, data-list, menu-toggle bugs

### DIFF
--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -158,8 +158,8 @@
   }
 
   .#{$button}.pf-m-inline {
-    --#{$button}--m-link--Color: var(--#{$banner}--link--Color);
-    --#{$button}--m-link--hover--Color: var(--#{$banner}--link--hover--Color);
+    --#{$button}--m-link--m-inline--Color: var(--#{$banner}--link--Color);
+    --#{$button}--m-link--m-inline--hover--Color: var(--#{$banner}--link--hover--Color);
     --#{$button}--disabled--Color: var(--#{$banner}--link--disabled--Color);
 
     text-decoration-line: var(--#{$banner}--link--TextDecoration);

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -871,7 +871,7 @@ When a list item includes more than one block of content, it can be difficult fo
 <div id="draggable-help">
   Activate the reorder button and use the arrow keys to reorder the list or use your mouse to drag/reorder. Press escape to cancel the reordering.
 </div>
-{{#> data-list data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"'}}
+{{#> data-list data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"' data-list--IsCompact=true}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -131,7 +131,7 @@
   --#{$menu-toggle}--m-plain--Color: var(--pf-t--global--icon--color--regular);
   --#{$menu-toggle}--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$menu-toggle}--m-plain--BorderColor: transparent;
-  --#{$menu-toggle}--m-plain--BorderRadius: var(--#{$menu-toggle}--BorderRadius);
+  --#{$menu-toggle}--m-plain--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$menu-toggle}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$menu-toggle}--m-plain--expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$menu-toggle}--m-plain--disabled--Color: var(--pf-t--global--text--color--disabled);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7297

There are 2 outstanding issues. Looks like both are the result of this PR (cc @srambach) - https://github.com/patternfly/patternfly/pull/7224

1. The "logo" area when using horizontal navigation (no sidebar/vertical navigation) is the same width as a page with vertical navigation. @andrew-ronaldson @lboehling can you confirm if that should be the case? Or when using horizontal navigation, should the logo just take up however much space is needed for the logo? Here's what it looks like now with horizontal nav in the front and vertical nav in the back


<img width="533" alt="Screenshot 2025-03-10 at 7 48 25 PM" src="https://github.com/user-attachments/assets/23250148-df2b-4619-b74e-158fb34956e8" />


FWIW here is what it looks like if the logo area is only as big as the logo


<img width="547" alt="Screenshot 2025-03-10 at 7 52 09 PM" src="https://github.com/user-attachments/assets/992ee3bf-8bc4-4233-ba13-dce7f1086a8f" />


2. We lost the right margin on the page sidebar/vertical navigation. You can see here that there is much less space to the right of the sidebar compared to the left, and when there is a scrollbar, it touches the main content container. @andrew-ronaldson @lboehling can you confirm which is preferred, or if there are any other changes you'd like to see?


<img width="540" alt="Screenshot 2025-03-10 at 7 53 33 PM" src="https://github.com/user-attachments/assets/3be29aac-e75f-4048-99dc-35c6a89e0d02" />
<img width="409" alt="Screenshot 2025-03-10 at 7 53 25 PM" src="https://github.com/user-attachments/assets/9493209f-acc2-4748-868f-80579562fc63" />

 
If we revert the change from https://github.com/patternfly/patternfly/pull/7224, you can see the space on the left side of the nav matches the right, and there is space between the scrollbar and main content container.


<img width="476" alt="Screenshot 2025-03-10 at 7 53 55 PM" src="https://github.com/user-attachments/assets/5cbf6508-298e-41a1-89fe-6d1e267f9a2e" />
<img width="493" alt="Screenshot 2025-03-10 at 7 54 00 PM" src="https://github.com/user-attachments/assets/40a2c878-4669-40cc-beb6-a1e17f6a8b3b" />
