### PR TITLE
feat(button): add click animation

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -25,6 +25,14 @@
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
 
+  // Button click (ripple) effect
+  --#{$button}--after--MaskPosition: center;
+  --#{$button}--after--MaskSize: 15000%;
+  --#{$button}--after--TransitionDuration: var(--pf-t--global--motion--duration--3xl);
+  --#{$button}--after--active--TransitionDuration: 0s;
+  --#{$button}--after--Opacity: 0;
+  --#{$button}--after--hover--Opacity: 0.12;
+
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
   --#{$button}--hover--BorderColor: transparent;
@@ -334,9 +342,13 @@
   text-decoration-style: var(--#{$button}--TextDecorationStyle);
   text-decoration-color: var(--#{$button}--TextDecorationColor);
   white-space: nowrap;
-  cursor: pointer; // needed for when a button does not use <button> - eg, <span>
+  cursor: pointer;
   user-select: none;
   background-color: var(--#{$button}--BackgroundColor);
+  background-image: var(--#{$button}--BackgroundImage);
+  background-repeat: no-repeat;
+  background-position: var(--#{$button}--BackgroundPosition);
+  background-size: var(--#{$button}--BackgroundSize);
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -346,7 +358,8 @@
   transition-duration: var(--#{$button}--TransitionDuration);
   transition-property: var(--#{$button}--TransitionProperty);
 
-  &::after {
+  // Border pseudo-element
+  &::before {
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -355,6 +368,35 @@
     border-color: var(--#{$button}--BorderColor);
     border-radius: inherit;
     transition: inherit;
+  }
+
+  // Click effect (ripple) pseudo-element
+  // The radial gradient mask expands from 0 to very large when moving from active state to default/hover
+  // currentcolor is used for the background so that it will show up on any color
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    background-color: currentcolor;
+    border-radius: inherit;
+    opacity: var(--#{$button}--after--Opacity);
+    // stylelint-disable property-no-vendor-prefix
+    // stylelint-disable color-named
+    -webkit-mask-image: radial-gradient(circle, transparent 1%, black 1%);
+            mask-image: radial-gradient(circle, transparent 1%, black 1%);
+    // stylelint-enable color-named 
+    -webkit-mask-repeat: no-repeat;
+            mask-repeat: no-repeat;
+    -webkit-mask-position: var(--#{$button}--after--MaskPosition);
+            mask-position: var(--#{$button}--after--MaskPosition);
+    -webkit-mask-size: var(--#{$button}--after--MaskSize);
+            mask-size: var(--#{$button}--after--MaskSize);
+    transition: opacity var(--#{$button}--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
+                -webkit-mask-size var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
+                mask-size var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
+
+    // styleline-enable property-no-vendor-prefix
   }
 
   // Primary
@@ -669,18 +711,27 @@
     --#{$button}--BorderWidth: var(--#{$button}--hover--BorderWidth);
     --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$button}--m-plain--m-no-padding--hover__icon--Color);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
+    --#{$button}--after--Opacity: var(--#{$button}--after--hover--Opacity);
+    --#{$button}--after--MaskSize: 15000%;
 
     text-decoration-line: var(--#{$button}--hover--TextDecorationLine);
     text-decoration-style: var(--#{$button}--hover--TextDecorationStyle);
     text-decoration-color: var(--#{$button}--hover--TextDecorationColor);
   }
 
+  &:active,
   &.pf-m-clicked {
     --#{$button}--Color: var(--#{$button}--m-clicked--Color);
     --#{$button}--BackgroundColor: var(--#{$button}--m-clicked--BackgroundColor);
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
+    --#{$button}--after--MaskSize: 0;
+
+    &::after {
+      transition: opacity var(--#{$button}--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
+                  -webkit-mask-size var(--#{$button}--#{$button}--after--active--TransitionDurationTransitionDurationActive) var(--#{$button}--TransitionTimingFunction);
+    }
   }
 
   // Disabled buttons
@@ -697,7 +748,7 @@
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
     background-color: var(--#{$button}--disabled--BackgroundColor);
 
-    &::after {
+    &::before {
       border-color: transparent;
     }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -336,7 +336,7 @@
   padding-block-end: var(--#{$button}--PaddingBlockEnd);
   padding-inline-start: var(--#{$button}--PaddingInlineStart);
   padding-inline-end: var(--#{$button}--PaddingInlineEnd);
-  overflow: hidden;
+  overflow: hidden; // needed for ripple effect
   font-size: var(--#{$button}--FontSize, inherit);
   font-weight: var(--#{$button}--FontWeight, inherit);
   line-height: var(--#{$button}--LineHeight, inherit);
@@ -346,13 +346,9 @@
   text-decoration-style: var(--#{$button}--TextDecorationStyle);
   text-decoration-color: var(--#{$button}--TextDecorationColor);
   white-space: nowrap;
-  cursor: pointer;
+  cursor: pointer; // needed for when a button does not use <button> - eg, <span>
   user-select: none;
   background-color: var(--#{$button}--BackgroundColor);
-  background-image: var(--#{$button}--BackgroundImage);
-  background-repeat: no-repeat;
-  background-position: var(--#{$button}--BackgroundPosition);
-  background-size: var(--#{$button}--BackgroundSize);
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -362,7 +358,6 @@
   transition-duration: var(--#{$button}--TransitionDuration);
   transition-property: var(--#{$button}--TransitionProperty);
 
-  // Border pseudo-element (now ::after)
   &::after {
     position: absolute;
     inset: 0;
@@ -374,7 +369,7 @@
     transition: inherit;
   }
 
-  // Click effect (ripple) pseudo-element (now ::before)
+  // Click effect (ripple) pseudo-element
   // The pseudoelement expands from 0 (active state) to very large (default and hover state) so that the semi-transparent background gradient creates the ripple.
   &::before {
     position: absolute;
@@ -739,7 +734,7 @@
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
     background-color: var(--#{$button}--disabled--BackgroundColor);
 
-    &::before {
+    &::after {
       border-color: transparent;
     }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -26,15 +26,15 @@
   --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
 
   // Button click (ripple) effect
-  --#{$button}--after--Scale: 15000%;
-  --#{$button}--after--Opacity: 0;
-  --#{$button}--after--hover--Opacity: 0.12;
-  --#{$button}--after--TransitionDuration--scale: var(--pf-t--global--motion--duration--3xl);
-  --#{$button}--after--TransitionTimingFunction--scale: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--after--TransitionDuration--opacity: var(--pf-t--global--motion--duration--3xl);
-  --#{$button}--after--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--after--active--TransitionDuration--scale: 0s;
-  --#{$button}--after--active--TransitionDuration--opacity: 0s;
+  --#{$button}--before--Scale: 15000%;
+  --#{$button}--before--Opacity: 0;
+  --#{$button}--before--hover--Opacity: 0.12;
+  --#{$button}--before--TransitionDuration--scale: var(--pf-t--global--motion--duration--3xl);
+  --#{$button}--before--TransitionTimingFunction--scale: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--before--TransitionDuration--opacity: var(--pf-t--global--motion--duration--3xl);
+  --#{$button}--before--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--before--active--TransitionDuration--scale: 0s;
+  --#{$button}--before--active--TransitionDuration--opacity: 0s;
 
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
@@ -362,8 +362,8 @@
   transition-duration: var(--#{$button}--TransitionDuration);
   transition-property: var(--#{$button}--TransitionProperty);
 
-  // Border pseudo-element
-  &::before {
+  // Border pseudo-element (now ::after)
+  &::after {
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -374,9 +374,9 @@
     transition: inherit;
   }
 
-  // Click effect (ripple) pseudo-element
+  // Click effect (ripple) pseudo-element (now ::before)
   // The pseudoelement expands from 0 (active state) to very large (default and hover state) so that the semi-transparent background gradient creates the ripple.
-  &::after {
+  &::before {
     position: absolute;
     inset: 0;
     pointer-events: none;
@@ -384,9 +384,9 @@
     background: radial-gradient(circle, transparent 1%, currentcolor 1%);
     background-position: center;
     border-radius: inherit;
-    opacity: var(--#{$button}--after--Opacity);
-    transition: scale var(--#{$button}--after--TransitionDuration--scale) var(--#{$button}--after--TransitionTimingFunction--scale), opacity var(--#{$button}--after--TransitionDuration--opacity) var(--#{$button}--after--TransitionTimingFunction--opacity);
-    scale: var(--#{$button}--after--Scale);
+    opacity: var(--#{$button}--before--Opacity);
+    transition: scale var(--#{$button}--before--TransitionDuration--scale) var(--#{$button}--before--TransitionTimingFunction--scale), opacity var(--#{$button}--before--TransitionDuration--opacity) var(--#{$button}--before--TransitionTimingFunction--opacity);
+    scale: var(--#{$button}--before--Scale);
   }
 
   // Primary
@@ -467,7 +467,7 @@
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-link--m-small--PaddingInlineStart);
 
     &.pf-m-inline {
-      --#{$button}--after--TransitionDuration--scale: 0; // don't show the ripple effect for inline links
+      --#{$button}--before--TransitionDuration--scale: 0; // don't show the ripple effect for inline links
 
       @at-root span#{&} {
         --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
@@ -703,8 +703,8 @@
     --#{$button}--BorderWidth: var(--#{$button}--hover--BorderWidth);
     --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$button}--m-plain--m-no-padding--hover__icon--Color);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
-    --#{$button}--after--Opacity: var(--#{$button}--after--hover--Opacity);
-    --#{$button}--after--Scale: 15000%;
+    --#{$button}--before--Opacity: var(--#{$button}--before--hover--Opacity);
+    --#{$button}--before--Scale: 15000%;
 
     text-decoration-line: var(--#{$button}--hover--TextDecorationLine);
     text-decoration-style: var(--#{$button}--hover--TextDecorationStyle);
@@ -718,10 +718,10 @@
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
-    --#{$button}--after--Scale: 0;
+    --#{$button}--before--Scale: 0;
 
-    &::after {
-      transition: scale var(--#{$button}--after--active--TransitionDuration--scale) var(--#{$button}--after--TransitionTimingFunction--scale), opacity var(--#{$button}--after--active--TransitionDuration--opacity) var(--#{$button}--after--TransitionTimingFunction--opacity);
+    &::before {
+      transition: scale var(--#{$button}--before--active--TransitionDuration--scale) var(--#{$button}--before--TransitionTimingFunction--scale), opacity var(--#{$button}--before--active--TransitionDuration--opacity) var(--#{$button}--before--TransitionTimingFunction--opacity);
     }
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -467,6 +467,8 @@
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-link--m-small--PaddingInlineStart);
 
     &.pf-m-inline {
+      --#{$button}--after--TransitionDuration--scale: 0; // don't show the ripple effect for inline links
+
       @at-root span#{&} {
         --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
         --#{$button}__icon--m-start--MarginInlineEnd: var(--#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -687,7 +687,9 @@
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
+  }
 
+  &:active {
     background-size: 100%; // apply the background surface for ripple
     transition-duration: 0s; // transition immediately
   }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -23,18 +23,7 @@
   --#{$button}--TextDecorationColor: currentcolor;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
-
-  // Button click (ripple) effect
-  --#{$button}--before--Scale: 15000%;
-  --#{$button}--before--Opacity: 0;
-  --#{$button}--before--hover--Opacity: 0.12;
-  --#{$button}--before--TransitionDuration--scale: var(--pf-t--global--motion--duration--3xl);
-  --#{$button}--before--TransitionTimingFunction--scale: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--before--TransitionDuration--opacity: var(--pf-t--global--motion--duration--3xl);
-  --#{$button}--before--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
-  --#{$button}--before--active--TransitionDuration--scale: 0s;
-  --#{$button}--before--active--TransitionDuration--opacity: 0s;
+  --#{$button}--TransitionProperty: color, background, border-width, border-color;
 
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
@@ -336,7 +325,6 @@
   padding-block-end: var(--#{$button}--PaddingBlockEnd);
   padding-inline-start: var(--#{$button}--PaddingInlineStart);
   padding-inline-end: var(--#{$button}--PaddingInlineEnd);
-  overflow: hidden; // needed for ripple effect
   font-size: var(--#{$button}--FontSize, inherit);
   font-weight: var(--#{$button}--FontWeight, inherit);
   line-height: var(--#{$button}--LineHeight, inherit);
@@ -347,8 +335,11 @@
   text-decoration-color: var(--#{$button}--TextDecorationColor);
   white-space: nowrap;
   cursor: pointer; // needed for when a button does not use <button> - eg, <span>
+  // stylelint-disable property-no-vendor-prefix
+  -webkit-user-select: none;
   user-select: none;
-  background-color: var(--#{$button}--BackgroundColor);
+  // stylelint-ensable property-no-vendor-prefix
+  background: var(--#{$button}--BackgroundColor) radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 1%) center/15000%;
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -367,21 +358,6 @@
     border-color: var(--#{$button}--BorderColor);
     border-radius: inherit;
     transition: inherit;
-  }
-
-  // Click effect (ripple) pseudo-element
-  // The pseudoelement expands from 0 (active state) to very large (default and hover state) so that the semi-transparent background gradient creates the ripple.
-  &::before {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    content: "";
-    background: radial-gradient(circle, transparent 1%, currentcolor 1%);
-    background-position: center;
-    border-radius: inherit;
-    opacity: var(--#{$button}--before--Opacity);
-    transition: scale var(--#{$button}--before--TransitionDuration--scale) var(--#{$button}--before--TransitionTimingFunction--scale), opacity var(--#{$button}--before--TransitionDuration--opacity) var(--#{$button}--before--TransitionTimingFunction--opacity);
-    scale: var(--#{$button}--before--Scale);
   }
 
   // Primary
@@ -462,8 +438,6 @@
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-link--m-small--PaddingInlineStart);
 
     &.pf-m-inline {
-      --#{$button}--before--TransitionDuration--scale: 0; // don't show the ripple effect for inline links
-
       @at-root span#{&} {
         --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
         --#{$button}__icon--m-start--MarginInlineEnd: var(--#{$button}--span--m-link--m-inline__icon--m-start--MarginInlineEnd);
@@ -499,6 +473,7 @@
 
       text-align: start;
       white-space: normal;
+      background: transparent; // don't show the ripple effect for inline links
       outline-offset: #{pf-size-prem(2px)};
     }
 
@@ -646,6 +621,7 @@
       --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-no-padding--m-small--PaddingInlineStart);
   
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
+      background: var(--#{$button}--BackgroundColor); // override the ripple background
     }
   }
 
@@ -698,8 +674,6 @@
     --#{$button}--BorderWidth: var(--#{$button}--hover--BorderWidth);
     --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$button}--m-plain--m-no-padding--hover__icon--Color);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
-    --#{$button}--before--Opacity: var(--#{$button}--before--hover--Opacity);
-    --#{$button}--before--Scale: 15000%;
 
     text-decoration-line: var(--#{$button}--hover--TextDecorationLine);
     text-decoration-style: var(--#{$button}--hover--TextDecorationStyle);
@@ -713,11 +687,9 @@
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
-    --#{$button}--before--Scale: 0;
 
-    &::before {
-      transition: scale var(--#{$button}--before--active--TransitionDuration--scale) var(--#{$button}--before--TransitionTimingFunction--scale), opacity var(--#{$button}--before--active--TransitionDuration--opacity) var(--#{$button}--before--TransitionTimingFunction--opacity);
-    }
+    background-size: 100%; // apply the background surface for ripple
+    transition-duration: 0s; // transition immediately
   }
 
   // Disabled buttons
@@ -732,7 +704,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background-color: var(--#{$button}--disabled--BackgroundColor);
+    background: var(--#{$button}--disabled--BackgroundColor);
 
     &::after {
       border-color: transparent;

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -26,12 +26,11 @@
   --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
 
   // Button click (ripple) effect
-  --#{$button}--after--MaskPosition: center;
-  --#{$button}--after--MaskSize: 15000%;
   --#{$button}--after--TransitionDuration: var(--pf-t--global--motion--duration--3xl);
   --#{$button}--after--active--TransitionDuration: 0s;
   --#{$button}--after--Opacity: 0;
   --#{$button}--after--hover--Opacity: 0.12;
+  --#{$button}--after--Scale: 15000%;
 
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
@@ -333,6 +332,7 @@
   padding-block-end: var(--#{$button}--PaddingBlockEnd);
   padding-inline-start: var(--#{$button}--PaddingInlineStart);
   padding-inline-end: var(--#{$button}--PaddingInlineEnd);
+  overflow: hidden;
   font-size: var(--#{$button}--FontSize, inherit);
   font-weight: var(--#{$button}--FontWeight, inherit);
   line-height: var(--#{$button}--LineHeight, inherit);
@@ -371,32 +371,19 @@
   }
 
   // Click effect (ripple) pseudo-element
-  // The radial gradient mask expands from 0 to very large when moving from active state to default/hover
-  // currentcolor is used for the background so that it will show up on any color
+  // The pseudoelement expands from 0 (active state) to very large (default and hover state) so that the semi-transparent background gradient creates the ripple.
   &::after {
     position: absolute;
     inset: 0;
     pointer-events: none;
     content: "";
-    background-color: currentcolor;
+    background: radial-gradient(circle, transparent 1%, currentcolor 1%);
+    background-position: center;
     border-radius: inherit;
     opacity: var(--#{$button}--after--Opacity);
-    // stylelint-disable property-no-vendor-prefix
-    // stylelint-disable color-named
-    -webkit-mask-image: radial-gradient(circle, transparent 1%, black 1%);
-            mask-image: radial-gradient(circle, transparent 1%, black 1%);
-    // stylelint-enable color-named 
-    -webkit-mask-repeat: no-repeat;
-            mask-repeat: no-repeat;
-    -webkit-mask-position: var(--#{$button}--after--MaskPosition);
-            mask-position: var(--#{$button}--after--MaskPosition);
-    -webkit-mask-size: var(--#{$button}--after--MaskSize);
-            mask-size: var(--#{$button}--after--MaskSize);
-    transition: opacity var(--#{$button}--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
-                -webkit-mask-size var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
-                mask-size var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
-
-    // styleline-enable property-no-vendor-prefix
+    transition: scale var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
+                opacity var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
+    scale: var(--#{$button}--after--Scale);
   }
 
   // Primary
@@ -712,7 +699,7 @@
     --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$button}--m-plain--m-no-padding--hover__icon--Color);
     --#{$button}__icon--Color: var(--#{$button}--hover__icon--Color);
     --#{$button}--after--Opacity: var(--#{$button}--after--hover--Opacity);
-    --#{$button}--after--MaskSize: 15000%;
+    --#{$button}--after--Scale: 15000%;
 
     text-decoration-line: var(--#{$button}--hover--TextDecorationLine);
     text-decoration-style: var(--#{$button}--hover--TextDecorationStyle);
@@ -726,11 +713,11 @@
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
-    --#{$button}--after--MaskSize: 0;
+    --#{$button}--after--Scale: 0;
 
     &::after {
-      transition: opacity var(--#{$button}--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
-                  -webkit-mask-size var(--#{$button}--#{$button}--after--active--TransitionDurationTransitionDurationActive) var(--#{$button}--TransitionTimingFunction);
+      transition: scale var(--#{$button}--after--active--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
+                  opacity var(--#{$button}--after--active--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
     }
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -338,7 +338,7 @@
   // stylelint-disable property-no-vendor-prefix
   -webkit-user-select: none;
   user-select: none;
-  // stylelint-ensable property-no-vendor-prefix
+  // stylelint-enable property-no-vendor-prefix
   background: var(--#{$button}--BackgroundColor) radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 1%) center/15000%;
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -26,11 +26,15 @@
   --#{$button}--TransitionProperty: color, background-color, border-width, border-color, padding;
 
   // Button click (ripple) effect
-  --#{$button}--after--TransitionDuration: var(--pf-t--global--motion--duration--3xl);
-  --#{$button}--after--active--TransitionDuration: 0s;
+  --#{$button}--after--Scale: 15000%;
   --#{$button}--after--Opacity: 0;
   --#{$button}--after--hover--Opacity: 0.12;
-  --#{$button}--after--Scale: 15000%;
+  --#{$button}--after--TransitionDuration--scale: var(--pf-t--global--motion--duration--3xl);
+  --#{$button}--after--TransitionTimingFunction--scale: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--after--TransitionDuration--opacity: var(--pf-t--global--motion--duration--3xl);
+  --#{$button}--after--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--after--active--TransitionDuration--scale: 0s;
+  --#{$button}--after--active--TransitionDuration--opacity: 0s;
 
   // Hover
   --#{$button}--hover--BackgroundColor: transparent;
@@ -381,8 +385,7 @@
     background-position: center;
     border-radius: inherit;
     opacity: var(--#{$button}--after--Opacity);
-    transition: scale var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
-                opacity var(--#{$button}--after--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
+    transition: scale var(--#{$button}--after--TransitionDuration--scale) var(--#{$button}--after--TransitionTimingFunction--scale), opacity var(--#{$button}--after--TransitionDuration--opacity) var(--#{$button}--after--TransitionTimingFunction--opacity);
     scale: var(--#{$button}--after--Scale);
   }
 
@@ -716,8 +719,7 @@
     --#{$button}--after--Scale: 0;
 
     &::after {
-      transition: scale var(--#{$button}--after--active--TransitionDuration) var(--#{$button}--TransitionTimingFunction),
-                  opacity var(--#{$button}--after--active--TransitionDuration) var(--#{$button}--TransitionTimingFunction);
+      transition: scale var(--#{$button}--after--active--TransitionDuration--scale) var(--#{$button}--after--TransitionTimingFunction--scale), opacity var(--#{$button}--after--active--TransitionDuration--opacity) var(--#{$button}--after--TransitionTimingFunction--opacity);
     }
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -22,7 +22,7 @@
   --#{$button}--TextDecorationStyle: none;
   --#{$button}--TextDecorationColor: currentcolor;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
   --#{$button}--TransitionProperty: color, background, border-width, border-color;
 
   // Hover


### PR DESCRIPTION
Fixes #7208 

- Uses the :after pseudoelement that has a background radial gradient with 1% transparent and 1% `currentcolor`. `currentcolor` gives the best contrast without having to define a color for each variant (using a background gray doesn't show up well on the filled buttons). Design has initially ok'd the `customcolor` (you can see the slight tint on the secondary buttons and the link buttons)
- Added `overflow: hidden` to button to contain the ripple effect
- The effect happens when coming out of the :active state - in default and hover, the gradient is scaled so large that the transparent "hole" in the middle covers the button. The :active state changes the scale to 0 so that the whole background is infinitely small, then when the state moves out of :active, the scale up creates the ripple effect.

