### PR TITLE
fix(backstop): force light mode and fix no motion class

### DIFF
--- a/backstop_data/engine_scripts/puppet/onReady.js
+++ b/backstop_data/engine_scripts/puppet/onReady.js
@@ -1,8 +1,20 @@
 module.exports = async (page, scenario, vp) => {
   await require('./overrideCSS')(page, scenario);
 
-  // add dark theme class to html tag if --dark flag passed
   if (process.argv.includes('--dark')) {
+    // Emulate dark mode
+    if (page.emulateMediaFeatures) {
+      await page.emulateMediaFeatures([
+        { name: 'prefers-color-scheme', value: 'dark' }
+      ]);
+    }
     await require('./addDarkThemeClass')(page, scenario);
+  } else {
+    // Emulate light mode
+    if (page.emulateMediaFeatures) {
+      await page.emulateMediaFeatures([
+        { name: 'prefers-color-scheme', value: 'light' }
+      ]);
+    }
   }
 };

--- a/backstop_data/engine_scripts/puppet/overrideCSS.js
+++ b/backstop_data/engine_scripts/puppet/overrideCSS.js
@@ -1,6 +1,6 @@
 module.exports = async (page, scenario) => {
+  // disable animations/transitions
   await page.evaluate(() => {
-    // disable animations/transitions
-    document.querySelector('html').classList.add('pf-m-no-motion');
+    document.documentElement.classList.add('pf-v6-m-no-motion');
   });
 };


### PR DESCRIPTION
This uses `page.emulateMediaFeatures` to force the light mode unless the `--dark` flag is set.
It also fixes the no motion class to include `-v6-` and adds it directly to the html element without a query to find it first.