### PR TITLE
fix(page): fix main layout with no sidebar

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -268,6 +268,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-v6-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required** |
 | `.pf-v6-c-page__main-group` | `<div>` | Creates the group of `.pf-v6-c-page__main-*` sections. Can be used in combination with `.pf-m-sticky-[top/bottom]` to make multiple sections sticky. |
 | `.pf-v6-c-page__drawer` | `<div>` | Creates a container for the drawer component when placing the main page element in the drawer body. |
+| `.pf-m-no-sidebar` | `.pf-v6-c-page` | Modifies the page grid for layouts without a sidebar. |
 | `.pf-m-expanded` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the expanded state. |
 | `.pf-m-collapsed` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the collapsed state. |
 | `.pf-m-page-insets` | `.pf-v6-c-page__sidebar-body` | Modifies a sidebar body padding/inset to visually match padding of page elements. |

--- a/src/patternfly/components/Page/page.hbs
+++ b/src/patternfly/components/Page/page.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}page{{#if page--modifier}} {{page--modifier}}{{/if}}"
+<div class="{{pfv}}page{{#if page--HasNoSidebar}} pf-m-no-sidebar{{/if}}{{#if page--modifier}} {{page--modifier}}{{/if}}"
   {{#if page--attribute}}
     {{{page--attribute}}}
   {{/if}}

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -14,8 +14,9 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Sidebar
   --#{$page}__sidebar--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$page}__sidebar--Width: #{pf-size-prem(290px)};
-  --#{$page}__sidebar--xl--Width: #{pf-size-prem(290px)}; // TODO Can remove at breaking change
+  --#{$page}__sidebar--Width--base: #{pf-size-prem(290px)};
+  --#{$page}__sidebar--Width: var(--#{$page}__sidebar--Width--base);
+  --#{$page}__sidebar--xl--Width: var(--#{$page}__sidebar--Width--base);
   --#{$page}__sidebar--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$page}__sidebar--BoxShadow: none;
 
@@ -352,6 +353,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   -webkit-overflow-scrolling: touch;
 
   @media screen and (min-width: $pf-v6-global--breakpoint--xl) {
+    @at-root .#{$page}.pf-m-no-sidebar,
     .#{$masthead} + &,
     .#{$page}__sidebar.pf-m-collapsed + & {
       --#{$page}__main-container--GridArea: var(--#{$page}--masthead--main-container--GridArea);

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -158,3 +158,13 @@ import './Page.css'
 ```hbs isFullscreen
 {{> page-template page-template--id="page-demo-sidebar-expanded" page-sidebar--modifier="pf-m-expanded"}}
 ```
+
+### No sidebar
+```hbs isFullscreen
+{{> page-template page-template--id="page-demo-no-sidebar" page-template--HasNoSidebar=true}}
+```
+
+### No sidebar or masthead
+```hbs isFullscreen
+{{> page-template page-template--id="page-demo-no-sidebar-masthead" page-template--HasNoSidebar=true page-template--HasNoMasthead=true}}
+```

--- a/src/patternfly/demos/Page/page-template.hbs
+++ b/src/patternfly/demos/Page/page-template.hbs
@@ -1,5 +1,7 @@
-{{#> page page--id=page-template--id page--modifier=page-template--modifier page-template-masthead-drilldown--IsHidden="true"}}
-  {{> masthead-template masthead-template--id=(concat page--id '-masthead')}}
+{{#> page page--id=page-template--id page--modifier=page-template--modifier page-template-masthead-drilldown--IsHidden="true" page--HasNoSidebar=page-template--HasNoSidebar}}
+  {{#unless page-template--HasNoMasthead}}
+    {{> masthead-template masthead-template--id=(concat page--id '-masthead')}}
+  {{/unless}}
   {{#unless page-template--HasNoSidebar}}
     {{> page-template-sidebar}}
   {{/unless}}


### PR DESCRIPTION
Partially addresses https://github.com/patternfly/patternfly/issues/7377
Fixes https://github.com/patternfly/patternfly/issues/7452
Fixes https://github.com/patternfly/patternfly/issues/7357

Adds `.pf-m-no-sidebar` to `.pf-v6-c-page` for layouts without a sidebar as an opt-in so it doesn't impact existing page layouts.