### PR TITLE
feat(wizard): add high-contrast borders

### DIFF
--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -60,8 +60,8 @@
   --#{$wizard}__nav-link-main--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$wizard}__nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$wizard}__nav-link-main--BorderWidth: 0;
-  --#{$wizard}__nav-link--hover--nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
-  --#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
+  --#{$wizard}__nav-link--hover__nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
+  --#{$wizard}__nav-link--m-current__nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
 
   // Nav link toggle icon
   --#{$wizard}__nav-link-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -58,6 +58,11 @@
   --#{$wizard}__nav-link-main--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-main--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$wizard}__nav-link-main--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$wizard}__nav-link-main--BorderColor: transparent;
+  --#{$wizard}__nav-link-main--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$wizard}__nav-link--hover--nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$wizard}__nav-link--m-current--nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth: var(--pf-t--global--border--width--strong);
 
   // Nav link toggle icon
   --#{$wizard}__nav-link-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
@@ -73,13 +78,17 @@
   --#{$wizard}__nav-link--before--Height: var(--pf-t--global--icon--size--font--xl);
   --#{$wizard}__nav-link--before--InsetBlockStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link--before--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$wizard}__nav-link--before--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$wizard}__nav-link--before--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$wizard}__nav-link--before--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$wizard}__nav-link--before--Color: var(--pf-t--global--text--color--regular);
   --#{$wizard}__nav-link--before--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$wizard}__nav-link--m-current--before--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$wizard}__nav-link--m-current--before--Color: var(--pf-t--global--text--color--on-brand--default);
+  --#{$wizard}__nav-link--m-current--before--BorderColor: transparent;
   --#{$wizard}__nav-link--m-disabled--before--BackgroundColor: transparent;
   --#{$wizard}__nav-link--m-disabled--before--Color: var(--pf-t--global--text--color--disabled);
+  --#{$wizard}__nav-link--m-disabled--before--BorderColor: transparent;
 
   // Nav link status icon
   --#{$wizard}__nav-link-status-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -466,18 +475,22 @@
 
   // Nav step number
   &::before {
-    inset-block-start:  var(--#{$wizard}__nav-link--before--InsetBlockStart); // 8px; // TODO variable
+    inset-block-start: var(--#{$wizard}__nav-link--before--InsetBlockStart); // 8px; // TODO variable
     content: counter(wizard-nav-count);
-}
+    border: var(--#{$wizard}__nav-link--before--BorderWidth) solid var(--#{$wizard}__nav-link--before--BorderColor);
+  }
 
   &.pf-m-current {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--m-current--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--m-current--BackgroundColor);
+    --#{$wizard}__nav-link-main--BorderColor: var(--#{$wizard}__nav-link--m-current--nav-link-main--BorderColor);
+    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth); 
 
     @at-root .#{$wizard}__toggle-num,
     &::before {
       --#{$wizard}__nav-link--before--BackgroundColor: var(--#{$wizard}__nav-link--m-current--before--BackgroundColor);
       --#{$wizard}__nav-link--before--Color: var(--#{$wizard}__nav-link--m-current--before--Color);
+      --#{$wizard}__nav-link--before--BorderColor: var(--#{$wizard}__nav-link--m-current--before--BorderColor);
     }
   }
 
@@ -498,6 +511,7 @@
   &:where(:hover, :focus) {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--hover--BackgroundColor);
+    --#{$wizard}__nav-link-main--BorderColor: var(--#{$wizard}__nav-link--hover--nav-link-main--BorderColor);
   }
 
   // override the button background/color for disabled nav links
@@ -511,11 +525,13 @@
     &::before {
       --#{$wizard}__nav-link--before--BackgroundColor: var(--#{$wizard}__nav-link--m-disabled--before--BackgroundColor);
       --#{$wizard}__nav-link--before--Color: var(--#{$wizard}__nav-link--m-disabled--before--Color);
+      --#{$wizard}__nav-link--before--BorderColor: var(--#{$wizard}__nav-link--m-disabled--before--BorderColor);
     }
   }
 }
 
 .#{$wizard}__nav-link-main {
+  position: relative;
   display: flex;
   flex-grow: 1;
   justify-content: space-between;
@@ -524,8 +540,16 @@
   padding-inline-start: var(--#{$wizard}__nav-link-main--PaddingInlineStart);
   padding-inline-end: var(--#{$wizard}__nav-link-main--PaddingInlineEnd);
   background-color: var(--#{$wizard}__nav-link-main--BackgroundColor);
-  border: none;
   border-radius: var(--#{$wizard}__nav-link-main--BorderRadius);
+
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$wizard}__nav-link-main--BorderWidth) solid var(--#{$wizard}__nav-link-main--BorderColor);
+    border-radius: inherit;
+  }
 }
 
 .#{$wizard}__nav-link-status-icon {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -482,7 +482,7 @@
   &.pf-m-current {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--m-current--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--m-current--BackgroundColor);
-    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth); 
+    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--m-current__nav-link-main--BorderWidth); 
 
     @at-root .#{$wizard}__toggle-num,
     &::before {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -509,7 +509,7 @@
   &:where(:hover, :focus) {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--hover--BackgroundColor);
-    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--hover--nav-link-main--BorderWidth);
+    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--hover__nav-link-main--BorderWidth);
   }
 
   // override the button background/color for disabled nav links

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -58,11 +58,10 @@
   --#{$wizard}__nav-link-main--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-main--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$wizard}__nav-link-main--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$wizard}__nav-link-main--BorderColor: transparent;
-  --#{$wizard}__nav-link-main--BorderWidth: var(--pf-t--global--border--width--regular);
-  --#{$wizard}__nav-link--hover--nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$wizard}__nav-link--m-current--nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth: var(--pf-t--global--border--width--strong);
+  --#{$wizard}__nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$wizard}__nav-link-main--BorderWidth: 0;
+  --#{$wizard}__nav-link--hover--nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
+  --#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
 
   // Nav link toggle icon
   --#{$wizard}__nav-link-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
@@ -483,7 +482,6 @@
   &.pf-m-current {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--m-current--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--m-current--BackgroundColor);
-    --#{$wizard}__nav-link-main--BorderColor: var(--#{$wizard}__nav-link--m-current--nav-link-main--BorderColor);
     --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--m-current--nav-link-main--BorderWidth); 
 
     @at-root .#{$wizard}__toggle-num,
@@ -511,7 +509,7 @@
   &:where(:hover, :focus) {
     --#{$wizard}__nav-link--Color: var(--#{$wizard}__nav-link--hover--Color);
     --#{$wizard}__nav-link-main--BackgroundColor: var(--#{$wizard}__nav-link--hover--BackgroundColor);
-    --#{$wizard}__nav-link-main--BorderColor: var(--#{$wizard}__nav-link--hover--nav-link-main--BorderColor);
+    --#{$wizard}__nav-link-main--BorderWidth: var(--#{$wizard}__nav-link--hover--nav-link-main--BorderWidth);
   }
 
   // override the button background/color for disabled nav links


### PR DESCRIPTION
Fixes #7609 

Added border styling to the nav-link-main element using a ::after pseudoelement
Border appears on hover and current states with high-contrast color
Border width increases for current/selected state
Border follows the same border radius as the background container

Added border styling to the ::before pseudoelement (step number)
Border appears by default with high-contrast color
Border is removed for current and disabled states
Border follows the existing border radius for the step number

Visual regression test at: https://drive.google.com/file/d/1WRRztj5K40iL59tYWDErCfyga-zraOk-/view?usp=sharing
I believe the visible changes are due to the new 1px border on modals. In the non-modal examples that failed I can't actually see a difference (other than the usual artifacts).

Assisted by Cursor autocomplete