### PR TITLE
fix(rtl): fixes RTL styling

### DIFF
--- a/src/patternfly/base/patternfly-variables.scss
+++ b/src/patternfly/base/patternfly-variables.scss
@@ -15,6 +15,6 @@
   @include dark.pf-v6-tokens;
 }
 
-@include pf-v6-rtl {
+@include pf-v6-rtl(false) {
   @include pf-v6-set-inverse;
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -370,15 +370,19 @@
 // [dir="rtl"] {
 //   background: red;
 // }
-@mixin pf-v6-rtl {
-  @at-root :where(.#{$pf-prefix}m-dir-rtl, [dir="rtl"]) #{&} {
+@mixin pf-v6-rtl($hasWhere: true) {
+  $sel: if($hasWhere,':where',':is');
+
+  @at-root #{$sel}(.#{$pf-prefix}m-dir-rtl, [dir="rtl"]) #{&} {
     @content;
   }
 }
 
 // Used to create the LTR selector for LTR specific styles
-@mixin pf-v6-ltr {
-  @at-root :where(.#{$pf-prefix}m-dir-ltr, [dir="ltr"]) #{&} {
+@mixin pf-v6-ltr($hasWhere: true) {
+  $sel: if($hasWhere,':where',':is');
+
+  @at-root #{$sel}(.#{$pf-prefix}m-dir-ltr, [dir="ltr"]) #{&} {
     @content;
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7414
fixes https://github.com/patternfly/patternfly/issues/7292

This fixes RTL styles that reference the `--pf-v6-global--inverse--multiplier` var when using `dir="rtl"`. To test, load any comnponents that use `@include pf-v6-bidirectional-style` (which is used mostly with styles that `translate` something directionally) or `@include pf-v6-mirror-inline-on-rtl`, which flips/mirrors icons mostly (like left/right directional carets)

A few that were broken and should now be fixed:
`pf-v6-bidirectional-style` - drawer, truncate, slider, switch, dual-list-selector
`pf-v6-mirror-inline-on-rtl` - tabs, card, tree view, table, data-list (probably the "expand" button in these)