### PR TITLE
feat(codeBlock): added high contrast border

### DIFF
--- a/src/patternfly/components/CodeBlock/code-block.scss
+++ b/src/patternfly/components/CodeBlock/code-block.scss
@@ -30,7 +30,7 @@
     pointer-events: none;
     content: "";
     border: var(--#{$code-block}--BorderWidth) solid var(--#{$code-block}--BorderColor);
-    border-radius: var(--#{$code-block}--BorderRadius);
+    border-radius: inherit;
   }
 }
 

--- a/src/patternfly/components/CodeBlock/code-block.scss
+++ b/src/patternfly/components/CodeBlock/code-block.scss
@@ -1,6 +1,8 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($code-block) {
+  --#{$code-block}--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$code-block}--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$code-block}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$code-block}--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$code-block}__header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
@@ -18,8 +20,18 @@
 }
 
 .#{$code-block} {
+  position: relative;
   background-color: var(--#{$code-block}--BackgroundColor);
   border-radius: var(--#{$code-block}--BorderRadius);
+
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$code-block}--BorderWidth) solid var(--#{$code-block}--BorderColor);
+    border-radius: var(--#{$code-block}--BorderRadius);
+  }
 }
 
 .#{$code-block}__header {


### PR DESCRIPTION
Commented in bit about `:root:where(.pf-v6-theme-high-contrast) {` and added it to root to check.

I added these tokens following Sarah's example in the modal PR, but let me know if you don't want these tokens here. I don't see them in the tokens table.

|Before|After|
|-|-|
|<img width="770" height="211" alt="Screenshot 2025-07-24 at 1 47 40 PM" src="https://github.com/user-attachments/assets/ac3dacf6-c7cc-497b-9a92-3ca9000a5722" />|<img width="753" height="201" alt="Screenshot 2025-07-25 at 9 35 55 AM" src="https://github.com/user-attachments/assets/d63e4542-1013-4b32-a1ce-a5ed8d4c1357" />

|Before|After|
|-|-|
|<img width="759" height="209" alt="Screenshot 2025-07-24 at 1 47 46 PM" src="https://github.com/user-attachments/assets/cafdafed-a328-43cc-b7b6-c004df723667" />|<img width="774" height="209" alt="Screenshot 2025-07-24 at 1 43 33 PM" src="https://github.com/user-attachments/assets/cf9ca745-93fa-46d0-b918-6d82b20209c9" />
