### PR TITLE
feat(text-input-group): animate error status

### DIFF
--- a/src/patternfly/base/patternfly-common.scss
+++ b/src/patternfly/base/patternfly-common.scss
@@ -67,3 +67,48 @@
 
   // stylelink-enable declaration-no-important
 }
+
+:root {
+  --#{$pf-global}--danger-jiggle--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
+  --#{$pf-global}--danger-jiggle--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
+}
+
+// Register the property type for the custom property to be animatable
+@property  --#{$pf-global}--danger-jiggle--TranslateX {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+// Animate danger jiggle
+@keyframes #{$pf-global}-danger-jiggle-motion {
+  33% {
+    --#{$pf-global}--danger-jiggle--TranslateX: -2px;
+  }
+  
+  66% {
+    --#{$pf-global}--danger-jiggle--TranslateX: 3px;
+  }
+}
+
+// Animate fade-in
+@keyframes #{$pf-global}-fade-in {
+  from {
+    opacity: 0;
+  }
+  
+  to {
+    opacity: 1;
+  }
+}
+
+// Animate fade-out
+@keyframes #{$pf-global}-fade-out {
+  from {
+    opacity: 1;
+  }
+  
+  to {
+    opacity: 0;
+  }
+}

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -290,7 +290,13 @@
     --#{$form-control}__icon--m-status--Color: var(--#{$form-control}--m-error__icon--m-status--Color);
     --#{$form-control}--after--BorderWidth: var(--#{$form-control}--m-error--after--BorderWidth);
 
-    @include pf-v6-animate-danger-jiggle("#{$form-control}");
+    @media (prefers-reduced-motion: no-preference) {
+      @include pf-v6-animate-danger-jiggle;
+    }
+
+    .pf-m-status {
+      @include pf-v6-fade-default(#{$form-control}, pf-v6-global-fade-in);
+    }
 
     > textarea {
       padding-inline-end: var(--#{$form-control}--m-error--PaddingInlineEnd, var(--#{$form-control}__textarea--m-error--PaddingInlineEnd));
@@ -434,9 +440,6 @@
   }
 }
 
-// Register the property type (unnested) for the custom property to be animatable
-@include pf-v6-animate-danger-translateX("#{$form-control}");
-
 .#{$form-control}__icon {
   font-size: var(--#{$form-control}__icon--FontSize);
   color: var(--#{$form-control}__icon--Color);
@@ -444,7 +447,6 @@
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
     
-    @include pf-v6-fade-default(#{$form-control}, pf-v6-global-fade-in);
   }
 }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -290,6 +290,8 @@
     --#{$form-control}__icon--m-status--Color: var(--#{$form-control}--m-error__icon--m-status--Color);
     --#{$form-control}--after--BorderWidth: var(--#{$form-control}--m-error--after--BorderWidth);
 
+    @include pf-v6-animate-danger-jiggle("#{$form-control}");
+
     > textarea {
       padding-inline-end: var(--#{$form-control}--m-error--PaddingInlineEnd, var(--#{$form-control}__textarea--m-error--PaddingInlineEnd));
     }
@@ -432,12 +434,17 @@
   }
 }
 
+// Register the property type (unnested) for the custom property to be animatable
+@include pf-v6-animate-danger-translateX("#{$form-control}");
+
 .#{$form-control}__icon {
   font-size: var(--#{$form-control}__icon--FontSize);
   color: var(--#{$form-control}__icon--Color);
 
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
+    
+    @include pf-v6-animate-icon-fade-in(#{$form-control});
   }
 }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -444,7 +444,7 @@
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
     
-    @include pf-v6-fade-default(#{$form-control}, fade-in);
+    @include pf-v6-fade-default(#{$form-control}, pf-v6-global-fade-in);
   }
 }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -444,7 +444,7 @@
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
     
-    @include pf-v6-animate-icon-fade-in(#{$form-control});
+    @include pf-v6-fade-default(#{$form-control}, fade-in);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -128,8 +128,14 @@
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-error--BorderColor);
     --#{$text-input-group}--m-hover--BorderColor: var(--#{$text-input-group}--m-hover--m-error--BorderColor);
     --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-error__icon--m-status--Color);  
-
-    @include pf-v6-animate-danger-jiggle("#{$text-input-group}");
+    
+    @media (prefers-reduced-motion: no-preference) {
+      @include pf-v6-animate-danger-jiggle;
+    }
+    
+    .pf-m-status {
+      @include pf-v6-fade-default(#{$text-input-group}, pf-v6-global-fade-in);
+    }
   }
   
   &:hover {
@@ -145,9 +151,6 @@
     --#{$text-input-group}--status__text-input--PaddingInlineEnd: var(--#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd);
   }
 }
-
-// Register the property type (unnested) for the custom property to be animatable
-@include pf-v6-animate-danger-translateX("#{$text-input-group}");
 
 .#{$text-input-group}__main {
   display: flex;
@@ -197,8 +200,6 @@
     inset-inline-start: auto;
     inset-inline-end: var(--#{$text-input-group}__icon--m-status--InsetInlineEnd);
     color: var(--#{$text-input-group}__icon--m-status--Color);
-
-    @include pf-v6-fade-default(#{$text-input-group}, pf-v6-global-fade-in);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -198,7 +198,7 @@
     inset-inline-end: var(--#{$text-input-group}__icon--m-status--InsetInlineEnd);
     color: var(--#{$text-input-group}__icon--m-status--Color);
 
-    @include pf-v6-animate-icon-fade-in(#{$text-input-group});
+    @include pf-v6-fade-default(#{$text-input-group}, fade-in);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -198,7 +198,7 @@
     inset-inline-end: var(--#{$text-input-group}__icon--m-status--InsetInlineEnd);
     color: var(--#{$text-input-group}__icon--m-status--Color);
 
-    @include pf-v6-fade-default(#{$text-input-group}, fade-in);
+    @include pf-v6-fade-default(#{$text-input-group}, pf-v6-global-fade-in);
   }
 }
 

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -128,6 +128,8 @@
     --#{$text-input-group}--BorderColor: var(--#{$text-input-group}--m-error--BorderColor);
     --#{$text-input-group}--m-hover--BorderColor: var(--#{$text-input-group}--m-hover--m-error--BorderColor);
     --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}__main--m-error__icon--m-status--Color);  
+
+    @include pf-v6-animate-danger-jiggle("#{$text-input-group}");
   }
   
   &:hover {
@@ -143,6 +145,9 @@
     --#{$text-input-group}--status__text-input--PaddingInlineEnd: var(--#{$text-input-group}--utilities--status__text-input--PaddingInlineEnd);
   }
 }
+
+// Register the property type (unnested) for the custom property to be animatable
+@include pf-v6-animate-danger-translateX("#{$text-input-group}");
 
 .#{$text-input-group}__main {
   display: flex;
@@ -192,6 +197,8 @@
     inset-inline-start: auto;
     inset-inline-end: var(--#{$text-input-group}__icon--m-status--InsetInlineEnd);
     color: var(--#{$text-input-group}__icon--m-status--Color);
+
+    @include pf-v6-animate-icon-fade-in(#{$text-input-group});
   }
 }
 

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -289,8 +289,6 @@
 @mixin pf-v6-animate-danger-jiggle($element) {
   --#{$element}--m-danger--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
   --#{$element}--m-danger--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
-  --#{$element}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--icon--default);
-  --#{$element}__status-icon--m-danger--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
 
   translate: var(--#{$element}--m-danger--TranslateX, 0);
   animation-name: #{$element}-m-danger-motion;
@@ -311,19 +309,32 @@
   }
 }
 
-// Animate icon fade in
-@mixin pf-v6-animate-icon-fade-in($element) {
-  animation-name: #{$element}-status-icon-fade-in;
-  animation-duration: var(--#{$element}__status-icon--m-danger--TransitionDuration--Opacity);
-  animation-timing-function: var(--#{$element}__status-icon--m-danger--TransitionTimingFunction--Opacity);
+// Animate default fade in/out
+@mixin pf-v6-fade-default($element, $fade) {
+  --#{$element}--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$element}--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+
+  animation-name: $fade;
+  animation-duration: var(--#{$element}--TransitionDuration--Opacity);
+  animation-timing-function: var(--#{$element}--TransitionTimingFunction--Opacity);
   
-  @keyframes #{$element}-status-icon-fade-in {
+  @keyframes fade-in {
     from {
       opacity: 0;
     }
 
     to {
       opacity: 1;
+    }
+  }
+
+  @keyframes fade-out {
+    from {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0;
     }
   }
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -276,6 +276,58 @@
   }
 }
 
+// Register the property type for the custom property to be animatable
+@mixin pf-v6-animate-danger-translateX($element) {
+  @property  --#{$element}--m-danger--TranslateX {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0;
+  }
+}
+
+// Animate error state on form elements
+@mixin pf-v6-animate-danger-jiggle($element) {
+  --#{$element}--m-danger--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
+  --#{$element}--m-danger--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
+  --#{$element}__status-icon--m-danger--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--icon--default);
+  --#{$element}__status-icon--m-danger--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+
+  translate: var(--#{$element}--m-danger--TranslateX, 0);
+  animation-name: #{$element}-m-danger-motion;
+  animation-duration: var(--#{$element}--m-danger--AnimationDuration--Transform);
+  animation-timing-function: var(--#{$element}--m-danger--AnimationTimingFunction--Transform);
+  animation-fill-mode: both;
+
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes #{$element}-m-danger-motion {
+      33% {
+        --#{$element}--m-danger--TranslateX: -2px;
+      }
+      
+      66% {
+        --#{$element}--m-danger--TranslateX: 3px;
+      }
+    }
+  }
+}
+
+// Animate icon fade in
+@mixin pf-v6-animate-icon-fade-in($element) {
+  animation-name: #{$element}-status-icon-fade-in;
+  animation-duration: var(--#{$element}__status-icon--m-danger--TransitionDuration--Opacity);
+  animation-timing-function: var(--#{$element}__status-icon--m-danger--TransitionTimingFunction--Opacity);
+  
+  @keyframes #{$element}-status-icon-fade-in {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+}
+
 // Build variable stack
 @mixin pf-v6-build-css-variable-stack($prop, $css-var, $breakpoint-map: $pf-v6-global--breakpoint-map, $important: false) {
   $list: ();

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -318,7 +318,7 @@
   animation-duration: var(--#{$element}--TransitionDuration--Opacity);
   animation-timing-function: var(--#{$element}--TransitionTimingFunction--Opacity);
   
-  @keyframes fade-in {
+  @keyframes #{$pf-global}-fade-in {
     from {
       opacity: 0;
     }
@@ -328,7 +328,7 @@
     }
   }
 
-  @keyframes fade-out {
+  @keyframes #{$pf-global}-fade-out {
     from {
       opacity: 1;
     }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -276,37 +276,13 @@
   }
 }
 
-// Register the property type for the custom property to be animatable
-@mixin pf-v6-animate-danger-translateX($element) {
-  @property  --#{$element}--m-danger--TranslateX {
-    syntax: "<length>";
-    inherits: false;
-    initial-value: 0;
-  }
-}
-
 // Animate error state on form elements
-@mixin pf-v6-animate-danger-jiggle($element) {
-  --#{$element}--m-danger--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
-  --#{$element}--m-danger--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
-
-  translate: var(--#{$element}--m-danger--TranslateX, 0);
-  animation-name: #{$element}-m-danger-motion;
-  animation-duration: var(--#{$element}--m-danger--AnimationDuration--Transform);
-  animation-timing-function: var(--#{$element}--m-danger--AnimationTimingFunction--Transform);
+@mixin pf-v6-animate-danger-jiggle {
+  translate: var(--#{$pf-global}--danger-jiggle--TranslateX, 0);
+  animation-name: #{$pf-global}-danger-jiggle-motion;
+  animation-duration: var(--#{$pf-global}--danger-jiggle--AnimationDuration--Transform);
+  animation-timing-function: var(--#{$pf-global}--danger-jiggle--AnimationTimingFunction--Transform);
   animation-fill-mode: both;
-
-  @media (prefers-reduced-motion: no-preference) {
-    @keyframes #{$element}-m-danger-motion {
-      33% {
-        --#{$element}--m-danger--TranslateX: -2px;
-      }
-      
-      66% {
-        --#{$element}--m-danger--TranslateX: 3px;
-      }
-    }
-  }
 }
 
 // Animate default fade in/out
@@ -317,26 +293,6 @@
   animation-name: $fade;
   animation-duration: var(--#{$element}--TransitionDuration--Opacity);
   animation-timing-function: var(--#{$element}--TransitionTimingFunction--Opacity);
-  
-  @keyframes #{$pf-global}-fade-in {
-    from {
-      opacity: 0;
-    }
-
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes #{$pf-global}-fade-out {
-    from {
-      opacity: 1;
-    }
-
-    to {
-      opacity: 0;
-    }
-  }
 }
 
 // Build variable stack


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/7343 and https://github.com/patternfly/patternfly/issues/7342

Create `mixin`'s that are applied to animate error status for `text-input-group` and `form-control` with `input` `textarea` `select` 

Working example https://codesandbox.io/p/sandbox/distracted-cray-mzkk8p