### PR TITLE
fix(textinputgroup): update placeholder text color for disabled state

### DIFF
--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -44,6 +44,7 @@
   --#{$text-input-group}__text-input--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$text-input-group}__text-input--MinWidth: 12ch;
   --#{$text-input-group}__text-input--m-hint--Color: var(--pf-t--global--text--color--placeholder);
+  --#{$text-input-group}__text-input--Color: var(--pf-t--global--text--color--regular);
   --#{$text-input-group}__text-input--placeholder--Color: var(--pf-t--global--text--color--placeholder);
   --#{$text-input-group}__text-input--BackgroundColor: transparent;
   --#{$text-input-group}__text-input--OutlineOffset: -6px;
@@ -97,6 +98,7 @@
 
   &.pf-m-disabled {
     --#{$text-input-group}--Color: var(--#{$text-input-group}--m-disabled--Color);
+    --#{$text-input-group}__text-input--Color: var(--#{$text-input-group}--m-disabled--Color);
     --#{$text-input-group}__text-input--placeholder--Color: var(--#{$text-input-group}--m-disabled--Color);
     --#{$text-input-group}__icon--Color: var(--#{$text-input-group}--m-disabled__icon--Color);
     --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}--m-disabled__icon--m-status--Color);
@@ -214,6 +216,7 @@
   padding-block-end: var(--#{$text-input-group}__text-input--PaddingBlockEnd);
   padding-inline-start: var(--#{$text-input-group}__text-input--PaddingInlineStart);
   padding-inline-end: var(--#{$text-input-group}__text-input--PaddingInlineEnd);
+  color: var(--#{$text-input-group}__text-input--Color);
   background-color: var(--#{$text-input-group}__text-input--BackgroundColor);
   border: 0;
   outline-offset: var(--#{$text-input-group}__text-input--OutlineOffset);

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -97,6 +97,7 @@
 
   &.pf-m-disabled {
     --#{$text-input-group}--Color: var(--#{$text-input-group}--m-disabled--Color);
+    --#{$text-input-group}__text-input--placeholder--Color: var(--#{$text-input-group}--m-disabled--Color);
     --#{$text-input-group}__icon--Color: var(--#{$text-input-group}--m-disabled__icon--Color);
     --#{$text-input-group}__icon--m-status--Color: var(--#{$text-input-group}--m-disabled__icon--m-status--Color);
     --#{$text-input-group}--BackgroundColor: var(--#{$text-input-group}--m-disabled--BackgroundColor);


### PR DESCRIPTION
Closes #7661 
Closes #7671 

This PR:
1. Adds new `--#{$text-input-group}__text-input--Color` variable which defaults to the current value of `var(--pf-t--global--text--color--regular)`.
2. Overrides default values for the text input (both placeholder & value) text color for disabled TextInputGroups
3.  Sets the `color` on the text input group text input to the new `--#{$text-input-group}__text-input--Color` variable.

Confirmed w/PF design placeholder text should use the on-disabled token, matching pattern used in similar components such as [FormControl](https://github.com/patternfly/patternfly/blob/main/src/patternfly/components/FormControl/form-control.scss#L279).


Before:
- Input placeholder:
  <img width="183" height="90" alt="Screenshot 2025-07-17 at 4 45 46 PM" src="https://github.com/user-attachments/assets/3a143f77-1340-4c72-a9b3-0eefd252f257" />
- Input text:
  <img width="124" height="90" alt="Screenshot 2025-07-21 at 10 26 58 AM" src="https://github.com/user-attachments/assets/25b54547-54a3-415b-94b3-63ca18f5142f" />


After:
- Input placeholder:
  <img width="165" height="83" alt="Screenshot 2025-07-17 at 4 45 54 PM" src="https://github.com/user-attachments/assets/5015cd6a-1f57-4e4c-98ee-951a7ebb60ca" />
- Input text:
  <img width="121" height="83" alt="Screenshot 2025-07-21 at 10 26 50 AM" src="https://github.com/user-attachments/assets/0e2cbc56-33f9-4361-9935-0ea896115497" />

