### PR TITLE
fix(ExpandableSection): made animation opt-in for detached variant

### DIFF
--- a/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
+++ b/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
@@ -128,10 +128,10 @@ cssPrefix: pf-v6-c-expandable-section
 | `.pf-v6-c-expandable-section__content` | `<div>` | Initiates the expandable section content. **Required** |
 | `.pf-m-expanded` | `.pf-v6-c-expandable-section` | Modifies the component for the expanded state. |
 | `.pf-m-detached` | `.pf-v6-c-expandable-section` | Modifies the component for a detached variant. |
+| `.pf-m-expand-top` | `.pf-v6-c-expandable-section__toggle-icon` | Modifies the toggle icon to point up when expanded. We recommend the new method of applying this class directly to the `.pf-v6-c-expandable-section` wrapper element. |
 | `.pf-m-expand-top` | `.pf-v6-c-expandable-section.pf-m-detached` | Modifies the expandable animation and icon rotation directions for detached expandable sections. **Required** when the content is above the toggle. |
 | `.pf-m-expand-bottom` | `.pf-v6-c-expandable-section.pf-m-detached` | Modifies the expandable animation direction for detached expandable sections. **Required** when the content is below the toggle. |
 | `.pf-m-display-lg` | `.pf-v6-c-expandable-section` | Modifies the styling of the component to have large display styling. |
 | `.pf-m-indented` | `.pf-v6-c-expandable-section` | Indicates that the expandable section content is indented and is aligned with the start of the title text to provide visual hierarchy. |
 | `.pf-m-truncate` | `.pf-v6-c-expandable-section` | Indicates that the expandable section content is truncated by default, and not truncated when expanded. |
-| `.pf-m-expand-top` | `.pf-v6-c-expandable-section__toggle-icon` | Modifies the toggle icon to point up when expanded. We recommend the new method of applying this class directly to the `.pf-v6-c-expandable-section` wrapper element. |
 | `--pf-v6-c-expandable-section--m-truncate__content--LineClamp` | `.pf-v6-c-expandable-section.pf-m-truncate` | Modifies the number of lines to show before truncating. |

--- a/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
+++ b/src/patternfly/components/ExpandableSection/examples/ExpandableSection.md
@@ -70,7 +70,7 @@ cssPrefix: pf-v6-c-expandable-section
 
 ### Detached
 ```hbs
-{{#> stack stack--modifier="pf-m-gutter" expandable-section--id="detached-toggle" expandable-section--IsDetached=true expandable-section--IsExpanded=true}}
+{{#> stack stack--modifier="pf-m-gutter" expandable-section--id="detached-toggle" expandable-section--IsDetached=true expandable-section--IsExpanded=true expandable-section--modifier="pf-m-expand-top"}}
   {{#> stack-item}}
     {{#> expandable-section}}
       {{#> expandable-section-content}}
@@ -80,7 +80,7 @@ cssPrefix: pf-v6-c-expandable-section
   {{/stack-item}}
 
   {{#> stack-item}}
-    {{#> expandable-section expandable-section-toggle-icon--modifier="pf-m-expand-top"}}
+    {{#> expandable-section expandable-section--IsDetached=true expandable-section--modifier="pf-m-expand-top"}}
       {{#> expandable-section-toggle}}
       {{/expandable-section-toggle}}
     {{/expandable-section}}
@@ -127,8 +127,11 @@ cssPrefix: pf-v6-c-expandable-section
 | `.pf-v6-c-expandable-section__toggle-icon` | `<span>` | Initiates the expandable toggle icon. **Required** |
 | `.pf-v6-c-expandable-section__content` | `<div>` | Initiates the expandable section content. **Required** |
 | `.pf-m-expanded` | `.pf-v6-c-expandable-section` | Modifies the component for the expanded state. |
+| `.pf-m-detached` | `.pf-v6-c-expandable-section` | Modifies the component for a detached variant. |
+| `.pf-m-expand-top` | `.pf-v6-c-expandable-section.pf-m-detached` | Modifies the expandable animation and icon rotation directions for detached expandable sections. **Required** when the content is above the toggle. |
+| `.pf-m-expand-bottom` | `.pf-v6-c-expandable-section.pf-m-detached` | Modifies the expandable animation direction for detached expandable sections. **Required** when the content is below the toggle. |
 | `.pf-m-display-lg` | `.pf-v6-c-expandable-section` | Modifies the styling of the component to have large display styling. |
 | `.pf-m-indented` | `.pf-v6-c-expandable-section` | Indicates that the expandable section content is indented and is aligned with the start of the title text to provide visual hierarchy. |
 | `.pf-m-truncate` | `.pf-v6-c-expandable-section` | Indicates that the expandable section content is truncated by default, and not truncated when expanded. |
-| `.pf-m-expand-top` | `.pf-v6-c-expandable-section__toggle-icon` | Modifies the toggle icon to point up when expanded. |
+| `.pf-m-expand-top` | `.pf-v6-c-expandable-section__toggle-icon` | Modifies the toggle icon to point up when expanded. We recommend the new method of applying this class directly to the `.pf-v6-c-expandable-section` wrapper element. |
 | `--pf-v6-c-expandable-section--m-truncate__content--LineClamp` | `.pf-v6-c-expandable-section.pf-m-truncate` | Modifies the number of lines to show before truncating. |

--- a/src/patternfly/components/ExpandableSection/expandable-section.hbs
+++ b/src/patternfly/components/ExpandableSection/expandable-section.hbs
@@ -1,5 +1,6 @@
 <div class="{{pfv}}expandable-section
   {{~#if expandable-section--IsExpanded}} pf-m-expanded{{/if}}
+  {{~#if expandable-section--IsDetached}} pf-m-detached{{/if}}
   {{~#if expandable-section--IsDisplayLg}} pf-m-display-lg pf-m-limit-width{{/if}}
   {{~#if expandable-section--IsIndented}} pf-m-indented{{/if}}
   {{~#if expandable-section--IsTruncate}} pf-m-truncate{{/if}}

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -89,7 +89,7 @@
     --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}__toggle-icon--m-expand-top--Rotate);
   }
 
-  &.pf-m-detached {
+  &:has(.#{$expandable-section}__content:only-child) {
     &:not(.pf-m-expand-top, .pf-m-expand-bottom) {
       --#{$expandable-section}__content--TranslateY: 0;
       --#{$expandable-section}__content--TransitionDuration--expand--fade: 0s;

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -89,6 +89,9 @@
     --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}__toggle-icon--m-expand-top--Rotate);
   }
 
+  // The following selector is for ensuring we target only detached expandable section contents without introducing a breaking change
+  // (since typically both toggle and content would both be in the expandable section wrapper)
+  // In a breaking change we could update this to utilize the pf-m-detached class
   &:has(.#{$expandable-section}__content:only-child) {
     &:not(.pf-m-expand-top, .pf-m-expand-bottom) {
       --#{$expandable-section}__content--TranslateY: 0;
@@ -146,7 +149,7 @@
   transition: var(--#{$expandable-section}__toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$expandable-section}__toggle-icon--Rotate));
 
-  &.pf-m-expand-top { // TODO: Remove this block in breaking change in favor of using modifier on outter expandable section wrapper
+  &.pf-m-expand-top { // TODO: Remove this block in breaking change in favor of using modifier on outer expandable section wrapper
     --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}__toggle-icon--m-expand-top--Rotate);
   }
 }

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -23,6 +23,8 @@
   --#{$expandable-section}__content--TransitionDelay--hide: var(--#{$expandable-section}__content--TransitionDuration--fade);
   --#{$expandable-section}__content--Opacity: 0;
   --#{$expandable-section}__content--TranslateY: 0;
+  --#{$expandable-section}--m-expand-top__content--TranslateY: 0;
+  --#{$expandable-section}--m-expand-bottom__content--TranslateY: 0;
   --#{$expandable-section}--m-expanded__content--Opacity: 1;
   --#{$expandable-section}--m-expanded__content--TranslateY: 0;
 
@@ -30,6 +32,8 @@
     --#{$expandable-section}__content--TransitionDuration--collapse--slide: var(--pf-t--global--motion--duration--fade--short);
     --#{$expandable-section}__content--TransitionDuration--expand--slide: var(--pf-t--global--motion--duration--fade--default);
     --#{$expandable-section}__content--TranslateY: -.5rem;
+    --#{$expandable-section}--m-expand-top__content--TranslateY: .5rem;
+    --#{$expandable-section}--m-expand-bottom__content--TranslateY: -.5rem;
   }
 
   // Content
@@ -81,6 +85,26 @@
     gap: var(--pf-v6-c-expandable-section--Gap);
   }
 
+  &.pf-m-expand-top {
+    --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}__toggle-icon--m-expand-top--Rotate);
+  }
+
+  &.pf-m-detached {
+    &:not(.pf-m-expand-top, .pf-m-expand-bottom) {
+      --#{$expandable-section}__content--TranslateY: 0;
+      --#{$expandable-section}__content--TransitionDuration--expand--fade: 0s;
+      --#{$expandable-section}__content--TransitionDuration--collapse--fade: 0s;
+    }
+
+    &.pf-m-expand-top:not(.pf-m-expanded) {
+      --#{$expandable-section}__content--TranslateY: var(--#{$expandable-section}--m-expand-top__content--TranslateY);
+    }
+
+    &.pf-m-expand-bottom:not(.pf-m-expanded) {
+      --#{$expandable-section}__content--TranslateY: var(--#{$expandable-section}--m-expand-bottom__content--TranslateY);
+    }
+  }
+
   &.pf-m-limit-width {
     --#{$expandable-section}__content--MaxWidth: var(--#{$expandable-section}--m-limit-width__content--MaxWidth);
   }
@@ -122,7 +146,7 @@
   transition: var(--#{$expandable-section}__toggle-icon--Transition); // TODO remove shorthand in breaking change
   transform: rotate(var(--#{$expandable-section}__toggle-icon--Rotate));
 
-  &.pf-m-expand-top {
+  &.pf-m-expand-top { // TODO: Remove this block in breaking change in favor of using modifier on outter expandable section wrapper
     --#{$expandable-section}__toggle-icon--Rotate: var(--#{$expandable-section}__toggle-icon--m-expand-top--Rotate);
   }
 }


### PR DESCRIPTION
Closes #7515 

Some notes:

- ~In React I believe we're fine to *add* things outside of breaking changes -- wasn't sure if we wanted to apply the `pf-m-detached` modifier to the `pf-v6-c-expandable-section` wrapper that only contains the toggle, but I did that here which should be fine to add into React + sorta seemed odd that only one of the wrapper would have that modifier~ Per discussion in retroplanning 6/4/2025, React won't have the detached class as it won't be needed for animations. Right now it's kept in Core though not marked as required; the plan is in the next breaking change to have those classes applied+required for detached variants
- Updated docs to mention the new method of changing the toggle icon rotation direction
- Removes the fade and slide animation for detached variants if neither the top or bottom modifiers are included