### PR TITLE
fix(truncate): enable inline links to have underline when used with truncate

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -770,6 +770,13 @@
   }
 }
 
+// enable inline link to have underline when used with truncate
+.#{$button}__text {
+  // stylelint-disable property-disallowed-list
+  text-decoration: inherit;
+  // stylelint-enable property-disallowed-list
+}
+
 .#{$button}__count {
   display: inline-flex;
   align-items: center;

--- a/src/patternfly/components/Timestamp/timestamp.scss
+++ b/src/patternfly/components/Timestamp/timestamp.scss
@@ -36,3 +36,10 @@
     }
   }
 }
+
+// enable timestamp with tooltip to have dashed underline when used with truncate
+.#{$timestamp}__text {
+  // stylelint-disable property-disallowed-list
+  text-decoration: inherit;
+  // stylelint-enable property-disallowed-list
+} 

--- a/src/patternfly/components/Truncate/truncate.scss
+++ b/src/patternfly/components/Truncate/truncate.scss
@@ -10,6 +10,9 @@
   grid-auto-flow: column;
   align-items: baseline;
   min-width: var(--#{$truncate}--MinWidth);
+  // stylelint-disable property-disallowed-list
+  text-decoration: inherit; // enable inline link to have underline
+  // stylelint-enable property-disallowed-list
 
   &.pf-m-fixed {
     display: inline;


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/7255

