### PR TITLE
fix(toolbar): align toolbar actions with filtered items

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -110,6 +110,15 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   row-gap: var(--#{$toolbar}__content--RowGap);
   padding-inline-start: var(--#{$toolbar}__content--PaddingInlineStart);
   padding-inline-end: var(--#{$toolbar}__content--PaddingInlineEnd);
+
+  &.pf-m-toolbar-filtered-items {
+    display: flex;
+    align-items: baseline;
+
+    > :first-child {
+      margin-inline-end: var(--pf-t--global--spacer--md);
+    }
+  }
 }
 
 // Toolbar content section
@@ -239,7 +248,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // - Toolbar label group
   &.pf-m-label-group {
-    flex: 1;
     flex-wrap: wrap;
     column-gap: var(--#{$toolbar}__group--m-label-group--ColumnGap);
   }

--- a/src/patternfly/demos/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/demos/Toolbar/examples/Toolbar.md
@@ -147,7 +147,7 @@ import './Toolbar.css'
     {{/toolbar-content-section}}
     {{> toolbar-expandable-content}}
   {{/toolbar-content}}
-  {{#> toolbar-content}}
+  {{#> toolbar-content toolbar-content--modifier="pf-m-toolbar-filtered-items"}}
     {{> toolbar-group-label-group}}
     {{> toolbar-group-action-inline}}
   {{/toolbar-content}}


### PR DESCRIPTION
address https://github.com/patternfly/patternfly/issues/7348

Moves toolbar action links to be inline with the filtered items.

Requires follow on changes to add `pf-m-toolbar-filtered-items` here. https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Toolbar/ToolbarLabelGroupContent.tsx#L76

https://patternfly-pr-7532.surge.sh/components/toolbar/html-demos#toolbar-attribute-value-checkbox-menu-toggle-filter-on-desktop

note: in the above html-demo there is wider spacing between the filter label groups and the action links, which is intended, because of [this change](https://github.com/patternfly/patternfly/pull/6987) to maintain long label groups presented inline and wrap when needed. The links will be spaced closer if there is only a single label group.
<img width="870" alt="Screenshot 2025-05-16 at 9 38 00 AM" src="https://github.com/user-attachments/assets/83dd880f-3ef0-4bab-a683-00545e9629ef" />

