### PR TITLE
chore(Truncate): added modifier and example for max characters logic

### DIFF
--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -8,7 +8,7 @@ import './Truncate.css'
 
 ## Examples
 
-The default behavior of the `Truncate` component is to truncate based on whether the content can fit within the width of its parent container, and to prevent text from wrapping. The following examples that use this default behavior render the `Truncate` component inside a resizable container, allowing you to see how the parent container width affects the truncation.
+The default behavior of the truncate component is to truncate based on whether the content can fit within the width of its parent container, and to prevent text from wrapping. The following examples that use this default behavior render the truncate component inside a resizable container, allowing you to see how the parent container width affects the truncation.
 
 ### Default
 
@@ -49,31 +49,39 @@ When only the `.pf-v6-c-truncate__end` element is used, truncation will occur at
 
 ### Based on max characters
 
-Apply the `pf-m-ignore-resizing` class to the `pf-v6-c-truncate` element to implement truncation based on an amount of characters rather than a parent container width. You must ensure that the omission designator (typically an ellipsis) is removed from the accessibility tree by wrapping it in a `<span>` with the `aria-hidden="true"` attribute.
+Apply the `.pf-m-fixed` class to the `.pf-v6-c-truncate` element to implement truncation based on a fixed amount of characters rather than a parent container width. You must ensure that the omission designator (typically an ellipsis) is removed from the accessibility tree by wrapping it in a `<span>` with the `aria-hidden="true"` attribute.
 
 ```hbs
 <div>Truncated at end position:</div>
-{{#> truncate truncate--ShouldIgnoreResize=true}}
-  <span>redhat_logo_black_and_white_reversed_simple_with_</span>
-  <span aria-hidden="true">…</span>
+{{#> truncate truncate--IsFixed=true}}
+  {{#> truncate-text}}
+    redhat_logo_black_and_white_reversed_simple_with_
+  {{/truncate-text}}
+  {{> truncate-omission}}
   {{#> screen-reader}}fedora_container.zip{{/screen-reader}}
 {{/truncate}}
 <br />
 <br />
 <div>Truncated at middle position:</div>
-{{#> truncate truncate--ShouldIgnoreResize=true}}
-  <span>redhat_logo_black_and_</span>
+{{#> truncate truncate--IsFixed=true}}
+  {{#> truncate-text}}
+    redhat_logo_black_and_
+  {{/truncate-text}}
   {{#> screen-reader}}white_reversed_simple_with_{{/screen-reader}}
-  <span aria-hidden="true">…</span>
-  <span>fedora_container.zip</span>
+  {{> truncate-omission}}
+  {{#> truncate-text}}
+    fedora_container.zip
+  {{/truncate-text}}
 {{/truncate}}
 <br />
 <br />
 <div>Truncated at start position:</div>
-{{#> truncate truncate--ShouldIgnoreResize=true}}
+{{#> truncate truncate--IsFixed=true}}
   {{#> screen-reader}}redhat_logo_black_{{/screen-reader}}
-  <span aria-hidden="true">…</span>
-  <span>and_white_reversed_simple_with_fedora_container.zip</span>
+  {{> truncate-omission}}
+  {{#> truncate-text}}
+    and_white_reversed_simple_with_fedora_container.zip
+  {{/truncate-text}}
 {{/truncate}}
 ```
 
@@ -84,7 +92,7 @@ Apply the `pf-m-ignore-resizing` class to the `pf-v6-c-truncate` element to impl
 | Class | Applied | Outcome |
 | -- | -- | -- |
 | `.pf-v6-c-truncate` | `<span>` | Initiates the truncate component. **Required** |
-| `.pf-v6-c-truncate__start` | `<span>` | Defines the truncate component starting text. |
-| `.pf-v6-c-truncate__end` | `<span>` | Defines the truncate component ending text. |
-| `.pf-m-ignore-resizing` | `span.pf-v6-c-truncate` | Modifies the truncate component to ignore resizing and container widths for truncation. |
-| `.pf-v6-screen-reader` | `.pf-v6-c-truncate span` | Visually hides text when truncation is meant to occur based on a maximum amount of characters rather than resizing/container width. | 
+| `.pf-v6-c-truncate__start` | `.pf-v6-c-truncate span` | Defines the truncate component starting text. Only to be used when the `.pf-m-fixed` class is **not** applied to the `.pf-v6-c-truncate` element. |
+| `.pf-v6-c-truncate__end` | `.pf-v6-c-truncate span` | Defines the truncate component ending text. Only to be used when the `.pf-m-fixed` class is **not** applied to the `.pf-v6-c-truncate` element. |
+| `.pf-v6-c-truncate__text` | `.pf-v6-c-truncate.pf-m-fixed span` | Defines the visible truncate component text when the `pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
+| `.pf-m-fixed` | `.pf-v6-c-truncate` | Modifies the truncate component to base truncation on a fixed amount of characters rather than container width. |

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -8,37 +8,74 @@ import './Truncate.css'
 
 ## Examples
 
-### Notes
-The truncate component contains two child elements, `.pf-v6-c-truncate__start` and `.pf-v6-c-truncate__end`. If both `start` and `end` are present within `.pf-v6-c-truncate`, trucation will occur in the middle of the string. If only `.pf-v6-c-truncate__start` is present, truncation will occur at the end of the string. If only `.pf-v6-c-truncate__end` is present, truncation will occur at the beginning of the string. A `.pf-v6-c-popover` will be automatically applied to the PatternFly React implementation. `&lrm;` must be included at the end of string to denote the ending punctuation mark. Otherwise it will occur and the beggining of truncation for a `pf-v6-c-truncate__end` element.
+The default behavior of the `Truncate` component is to truncate based on whether the content can fit within the width of its parent container, and to prevent text from wrapping. The following examples that use this default behavior render the `Truncate` component inside a resizable container, allowing you to see how the parent container width affects the truncation.
 
 ### Default
+
+When only the `.pf-v6-c-truncate__start` element is used, truncation will occur at the end of the string.
+
 ```hbs
 <div class="pf-v6-c-truncate--example">
   {{#> truncate truncate--id='default-truncation-example'}}
-    {{> truncate-start truncate-start--text='Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.'}}
+    {{> truncate-start truncate-start--text='redhat_logo_black_and_white_reversed_simple_with_fedora_container.zip'}}
   {{/truncate}}
 </div>
 ```
 
 ### Middle
+
+When both `.pf-v6-c-truncate__start` and `.pf-v6-c-truncate__end` elements are used, truncation will occur between the strings that are in each respective element. As the parent container width changes, the point at which content within the `.pf-v6-c-truncate__start` element is truncated will also change.
+
 ```hbs
 <div class="pf-v6-c-truncate--example">
   {{#> truncate truncate--id='middle-of-line-truncation-example'}}
-    {{> truncate-start truncate-start--text='Vestibulum interdum risus et enim faucibus,&nbsp;'}}
-    {{> truncate-end truncate-end--text='sit amet molestie est accumsan.'}}
+    {{> truncate-start truncate-start--text='redhat_logo_black_and_white_reversed_simple_'}}
+    {{> truncate-end truncate-end--text='with_fedora_container.zip'}}
   {{/truncate}}
 </div>
 ```
 
 ### Start
+
+When only the `.pf-v6-c-truncate__end` element is used, truncation will occur at the start of the string. `&lrm;` **must** be included at the end of a string to denote the ending punctuation mark, otherwise it will render at the start of the truncated content.
+
 ```hbs
 <div class="pf-v6-c-truncate--example">
   {{#> truncate truncate--id='start-truncation-example'}}
-    {{> truncate-end truncate-end--text='Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.&lrm;'}}
+    {{> truncate-end truncate-end--text='redhat_logo_black_and_white_reversed_simple_with_fedora_container.zip'}}
   {{/truncate}}
 </div>
 ```
 
+### Based on max characters
+
+Apply the `pf-m-ignore-resizing` class to the `pf-v6-c-truncate` element to implement truncation based on an amount of characters rather than a parent container width. You must ensure that the omission designator (typically an ellipsis) is removed from the accessibility tree by wrapping it in a `<span>` with the `aria-hidden="true"` attribute.
+
+```hbs
+<div>Truncated at end position:</div>
+{{#> truncate truncate--id='max-chars-truncation-example'}}
+  redhat_logo_black_and_white_reversed_simple_with_
+  <span aria-hidden="true">…</span>
+  {{#> screen-reader}}fedora_container.zip{{/screen-reader}}
+{{/truncate}}
+<br />
+<br />
+<div>Truncated at middle position:</div>
+{{#> truncate truncate--id='max-chars-truncation-example'}}
+  redhat_logo_black_and_
+  {{#> screen-reader}}white_reversed_simple_with_{{/screen-reader}}
+  <span aria-hidden="true">…</span>
+  fedora_container.zip
+{{/truncate}}
+<br />
+<br />
+<div>Truncated at start position:</div>
+{{#> truncate truncate--id='max-chars-truncation-example'}}
+  {{#> screen-reader}}redhat_logo_black_{{/screen-reader}}
+  <span aria-hidden="true">…</span>
+  and_white_reversed_simple_with_fedora_container.zip
+{{/truncate}}
+```
 
 ## Documentation
 
@@ -46,6 +83,8 @@ The truncate component contains two child elements, `.pf-v6-c-truncate__start` a
 
 | Class | Applied | Outcome |
 | -- | -- | -- |
-| `.pf-v6-c-truncate` | `<span>` | Initiates the truncate component. |
+| `.pf-v6-c-truncate` | `<span>` | Initiates the truncate component. **Required** |
 | `.pf-v6-c-truncate__start` | `<span>` | Defines the truncate component starting text. |
 | `.pf-v6-c-truncate__end` | `<span>` | Defines the truncate component ending text. |
+| `.pf-m-ignore-resizing` | `span.pf-v6-c-truncate` | Modifies the truncate component to ignore resizing and container widths for truncation. |
+| `.pf-v6-screen-reader` | `.pf-v6-c-truncate span` | Visually hides text when truncation is meant to occur based on a maximum amount of characters rather than resizing/container width. | 

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -49,7 +49,7 @@ When only the `.pf-v6-c-truncate__end` element is used, truncation will occur at
 
 ### Based on max characters
 
-Apply the `.pf-m-fixed` class to the `.pf-v6-c-truncate` element to implement truncation based on a fixed amount of characters rather than a parent container width. You must ensure that the omission designator (typically an ellipsis) is removed from the accessibility tree by wrapping it in a `<span>` with the `aria-hidden="true"` attribute.
+Apply the `.pf-m-fixed` class to the `.pf-v6-c-truncate` element to implement truncation based on a fixed amount of characters rather than a parent container width.
 
 ```hbs
 <div>Truncated at end position:</div>
@@ -92,7 +92,7 @@ Apply the `.pf-m-fixed` class to the `.pf-v6-c-truncate` element to implement tr
 | Class | Applied | Outcome |
 | -- | -- | -- |
 | `.pf-v6-c-truncate` | `<span>` | Initiates the truncate component. **Required** |
-| `.pf-v6-c-truncate__start` | `.pf-v6-c-truncate span` | Defines the truncate component starting text. Only to be used when the `.pf-m-fixed` class is **not** applied to the `.pf-v6-c-truncate` element. |
-| `.pf-v6-c-truncate__end` | `.pf-v6-c-truncate span` | Defines the truncate component ending text. Only to be used when the `.pf-m-fixed` class is **not** applied to the `.pf-v6-c-truncate` element. |
-| `.pf-v6-c-truncate__text` | `.pf-v6-c-truncate.pf-m-fixed span` | Defines the visible truncate component text when the `pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
+| `.pf-v6-c-truncate__start` | `<span>` | Defines the truncate component starting text. **Required** when using default/end or middle truncation, **except** for when the `.pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
+| `.pf-v6-c-truncate__end` | `<span>` | Defines the truncate component ending text. **Required** when using start or middle truncation, **except** for when the `.pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element.  |
+| `.pf-v6-c-truncate__text` | `<span>` | Defines the visible truncate component text. **Required** and should only be used when the `pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
 | `.pf-m-fixed` | `.pf-v6-c-truncate` | Modifies the truncate component to base truncation on a fixed amount of characters rather than container width. |

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -94,5 +94,5 @@ Apply the `.pf-m-fixed` class to the `.pf-v6-c-truncate` element to implement tr
 | `.pf-v6-c-truncate` | `<span>` | Initiates the truncate component. **Required** |
 | `.pf-v6-c-truncate__start` | `<span>` | Defines the truncate component starting text. **Required** when using default/end or middle truncation, **except** for when the `.pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
 | `.pf-v6-c-truncate__end` | `<span>` | Defines the truncate component ending text. **Required** when using start or middle truncation, **except** for when the `.pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element.  |
-| `.pf-v6-c-truncate__text` | `<span>` | Defines the visible truncate component text. **Required** and should only be used when the `pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
+| `.pf-v6-c-truncate__text` | `<span>` | Defines the visible truncate component text. **Required** and should only be used when the `.pf-m-fixed` class is applied to the `.pf-v6-c-truncate` element. |
 | `.pf-m-fixed` | `.pf-v6-c-truncate` | Modifies the truncate component to base truncation on a fixed amount of characters rather than container width. |

--- a/src/patternfly/components/Truncate/examples/Truncate.md
+++ b/src/patternfly/components/Truncate/examples/Truncate.md
@@ -53,27 +53,27 @@ Apply the `pf-m-ignore-resizing` class to the `pf-v6-c-truncate` element to impl
 
 ```hbs
 <div>Truncated at end position:</div>
-{{#> truncate truncate--id='max-chars-truncation-example'}}
-  redhat_logo_black_and_white_reversed_simple_with_
+{{#> truncate truncate--ShouldIgnoreResize=true}}
+  <span>redhat_logo_black_and_white_reversed_simple_with_</span>
   <span aria-hidden="true">…</span>
   {{#> screen-reader}}fedora_container.zip{{/screen-reader}}
 {{/truncate}}
 <br />
 <br />
 <div>Truncated at middle position:</div>
-{{#> truncate truncate--id='max-chars-truncation-example'}}
-  redhat_logo_black_and_
+{{#> truncate truncate--ShouldIgnoreResize=true}}
+  <span>redhat_logo_black_and_</span>
   {{#> screen-reader}}white_reversed_simple_with_{{/screen-reader}}
   <span aria-hidden="true">…</span>
-  fedora_container.zip
+  <span>fedora_container.zip</span>
 {{/truncate}}
 <br />
 <br />
 <div>Truncated at start position:</div>
-{{#> truncate truncate--id='max-chars-truncation-example'}}
+{{#> truncate truncate--ShouldIgnoreResize=true}}
   {{#> screen-reader}}redhat_logo_black_{{/screen-reader}}
   <span aria-hidden="true">…</span>
-  and_white_reversed_simple_with_fedora_container.zip
+  <span>and_white_reversed_simple_with_fedora_container.zip</span>
 {{/truncate}}
 ```
 

--- a/src/patternfly/components/Truncate/truncate-omission.hbs
+++ b/src/patternfly/components/Truncate/truncate-omission.hbs
@@ -1,8 +1,8 @@
 <span class="{{pfv}}truncate__omission{{#if truncate-omission--modifier}} {{truncate-omission--modifier}}{{/if}}"
+  aria-hidden="true"
   {{#if truncate-start--attribute}}
     {{{truncate-start--attribute}}}
-  {{/if}}
-  aria-hidden="true">
+  {{/if}}>
   {{#if truncate-omission--text}}
     {{{truncate-omission--text}}}
   {{else}}

--- a/src/patternfly/components/Truncate/truncate-omission.hbs
+++ b/src/patternfly/components/Truncate/truncate-omission.hbs
@@ -1,0 +1,11 @@
+<span class="{{pfv}}truncate__omission{{#if truncate-omission--modifier}} {{truncate-omission--modifier}}{{/if}}"
+  {{#if truncate-start--attribute}}
+    {{{truncate-start--attribute}}}
+  {{/if}}
+  aria-hidden="true">
+  {{#if truncate-omission--text}}
+    {{{truncate-omission--text}}}
+  {{else}}
+    &hellip;
+  {{/if}}
+</span>

--- a/src/patternfly/components/Truncate/truncate-text.hbs
+++ b/src/patternfly/components/Truncate/truncate-text.hbs
@@ -1,0 +1,6 @@
+<span class="{{pfv}}truncate__text{{#if truncate-text--modifier}} {{truncate-text--modifier}}{{/if}}"
+  {{#if truncate-text--attribute}}
+    {{{truncate-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Truncate/truncate.hbs
+++ b/src/patternfly/components/Truncate/truncate.hbs
@@ -1,4 +1,4 @@
-<span class="{{pfv}}truncate{{#if truncate--ShouldIgnoreResize}} pf-m-ignore-resizing{{/if}}{{#if truncate--modifier}} {{truncate--modifier}}{{/if}}"
+<span class="{{pfv}}truncate{{#if truncate--IsFixed}} pf-m-fixed{{/if}}{{#if truncate--modifier}} {{truncate--modifier}}{{/if}}"
   {{#if truncate--attribute}}
     {{{truncate--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Truncate/truncate.hbs
+++ b/src/patternfly/components/Truncate/truncate.hbs
@@ -1,4 +1,4 @@
-<span class="{{pfv}}truncate{{#if truncate--modifier}} {{truncate--modifier}}{{/if}}"
+<span class="{{pfv}}truncate{{#if truncate--ShouldIgnoreResize}} pf-m-ignore-resizing{{/if}}{{#if truncate--modifier}} {{truncate--modifier}}{{/if}}"
   {{#if truncate--attribute}}
     {{{truncate--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -10,6 +10,11 @@
   grid-auto-flow: column;
   align-items: baseline;
   min-width: var(--#{$truncate}--MinWidth);
+
+  &.pf-m-ignore-resizing {
+    display: inline;
+    min-width: 0;
+  }
 }
 
 .#{$truncate}__start,

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -11,7 +11,7 @@
   align-items: baseline;
   min-width: var(--#{$truncate}--MinWidth);
 
-  &.pf-m-ignore-resizing {
+  &.pf-m-fixed {
     display: inline;
     min-width: 0;
   }

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -13,7 +13,8 @@
 
   &.pf-m-fixed {
     display: inline;
-    min-width: 0;
+    align-items: revert;
+    min-width: revert;
   }
 }
 


### PR DESCRIPTION
Closes #7438 

Couple of things:

- Is the content rendered correctly when RTL is enabled for the page? I can't recall whether the existing examples are how truncation is expected to look in RTL, or if that's more something the consumer has to handle.
- Should we still use the `__start` and `__end` elements for this new implementation and update additional styles base don this new modifier class?