### PR TITLE
fix(file-upload): add default border, updates hover color

### DIFF
--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -8,11 +8,11 @@
   --#{$file-upload}--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$file-upload}--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$file-upload}--BorderWidth: var(--pf-t--global--border--width--regular);
-  --#{$file-upload}--BorderColor: transparent;
-  --#{$file-upload}--BorderStyle: solid;
+  --#{$file-upload}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$file-upload}--BorderStyle: dashed;
 
   // pf-m-drag-hover
-  --#{$file-upload}--m-drag-hover--BorderColor: var(--pf-t--global--icon--color--brand--default);
+  --#{$file-upload}--m-drag-hover--BorderColor: var(--pf-t--global--border--color--clicked);
   --#{$file-upload}--m-drag-hover--BorderStyle: dashed;
 
   // File select > Button


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7372

Adds a default grey border to match multiple file upload. Updates the hover border color from `--pf-t--global--icon--color--brand--default` to `--pf-t--global--border--color--clicked`, which matches multiple file upload.