### PR TITLE
fix(CI): Enforce node version 20.18.3 in CI

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,7 +26,7 @@ jobs:
       # Injected by generate-workflows.js
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.18.3'
       #- uses: actions/cache@v4
       #  id: yarn-cache
       #  name: Load npm deps from cache

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,7 +17,7 @@ jobs:
         run: yarn install --frozen-lockfile && yarn build
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.18.3'
           registry-url: 'https://registry.npmjs.org'
       - name: GitHub Tag Name example
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Injected by generate-workflows.js
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.18.3'
       # - uses: actions/cache@v4
       #   id: yarn-cache
       #   name: Load npm deps from cache


### PR DESCRIPTION
20.19.0 is throwing errors because of this change:
https://nodejs.org/en/blog/release/v20.19.0#requireesm-is-now-enabled-by-default
