### PR TITLE
fix(menu): respect reduced motion for drilldown menu

### DIFF
--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -32,11 +32,21 @@
   --#{$input-group}__item--m-disabled__text--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
 
-    // Input group search expanded
-  --#{$input-group}__text-input--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__text-input--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
-  --#{$input-group}__text-input--TransitionTimingFunction--Width: var(--pf-t--global--motion--timing-function--default);
-  --#{$input-group}__text-input--TransitionDuration--Width: var(--pf-t--global--motion--duration--slide-in--short);
+  // Input group search expanded
+  --#{$input-group}-expandable__search-input--TransitionTimingFunction--expand: var(--pf-t--global--motion--timing-function--decelerate);
+  --#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$input-group}-expandable__search-input--TransitionDuration--expand: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__search-input--TransitionDuration--collapse: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__search-input--ScaleX: 1;
+  --#{$input-group}-expandable__search-input--TransformOriginX--expand-left: 100%;
+  --#{$input-group}-expandable__search-input--TransformOriginX--expand-right: 0;
+  --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-right);
+  --#{$input-group}-expandable__button-icon--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$input-group}-expandable__search-input--ScaleX: .7;
+  }
 }
 
 .#{$input-group} {
@@ -44,46 +54,59 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 }
-
-@mixin pf-v6-c-input-group-fade-in {
-    animation-name: #{$input-group}-fade-in;
-    animation-duration: var(
-      --#{$input-group}__text-input--TransitionDuration--Opacity
-    );
-    animation-timing-function: var(
-      --#{$input-group}__text-input--TransitionTimingFunction--Opacity
-    );
-
-    @keyframes #{$input-group}-fade-in {
-      from {
-        opacity: 0;
-      }
-
-      to {
-        opacity: 1;
-      }
+  
+.#{$input-group}-expandable {
+  &:not(.pf-m-expanded) {
+    .pf-v6-c-search-input {
+      display: none;
     }
+  }
+
+  .pf-v6-c-search-input {
+    width: 100%;
+    opacity: 0;
+    transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--collapse);
+    transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--collapse);
+    transition-property: opacity, scale, display;
+    transition-behavior: allow-discrete;
+    transform-origin: var(--#{$input-group}-expandable__search-input--TransformOriginX) center;
+    scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
   }
   
-  .#{$input-group}__search-expandable.pf-m-expanded { 
-    .#{$text-input-group},
-    .#{$button}__icon {
-      @include pf-v6-c-input-group-fade-in;
-    }
-
-    @media (prefers-reduced-motion: no-preference) {
-      .#{$input-group}__item {
-        flex-grow: 0;
-        transition-timing-function: var(--#{$input-group}__text-input--TransitionTimingFunction--Width);
-        transition-duration: var(--#{$input-group}__text-input--TransitionDuration--Width);
-        transition-property: flex-grow;
-        
-        &.pf-m-fill {
-          flex-grow: 1;
-        }
+  &.pf-m-expand-left {
+    --#{$input-group}-expandable__search-input--TransformOriginX: var(--#{$input-group}-expandable__search-input--TransformOriginX--expand-left);
+  }
+  
+  &.pf-m-expanded {
+    .pf-v6-c-search-input {
+      opacity: 1;
+      transition-timing-function: var(--#{$input-group}-expandable__search-input--TransitionTimingFunction--expand);
+      transition-duration: var(--#{$input-group}-expandable__search-input--TransitionDuration--expand);
+      scale: 1 1; 
+    
+      @starting-style {
+        opacity: 0;
+        scale: var(--#{$input-group}-expandable__search-input--ScaleX) 1;
       }
     }
+          
+    .#{$input-group}__item {
+      animation-name: #{$input-group}-expandable-fade;
+      animation-duration: var(--#{$input-group}-expandable__button-icon--TransitionDuration--Opacity);
+      animation-timing-function: var(--#{$input-group}-expandable__button-icon--TransitionTimingFunction--Opacity);
+    }
   }
+}
+
+@keyframes #{$input-group}-expandable-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
 
 .#{$input-group}__item {
   position: relative; // stack items without explicit z-index

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -31,6 +31,12 @@
   // Input group text, disabled variant
   --#{$input-group}__item--m-disabled__text--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$input-group}__item--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+
+    // Input group search expanded
+  --#{$input-group}__text-input--TransitionTimingFunction--Opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__text-input--TransitionDuration--Opacity: var(--pf-t--global--motion--duration--fade--default);
+  --#{$input-group}__text-input--TransitionTimingFunction--Width: var(--pf-t--global--motion--timing-function--default);
+  --#{$input-group}__text-input--TransitionDuration--Width: var(--pf-t--global--motion--duration--slide-in--short);
 }
 
 .#{$input-group} {
@@ -38,6 +44,46 @@
   gap: var(--#{$input-group}--Gap);
   width: 100%;
 }
+
+@mixin pf-v6-c-input-group-fade-in {
+    animation-name: #{$input-group}-fade-in;
+    animation-duration: var(
+      --#{$input-group}__text-input--TransitionDuration--Opacity
+    );
+    animation-timing-function: var(
+      --#{$input-group}__text-input--TransitionTimingFunction--Opacity
+    );
+
+    @keyframes #{$input-group}-fade-in {
+      from {
+        opacity: 0;
+      }
+
+      to {
+        opacity: 1;
+      }
+    }
+  }
+  
+  .#{$input-group}__search-expandable.pf-m-expanded { 
+    .#{$text-input-group},
+    .#{$button}__icon {
+      @include pf-v6-c-input-group-fade-in;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .#{$input-group}__item {
+        flex-grow: 0;
+        transition-timing-function: var(--#{$input-group}__text-input--TransitionTimingFunction--Width);
+        transition-duration: var(--#{$input-group}__text-input--TransitionDuration--Width);
+        transition-property: flex-grow;
+        
+        &.pf-m-fill {
+          flex-grow: 1;
+        }
+      }
+    }
+  }
 
 .#{$input-group}__item {
   position: relative; // stack items without explicit z-index

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -15,8 +15,12 @@
   --#{$menu}--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$menu}--button--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$menu}--icon--disabled--Color: var(--pf-t--global--icon--color--disabled);
-  --#{$menu}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$menu}--TransitionDuration: 0s;
   --#{$menu}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$menu}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  }
 
   // * Menu plain
   --#{$menu}--m-plain--BoxShadow: none;
@@ -126,19 +130,30 @@
   --#{$menu}--m-flyout__menu--m-left--InsetInlineEnd: calc(100% + var(--#{$menu}--m-flyout__menu--m-left--right-offset));
 
   // * Menu drilldown content
-  // TODO Reduced motion default needed for drilldown
   --#{$menu}--m-drilldown__content--TransitionDuration--height: var(--pf-t--global--motion--duration--slide-in--default);
   --#{$menu}--m-drilldown__content--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
-  --#{$menu}--m-drilldown__content--Transition: transform var(--#{$menu}--m-drilldown__content--TransitionDuration--transform), height var(--#{$menu}--m-drilldown__content--TransitionDuration--height);
+  --#{$menu}--m-drilldown__content--Transition: height var(--#{$menu}--m-drilldown__content--TransitionDuration--height);
+  
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$menu}--m-drilldown__content--Transition: transform var(--#{$menu}--m-drilldown__content--TransitionDuration--transform), height var(--#{$menu}--m-drilldown__content--TransitionDuration--height);
+  }
 
   // * Menu drilldown menu
   --#{$menu}--m-drilldown--c-menu--InsetBlockStart: 0;
-  --#{$menu}--m-drilldown--c-menu--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
+  --#{$menu}--m-drilldown--c-menu--TransitionDuration--transform: 0s;
   --#{$menu}--m-drilldown--c-menu--Transition: transform var(--#{$menu}--m-drilldown--c-menu--TransitionDuration--transform);
 
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$menu}--m-drilldown--c-menu--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
+  }
+
   // * Menu drilldown list
-  --#{$menu}--m-drilldown__list--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
+  --#{$menu}--m-drilldown__list--TransitionDuration--transform: 0s;
   --#{$menu}--m-drilldown__list--Transition: transform var(--#{$menu}--m-drilldown__list--TransitionDuration--transform);
+  
+  @media (prefers-reduced-motion: no-preference) {
+    --#{$menu}--m-drilldown__list--TransitionDuration--transform: var(--pf-t--global--motion--duration--slide-in--default);
+  }
 
   // * Menu drilled in
   --#{$menu}--m-drilled-in--c-menu__list-item--m-current-path--c-menu--ZIndex: var(--pf-t--global--z-index--xs);

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -165,7 +165,10 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 ```hbs
 <h3>Collapsed</h3>
 <br>
-{{#> input-group input-group--IsPlain=true}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable"}}
+  {{#> input-group-item input-group-item--modifier="pf-v6-c-search-input"}}
+    {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
+  {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}
     {{> button button--IsPlain=true button--IsIcon=true button--icon="search fa-fw" button--attribute='aria-label="Open search"'}}
   {{/input-group-item}}
@@ -174,8 +177,8 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
 <br>
 <h3>Expanded</h3>
 <br>
-{{#> input-group input-group--IsPlain=true}}
-  {{#> input-group-item input-group-item--IsFill=true}}
+{{#> input-group input-group--IsPlain=true input-group--modifier="pf-v6-c-input-group-expandable pf-m-expanded"}}
+  {{#> input-group-item input-group-item--IsFill=true input-group-item--modifier="pf-v6-c-search-input"}}
     {{> text-input-group--search-input text-input-group--id="text-input-group-search-input-group-expandable" text-input-group-text-input--placeholder="Search"}}
   {{/input-group-item}}
   {{#> input-group-item input-group-item--IsPlain=true}}


### PR DESCRIPTION
Fixes #6739 

Adds support for the prefers-reduced-motion media query to the Menu component drilldown menu.

Changes:
Set default transition duration to 0s for all transitions
Apply standard transition durations only for users who don't prefer reduced motion
Instead of removing transitions, I had to set the durations to 0s; otherwise the menu did not behave properly.
Setting the overall menu transition duration was necessary or else the nested menus would still have a transition duration and show the translate happening.
That said, the 0s duration does not seem to affect the fade in of other menus - that seems like it might still be coming from Popper despite the `!important` declaration.