### PR TITLE
fix(table): animate expandable

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -118,6 +118,27 @@
   --#{$table}__action--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$table}__action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
+  // * Table expandable row
+  --#{$table}__expandable-row--TransitionDuration--display: var(--#{$table}__expandable-row--TransitionDuration--fade);
+  --#{$table}__expandable-row--TransitionDuration--expand--slide: 0s;
+  --#{$table}__expandable-row--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$table}__expandable-row--TransitionDuration--collapse--slide: 0s;
+  --#{$table}__expandable-row--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--default);
+  --#{$table}__expandable-row--TransitionDuration--slide: var(--#{$table}__expandable-row--TransitionDuration--expand--slide);
+  --#{$table}__expandable-row--TransitionDuration--fade: var(--#{$table}__expandable-row--TransitionDuration--expand--fade);
+  --#{$table}__expandable-row--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}__expandable-row--TransitionDelay: 0;
+  --#{$table}__expandable-row--Opacity: 0;
+  --#{$table}__tbody--m-expanded__expandable-row--Opacity: 1;
+  --#{$table}__expandable-row--TranslateY: 0;
+  --#{$table}__tbody--m-expanded__expandable-row--TranslateY: 0;
+
+  @media screen and (prefers-reduced-motion: no-preference) {
+    --#{$table}__expandable-row--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
+    --#{$table}__expandable-row--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--default);
+    --#{$table}__expandable-row--TranslateY: -1rem;
+  }
+
   // * Table expandable row content
   --#{$table}__expandable-row-content--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$table}__expandable-row-content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
@@ -953,6 +974,12 @@
 .#{$table}__expandable-row {
   position: relative;
   border-block-end: 0 solid transparent;
+  opacity: var(--#{$table}__expandable-row--Opacity);
+  transition-timing-function: var(--#{$table}__expandable-row--TransitionTimingFunction);
+  transition-duration: var(--#{$table}__expandable-row--TransitionDuration--fade), var(--#{$table}__expandable-row--TransitionDuration--slide), var(--#{$table}__expandable-row--TransitionDuration--fade);
+  transition-property: opacity, translate, display;
+  transition-behavior: allow-discrete;
+  translate: 0 var(--#{$table}__expandable-row--TranslateY);
 
   @at-root :not(.#{$table}__control-row) ~ .#{$table}__expandable-row {
     > .#{$table}__th,
@@ -989,6 +1016,14 @@
   &.pf-m-expanded {
     border-block-end-color: var(--#{$table}__expandable-row--m-expanded--BorderBlockEndColor);
     border-block-end-width: var(--#{$table}--border-width--base);
+    opacity: var(--#{$table}__tbody--m-expanded__expandable-row--Opacity);
+    transition-duration: var(--#{$table}__expandable-row--TransitionDuration--collapse--fade), var(--#{$table}__expandable-row--TransitionDuration--collapse--slide), var(--#{$table}__expandable-row--TransitionDuration--collapse--fade);
+    translate: 0 var(--#{$table}__tbody--m-expanded__expandable-row--TranslateY);
+
+    @starting-style {
+      opacity: var(--#{$table}__expandable-row--Opacity);
+      translate: 0 var(--#{$table}__expandable-row--TranslateY);
+    }
   }
 
   &:not(.pf-m-expanded) {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -122,9 +122,9 @@
   --#{$table}__expandable-row--TransitionDuration--expand--slide: 0s;
   --#{$table}__expandable-row--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
   --#{$table}__expandable-row--TransitionDuration--collapse--slide: 0s;
-  --#{$table}__expandable-row--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--default);
-  --#{$table}__expandable-row--TransitionDuration--slide: var(--#{$table}__expandable-row--TransitionDuration--expand--slide);
-  --#{$table}__expandable-row--TransitionDuration--fade: var(--#{$table}__expandable-row--TransitionDuration--expand--fade);
+  --#{$table}__expandable-row--TransitionDuration--collapse--fade: var(--pf-t--global--motion--duration--fade--short);
+  --#{$table}__expandable-row--TransitionDuration--slide: var(--#{$table}__expandable-row--TransitionDuration--collapse--slide);
+  --#{$table}__expandable-row--TransitionDuration--fade: var(--#{$table}__expandable-row--TransitionDuration--collapse--fade);
   --#{$table}__expandable-row--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$table}__expandable-row--Opacity: 0;
   --#{$table}__tbody--m-expanded__expandable-row--Opacity: 1;
@@ -133,8 +133,8 @@
 
   @media screen and (prefers-reduced-motion: no-preference) {
     --#{$table}__expandable-row--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
-    --#{$table}__expandable-row--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--default);
-    --#{$table}__expandable-row--TranslateY: -1rem;
+    --#{$table}__expandable-row--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--short);
+    --#{$table}__expandable-row--TranslateY: -.5rem;
   }
 
   // * Table expandable row content
@@ -1015,7 +1015,7 @@
     border-block-end-color: var(--#{$table}__expandable-row--m-expanded--BorderBlockEndColor);
     border-block-end-width: var(--#{$table}--border-width--base);
     opacity: var(--#{$table}__tbody--m-expanded__expandable-row--Opacity);
-    transition-duration: var(--#{$table}__expandable-row--TransitionDuration--collapse--fade), var(--#{$table}__expandable-row--TransitionDuration--collapse--slide), var(--#{$table}__expandable-row--TransitionDuration--collapse--fade);
+    transition-duration: var(--#{$table}__expandable-row--TransitionDuration--expand--fade), var(--#{$table}__expandable-row--TransitionDuration--expand--slide), var(--#{$table}__expandable-row--TransitionDuration--expand--fade);
     translate: 0 var(--#{$table}__tbody--m-expanded__expandable-row--TranslateY);
 
     @starting-style {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -119,7 +119,6 @@
   --#{$table}__action--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
 
   // * Table expandable row
-  --#{$table}__expandable-row--TransitionDuration--display: var(--#{$table}__expandable-row--TransitionDuration--fade);
   --#{$table}__expandable-row--TransitionDuration--expand--slide: 0s;
   --#{$table}__expandable-row--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
   --#{$table}__expandable-row--TransitionDuration--collapse--slide: 0s;
@@ -127,7 +126,6 @@
   --#{$table}__expandable-row--TransitionDuration--slide: var(--#{$table}__expandable-row--TransitionDuration--expand--slide);
   --#{$table}__expandable-row--TransitionDuration--fade: var(--#{$table}__expandable-row--TransitionDuration--expand--fade);
   --#{$table}__expandable-row--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$table}__expandable-row--TransitionDelay: 0;
   --#{$table}__expandable-row--Opacity: 0;
   --#{$table}__tbody--m-expanded__expandable-row--Opacity: 1;
   --#{$table}__expandable-row--TranslateY: 0;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7363

Link - https://patternfly-pr-7497.surge.sh/components/table#expandable

To trigger the animation, in dev tools find a `<tr class="pf-m-expanded pf-v6-c-table__expandable-row pf-v6-c-table__tr">`, click on the ".cls" button in the top/right of dev tools (near the ":hov" hover/focus button) and toggle the `.pf-m-expanded` class. Here's a screenshot:

<img width="1341" alt="Screenshot 2025-04-30 at 6 02 02 PM" src="https://github.com/user-attachments/assets/b1962a93-354e-4da6-9b4c-8c01543f637e" />

One note about this animation is, without some changes, on collapse the slide/fade runs and then the empty space collapses. I had mentioned that I expected the empty space to collapse immediately as the animation ran but I was mistaken - it collapses after the animation runs. WDYT @andrew-ronaldson @lboehling? I can update this and the other animations to collapse immediately if we prefer that interaction.

Currently table is different than some of the others because it uses `display: none` to hide the expandable content. As we discussed, we're OK with allowing `transition-behavior: allow-discrete` for that as a progressive enhancement (browser support here - https://caniuse.com/?search=allow-discrete). However, if we just go with that, then we'll also need to use `@starting-style` for the expand transition to work. [`@starting-style`](https://caniuse.com/?search=starting-style) also doesn't have full browser support, either. Here's a TL;DR on where that stands with our official support. I'm only going to call out FF and Safari as they're the ones lagging with support for these two properties.

* PF supports FF and Safari v17.0+
* `@starting-style` only works on Safari starting v17.5. Works fine in FF.
* `transition-behavior: allow-discrete` only works on Safari starting v18, and doesn't work at all in FF.

So what does that mean?
* If you're on the latest browser of the ones we support, FF will only animate the "expand" state (due to support for `@starting-style` but no support for `allow-discrete`). Collapse animation will not work in FF.
* If you're on Safari v17.5+ (but not on v18), same as above - expansion animation works, collapse doesn't.
* If you're below Safari v17.5, you get no animation on expand or collapse.

I mention this because I believe I overheard that we would use `allow-discrete` and for anyone that uses a browser that doesn't support it, they would get the expand animation but not the collapse animation, and I wanted to call out that if you're below Safari v17.5, you won't get either. 

If that's OK then 🚀. If not, we can work around it, we'll probably just need to add a new class or two and react will need an update, too.


