### PR TITLE
fix(alert-group): make animation respect RTL

### DIFF
--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -38,34 +38,58 @@
     var(--#{$alert-group}--m-toast__item--c-alert--TransitionTimingFunction)
     0s;
 
-  // Alert group item removal reduced motion
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity--default: var(--pf-t--global--motion--duration--fade--default);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity--default: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows--default: var(--pf-t--global--motion--duration--fade--default);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block--default: var(--pf-t--global--motion--duration--fade--default);
-  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDelay--default: var(--pf-t--global--motion--duration--fade--default);
+  // Alert group item removal (outgoing) reduced motion
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--opacity--default: var(--pf-t--global--motion--duration--fade--default);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--opacity--default: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--grid-template-rows--default: var(--pf-t--global--motion--duration--fade--default);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--margin-block--default: var(--pf-t--global--motion--duration--fade--default);
+  --#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionDelay--default: var(--pf-t--global--motion--duration--fade--default);
 
-  // Alert group item removal
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-out--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-out--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--margin-block: var(--pf-t--global--motion--duration--fade--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--margin-block: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block: var(--pf-t--global--motion--duration--slide-out--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows: var(--pf-t--global--motion--duration--slide-out--short);
-    
-    // Alert removal
-  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDuration: var(--pf-t--global--motion--duration--slide-out--short);
-  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition: all 
-    var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDuration) 
-    var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionTimingFunction) 
-    var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDuration);
+  // TODO Legacy variables for alert group item removal reduced motion - remove in breaking change
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity--default: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity--default: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows--default: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block--default: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDelay--default: initial;
   
-  // Overflow button
+  // Alert group item removal (outgoing)
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-out--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--transform: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-out--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--margin-block: var(--pf-t--global--motion--duration--fade--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--margin-block: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--margin-block: var(--pf-t--global--motion--duration--slide-out--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--grid-template-rows: var(--pf-t--global--motion--duration--slide-out--short);
+    
+  // TODO Legacy variables for Alert group item removal - remove in breaking change
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--transform: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--transform: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--margin-block: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--margin-block: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--grid-template-rows: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--grid-template-rows: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows: initial;
+
+  // Alert removal (outgoing)
+  --#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionDuration: var(--pf-t--global--motion--duration--slide-out--short);
+  --#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$alert-group}--m-toast__item--m-outgoing--c-alert--Transition: all 
+    var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionDuration) 
+    var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionTimingFunction) 
+    var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionDuration);
+  
+  // TODO Legacy variables for Alert removal - remove in breaking change
+  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDuration: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionTimingFunction: initial;
+  --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition: initial;
+
+    // Overflow button
   --#{$alert-group}__overflow-button--BorderWidth: 0;
   --#{$alert-group}__overflow-button--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$alert-group}__overflow-button--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -155,7 +179,8 @@
 
   // This class is used BEFORE the alert item comes into the list
   // Only apply if the item is the first alert in the list (all new alerts should appear at the top)
-  &.pf-m-offstage-top:first-child {
+  &.pf-m-offstage-top:first-child, // TODO remove in breaking change
+  &.pf-m-incoming:first-child {
     // make the item have no height and position it up above
     grid-template-rows: 0fr;
     margin-block: 0;
@@ -174,7 +199,8 @@
 
   // Add this class before removing an alert
   // TODO auto dismissal should be the same motion, but has a different duration
-  &.pf-m-offstage-right {
+  &.pf-m-offstage-right, // TODO remove in breaking change
+  &.pf-m-outgoing {
     grid-template-rows: 0fr; // collapse vertically to bring up the items below
     margin-block: 0;
     overflow: hidden;
@@ -186,13 +212,13 @@
     transition: 
       grid-template-rows 
         0s
-        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows--default),
+        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows--default, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--grid-template-rows--default)),
       margin-block 
         0s
-        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block--default),
+        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block--default, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--margin-block--default)),
       opacity
-        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity--default)
-        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity--default);
+        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity--default, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--opacity--default))
+        var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity--default, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--opacity--default));
       
       & .pf-v6-c-alert {
         min-height: 0;
@@ -202,32 +228,37 @@
         transition: 
           all 
             0s
-            var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDelay--default);
+            var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--TransitionDelay--default, var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--TransitionDelay--default));
       }
       
-      // This transition will happen when the item is removed (.pf-m-offstage-right is added)
+      // This transition will happen when the item is removed (.pf-m-outgoing is added)
       // Slide it down into place, then reduce height
       // These values are for regular motion
       @media screen and (prefers-reduced-motion: no-preference) {
       transition: 
         transform 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--transform) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--transform), 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--transform, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--transform)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--transform, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--transform)), 
         opacity 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity),
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--opacity, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--opacity)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--opacity, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--opacity)),
         margin-block 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--margin-block) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--margin-block) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block), 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--margin-block, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--margin-block)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--margin-block, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--margin-block)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--margin-block, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--margin-block)), 
         grid-template-rows 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--grid-template-rows) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--grid-template-rows) 
-          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows);
-      transform: translateX(100%);
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDuration--grid-template-rows, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDuration--grid-template-rows)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionTimingFunction--grid-template-rows, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionTimingFunction--grid-template-rows)) 
+          var(--#{$alert-group}--m-toast__item--m-offstage-right--TransitionDelay--grid-template-rows, var(--#{$alert-group}--m-toast__item--m-outgoing--TransitionDelay--grid-template-rows));
 
+        @include pf-v6-bidirectional-style(
+          $prop: transform,
+          $ltr-val: translateX(100%),
+          $rtl-val: translateX(#{pf-v6-calc-inverse(100%)}),
+        );
+    
         & .pf-v6-c-alert {
-          transition: var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition);
+          transition: var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition, var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--Transition));
         }
     }
   }


### PR DESCRIPTION
This does two things:

- Adds the RTL calculation to reverse the translate when appropriate
- Renames `.pf-m-offstage-top` and `.pf-m-offstage-right` to `.pf-m-incoming` and `.pf-m-outgoing` to be more descriptive for the state rather than the specific action. (Old classes remain until a breaking change.) I've created variables with the updated names and have used fallbacks to ensure that the old variables will continue to work until a breaking change can remove them.

React will continue to work because of the fallbacks/old classnames still existing, but a followup should be created in order to use the new classes.

Fixes #7365 