### PR TITLE
feat(dual-list-selector): add high-contrast

### DIFF
--- a/src/patternfly/components/DualListSelector/dual-list-selector-item.hbs
+++ b/src/patternfly/components/DualListSelector/dual-list-selector-item.hbs
@@ -21,12 +21,14 @@
         {{/dual-list-selector-item--text}}
       {{/dual-list-selector-item-text}}
     {{/dual-list-selector-item-main}}
-    {{#> dual-list-selector-item--count}}
-      {{#> dual-list-selector-item-count}}
-        {{#> badge badge--modifier="pf-m-read"}}
-          {{dual-list-selector-item--count}}
-        {{/badge}}
-      {{/dual-list-selector-item-count}}
-    {{/dual-list-selector-item--count}}
+    {{#if dual-list-selector-item--count}}
+      {{#> dual-list-selector-item--count}}
+        {{#> dual-list-selector-item-count}}
+          {{#> badge badge--modifier="pf-m-read"}}
+            {{dual-list-selector-item--count}}
+          {{/badge}}
+        {{/dual-list-selector-item-count}}
+      {{/dual-list-selector-item--count}}
+    {{/if}}
   </{{#if dual-list-selector-item--type}}{{dual-list-selector-item--type}}{{else}}span{{/if}}>
 {{/dual-list-selector-list-item-row}}

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -62,7 +62,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item-row--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
   --#{$dual-list-selector}__list-item-row--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
-  --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
+  --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
   --#{$dual-list-selector}__list-item--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$dual-list-selector}__list-item--m-ghost-row--Opacity: .4;
 

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -219,7 +219,6 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 .#{$dual-list-selector}__list-item {
   &:focus-visible {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
-
   }
 
   &.pf-m-expandable {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -57,13 +57,12 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   // List item
   --#{$dual-list-selector}__list-item-row--FontSize: var(--pf-t--global--font--size--sm);
   --#{$dual-list-selector}__list-item-row--BackgroundColor:  var(--pf-t--global--background--color--action--plain--default);
-  --#{$dual-list-selector}__list-item-row--BorderWidth: var(--pf-t--global--border--width--regular);
-  --#{$dual-list-selector}__list-item-row--BorderColor: transparent;
+  --#{$dual-list-selector}__list-item-row--BorderWidth: 0;
+  --#{$dual-list-selector}__list-item-row--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$dual-list-selector}__list-item-row--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
-  --#{$dual-list-selector}__list-item-row--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$dual-list-selector}__list-item-row--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
   --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
-  --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--border--width--strong);
-  --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
   --#{$dual-list-selector}__list-item--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$dual-list-selector}__list-item--m-ghost-row--Opacity: .4;
 
@@ -220,7 +219,6 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 .#{$dual-list-selector}__list-item {
   &:focus-visible {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
-    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--BorderColor);
 
   }
 
@@ -282,7 +280,6 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   &.pf-m-selected {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor);
     --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderWidth);
-    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderColor);
 
     .#{$dual-list-selector}__item-text {
       --#{$dual-list-selector}__item-text--Color: var(--#{$dual-list-selector}__list-item-row--m-selected__text--Color);
@@ -293,7 +290,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
   &:hover {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
-    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--hover--BorderColor);
+    --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--hover--BorderWidth);
   }
 
   &.pf-m-check {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -60,7 +60,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   --#{$dual-list-selector}__list-item-row--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$dual-list-selector}__list-item-row--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$dual-list-selector}__list-item-row--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
-  --#{$dual-list-selector}__list-item-row--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
+  --#{$dual-list-selector}__list-item-row--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
   --#{$dual-list-selector}__list-item--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -218,8 +218,10 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 .#{$dual-list-selector}__list-item {
-  &:focus {
+  &:focus-visible {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
+    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--BorderColor);
+
   }
 
   &.pf-m-expandable {
@@ -292,12 +294,12 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   &:hover {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
     --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--hover--BorderColor);
-    --#{$dual-list-selector}__list-item-row--BorderWidth: revert;
   }
 
   &.pf-m-check {
     --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: transparent;
     --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: transparent;
+    --#{$dual-list-selector}__list-item-row--BorderWidth: revert;
   }
 
   &.pf-m-ghost-row {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -57,8 +57,13 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   // List item
   --#{$dual-list-selector}__list-item-row--FontSize: var(--pf-t--global--font--size--sm);
   --#{$dual-list-selector}__list-item-row--BackgroundColor:  var(--pf-t--global--background--color--action--plain--default);
+  --#{$dual-list-selector}__list-item-row--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$dual-list-selector}__list-item-row--BorderColor: transparent;
   --#{$dual-list-selector}__list-item-row--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+  --#{$dual-list-selector}__list-item-row--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
+  --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: var(--pf-t--global--border--width--strong);
+  --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$dual-list-selector}__list-item--m-ghost-row--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$dual-list-selector}__list-item--m-ghost-row--Opacity: .4;
 
@@ -182,6 +187,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   overflow: auto;
   border: var(--#{$dual-list-selector}__menu--BorderWidth) solid var(--#{$dual-list-selector}__menu--BorderColor);
   border-radius: var(--#{$dual-list-selector}__menu--BorderRadius);
+  outline-offset: 2px; // push the focus outline out so that it is not broken by the list item row background
 }
 
 .#{$dual-list-selector}__list {
@@ -257,12 +263,24 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 }
 
 .#{$dual-list-selector}__list-item-row {
+  position: relative;
   display: flex;
   font-size: var(--#{$dual-list-selector}__list-item-row--FontSize);
   background-color: var(--#{$dual-list-selector}__list-item-row--BackgroundColor);
 
+  &::before {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border-block-start: var(--#{$dual-list-selector}__list-item-row--BorderWidth) solid var(--#{$dual-list-selector}__list-item-row--BorderColor);
+    border-block-end: var(--#{$dual-list-selector}__list-item-row--BorderWidth) solid var(--#{$dual-list-selector}__list-item-row--BorderColor);
+  }
+
   &.pf-m-selected {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor);
+    --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderWidth);
+    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderColor);
 
     .#{$dual-list-selector}__item-text {
       --#{$dual-list-selector}__item-text--Color: var(--#{$dual-list-selector}__list-item-row--m-selected__text--Color);
@@ -273,10 +291,13 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
   &:hover {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
+    --#{$dual-list-selector}__list-item-row--BorderColor: var(--#{$dual-list-selector}__list-item-row--hover--BorderColor);
+    --#{$dual-list-selector}__list-item-row--BorderWidth: revert;
   }
 
   &.pf-m-check {
     --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: transparent;
+    --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: transparent;
   }
 
   &.pf-m-ghost-row {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -57,7 +57,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
   // List item
   --#{$dual-list-selector}__list-item-row--FontSize: var(--pf-t--global--font--size--sm);
   --#{$dual-list-selector}__list-item-row--BackgroundColor:  var(--pf-t--global--background--color--action--plain--default);
-  --#{$dual-list-selector}__list-item-row--BorderWidth: 0;
+  --#{$dual-list-selector}__list-item-row--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$dual-list-selector}__list-item-row--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$dual-list-selector}__list-item-row--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
   --#{$dual-list-selector}__list-item-row--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);


### PR DESCRIPTION
Fixes #7617 
Figma design: https://www.figma.com/design/wKcOq7IrzfL1gEK2mocd6r/Semantic-dimension-border-width----font-weight-adjustment-test?node-id=10994-57326&t=r888cXH4fIPuJcgE-4

Top/bottom 1px border on hover (along with background change)
Top/bottom 2px border for selected items UNLESS there's a checkbox
Moves outline on the container out 2px so that the focus outline is not covered by the item's background. Question - use a spacer here or hard-coded pixels? It's not really a logical number.
Changes :focus to :focus-visible because the current implementation leaves a background hanging around if you click something to UNselect it and then move the mouse away.

Note: the border width of list items changes when selected, so we still need to use the pseudoelement

Assisted by Cursor autocomplete