### PR TITLE
feat(accordion): add borders for high contrast

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -161,7 +161,7 @@
     transition-property: opacity;
   }
 
-  &:is(:hover, :active),
+  &:is(:hover, :focus-within),
   &.pf-m-expanded {
     &::after {
       position: absolute;

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -20,6 +20,9 @@
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$accordion}__toggle--BorderWidth: 0;
+  --#{$accordion}__toggle--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$accordion}__toggle--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
 
   // Accordion toggle toggle-start modifier
   // This decreases the gap between icon and text, alternative is calc it to * 2 the token or create a new token
@@ -101,8 +104,9 @@
   --#{$accordion}__item--m-bordered--BorderBlockEndColor: var(--pf-t--global--border--color--default);
   
   // accordion item border for high contrast
-  --#{$accordion}__item--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
-  --#{$accordion}__item--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$accordion}__item--BorderWidth: 0;
+  --#{$accordion}__item--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$accordion}__item--m-expanded--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
 
   // expandable content border for high contrast
   --#{$accordion}__expandable-content--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
@@ -137,7 +141,7 @@
     --#{$accordion}--RowGap: var(--#{$accordion}--m-bordered--RowGap);
     --#{$accordion}__item--BorderRadius: 0;
     --#{$accordion}__toggle--BorderRadius: 0;
-    --#{$accordion}__item--after--BorderWidth: 0;
+    --#{$accordion}__item--BorderWidth: 0;
   
     .#{$accordion}__item {
       border-block-end: var(--#{$accordion}__item--m-bordered--BorderBlockEndWidth) solid var(--#{$accordion}__item--m-bordered--BorderBlockEndColor);
@@ -154,7 +158,7 @@
     pointer-events: none;
     content: "";
     background-color: var(--#{$accordion}__item--m-expanded--BackgroundColor);
-    border: var(--#{$accordion}__item--after--BorderWidth) solid var(--#{$accordion}__item--after--BorderColor);
+    border: var(--#{$accordion}__item--BorderWidth) solid var(--#{$accordion}__item--BorderColor);
     border-radius: var(--#{$accordion}__item--BorderRadius);
     opacity: var(--#{$accordion}__item--before--Opacity);
     transition-timing-function: var(--#{$accordion}__item--before--TransitionTimingFunction);
@@ -169,6 +173,7 @@
     --#{$accordion}__item--before--TransitionDuration--fade: var(--#{$accordion}__item--before--TransitionDuration--expand--fade);
     --#{$accordion}__item--before--Opacity: var(--#{$accordion}__item--m-expanded--before--Opacity);
     --#{$accordion}__item--before--TranslateY: var(--#{$accordion}__item--m-expanded--before--TranslateY);
+    --#{$accordion}__item--BorderWidth: var(--#{$accordion}__item--m-expanded--BorderWidth);
     --#{$accordion}__expandable-content--TransitionDuration--slide: var(--#{$accordion}__expandable-content--TransitionDuration--expand--slide);
     --#{$accordion}__expandable-content--TransitionDuration--fade: var(--#{$accordion}__expandable-content--TransitionDuration--expand--fade);
     --#{$accordion}__expandable-content--Opacity: var(--#{$accordion}__item--m-expanded__expandable-content--Opacity);
@@ -198,8 +203,18 @@
   border: 0;
   border-radius: var(--#{$accordion}__toggle--BorderRadius);
 
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$accordion}__toggle--BorderWidth) solid var(--#{$accordion}__toggle--BorderColor);
+    border-radius: inherit;
+  }
+
   &:is(:hover, :focus) {
     --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--hover--BackgroundColor);
+    --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--hover--BorderWidth);
   }
 }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -99,6 +99,14 @@
   --#{$accordion}--m-bordered--RowGap: 0;
   --#{$accordion}__item--m-bordered--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$accordion}__item--m-bordered--BorderBlockEndColor: var(--pf-t--global--border--color--default);
+  
+  // accordion item border for high contrast
+  --#{$accordion}__item--after--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$accordion}__item--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
+
+  // expandable content border for high contrast
+  --#{$accordion}__expandable-content--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$accordion}__expandable-content--BorderColor: var(--pf-t--global--border--color--high-contrast);
 }
 
 .#{$accordion} {
@@ -129,7 +137,8 @@
     --#{$accordion}--RowGap: var(--#{$accordion}--m-bordered--RowGap);
     --#{$accordion}__item--BorderRadius: 0;
     --#{$accordion}__toggle--BorderRadius: 0;
-
+    --#{$accordion}__item--after--BorderWidth: 0;
+  
     .#{$accordion}__item {
       border-block-end: var(--#{$accordion}__item--m-bordered--BorderBlockEndWidth) solid var(--#{$accordion}__item--m-bordered--BorderBlockEndColor);
     }
@@ -150,6 +159,18 @@
     transition-timing-function: var(--#{$accordion}__item--before--TransitionTimingFunction);
     transition-duration: var(--#{$accordion}__item--before--TransitionDuration--fade);
     transition-property: opacity;
+  }
+
+  &:is(:hover, :active),
+  &.pf-m-expanded {
+    &::after {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      content: "";
+      border: var(--#{$accordion}__item--after--BorderWidth) solid var(--#{$accordion}__item--after--BorderColor);
+      border-radius: var(--#{$accordion}__item--BorderRadius);
+    }
   }
 
   &.pf-m-expanded {
@@ -235,6 +256,7 @@
     max-height: 99999px;
     margin-block-end: var(--#{$accordion}__expandable-content--MarginBlockEnd);
     visibility: revert;
+    border: var(--#{$accordion}__expandable-content--BorderWidth) solid var(--#{$accordion}__expandable-content--BorderColor);
     transition-delay: 0s;
 
     &.pf-m-fixed {

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -20,9 +20,9 @@
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$accordion}__toggle--BorderWidth: 0;
+  --#{$accordion}__toggle--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$accordion}__toggle--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$accordion}__toggle--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
+  --#{$accordion}__toggle--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
 
   // Accordion toggle toggle-start modifier
   // This decreases the gap between icon and text, alternative is calc it to * 2 the token or create a new token

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -101,11 +101,11 @@
   --#{$accordion}__item--m-bordered--BorderBlockEndColor: var(--pf-t--global--border--color--default);
   
   // accordion item border for high contrast
-  --#{$accordion}__item--after--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$accordion}__item--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
   --#{$accordion}__item--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // expandable content border for high contrast
-  --#{$accordion}__expandable-content--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$accordion}__expandable-content--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
   --#{$accordion}__expandable-content--BorderColor: var(--pf-t--global--border--color--high-contrast);
 }
 
@@ -154,23 +154,12 @@
     pointer-events: none;
     content: "";
     background-color: var(--#{$accordion}__item--m-expanded--BackgroundColor);
+    border: var(--#{$accordion}__item--after--BorderWidth) solid var(--#{$accordion}__item--after--BorderColor);
     border-radius: var(--#{$accordion}__item--BorderRadius);
     opacity: var(--#{$accordion}__item--before--Opacity);
     transition-timing-function: var(--#{$accordion}__item--before--TransitionTimingFunction);
     transition-duration: var(--#{$accordion}__item--before--TransitionDuration--fade);
     transition-property: opacity;
-  }
-
-  &:is(:hover, :focus-within),
-  &.pf-m-expanded {
-    &::after {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      content: "";
-      border: var(--#{$accordion}__item--after--BorderWidth) solid var(--#{$accordion}__item--after--BorderColor);
-      border-radius: var(--#{$accordion}__item--BorderRadius);
-    }
   }
 
   &.pf-m-expanded {


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/7611

Adds a pseudoelement border for the item to the `::after`.
Adds the border on the `expandable-content` element so that it scrolls properly when there are multiple `expandable-content-body`s.

Backstop report showing high contrast difference: https://drive.google.com/file/d/1UH15vqvcKXQJJC_vhwBskjj7iaYap16Q/view?usp=sharing

Assisted by Cursor autocomplete