### PR TITLE
fix(menu-toggle): correct avatar alignment within menu-toggle 

### DIFF
--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -280,7 +280,7 @@ import './MenuToggle.css'
 ### With avatar and text
 ```hbs
 {{#> menu-toggle}}
-  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
+  {{#> menu-toggle-icon}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -294,7 +294,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--IsExpanded="true"}}
-  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
+  {{#> menu-toggle-icon}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -308,7 +308,7 @@ import './MenuToggle.css'
 &nbsp;
 
 {{#> menu-toggle menu-toggle--IsDisabled="true"}}
-  {{#> menu-toggle-icon menu-toggle-icon--HasAvatar=true}}
+  {{#> menu-toggle-icon}}
     {{> avatar avatar--modifier="pf-m-sm"}}
   {{/menu-toggle-icon}}
   {{#> menu-toggle-text}}
@@ -1034,4 +1034,3 @@ Shown with default, primary, and secondary styling
 | `.pf-m-warning` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the warning state. |
 | `.pf-m-danger` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the danger state. |
 | `.pf-m-placeholder` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle text for placeholder styles. |
-| `.pf-m-avatar` | `.pf-v6-c-menu-toggle__icon` | Modifies the menu toggle icon for avatar styles. |

--- a/src/patternfly/components/MenuToggle/menu-toggle-icon.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-icon.hbs
@@ -1,6 +1,5 @@
 <span class="{{pfv}}menu-toggle__icon
   {{setModifiers
-    menu-toggle-icon--HasAvatar='pf-m-avatar'
     menu-toggle-icon--modifier=menu-toggle-icon--modifier
   }}"
   {{#if menu-toggle-icon--attribute}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -567,16 +567,28 @@
   flex-wrap: nowrap;
 }
 
+%pf-v6-menu-toggle__icon--MarginBlock {
+  margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) * -1);
+  margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) * -1);
+}
+
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
-
+  
+  @at-root .#{$menu-toggle}:not(.pf-m-plain) & {
+    @extend %pf-v6-menu-toggle__icon--MarginBlock;
+  }
+  
   &.pf-m-avatar {
     .#{$avatar},
     img,
     svg {
-      margin-block-start: calc(var(--#{$menu-toggle}--PaddingBlockStart) * -1);
-      margin-block-end: calc(var(--#{$menu-toggle}--PaddingBlockEnd) * -1);
+      @extend %pf-v6-menu-toggle__icon--MarginBlock;
     }
+  }
+
+  :where(picture, img) {
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7410

Aligns the menu-toggle icon `img` correctly. Also removed `pf-m-avatar` modifier.
