### PR TITLE
feat(search-input): animate expandable search input

### DIFF
--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -150,4 +150,4 @@ When using the `.pf-v6-c-input-group` always ensure labels are used outside the 
 | `.pf-m-search-expandable` | `.pf-v6-c-input-group` | Modifies an input group to be an expandable search input. **Note:** The expandable search input can be found in the [search input](/components/search-input/) component docs for react and [text input group](/components/text-input-group/html#search-input-group-expandable) component docs for core. |
 | `.pf-m-search-input` | `.pf-v6-c-input-group__item` | Identifies the text input an expandable search input. |
 | `.pf-m-search-expand` | `.pf-v6-c-input-group__item` | Identifies the expand button in an expandable search input. |
-| `.pf-m-search-action` | `.pf-v6-c-input-group__item` | Identifies additional items adjacent to the search input when expanded in an expandable search input. |
+| `.pf-m-search-action` | `.pf-v6-c-input-group__item` | Identifies actions adjacent to the search input when an expandable search input is expanded. |

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -137,7 +137,6 @@ When using the `.pf-v6-c-input-group` always ensure labels are used outside the 
 | -- | -- | -- |
 | `aria-describedby` | `.pf-v6-c-form-control` |  When using `.pf-v6-c-input-group__text` or `.pf-v6-c-input-group__action` make use of this on the input field. |
 
-
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
@@ -148,4 +147,7 @@ When using the `.pf-v6-c-input-group` always ensure labels are used outside the 
 | `.pf-m-box` | `.pf-v6-c-input-group__item` | Adds appropriate styling for items that are not form controls. |
 | `.pf-m-fill` | `.pf-v6-c-input-group__item` | Allows the input group element to stretch to fill available space. |
 | `.pf-m-disabled` | `.pf-v6-c-input-group__item` | Adds disabled styling to match a disabled input within the input group. |
-
+| `.pf-m-search-expandable` | `.pf-v6-c-input-group` | Modifies an input group to be an expandable search input. **Note:** The expandable search input can be found in the [search input](/components/search-input/) component docs for react and [text input group](/components/text-input-group/html#search-input-group-expandable) component docs for core. |
+| `.pf-m-search-input` | `.pf-v6-c-input-group__item` | Identifies the text input an expandable search input. |
+| `.pf-m-search-expand` | `.pf-v6-c-input-group__item` | Identifies the expand button in an expandable search input. |
+| `.pf-m-search-collapse` | `.pf-v6-c-input-group__item` | Identifies the collapse button in an expandable search input. |

--- a/src/patternfly/components/InputGroup/examples/InputGroup.md
+++ b/src/patternfly/components/InputGroup/examples/InputGroup.md
@@ -150,4 +150,4 @@ When using the `.pf-v6-c-input-group` always ensure labels are used outside the 
 | `.pf-m-search-expandable` | `.pf-v6-c-input-group` | Modifies an input group to be an expandable search input. **Note:** The expandable search input can be found in the [search input](/components/search-input/) component docs for react and [text input group](/components/text-input-group/html#search-input-group-expandable) component docs for core. |
 | `.pf-m-search-input` | `.pf-v6-c-input-group__item` | Identifies the text input an expandable search input. |
 | `.pf-m-search-expand` | `.pf-v6-c-input-group__item` | Identifies the expand button in an expandable search input. |
-| `.pf-m-search-collapse` | `.pf-v6-c-input-group__item` | Identifies the collapse button in an expandable search input. |
+| `.pf-m-search-action` | `.pf-v6-c-input-group__item` | Identifies additional items adjacent to the search input when expanded in an expandable search input. |

--- a/src/patternfly/components/InputGroup/input-group-item.hbs
+++ b/src/patternfly/components/InputGroup/input-group-item.hbs
@@ -4,8 +4,8 @@
     input-group-item--IsPlain='pf-m-plain'
     input-group-item--IsFill='pf-m-fill'
     input-group-item--IsDisabled='pf-m-disabled'
-    input-group-item--IsSearchTextInput='pf-m-search-input'
-    input-group-item--IsSearchClose='pf-m-search-close'
+    input-group-item--IsSearchInput='pf-m-search-input'
+    input-group-item--IsSearchAction='pf-m-search-action'
     input-group-item--IsSearchExpand='pf-m-search-expand'
     input-group-item--modifier=input-group-item--modifier
   }}"

--- a/src/patternfly/components/InputGroup/input-group-item.hbs
+++ b/src/patternfly/components/InputGroup/input-group-item.hbs
@@ -1,9 +1,14 @@
 <div class="{{pfv}}input-group__item
-  {{#if input-group-item--IsBox}} pf-m-box{{/if}}
-  {{#if input-group-item--IsPlain}} pf-m-plain{{/if}}
-  {{#if input-group-item--IsFill}} pf-m-fill{{/if}}
-  {{#if input-group-item--IsDisabled}} pf-m-disabled{{/if}}
-  {{#if input-group-item--modifier}} {{input-group-item--modifier}}{{/if}}"
+  {{setModifiers
+    input-group-item--IsBox='pf-m-box'
+    input-group-item--IsPlain='pf-m-plain'
+    input-group-item--IsFill='pf-m-fill'
+    input-group-item--IsDisabled='pf-m-disabled'
+    input-group-item--IsSearchTextInput='pf-m-search-text-input'
+    input-group-item--IsSearchClose='pf-m-search-close'
+    input-group-item--IsSearchExpand='pf-m-search-expand'
+    input-group-item--modifier=input-group-item--modifier
+  }}"
   {{#if input-group-item--attribute}}
     {{{input-group-item--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/InputGroup/input-group-item.hbs
+++ b/src/patternfly/components/InputGroup/input-group-item.hbs
@@ -4,7 +4,7 @@
     input-group-item--IsPlain='pf-m-plain'
     input-group-item--IsFill='pf-m-fill'
     input-group-item--IsDisabled='pf-m-disabled'
-    input-group-item--IsSearchTextInput='pf-m-search-text-input'
+    input-group-item--IsSearchTextInput='pf-m-search-input'
     input-group-item--IsSearchClose='pf-m-search-close'
     input-group-item--IsSearchExpand='pf-m-search-expand'
     input-group-item--modifier=input-group-item--modifier

--- a/src/patternfly/components/InputGroup/input-group.hbs
+++ b/src/patternfly/components/InputGroup/input-group.hbs
@@ -1,6 +1,10 @@
 <div class="{{pfv}}input-group
-  {{#if input-group--IsPlain}} pf-m-plain{{/if}}
-  {{#if input-group--modifier}} {{input-group--modifier}}{{/if}}"
+  {{setModifiers
+    input-group--IsPlain='pf-m-plain'
+    input-group--IsSearchInput='pf-m-search-input'
+    input-group--IsExpanded='pf-m-expanded'
+    input-group--modifier=input-group--modifier
+  }}"
   {{#if input-group--attribute}}
     {{{input-group--attribute}}}
   {{/if}}

--- a/src/patternfly/components/InputGroup/input-group.hbs
+++ b/src/patternfly/components/InputGroup/input-group.hbs
@@ -1,7 +1,7 @@
 <div class="{{pfv}}input-group
   {{setModifiers
     input-group--IsPlain='pf-m-plain'
-    input-group--IsSearchInput='pf-m-search-input'
+    input-group--IsSearchInput='pf-m-search-expandable'
     input-group--IsExpanded='pf-m-expanded'
     input-group--modifier=input-group--modifier
   }}"

--- a/src/patternfly/components/InputGroup/input-group.hbs
+++ b/src/patternfly/components/InputGroup/input-group.hbs
@@ -1,7 +1,7 @@
 <div class="{{pfv}}input-group
   {{setModifiers
     input-group--IsPlain='pf-m-plain'
-    input-group--IsSearchInput='pf-m-search-expandable'
+    input-group--IsSearchExpandable='pf-m-search-expandable'
     input-group--IsExpanded='pf-m-expanded'
     input-group--modifier=input-group--modifier
   }}"

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -63,7 +63,7 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 
-  &.pf-m-search-input {
+  &.pf-m-search-expandable {
     &:not(.pf-m-expanded) {
       --#{$input-group}--Gap: 0;
 
@@ -71,7 +71,7 @@
     }
 
     .#{$input-group}__item {
-      &.pf-m-search-text-input {
+      &.pf-m-search-input {
         flex-grow: 1;
         max-width: var(--#{$input-group}__item--m-search-text-input--MaxWidth, 0);
         visibility: var(--#{$input-group}__item--m-search-text-input--Visibility, hidden);
@@ -125,7 +125,7 @@
       --#{$input-group}__item--m-search-expand--Opacity: 0;
       --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
 
-      .#{$input-group}__item:is(.pf-m-search-text-input, .pf-m-search-expand, .pf-m-search-close) {
+      .#{$input-group}__item:is(.pf-m-search-input, .pf-m-search-expand, .pf-m-search-close) {
         transition-delay: 0s;
       }
     }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -36,7 +36,7 @@
   --#{$input-group}-expandable__search-input--TransitionTimingFunction--expand: var(--pf-t--global--motion--timing-function--decelerate);
   --#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse: var(--pf-t--global--motion--timing-function--accelerate);
   --#{$input-group}-expandable__search-input--TransitionDuration--expand: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}-expandable__search-input--TransitionDuration--collapse: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__search-input--TransitionDuration--collapse: var(--pf-t--global--motion--duration--fade--short);
   --#{$input-group}-expandable__search-input--ScaleX: 1;
   --#{$input-group}-expandable__search-input--TransformOriginX--expand-left: 100%;
   --#{$input-group}-expandable__search-input--TransformOriginX--expand-right: 0;
@@ -57,12 +57,12 @@
   
 .#{$input-group}-expandable {
   &:not(.pf-m-expanded) {
-    .pf-v6-c-search-input {
+    .#{$pf-prefix}c-search-input {
       display: none;
     }
   }
 
-  .pf-v6-c-search-input {
+  .#{$pf-prefix}c-search-input {
     width: 100%;
     opacity: 0;
     transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
@@ -72,13 +72,13 @@
     transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
     scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
   }
-  
+
   &.pf-m-expand-left {
     --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
   }
   
   &.pf-m-expanded {
-    .pf-v6-c-search-input {
+    .#{$pf-prefix}c-search-input {
       opacity: 1;
       transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
       transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -33,28 +33,28 @@
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // Input group search expanded
-  --#{$input-group}__item--m-search-input--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__item--m-search-input--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__item--m-search-input--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
-  --#{$input-group}__item--m-search-input--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__item--m-search-input--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--short);
-  --#{$input-group}__item--m-search-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-input--TransitionDuration--collapse--fade);
-  --#{$input-group}__item--m-search-input--TransitionDuration--slide: var(-#{$input-group}__item--m-search-input--TransitionDuration--collapse--slide);
-  --#{$input-group}__item--m-search-input--ScaleX: 1;
-  --#{$input-group}__item--m-search-input--TransformOriginX--expand-start: 100%;
-  --#{$input-group}__item--m-search-input--TransformOriginX--expand-end: 0;
-  --#{$input-group}__item--m-search-input--TransformOriginX: var(--#{$input-group}__item--m-search-input--TransformOriginX--expand-end);
-  --#{$input-group}__item--m-search-close--Opacity: 0;
-  --#{$input-group}__item--m-search-close--TransitionTimingFunction: 0;
-  --#{$input-group}__item--m-search-close--TransitionDuration: 0;
-  --#{$input-group}__item--m-search-expand--Opacity: 0;
-  --#{$input-group}__item--m-search-expand--TransitionTimingFunction: 0;
-  --#{$input-group}__item--m-search-expand--TransitionDuration: 0;
-  --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__item--m-search-close--TransitionTimingFunction--fade: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-text-input--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--collapse--fade);
+  --#{$input-group}__item--m-search-text-input--TransitionDuration--slide: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--collapse--slide);
+  --#{$input-group}__item--m-search-text-input--ScaleX: 1;
+  --#{$input-group}__item--m-search-text-input--TransformOriginX--expand-start: 100%;
+  --#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end: 0;
+  --#{$input-group}__item--m-search-text-input--TransformOriginX: var(--#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end);
+  --#{$input-group}__item--m-search-expand--TransitionTimingFunction:var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade: 0s;
+  --#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
+  --#{$input-group}__item--m-search-close--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-close--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-close--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--#{$input-group}__item--m-search-close--TransitionDuration--collapse--fade);
   
   @media (prefers-reduced-motion: no-preference) {
-    --#{$input-group}__item--m-search-input--ScaleX: .7;
+    --#{$input-group}__item--m-search-text-input--ScaleX: .7;
   }
 }
 
@@ -63,10 +63,10 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 
-  &.pf-m-search-input-expandable {
+  &.pf-m-search-input {
     &:not(.pf-m-expanded) {
       // stylelint-disable max-nesting-depth
-      &.pf-m-search-input {
+      &.pf-m-search-text-input {
         width: 0;
         visibility: hidden;
       }
@@ -74,48 +74,62 @@
     }
   
     .#{$input-group}__item {
-      &.pf-m-search-input {
-        width: 100%;
-        visibility: visible;
-        opacity: var(--#{$input-group}__item--m-search-input--Opacity);
-        transition-timing-function: var(--#{$input-group}__item--m-search-input--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-input--TransitionDuration--fade), var(--#{$input-group}__item--m-search-input--TransitionDuration--slide), var(--#{$input-group}__item--m-search-input--TransitionTimingFunction--fade);
-        transition-property: opacity, scale, visibility;
-        transform-origin: var(--#{$input-group}__item--m-search-input--TransformOriginX) center;
-        scale: var(--#{$input-group}__item--m-search-input--ScaleX) 1;
-      }
-
-      &.pf-m-search-close {
-        opacity: var(--#{$input-group}__item--m-search-close--Opacity);
-        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration);
-        transition-property: opacity, visibility;
+      &.pf-m-search-text-input {
+        flex-grow: 1;
+        max-width: var(--#{$input-group}__item--m-search-text-input--MaxWidth, 0);
+        visibility: var(--#{$input-group}__item--m-search-text-input--Visibility, hidden);
+        opacity: var(--#{$input-group}__item--m-search-text-input--Opacity, 0);
+        transition-delay: 0s, 0s, var(--#{$input-group}__item--m-search-text-input--TransitionDuration--fade), var(--#{$input-group}__item--m-search-text-input--TransitionDuration--fade);
+        transition-timing-function: var(--#{$input-group}__item--m-search-text-input--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--fade), var(--#{$input-group}__item--m-search-text-input--TransitionDuration--slide), 0s, 0s;
+        transition-property: opacity, scale, visibility, max-width;
+        transform-origin: var(--#{$input-group}__item--m-search-text-input--TransformOriginX) center;
+        scale: var(--#{$input-group}__item--m-search-text-input--ScaleX) 1;
       }
 
       &.pf-m-search-expand {
-        opacity: var(--#{$input-group}__item--m-search-expand--Opacity);
+        max-width: var(--#{$input-group}__item--m-search-expand--MaxWidth, 100%);
+        visibility: var(--#{$input-group}__item--m-search-expand--Visibility, visible);
+        opacity: var(--#{$input-group}__item--m-search-expand--Opacity, 1);
+        transition-delay: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
         transition-timing-function: var(--#{$input-group}__item--m-search-expand--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration);
-        transition-property: opacity, visibility;
+        transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration--fade);
+        transition-property: opacity, visibility, max-width;
+      }
+
+      &.pf-m-search-close {
+        max-width: var(--#{$input-group}__item--m-search-close--MaxWidth, 0);
+        visibility: var(--#{$input-group}__item--m-search-close--Visibility, hidden);
+        opacity: var(--#{$input-group}__item--m-search-close--Opacity, 0);
+        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
+        transition-property: opacity, visibility, max-width;
       }
     }
   
     &.pf-m-expand-start {
-      --#{$input-group}__item--m-search-input--TransformOriginX: var(--#{$input-group}__item--m-search-input--TransformOriginX--expand-start);
+      --#{$input-group}__item--m-search-text-input--TransformOriginX: var(--#{$input-group}__item--m-search-text-input--TransformOriginX--expand-start);
     }
     
     &.pf-m-expanded {
-      --#{$input-group}__item--m-search-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-input--TransitionDuration--expand--fade);
-      --#{$input-group}__item--m-search-input--TransitionDuration--slide: var(--#{$input-group}__item--m-search-input--TransitionDuration--expand--slide);
-      --#{$input-group}__item--m-search-input--ScaleX: 1;
-      --#{$input-group}__item--m-search-input--Opacity: 1;
+      --#{$input-group}__item--m-search-text-input--MaxWidth: 100%;
+      --#{$input-group}__item--m-search-text-input--Visibility: visible;
+      --#{$input-group}__item--m-search-text-input--Opacity: 1;
+      --#{$input-group}__item--m-search-text-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--expand--fade);
+      --#{$input-group}__item--m-search-text-input--TransitionDuration--slide: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--expand--slide);
+      --#{$input-group}__item--m-search-text-input--ScaleX: 1;
+      --#{$input-group}__item--m-search-close--MaxWidth: 100%;
+      --#{$input-group}__item--m-search-close--Visibility: visible;
+      --#{$input-group}__item--m-search-close--Opacity: 1;
+      --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--#{$input-group}__item--m-search-close--TransitionDuration--expand--fade);
+      --#{$input-group}__item--m-search-expand--MaxWidth: 0;
+      --#{$input-group}__item--m-search-expand--Visibility: hidden;
+      --#{$input-group}__item--m-search-expand--Opacity: 0;
+      --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade);
 
-      .#{$input-group}__item.pf-m-search-close {
-        opacity: 1;
-        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction--fade);
-        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
-        transition-property: opacity;
-      }
+      .#{$input-group}__item:is(.pf-m-search-text-input, .pf-m-search-expand) {
+          transition-delay: 0s;
+        }
     }
   }
 }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -32,11 +32,21 @@
   --#{$input-group}__item--m-disabled__text--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
-    // Input group search expanded
-  --#{$input-group}__text-input--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__text-input--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__text-input--TransitionTimingFunction--Width: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__text-input--TransitionDuration--Width: var(--pf-t--global--motion--duration--slide-in--short);
+  // Input group search expanded
+  --#{$input-group}-expandable__search-input--TransitionTimingFunction--expand: var(--pf-t--global--motion--timing-function--decelerate);
+  --#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$input-group}-expandable__search-input--TransitionDuration--expand: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__search-input--TransitionDuration--collapse: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__search-input--ScaleX: 1;
+  --#{$input-group}-expandable__search-input--TransformOriginX--expand-left: 100%;
+  --#{$input-group}-expandable__search-input--TransformOriginX--expand-right: 0;
+  --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-right);
+  --#{$input-group}-expandable__button-icon--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$input-group}-expandable__search-input--ScaleX: .7;
+  }
 }
 
 .#{$input-group} {
@@ -44,46 +54,59 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 }
-
-@mixin pf-v6-c-input-group-fade-in {
-    animation-name: #{$input-group}-fade-in;
-    animation-duration: var(
-      --#{$input-group}__text-input--TransitionDuration--Opacity
-    );
-    animation-timing-function: var(
-      --#{$input-group}__text-input--TransitionTimingFunction--Opacity
-    );
-
-    @keyframes #{$input-group}-fade-in {
-      from {
-        opacity: 0;
-      }
-
-      to {
-        opacity: 1;
-      }
+  
+.#{$input-group}-expandable {
+  &:not(.pf-m-expanded) {
+    .pf-v6-c-search-input {
+      display: none;
     }
+  }
+
+  .pf-v6-c-search-input {
+    width: 100%;
+    opacity: 0;
+    transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
+    transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--collapse);
+    transition-property: opacity, scale, display;
+    transition-behavior: allow-discrete;
+    transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
+    scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
   }
   
-  .#{$input-group}__search-expandable.pf-m-expanded { 
-    .#{$text-input-group},
-    .#{$button}__icon {
-      @include pf-v6-c-input-group-fade-in;
-    }
-
-    @media (prefers-reduced-motion: no-preference) {
-      .#{$input-group}__item {
-        flex-grow: 0;
-        transition-timing-function: var(--#{$input-group}__text-input--TransitionTimingFunction--Width);
-        transition-duration: var(--#{$input-group}__text-input--TransitionDuration--Width);
-        transition-property: flex-grow;
-        
-        &.pf-m-fill {
-          flex-grow: 1;
-        }
+  &.pf-m-expand-left {
+    --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
+  }
+  
+  &.pf-m-expanded {
+    .pf-v6-c-search-input {
+      opacity: 1;
+      transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
+      transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);
+      scale: 1 1; 
+    
+      @starting-style {
+        opacity: 0;
+        scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
       }
     }
+          
+    .#{$input-group}__item {
+      animation-name: #{$input-group}-expandable-fade;
+      animation-duration: var(--#{$input-group}-expandable__button-icon--TransitionDuration--Opacity);
+      animation-timing-function: var(--#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity);
+    }
   }
+}
+
+@keyframes #{$input-group}-expandable-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
 
 .#{$input-group}__item {
   position: relative; // stack items without explicit z-index

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -31,6 +31,12 @@
   // Input group text, disabled variant
   --#{$input-group}__item--m-disabled__text--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+
+    // Input group search expanded
+  --#{$input-group}__text-input--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__text-input--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__text-input--TransitionTimingFunction--Width: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__text-input--TransitionDuration--Width: var(--pf-t--global--motion--duration--slide-in--short);
 }
 
 .#{$input-group} {
@@ -38,6 +44,46 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 }
+
+@mixin pf-v6-c-input-group-fade-in {
+    animation-name: #{$input-group}-fade-in;
+    animation-duration: var(
+      --#{$input-group}__text-input--TransitionDuration--Opacity
+    );
+    animation-timing-function: var(
+      --#{$input-group}__text-input--TransitionTimingFunction--Opacity
+    );
+
+    @keyframes #{$input-group}-fade-in {
+      from {
+        opacity: 0;
+      }
+
+      to {
+        opacity: 1;
+      }
+    }
+  }
+  
+  .#{$input-group}__search-expandable.pf-m-expanded { 
+    .#{$text-input-group},
+    .#{$button}__icon {
+      @include pf-v6-c-input-group-fade-in;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .#{$input-group}__item {
+        flex-grow: 0;
+        transition-timing-function: var(--#{$input-group}__text-input--TransitionTimingFunction--Width);
+        transition-duration: var(--#{$input-group}__text-input--TransitionDuration--Width);
+        transition-property: flex-grow;
+        
+        &.pf-m-fill {
+          flex-grow: 1;
+        }
+      }
+    }
+  }
 
 .#{$input-group}__item {
   position: relative; // stack items without explicit z-index

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -65,14 +65,9 @@
 
   &.pf-m-search-input {
     &:not(.pf-m-expanded) {
-      // stylelint-disable max-nesting-depth
-      &.pf-m-search-text-input {
-        width: 0;
-        visibility: hidden;
-      }
-      // stylelint-enable max-nesting-depth
+      --#{$input-group}--Gap: 0;
     }
-  
+
     .#{$input-group}__item {
       &.pf-m-search-text-input {
         flex-grow: 1;

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -90,7 +90,7 @@
         opacity: var(--#{$input-group}__item--m-search-expand--Opacity, 1);
         transition-delay: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
         transition-timing-function: var(--#{$input-group}__item--m-search-expand--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration--fade);
+        transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration--fade), 0s, 0s;
         transition-property: opacity, visibility, max-width;
       }
 
@@ -98,8 +98,9 @@
         max-width: var(--#{$input-group}__item--m-search-close--MaxWidth, 0);
         visibility: var(--#{$input-group}__item--m-search-close--Visibility, hidden);
         opacity: var(--#{$input-group}__item--m-search-close--Opacity, 0);
+        transition-delay: 0s, var(--#{$input-group}__item--m-search-close--TransitionDuration--fade), var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
         transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
+        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade), 0s, 0s;
         transition-property: opacity, visibility, max-width;
       }
     }
@@ -124,9 +125,9 @@
       --#{$input-group}__item--m-search-expand--Opacity: 0;
       --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
 
-      .#{$input-group}__item:is(.pf-m-search-text-input, .pf-m-search-expand) {
-          transition-delay: 0s;
-        }
+      .#{$input-group}__item:is(.pf-m-search-text-input, .pf-m-search-expand, .pf-m-search-close) {
+        transition-delay: 0s;
+      }
     }
   }
 }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -45,13 +45,13 @@
   --#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end: 0;
   --#{$input-group}__item--m-search-text-input--TransformOriginX: var(--#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end);
   --#{$input-group}__item--m-search-expand--TransitionTimingFunction:var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade: 0s;
   --#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade: 0s;
   --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade);
-  --#{$input-group}__item--m-search-close--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__item--m-search-close--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__item--m-search-close--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
-  --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--#{$input-group}__item--m-search-close--TransitionDuration--collapse--fade);
+  --#{$input-group}__item--m-search-action--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-action--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-action--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-action--TransitionDuration--fade: var(--#{$input-group}__item--m-search-action--TransitionDuration--collapse--fade);
   
   @media (prefers-reduced-motion: no-preference) {
     --#{$input-group}__item--m-search-text-input--ScaleX: .7;
@@ -84,23 +84,25 @@
         scale: var(--#{$input-group}__item--m-search-text-input--ScaleX) 1;
       }
 
+      // the expand button (magnifying glass)
       &.pf-m-search-expand {
         max-width: var(--#{$input-group}__item--m-search-expand--MaxWidth, 100%);
         visibility: var(--#{$input-group}__item--m-search-expand--Visibility, visible);
         opacity: var(--#{$input-group}__item--m-search-expand--Opacity, 1);
-        transition-delay: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
+        transition-delay: var(--#{$input-group}__item--m-search-action--TransitionDuration--fade);
         transition-timing-function: var(--#{$input-group}__item--m-search-expand--TransitionTimingFunction);
         transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration--fade), 0s, 0s;
         transition-property: opacity, visibility, max-width;
       }
 
-      &.pf-m-search-close {
-        max-width: var(--#{$input-group}__item--m-search-close--MaxWidth, 0);
-        visibility: var(--#{$input-group}__item--m-search-close--Visibility, hidden);
-        opacity: var(--#{$input-group}__item--m-search-close--Opacity, 0);
-        transition-delay: 0s, var(--#{$input-group}__item--m-search-close--TransitionDuration--fade), var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
-        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction);
-        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade), 0s, 0s;
+      // other input group items adjacent to the search input that are shown when expanded
+      &.pf-m-search-action {
+        max-width: var(--#{$input-group}__item--m-search-action--MaxWidth, 0);
+        visibility: var(--#{$input-group}__item--m-search-action--Visibility, hidden);
+        opacity: var(--#{$input-group}__item--m-search-action--Opacity, 0);
+        transition-delay: 0s, var(--#{$input-group}__item--m-search-action--TransitionDuration--fade), var(--#{$input-group}__item--m-search-action--TransitionDuration--fade);
+        transition-timing-function: var(--#{$input-group}__item--m-search-action--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-action--TransitionDuration--fade), 0s, 0s;
         transition-property: opacity, visibility, max-width;
       }
     }
@@ -116,16 +118,16 @@
       --#{$input-group}__item--m-search-text-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--expand--fade);
       --#{$input-group}__item--m-search-text-input--TransitionDuration--slide: var(--#{$input-group}__item--m-search-text-input--TransitionDuration--expand--slide);
       --#{$input-group}__item--m-search-text-input--ScaleX: 1;
-      --#{$input-group}__item--m-search-close--MaxWidth: 100%;
-      --#{$input-group}__item--m-search-close--Visibility: visible;
-      --#{$input-group}__item--m-search-close--Opacity: 1;
-      --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--#{$input-group}__item--m-search-close--TransitionDuration--expand--fade);
+      --#{$input-group}__item--m-search-action--MaxWidth: 100%;
+      --#{$input-group}__item--m-search-action--Visibility: visible;
+      --#{$input-group}__item--m-search-action--Opacity: 1;
+      --#{$input-group}__item--m-search-action--TransitionDuration--fade: var(--#{$input-group}__item--m-search-action--TransitionDuration--expand--fade);
       --#{$input-group}__item--m-search-expand--MaxWidth: 0;
       --#{$input-group}__item--m-search-expand--Visibility: hidden;
       --#{$input-group}__item--m-search-expand--Opacity: 0;
       --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
 
-      .#{$input-group}__item:is(.pf-m-search-input, .pf-m-search-expand, .pf-m-search-close) {
+      .#{$input-group}__item:is(.pf-m-search-input, .pf-m-search-expand, .pf-m-search-action) {
         transition-delay: 0s;
       }
     }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -53,47 +53,43 @@
   display: flex;
   gap: var(--#{$input-group}--Gap);
   width: 100%;
-}
-  
-.#{$input-group}-expandable {
-  &:not(.pf-m-expanded) {
-    .#{$pf-prefix}c-search-input {
-      display: none;
-    }
-  }
 
-  .#{$pf-prefix}c-search-input {
-    width: 100%;
-    opacity: 0;
-    transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
-    transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--collapse);
-    transition-property: opacity, scale, display;
-    transition-behavior: allow-discrete;
-    transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
-    scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
-  }
-
-  &.pf-m-expand-left {
-    --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
-  }
-  
-  &.pf-m-expanded {
-    .#{$pf-prefix}c-search-input {
-      opacity: 1;
-      transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
-      transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);
-      scale: 1 1; 
-    
-      @starting-style {
-        opacity: 0;
-        scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
+  &.pf-m-search-input {
+    &:not(.pf-m-expanded) {
+      .pf-m-search-text-input {
+        width: 0;
+        visibility: hidden;
       }
     }
-          
-    .#{$input-group}__item {
-      animation-name: #{$input-group}-expandable-fade;
-      animation-duration: var(--#{$input-group}-expandable__button-icon--TransitionDuration--Opacity);
-      animation-timing-function: var(--#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity);
+  
+    .pf-m-search-text-input {
+      width: 100%;
+      visibility: visible;
+      opacity: 0;
+      transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
+      transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--collapse);
+      transition-property: opacity, scale;
+      transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
+      scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
+    }
+  
+    &.pf-m-expand-left {
+      --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
+    }
+    
+    &.pf-m-expanded {
+      .pf-m-search-text-input {
+        opacity: 1;
+        transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
+        transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);
+        scale: 1 1; 
+      }
+            
+      .#{$input-group}__item {
+        animation-name: #{$input-group}-expandable-fade;
+        animation-duration: var(--#{$input-group}-expandable__button-icon--TransitionDuration--Opacity);
+        animation-timing-function: var(--#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity);
+      }
     }
   }
 }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -33,19 +33,28 @@
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
   // Input group search expanded
-  --#{$input-group}-expandable__search-input--TransitionTimingFunction--expand: var(--pf-t--global--motion--timing-function--decelerate);
-  --#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$input-group}-expandable__search-input--TransitionDuration--expand: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}-expandable__search-input--TransitionDuration--collapse: var(--pf-t--global--motion--duration--fade--short);
-  --#{$input-group}-expandable__search-input--ScaleX: 1;
-  --#{$input-group}-expandable__search-input--TransformOriginX--expand-left: 100%;
-  --#{$input-group}-expandable__search-input--TransformOriginX--expand-right: 0;
-  --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-right);
-  --#{$input-group}-expandable__button-icon--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-input--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__item--m-search-input--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-input--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-input--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-input--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--short);
+  --#{$input-group}__item--m-search-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-input--TransitionDuration--collapse--fade);
+  --#{$input-group}__item--m-search-input--TransitionDuration--slide: var(-#{$input-group}__item--m-search-input--TransitionDuration--collapse--slide);
+  --#{$input-group}__item--m-search-input--ScaleX: 1;
+  --#{$input-group}__item--m-search-input--TransformOriginX--expand-start: 100%;
+  --#{$input-group}__item--m-search-input--TransformOriginX--expand-end: 0;
+  --#{$input-group}__item--m-search-input--TransformOriginX: var(--#{$input-group}__item--m-search-input--TransformOriginX--expand-end);
+  --#{$input-group}__item--m-search-close--Opacity: 0;
+  --#{$input-group}__item--m-search-close--TransitionTimingFunction: 0;
+  --#{$input-group}__item--m-search-close--TransitionDuration: 0;
+  --#{$input-group}__item--m-search-expand--Opacity: 0;
+  --#{$input-group}__item--m-search-expand--TransitionTimingFunction: 0;
+  --#{$input-group}__item--m-search-expand--TransitionDuration: 0;
+  --#{$input-group}__item--m-search-close--TransitionDuration--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-close--TransitionTimingFunction--fade: var(--pf-t--global--motion--timing-function--default);
   
   @media (prefers-reduced-motion: no-preference) {
-    --#{$input-group}-expandable__search-input--ScaleX: .7;
+    --#{$input-group}__item--m-search-input--ScaleX: .7;
   }
 }
 
@@ -54,53 +63,60 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 
-  &.pf-m-search-input {
+  &.pf-m-search-input-expandable {
     &:not(.pf-m-expanded) {
-      .pf-m-search-text-input {
+      // stylelint-disable max-nesting-depth
+      &.pf-m-search-input {
         width: 0;
         visibility: hidden;
       }
+      // stylelint-enable max-nesting-depth
     }
   
-    .pf-m-search-text-input {
-      width: 100%;
-      visibility: visible;
-      opacity: 0;
-      transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
-      transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--collapse);
-      transition-property: opacity, scale;
-      transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
-      scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
+    .#{$input-group}__item {
+      &.pf-m-search-input {
+        width: 100%;
+        visibility: visible;
+        opacity: var(--#{$input-group}__item--m-search-input--Opacity);
+        transition-timing-function: var(--#{$input-group}__item--m-search-input--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-input--TransitionDuration--fade), var(--#{$input-group}__item--m-search-input--TransitionDuration--slide), var(--#{$input-group}__item--m-search-input--TransitionTimingFunction--fade);
+        transition-property: opacity, scale, visibility;
+        transform-origin: var(--#{$input-group}__item--m-search-input--TransformOriginX) center;
+        scale: var(--#{$input-group}__item--m-search-input--ScaleX) 1;
+      }
+
+      &.pf-m-search-close {
+        opacity: var(--#{$input-group}__item--m-search-close--Opacity);
+        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration);
+        transition-property: opacity, visibility;
+      }
+
+      &.pf-m-search-expand {
+        opacity: var(--#{$input-group}__item--m-search-expand--Opacity);
+        transition-timing-function: var(--#{$input-group}__item--m-search-expand--TransitionTimingFunction);
+        transition-duration: var(--#{$input-group}__item--m-search-expand--TransitionDuration);
+        transition-property: opacity, visibility;
+      }
     }
   
-    &.pf-m-expand-left {
-      --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
+    &.pf-m-expand-start {
+      --#{$input-group}__item--m-search-input--TransformOriginX: var(--#{$input-group}__item--m-search-input--TransformOriginX--expand-start);
     }
     
     &.pf-m-expanded {
-      .pf-m-search-text-input {
+      --#{$input-group}__item--m-search-input--TransitionDuration--fade: var(--#{$input-group}__item--m-search-input--TransitionDuration--expand--fade);
+      --#{$input-group}__item--m-search-input--TransitionDuration--slide: var(--#{$input-group}__item--m-search-input--TransitionDuration--expand--slide);
+      --#{$input-group}__item--m-search-input--ScaleX: 1;
+      --#{$input-group}__item--m-search-input--Opacity: 1;
+
+      .#{$input-group}__item.pf-m-search-close {
         opacity: 1;
-        transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
-        transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);
-        scale: 1 1; 
-      }
-            
-      .#{$input-group}__item {
-        animation-name: #{$input-group}-expandable-fade;
-        animation-duration: var(--#{$input-group}-expandable__button-icon--TransitionDuration--Opacity);
-        animation-timing-function: var(--#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity);
+        transition-timing-function: var(--#{$input-group}__item--m-search-close--TransitionTimingFunction--fade);
+        transition-duration: var(--#{$input-group}__item--m-search-close--TransitionDuration--fade);
+        transition-property: opacity;
       }
     }
-  }
-}
-
-@keyframes #{$input-group}-expandable-fade {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
   }
 }
 

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -45,9 +45,9 @@
   --#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end: 0;
   --#{$input-group}__item--m-search-text-input--TransformOriginX: var(--#{$input-group}__item--m-search-text-input--TransformOriginX--expand-end);
   --#{$input-group}__item--m-search-expand--TransitionTimingFunction:var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade: 0s;
-  --#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
-  --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
+  --#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade: 0s;
+  --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade);
   --#{$input-group}__item--m-search-close--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$input-group}__item--m-search-close--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
   --#{$input-group}__item--m-search-close--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
@@ -66,6 +66,8 @@
   &.pf-m-search-input {
     &:not(.pf-m-expanded) {
       --#{$input-group}--Gap: 0;
+
+      transition: gap 0s var(--#{$input-group}__item--m-search-text-input--TransitionDuration--fade);
     }
 
     .#{$input-group}__item {
@@ -120,7 +122,7 @@
       --#{$input-group}__item--m-search-expand--MaxWidth: 0;
       --#{$input-group}__item--m-search-expand--Visibility: hidden;
       --#{$input-group}__item--m-search-expand--Opacity: 0;
-      --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--expand--fade);
+      --#{$input-group}__item--m-search-expand--TransitionDuration--fade: var(--#{$input-group}__item--m-search-expand--TransitionDuration--collapse--fade);
 
       .#{$input-group}__item:is(.pf-m-search-text-input, .pf-m-search-expand) {
           transition-delay: 0s;

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -165,9 +165,9 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```hbs
 <h3>Collapsed</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable"}}
-  {{#> input-group-item input-group-item--modifier="pf-v6-c-search-input"}}
-    {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input"}}
+  {{#> input-group-item input-group-item--modifier="pf-m-search-text-input"}}
+    {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
@@ -177,9 +177,9 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <br>
 <h3>Expanded</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable pf-m-expanded"}}
-  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-v6-c-search-input"}}
-    {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input pf-m-expanded"}}
+  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-m-search-text-input"}}
+    {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -142,6 +142,9 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```
 
 ### Search input group
+
+The react implementation can be found in the [search input](/components/search-input) component docs.
+
 ```hbs
 {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Find by name"}}
 ```

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -218,7 +218,6 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
     {{> button button--IsControl=true button--IsIcon=true button--icon="arrow-right" button--attribute='aria-label="Search"' button--IsSubmit="true"}}
   {{/input-group-item}}
 {{/input-group}}
-
 ```
 
 ### Search input group, advanced search expanded

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -165,7 +165,10 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```hbs
 <h3>Collapsed</h3>
 <br>
-{{#> input-group input-group--IsPlain=true}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable"}}
+  {{#> input-group-item input-group-item--modifier="pf-v6-c-search-input"}}
+    {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
+  {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
@@ -174,8 +177,8 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <br>
 <h3>Expanded</h3>
 <br>
-{{#> input-group input-group--IsPlain=true}}
-  {{#> input-group-item input-group-item--IsFill=true}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable pf-m-expanded"}}
+  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-v6-c-search-input"}}
     {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -143,7 +143,7 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 
 ### Search input group
 
-The react implementation can be found in the [search input](/components/search-input) component docs.
+The React implementation can be found in the [search input](/components/search-input) component.
 
 ```hbs
 {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group" text-input-group-text-input--placeholder="Find by name"}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -165,14 +165,14 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```hbs
 <h3>Collapsed</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--IsSearchInput=true}}
-  {{#> input-group-item input-group-item--IsSearchTextInput=true}}
+{{#> input-group input-group--IsPlain=true input-group--IsSearchExpandable=true}}
+  {{#> input-group-item input-group-item--IsSearchInput=true}}
     {{> text-input-group--search-input text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchClose=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchActions=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}
@@ -180,14 +180,14 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <br>
 <h3>Expanded</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--IsSearchInput=true input-group--IsExpanded=true}}
-  {{#> input-group-item input-group-item--IsSearchTextInput=true}}
+{{#> input-group input-group--IsPlain=true input-group--IsSearchExpandable=true input-group--IsExpanded=true}}
+  {{#> input-group-item input-group-item--IsSearchInput=true}}
     {{> text-input-group--search-input text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchClose=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchActions=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -166,7 +166,7 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <h3>Collapsed</h3>
 <br>
 {{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input"}}
-  {{#> input-group-item input-group-item--modifier="pf-m-search-text-input"}}
+  {{#> input-group-item input-group-item--modifier="pf-m-search-input"}}
     {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}
@@ -178,13 +178,15 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <h3>Expanded</h3>
 <br>
 {{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input pf-m-expanded"}}
-  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-m-search-text-input"}}
+  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-m-search-input"}}
     {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--modifier="pf-m-search-expand"}}
+    {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
+  {{/input-group-item}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--modifier="pf-m-search-close"}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
-
 {{/input-group}}
 ```
 

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -175,7 +175,7 @@ The React implementation can be found in the [search input](/components/search-i
   {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchActions=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchAction=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}
@@ -190,7 +190,7 @@ The React implementation can be found in the [search input](/components/search-i
   {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchActions=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchAction=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -165,26 +165,29 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```hbs
 <h3>Collapsed</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input"}}
-  {{#> input-group-item input-group-item--modifier="pf-m-search-input"}}
-    {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
+{{#> input-group input-group--IsPlain=true input-group--IsSearchInput=true}}
+  {{#> input-group-item input-group-item--IsSearchTextInput=true}}
+    {{> text-input-group--search-input text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
+  {{/input-group-item}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchClose=true}}
+    {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}
 <br>
 <br>
 <h3>Expanded</h3>
 <br>
-{{#> input-group input-group--IsPlain=true input-group--modifier="pf-m-search-input pf-m-expanded"}}
-  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-m-search-input"}}
-    {{> text-input-group--search-input text-input-group--id="pf-m-search-input-expandable" text-input-group-text-input--placeholder="Search"}}
+{{#> input-group input-group--IsPlain=true input-group--IsSearchInput=true input-group--IsExpanded=true}}
+  {{#> input-group-item input-group-item--IsSearchTextInput=true}}
+    {{> text-input-group--search-input text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--modifier="pf-m-search-expand"}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchExpand=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
-  {{#> input-group-item input-group-item--IsPlain=true input-group-item--modifier="pf-m-search-close"}}
+  {{#> input-group-item input-group-item--IsPlain=true input-group-item--IsSearchClose=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="times fa-fw" button--attribute='aria-label="Close"'}}
   {{/input-group-item}}
 {{/input-group}}


### PR DESCRIPTION
Feature https://github.com/patternfly/patternfly/issues/6603

This expand behavior is based off [@mcokers POC codepen](https://codepen.io/mcoker/pen/RNNGqzp) using `scale` transition for the search input that. It's set to `display: none` in the collapsed state.


To see the animation, use the chrome dev tools to toggle the `pf-m-expanded` modifier class. (Note: at closed state the X button will display because it requires the react component to switch the displayed icon to the magnifying glass.
<img width="2292" alt="Screenshot 2025-05-05 at 1 58 14 PM" src="https://github.com/user-attachments/assets/162ac409-df9e-4923-aec9-d086c66989a2" />


These changes key off a `pf-v6-c-input-group__search-expandable` class along with modifier `pf-m-expanded` added to the `<SearchInput...` component.

The expanded text input uses an abbreviated `scale(.7`) value to transition from partial to full width `scale(1)` and by default the `transition-origin` direction is from left to right. Adding a `pf-m-expand-left` modifier will set the `transition-origin` to transition from right to left.

These changes necessitate a few changes to the React component.

In the “collapsed” state, an `<InputGroupItem className="pf-v6-c-search-input">{buildTextInputGroup()}</InputGroupItem>` is included with toggle button https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/SearchInput/SearchInput.tsx#L415-L417 Without the `pf-m-expanded` and `pf-m-fill` classes and will be set to display:none 

_Additional changes:_ The close button icon opacity fade-in specified in `@keyframes`  `animation-name: #{$input-group}-expandable-fade-in`  could be replaced by a [generic fade mixin that is proposed for inclusion with this PR](https://github.com/patternfly/patternfly/pull/7473/files#diff-735d6082e3c81d5c30b7bea7871588a4d944b65fd492d4096da6b672ec248bdeR313).



