### PR TITLE
fix(CodeEditor): remove command palette underlining

### DIFF
--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -157,7 +157,7 @@
 }
 
 .#{$code-editor}__main {
-  position: relative; 
+  position: relative;
   flex-grow: 1;
   color: var(--#{$code-editor}__main--Color, inherit);
   background-color: var(--#{$code-editor}__main--BackgroundColor);
@@ -175,6 +175,8 @@
   .monaco-editor {
     background-color: var(--#{$code-editor}__main--BackgroundColor);
   }
+
+  a.label-name { text-decoration-line: none; } // revert normalize.scss
   // stylelint-enable selector-class-pattern
 }
 


### PR DESCRIPTION
reverts `normalize.scss` changes to the command palette

before:
![image](https://github.com/user-attachments/assets/7efd868c-4265-4e77-a95c-acd850a4b7a1)

after:
![image](https://github.com/user-attachments/assets/36df08e1-2627-46f8-b63d-ba86b40bed5f)

