### PR TITLE
fix(textInputGroup): fix overlapping status icon and utility button

### DIFF
--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -97,6 +97,21 @@ For the purposes of this example, the `TextInputGroup` is contained in a wrapper
     {{/button}}
   {{/text-input-group-utilities}}
 {{/text-input-group}}
+
+<br/>
+{{#> text-input-group text-input-group--IsError=true text-input-group--id="text-input-group-validation-error"}}
+  {{#> text-input-group-main }}
+    {{#> text-input-group-text}}
+      {{> text-input-group-text-input text-input-group--value="Error validation with no icon but with utilities"}}
+      {{> text-input-group-icon text-input-group-icon--IsStatus=true}}
+    {{/text-input-group-text}}
+  {{/text-input-group-main}}
+  {{#> text-input-group-utilities}}
+    {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Clear input"'}}
+      <i class="fas fa-times fa-fw" aria-hidden="true"></i>
+    {{/button}}
+  {{/text-input-group-utilities}}
+{{/text-input-group}}
 ```
 
 ### Filters

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -144,6 +144,10 @@
 
   &:where(.pf-m-success, .pf-m-warning, .pf-m-error) {
     --#{$text-input-group}__text-input--PaddingInlineEnd: var(--#{$text-input-group}--status__text-input--PaddingInlineEnd);
+
+    & .pf-v6-c-text-input-group__text {
+      --#{$text-input-group}__text--Position: relative;
+    }
   }
 
   &:has(> .#{$text-input-group}__utilities) {
@@ -246,4 +250,3 @@
 .#{$text-input-group}__group {
   display: flex;
 }
-


### PR DESCRIPTION
When the icon prop was not set on a text input group, the status icon (error, warning, success) could overlap with the close button due to missing layout adjustments.

What’s changed?
The SCSS now sets `--#{$text-input-group}__text--Position: relative;` whenever a status modifier is present, ensuring the status icon is always spaced correctly from the close button, even if there’s no leading icon.

A new example has been added in text input group.

Closes #7462