### PR TITLE
fix(table): correct alignment with a table cell that contains a button

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -654,7 +654,7 @@ These classes can be used to ensure that the table changes between the tabular a
         6
       {{/table-td}}
       {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
-        <span class="pf-v6-c-table__text">
+        <span>
           {{#> button button--IsTertiary=true}}
             Start
           {{/button}}
@@ -674,7 +674,7 @@ These classes can be used to ensure that the table changes between the tabular a
         2
       {{/table-td}}
       {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
-        <span class="pf-v6-c-table__text">
+        <span>
           {{#> button button--IsTertiary=true}}
             Start
           {{/button}}
@@ -694,7 +694,7 @@ These classes can be used to ensure that the table changes between the tabular a
         7
       {{/table-td}}
       {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
-        <span class="pf-v6-c-table__text">
+        <span>
           {{#> button button--IsTertiary=true}}
             Start
           {{/button}}

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -621,6 +621,92 @@ These classes can be used to ensure that the table changes between the tabular a
 {{/table}}
 ```
 
+### Table with buttons and actions
+```hbs
+{{#> table table--id="table-buttons-and-actions" table--IsGrid=true table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a table with buttons and actions"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Deployment
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Status
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Builds
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Start New Build
+      {{/table-th}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Deployment"}}
+        Deployment 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Status"}}
+        Success
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Builds"}}
+        6
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+        <span class="pf-v6-c-table__text">
+          {{#> button button--IsTertiary=true}}
+            Start
+          {{/button}}
+        </span>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+    
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Deployment"}}
+        Deployment 2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Status"}}
+        Failed
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Builds"}}
+        2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+        <span class="pf-v6-c-table__text">
+          {{#> button button--IsTertiary=true}}
+            Start
+          {{/button}}
+        </span>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+    
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Deployment"}}
+        Deployment 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Status"}}
+        Success
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Builds"}}
+        7
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+        <span class="pf-v6-c-table__text">
+          {{#> button button--IsTertiary=true}}
+            Start
+          {{/button}}
+        </span>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+
+  {{/table-tbody}}
+{{/table}}
+```
+
 When including interactive elements in a table, the primary, descriptive cell in the corresponding row is a `<th>`, rather than a `<td>`. In this example, 'Node 1' and 'Node 2 siemur/test-space' are `<th>`s.
 
 When header cells are empty or they contain interactive elements, `<th>` should be replaced with `<td>`.
@@ -639,6 +725,7 @@ When header cells are empty or they contain interactive elements, `<th>` should 
 | `.pf-v6-c-table__check` | `<th>`, `<td>` | Initiates a checkbox or radio input table cell. |
 | `.pf-v6-c-table__action` | `<th>`, `<td>` | Initiates an action table cell. |
 | `.pf-v6-c-table__inline-edit-action` | `<th>`, `<td>` | Initiates an inline edit action table cell. |
+| `.pf-v6-c-table__td-button` | `<td>` | Initiates an table cell with button. |
 
 ## Expandable
 

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -653,7 +653,7 @@ These classes can be used to ensure that the table changes between the tabular a
       {{#> table-td table-td--data-label="Builds"}}
         6
       {{/table-td}}
-      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
         <span class="pf-v6-c-table__text">
           {{#> button button--IsTertiary=true}}
             Start
@@ -673,7 +673,7 @@ These classes can be used to ensure that the table changes between the tabular a
       {{#> table-td table-td--data-label="Builds"}}
         2
       {{/table-td}}
-      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
         <span class="pf-v6-c-table__text">
           {{#> button button--IsTertiary=true}}
             Start
@@ -693,7 +693,7 @@ These classes can be used to ensure that the table changes between the tabular a
       {{#> table-td table-td--data-label="Builds"}}
         7
       {{/table-td}}
-      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-v6-c-table__td-button"}}
+      {{#> table-td table-td--data-label="Start Build" table-td--modifier="pf-m-action"}}
         <span class="pf-v6-c-table__text">
           {{#> button button--IsTertiary=true}}
             Start
@@ -725,7 +725,7 @@ When header cells are empty or they contain interactive elements, `<th>` should 
 | `.pf-v6-c-table__check` | `<th>`, `<td>` | Initiates a checkbox or radio input table cell. |
 | `.pf-v6-c-table__action` | `<th>`, `<td>` | Initiates an action table cell. |
 | `.pf-v6-c-table__inline-edit-action` | `<th>`, `<td>` | Initiates an inline edit action table cell. |
-| `.pf-v6-c-table__td-button` | `<td>` | Initiates an table cell with button. |
+| `.pf-m-action` | `<td>` | Initiates an table cell with button. |
 
 ## Expandable
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -266,7 +266,7 @@
     grid-template-columns: 1fr minmax(0, 1.5fr);
     align-items: start;
 
-    &.#{$table}__td-button {
+    &.pf-m-action {
       align-items: center;
     }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -266,6 +266,10 @@
     grid-template-columns: 1fr minmax(0, 1.5fr);
     align-items: start;
 
+    &.#{$table}__td-button {
+      align-items: center;
+    }
+
     // set contents of td to start at column two of td grid
     > * {
       grid-column: 2;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -198,6 +198,14 @@
   --#{$table}--m-compact--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$table}--m-compact--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
+  // * Table cell with button
+  --#{$table}__td-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__td-button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+
+  // * Table compact cell with button
+  --#{$table}--m-compact__td-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__td-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+
   // * Table compact action
   --#{$table}--m-compact__action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$table}--m-compact__action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
@@ -479,6 +487,11 @@
   //     padding: 0;
   //   }
   // }
+
+  .#{$table}__td.#{$table}__td-button {
+    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}__td-button--PaddingBlockStart);
+    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}__td-button--PaddingBlockEnd);
+  }
 
   // - Table sort
   // set property here to increase specificity
@@ -1062,6 +1075,11 @@
   .#{$table}__draggable {
     --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__action--PaddingBlockStart);
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
+  }
+
+  .#{$table}__td-button {
+    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}--m-compact__td-button--PaddingBlockStart);
+    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}--m-compact__td-button--PaddingBlockEnd);
   }
 
   .#{$table}__icon {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -199,12 +199,12 @@
   --#{$table}--m-compact--cell--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table cell with button
-  --#{$table}__td-button--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$table}__td-button--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$table}__td--m-action--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$table}__td--m-action--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
 
   // * Table compact cell with button
-  --#{$table}--m-compact__td-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
-  --#{$table}--m-compact__td-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__td--m-action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$table}--m-compact__td--m-action--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
   // * Table compact action
   --#{$table}--m-compact__action--PaddingBlockStart: var(--pf-t--global--spacer--xs);
@@ -489,8 +489,8 @@
   // }
 
   .#{$table}__td.pf-m-action {
-    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}__td-button--PaddingBlockStart);
-    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}__td-button--PaddingBlockEnd);
+    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}__td--m-action--PaddingBlockStart);
+    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}__td--m-action--PaddingBlockEnd);
   }
 
   // - Table sort
@@ -1078,8 +1078,8 @@
   }
 
   .pf-m-action {
-    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}--m-compact__td-button--PaddingBlockStart);
-    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}--m-compact__td-button--PaddingBlockEnd);
+    --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}--m-compact__td--m-action--PaddingBlockStart);
+    --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}--m-compact__td--m-action--PaddingBlockEnd);
   }
 
   .#{$table}__icon {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -488,7 +488,7 @@
   //   }
   // }
 
-  .#{$table}__td.#{$table}__td-button {
+  .#{$table}__td.pf-m-action {
     --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}__td-button--PaddingBlockStart);
     --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}__td-button--PaddingBlockEnd);
   }
@@ -1077,7 +1077,7 @@
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
   }
 
-  .#{$table}__td-button {
+  .pf-m-action {
     --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}--m-compact__td-button--PaddingBlockStart);
     --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}--m-compact__td-button--PaddingBlockEnd);
   }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1077,7 +1077,7 @@
     --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__action--PaddingBlockEnd);
   }
 
-  .pf-m-action {
+  .#{$table}__td.pf-m-action {
     --pf-v6-c-table--cell--PaddingBlockStart: var(--#{$table}--m-compact__td--m-action--PaddingBlockStart);
     --pf-v6-c-table--cell--PaddingBlockEnd: var(--#{$table}--m-compact__td--m-action--PaddingBlockEnd);
   }


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/7534

Adds a new html example of `table` `td` cells that contain a `button`. A new modifier class sets cell padding so the button is aligned within the row of elements.

https://patternfly-pr-7551.surge.sh/components/table/html/table-with-buttons-and-actions/