### PR TITLE
fix(tabs): add opt-in for current animation, performance

### DIFF
--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -38,7 +38,7 @@ __tabs-list--IsCloseDisabled: bool
     __tabs-item--id="containers"
     __tabs-item--icon-name="fas fa-box"
     __tabs-item--aria-label="Containers"
-    __tabs-item--text="Containers"
+    __tabs-item--text=(ternary __tabs-list--HasMultiLine "Containers <br> and more" "Containers")
     }}
   {{> __tabs-item
     __tabs-item--id="database"

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -327,35 +327,39 @@ cssPrefix: pf-v6-c-tabs
 ```
 
 ## Animate current tab accent
+To animate the current tab accent, you must set the following variables on the `.pf-v6-c-tabs` wrapper. As tabs are added, removed, and resized, these values may need to be updated dynamically. The following examples use static values for these values and are not updated dynamically, so there may be styling issues. For more functional examples, see the [react tabs component examples](/components/tabs).
+
+* `--pf-v6-c-tabs--link-accent--start` - the left offset of the current tab
+* `--pf-v6-c-tabs--link-accent--length` - the width of the current tab
 
 ### Animate default tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Animate sub tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
   {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 63px;"'}}
   {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
 ### Animate filled tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 253px;"'}}
   {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
 ### Animate vertical tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 8px; --pf-v6-c-tabs--link-accent--length: 45px;"'}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
@@ -447,8 +451,8 @@ Whenever a list of tabs is unique on the current page, it can be used in a `<nav
 | `.pf-m-expanded` | `.pf-v6-c-tabs` | Modifies the expandable tabs component for the expanded state. |
 | `.pf-m-animate-current` | `.pf-v6-c-tabs` | Modifies tabs to animate movement of the current tab accent line. |
 | `.pf-m-initializing-accent` | `.pf-v6-c-tabs.pf-m-animate-current` | Modifies tabs styles while initializing the "current" tab's accent styles. |
-| `--pf-v6-c-tabs--link-accent--start` | `.pf-v6-c-tabs` | Sets the value for the "start" inset of the current tab's accent. |
-| `--pf-v6-c-tabs--link-accent--length` | `.pf-v6-c-tabs` | Sets the value for the length of the current tab's accent. |
+| `--pf-v6-c-tabs--link-accent--start` | `.pf-v6-c-tabs.pf-m-animate-current` | Sets the value for the "start" inset of the current tab's accent. |
+| `--pf-v6-c-tabs--link-accent--length` | `.pf-v6-c-tabs.pf-m-animate-current` | Sets the value for the length of the current tab's accent. |
 | `.pf-m-current` | `.pf-v6-c-tabs__item` | Indicates that a tab item is currently selected. |
 | `.pf-m-action` | `.pf-v6-c-tabs__item` | Indicates that a tab item contains actions other than the tab link. |
 | `.pf-m-overflow` | `.pf-v6-c-tabs__item` | Applies overflow menu styling to a tab item. |

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -355,7 +355,7 @@ cssPrefix: pf-v6-c-tabs
 
 ### Animate vertical tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true}}
   {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -327,7 +327,7 @@ cssPrefix: pf-v6-c-tabs
 ```
 
 ## Animate current tab accent
-To animate the current tab accent, you must set the following variables on the `.pf-v6-c-tabs` wrapper. As tabs are added, removed, and resized, these values may need to be updated dynamically. The following examples use static values for these values and are not updated dynamically, so there may be styling issues. For more functional examples, see the [react tabs component examples](/components/tabs).
+To animate the current tab accent, you must set the following variables on the `.pf-v6-c-tabs` wrapper. As tabs are added, removed, and resized, these values may need to be updated dynamically. The following examples use static values for these variables and are not updated dynamically, so there may be styling issues. For more functional examples, see the [react tabs component examples](/components/tabs).
 
 * `--pf-v6-c-tabs--link-accent--start` - the left offset of the current tab
 * `--pf-v6-c-tabs--link-accent--length` - the width of the current tab

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -325,6 +325,41 @@ cssPrefix: pf-v6-c-tabs
   {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 ```
+
+## Animate current tab accent
+
+### Animate default tabs accent
+```hbs
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true"}}
+{{/tabs}}
+```
+
+### Animate sub tabs accent
+```hbs
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true"}}
+{{/tabs}}
+
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
+{{/tabs}}
+```
+
+### Animate filled tabs accent
+```hbs
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill"}}
+  {{> __tabs-list __tabs-list--IsShort="true"}}
+{{/tabs}}
+```
+
+### Animate vertical tabs accent
+```hbs
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+{{/tabs}}
+```
+
 ## Tab content
 
 ### Default tab content example
@@ -410,7 +445,8 @@ Whenever a list of tabs is unique on the current page, it can be used in a `<nav
 | `.pf-m-expandable{-on-[breakpoint]}` | `.pf-v6-c-tabs` | Modifies the tabs component to be expandable via a toggle at optional [breakpoint](/tokens/all-patternfly-tokens). **Note:** works with vertical tabs only. |
 | `.pf-m-non-expandable{-on-[breakpoint]}` | `.pf-v6-c-tabs` | Modifies the tabs component to be non-expandable at optional [breakpoint](/tokens/all-patternfly-tokens). |
 | `.pf-m-expanded` | `.pf-v6-c-tabs` | Modifies the expandable tabs component for the expanded state. |
-| `.pf-m-initializing-accent` | `.pf-v6-c-tabs` | Modifies tabs styles while initializing the "current" tab's accent styles. |
+| `.pf-m-animate-current` | `.pf-v6-c-tabs` | Modifies tabs to animate movement of the current tab accent line. |
+| `.pf-m-initializing-accent` | `.pf-v6-c-tabs.pf-m-animate-current` | Modifies tabs styles while initializing the "current" tab's accent styles. |
 | `--pf-v6-c-tabs--link-accent--start` | `.pf-v6-c-tabs` | Sets the value for the "start" inset of the current tab's accent. |
 | `--pf-v6-c-tabs--link-accent--length` | `.pf-v6-c-tabs` | Sets the value for the length of the current tab's accent. |
 | `.pf-m-current` | `.pf-v6-c-tabs__item` | Indicates that a tab item is currently selected. |

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -36,10 +36,10 @@
         li.classList.add('pf-m-current');
         {{#if tabs--IsVertical}}
           tabs.style.setProperty('--pf-v6-c-tabs--link-accent--start', top + 'px');
-          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', height);
+          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', height + 'px');
         {{else}}
           tabs.style.setProperty('--pf-v6-c-tabs--link-accent--start', left + 'px');
-          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', width);
+          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', width + 'px');
         {{/if}}
       }
     )()"

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -20,16 +20,25 @@
 
   {{#if tabs--IsAnimateCurrent}}
   onClick="
+    const doc = document.querySelector('html');
+    let isRTL = doc.dir === 'rtl' ? true : false;
     event.preventDefault();
     ((e) => {
       const el = this,
             li = this.closest('li'),
             ul = this.closest('ul'),
             tabs = this.closest('.pf-v6-c-tabs'),
-            left = Math.round(li.offsetLeft),
             top = Math.round(li.offsetTop),
             width = Math.round(li.offsetWidth),
             height = Math.round(li.offsetHeight);
+      
+      let left = Math.round(li.offsetLeft);
+
+      const getRight = () => {
+        return ul.offsetWidth - left - width;
+      }
+      
+      left = isRTL ? getRight(left) : Math.round(li.offsetLeft);
 
       ul.querySelectorAll('li').forEach(function(el) {
         el.classList.remove('pf-m-current')});

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -36,10 +36,10 @@
         li.classList.add('pf-m-current');
         {{#if tabs--IsVertical}}
           tabs.style.setProperty('--pf-v6-c-tabs--link-accent--start', top + 'px');
-          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', height + 'px');
+          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', height);
         {{else}}
           tabs.style.setProperty('--pf-v6-c-tabs--link-accent--start', left + 'px');
-          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', width + 'px');
+          tabs.style.setProperty('--pf-v6-c-tabs--link-accent--length', width);
         {{/if}}
       }
     )()"

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -17,7 +17,8 @@
       disabled
     {{/if}}
   {{/if}}
-  
+
+  {{#if tabs--IsAnimateCurrent}}
   onClick="
     event.preventDefault();
     ((e) => {
@@ -42,6 +43,7 @@
         {{/if}}
       }
     )()"
+  {{/if}}
  
   {{~#if tabs-link--IsAriaDisabled}}
     aria-disabled="true"

--- a/src/patternfly/components/Tabs/tabs.hbs
+++ b/src/patternfly/components/Tabs/tabs.hbs
@@ -6,6 +6,7 @@
   {{~#if tabs--IsExpanded}} pf-m-expanded{{/if}}
   {{~#if tabs--HasNoBorderBottom}} pf-m-no-border-bottom{{/if}}
   {{~#if __tabs-list--IsOverflow}} pf-m-overflow{{/if}}
+  {{~#if tabs--IsAnimateCurrent}} pf-m-animate-current{{/if}}
   {{~#if tabs--modifier}} {{tabs--modifier}}{{/if}}"
   {{#if tabs--attribute}}
     {{{tabs--attribute}}}

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -3,19 +3,19 @@
 $pf-v6-c-tabs--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-@property --#{$tabs}--link-accent--length {
-  syntax: "<length>";
-  inherits: true;
-  // stylelint-disable-next-line length-zero-no-unit
-  initial-value: 0px;
-}
+// @property --#{$tabs}--link-accent--length {
+//   syntax: "<length>";
+//   inherits: true;
+//   // stylelint-disable-next-line length-zero-no-unit
+//   initial-value: 0px;
+// }
 
-@property --#{$tabs}--link-accent--start {
-  syntax: "<length>";
-  inherits: true;
-  // stylelint-disable-next-line length-zero-no-unit
-  initial-value: 0px;
-}
+// @property --#{$tabs}--link-accent--start {
+//   syntax: "<length>";
+//   inherits: true;
+//   // stylelint-disable-next-line length-zero-no-unit
+//   initial-value: 0px;
+// }
 
 @include pf-root($tabs) {
   --#{$tabs}--inset: 0;
@@ -121,25 +121,30 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   // Link accent
   --#{$tabs}--link-accent--start: 0; // needed to create react-token
-  --#{$tabs}--link-accent--length: auto; // needed to create react-token
+  --#{$tabs}--link-accent--length: 0; // needed to create react-token
   --#{$tabs}--link-accent--color: var(--#{$tabs}__item--m-current__link--after--BorderColor);
   --#{$tabs}--link-accent--border-size: var(--#{$tabs}__item--m-current__link--after--BorderWidth);
-  --#{$tabs}--link-accent--InsetBlockStart: auto;
-  --#{$tabs}--link-accent--InsetBlockEnd: 0;
-  --#{$tabs}--link-accent--InsetInlineStart: initial;
-  --#{$tabs}--link-accent--Width: initial;
-  --#{$tabs}--link-accent--Height: 0;
-  --#{$tabs}--link-accent--BorderBlockEndWidth: var(--#{$tabs}--link-accent--border-size);
-  --#{$tabs}--link-accent--BorderInlineStartWidth: 0;
-  --#{$tabs}--m-vertical--link-accent--InsetBlockStart: initial;
-  --#{$tabs}--m-vertical--link-accent--InsetBlockEnd: auto;
-  --#{$tabs}--m-vertical--link-accent--InsetInlineStart: 0; 
-  --#{$tabs}--m-vertical--link-accent--Width: 0;
-  --#{$tabs}--m-vertical--link-accent--Height: initial;
-  --#{$tabs}--m-vertical--link-accent--BorderBlockEndWidth: 0;
-  --#{$tabs}--m-vertical--link-accent--BorderInlineStartWidth: var(--#{$tabs}--link-accent--border-size);
   --#{$tabs}--link-accent--TransitionDuration: var(--pf-t--global--motion--duration--md);
   --#{$tabs}--link-accent--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--decelerate);
+  --#{$tabs}--link-accent--InsetBlockStart: auto;
+  --#{$tabs}--link-accent--InsetBlockEnd: 0;
+  --#{$tabs}--link-accent--InsetInlineStart: 0;
+  --#{$tabs}--link-accent--BorderBlockEndWidth: var(--#{$tabs}--link-accent--border-size);
+  --#{$tabs}--link-accent--BorderInlineStartWidth: 0;
+  --#{$tabs}--link-accent--ScaleX: var(--#{$tabs}--link-accent--length);
+  --#{$tabs}--link-accent--ScaleY: 1;
+  --#{$tabs}--link-accent--TranslateX: var(--#{$tabs}--link-accent--start);
+  --#{$tabs}--link-accent--TranslateY: 0;
+  --#{$tabs}--link-accent--TransformOrigin: 0 center;
+  --#{$tabs}--m-vertical--link-accent--InsetBlockStart: 0;
+  --#{$tabs}--m-vertical--link-accent--InsetBlockEnd: auto;
+  --#{$tabs}--m-vertical--link-accent--BorderBlockEndWidth: 0;
+  --#{$tabs}--m-vertical--link-accent--BorderInlineStartWidth: var(--#{$tabs}--link-accent--border-size);
+  --#{$tabs}--m-vertical--link-accent--ScaleX: 1;
+  --#{$tabs}--m-vertical--link-accent--ScaleY: var(--#{$tabs}--link-accent--length);
+  --#{$tabs}--m-vertical--link-accent--TranslateX: 0;
+  --#{$tabs}--m-vertical--link-accent--TranslateY: var(--#{$tabs}--link-accent--start);
+  --#{$tabs}--m-vertical--link-accent--TransformOrigin: center 0;
 
   // Scroll buttons
   --#{$tabs}__scroll-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -354,11 +359,13 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__list--ScrollSnapTypeAxis: var(--#{$tabs}--m-vertical__list--ScrollSnapTypeAxis);
     --#{$tabs}--link-accent--InsetBlockStart: var(--#{$tabs}--m-vertical--link-accent--InsetBlockStart);
     --#{$tabs}--link-accent--InsetBlockEnd: var(--#{$tabs}--m-vertical--link-accent--InsetBlockEnd);
-    --#{$tabs}--link-accent--InsetInlineStart: var(--#{$tabs}--m-vertical--link-accent--InsetInlineStart);
-    --#{$tabs}--link-accent--Width: var(--#{$tabs}--m-vertical--link-accent--Width);
-    --#{$tabs}--link-accent--Height: var(--#{$tabs}--m-vertical--link-accent--Height);
     --#{$tabs}--link-accent--BorderBlockEndWidth: var(--#{$tabs}--m-vertical--link-accent--BorderBlockEndWidth);
     --#{$tabs}--link-accent--BorderInlineStartWidth: var(--#{$tabs}--m-vertical--link-accent--BorderInlineStartWidth);
+    --#{$tabs}--link-accent--ScaleX: var(--#{$tabs}--m-vertical--link-accent--ScaleX);
+    --#{$tabs}--link-accent--ScaleY: var(--#{$tabs}--m-vertical--link-accent--ScaleY);
+    --#{$tabs}--link-accent--TranslateX: var(--#{$tabs}--m-vertical--link-accent--TranslateX);
+    --#{$tabs}--link-accent--TranslateY: var(--#{$tabs}--m-vertical--link-accent--TranslateY);
+    --#{$tabs}--link-accent--TransformOrigin: var(--#{$tabs}--m-vertical--link-accent--TransformOrigin);
 
     display: inline-flex;
     flex-direction: column;
@@ -795,18 +802,21 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
     .#{$tabs}__list::after {
       position: absolute;
-      inset-block-start: var(--#{$tabs}--link-accent--InsetBlockStart, var(--#{$tabs}--link-accent--start));
+      inset-block-start: var(--#{$tabs}--link-accent--InsetBlockStart);
       inset-block-end: var(--#{$tabs}--link-accent--InsetBlockEnd);
-      inset-inline-start: var(--#{$tabs}--link-accent--InsetInlineStart, var(--#{$tabs}--link-accent--start));
-      width: var(--#{$tabs}--link-accent--Width, var(--#{$tabs}--link-accent--length));
-      height: var(--#{$tabs}--link-accent--Height, var(--#{$tabs}--link-accent--length));
+      inset-inline-start: var(--#{$tabs}--link-accent--InsetInlineStart);
+      width: 1px;
+      height: 1px;
       content: "";
       border: 0 solid var(--#{$tabs}--link-accent--color);
       border-block-end-width: var(--#{$tabs}--link-accent--BorderBlockEndWidth);
       border-inline-start-width: var(--#{$tabs}--link-accent--BorderInlineStartWidth);
       transition-timing-function: var(--#{$tabs}--link-accent--TransitionTimingFunction);
       transition-duration: var(--#{$tabs}--link-accent--TransitionDuration);
-      transition-property: --#{$tabs}--link-accent--length, --#{$tabs}--link-accent--start, width;
+      transition-property: scale, translate;
+      transform-origin: var(--#{$tabs}--link-accent--TransformOrigin);
+      scale: var(--#{$tabs}--link-accent--ScaleX) var(--#{$tabs}--link-accent--ScaleY);
+      translate: var(--#{$tabs}--link-accent--TranslateX) var(--#{$tabs}--link-accent--TranslateY);
     }
   }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -3,6 +3,21 @@
 $pf-v6-c-tabs--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
+
+@property --#{$tabs}--link-accent--length {
+  syntax: "<length>";
+  inherits: true;
+  // stylelint-disable-next-line length-zero-no-unit
+  initial-value: 0px;
+}
+
+@property --#{$tabs}--link-accent--start {
+  syntax: "<length>";
+  inherits: true;
+  // stylelint-disable-next-line length-zero-no-unit
+  initial-value: 0px;
+}
+
 @include pf-root($tabs) {
   --#{$tabs}--inset: 0;
   --#{$tabs}--Width: auto;
@@ -115,10 +130,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--link-accent--InsetBlockStart: auto;
   --#{$tabs}--link-accent--InsetBlockEnd: 0;
   --#{$tabs}--link-accent--InsetInlineStart: 0;
+  --#{$tabs}--link-accent--Width: initial;
+  --#{$tabs}--link-accent--Height: 0;
   --#{$tabs}--link-accent--BorderBlockEndWidth: var(--#{$tabs}--link-accent--border-size);
   --#{$tabs}--link-accent--BorderInlineStartWidth: 0;
-  --#{$tabs}--link-accent--ScaleX: var(--#{$tabs}--link-accent--length);
-  --#{$tabs}--link-accent--ScaleY: 1;
   --#{$tabs}--link-accent--TranslateX: var(--#{$tabs}--link-accent--start);
   --#{$tabs}--link-accent--TranslateY: 0;
   --#{$tabs}--link-accent--TransformOrigin: 0 center;
@@ -126,8 +141,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical--link-accent--InsetBlockEnd: auto;
   --#{$tabs}--m-vertical--link-accent--BorderBlockEndWidth: 0;
   --#{$tabs}--m-vertical--link-accent--BorderInlineStartWidth: var(--#{$tabs}--link-accent--border-size);
-  --#{$tabs}--m-vertical--link-accent--ScaleX: 1;
-  --#{$tabs}--m-vertical--link-accent--ScaleY: var(--#{$tabs}--link-accent--length);
   --#{$tabs}--m-vertical--link-accent--TranslateX: 0;
   --#{$tabs}--m-vertical--link-accent--TranslateY: var(--#{$tabs}--link-accent--start);
   --#{$tabs}--m-vertical--link-accent--TransformOrigin: center 0;
@@ -345,10 +358,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__list--ScrollSnapTypeAxis: var(--#{$tabs}--m-vertical__list--ScrollSnapTypeAxis);
     --#{$tabs}--link-accent--InsetBlockStart: var(--#{$tabs}--m-vertical--link-accent--InsetBlockStart);
     --#{$tabs}--link-accent--InsetBlockEnd: var(--#{$tabs}--m-vertical--link-accent--InsetBlockEnd);
+    --#{$tabs}--link-accent--Width: var(--#{$tabs}--m-vertical--link-accent--Width);
+    --#{$tabs}--link-accent--Height: var(--#{$tabs}--m-vertical--link-accent--Height);
     --#{$tabs}--link-accent--BorderBlockEndWidth: var(--#{$tabs}--m-vertical--link-accent--BorderBlockEndWidth);
     --#{$tabs}--link-accent--BorderInlineStartWidth: var(--#{$tabs}--m-vertical--link-accent--BorderInlineStartWidth);
-    --#{$tabs}--link-accent--ScaleX: var(--#{$tabs}--m-vertical--link-accent--ScaleX);
-    --#{$tabs}--link-accent--ScaleY: var(--#{$tabs}--m-vertical--link-accent--ScaleY);
     --#{$tabs}--link-accent--TranslateX: var(--#{$tabs}--m-vertical--link-accent--TranslateX);
     --#{$tabs}--link-accent--TranslateY: var(--#{$tabs}--m-vertical--link-accent--TranslateY);
     --#{$tabs}--link-accent--TransformOrigin: var(--#{$tabs}--m-vertical--link-accent--TransformOrigin);
@@ -791,17 +804,16 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
       inset-block-start: var(--#{$tabs}--link-accent--InsetBlockStart);
       inset-block-end: var(--#{$tabs}--link-accent--InsetBlockEnd);
       inset-inline-start: var(--#{$tabs}--link-accent--InsetInlineStart);
-      width: 1px;
-      height: 1px;
+      width: var(--#{$tabs}--link-accent--Width, var(--#{$tabs}--link-accent--length));
+      height: var(--#{$tabs}--link-accent--Height, var(--#{$tabs}--link-accent--length));
       content: "";
       border: 0 solid var(--#{$tabs}--link-accent--color);
       border-block-end-width: var(--#{$tabs}--link-accent--BorderBlockEndWidth);
       border-inline-start-width: var(--#{$tabs}--link-accent--BorderInlineStartWidth);
       transition-timing-function: var(--#{$tabs}--link-accent--TransitionTimingFunction);
       transition-duration: var(--#{$tabs}--link-accent--TransitionDuration);
-      transition-property: scale, translate;
+      transition-property: width, height, translate;
       transform-origin: var(--#{$tabs}--link-accent--TransformOrigin);
-      scale: var(--#{$tabs}--link-accent--ScaleX) var(--#{$tabs}--link-accent--ScaleY);
       translate: var(--#{$tabs}--link-accent--TranslateX) var(--#{$tabs}--link-accent--TranslateY);
     }
   }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -785,7 +785,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 // stylelint-enable
 
 @media (prefers-reduced-motion: no-preference) {
-  .#{$tabs}:not(.pf-m-box) {
+  .#{$tabs}.pf-m-animate-current:not(.pf-m-box) {
     .#{$tabs}__link,
     .#{$tabs}__item.pf-m-action {
       &::after {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -814,7 +814,12 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
       transition-duration: var(--#{$tabs}--link-accent--TransitionDuration);
       transition-property: width, height, translate;
       transform-origin: var(--#{$tabs}--link-accent--TransformOrigin);
-      translate: var(--#{$tabs}--link-accent--TranslateX) var(--#{$tabs}--link-accent--TranslateY);
+
+      @include pf-v6-bidirectional-style(
+        $prop: translate,
+        $ltr-val: var(--#{$tabs}--link-accent--TranslateX) var(--#{$tabs}--link-accent--TranslateY),
+        $rtl-val: #{pf-v6-calc-inverse(var(--#{$tabs}--link-accent--TranslateX))} var(--#{$tabs}--link-accent--TranslateY)
+      );
     }
   }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -3,20 +3,6 @@
 $pf-v6-c-tabs--breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg", "xl", "2xl");
 $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl");
 
-// @property --#{$tabs}--link-accent--length {
-//   syntax: "<length>";
-//   inherits: true;
-//   // stylelint-disable-next-line length-zero-no-unit
-//   initial-value: 0px;
-// }
-
-// @property --#{$tabs}--link-accent--start {
-//   syntax: "<length>";
-//   inherits: true;
-//   // stylelint-disable-next-line length-zero-no-unit
-//   initial-value: 0px;
-// }
-
 @include pf-root($tabs) {
   --#{$tabs}--inset: 0;
   --#{$tabs}--Width: auto;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7437

Moves animation behind `.pf-m-animate-current`. Converts `width`/`inset-inline-start` transition to `scale`/`translate` for supercharged turbo performance TO THE MAX!!!