### PR TITLE
fix(alert-group): only apply incoming animation to the newest alert

### DIFF
--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -154,7 +154,8 @@
   }
 
   // This class is used BEFORE the alert item comes into the list
-  &.pf-m-offstage-top {
+  // Only apply if the item is the first alert in the list (all new alerts should appear at the top)
+  &.pf-m-offstage-top:first-child {
     // make the item have no height and position it up above
     grid-template-rows: 0fr;
     margin-block: 0;


### PR DESCRIPTION
Tweak to alert animation to apply the incoming animation (sliding down from the top) only to the most recent - i.e. the first - alert. This supports React PR https://github.com/patternfly/patternfly-react/pull/11495 where the animations are connected to adding and removing alerts from the alert group.
