### PR TITLE
feat(label): add high-contrast borders

### DIFF
--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -17,7 +17,6 @@
   --#{$label}--Color: var(--pf-t--global--text--color--nonstatus--on-gray--default);
   --#{$label}__icon--Color: var(--pf-t--global--icon--color--nonstatus--on-gray--default);
   --#{$label}--m-clickable--hover--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--hover);
-  --#{$label}--m-clickable--hover--BorderWidth: var(--pf-t--global--border--width--action--hover);
   --#{$label}--m-clickable--hover--Color: var(--pf-t--global--text--color--nonstatus--on-gray--hover);
   --#{$label}--m-clickable--hover__icon--Color: var(--pf-t--global--icon--color--nonstatus--on-gray--hover);
   --#{$label}--m-outline--BorderColor: var(--pf-t--global--border--color--nonstatus--gray--default);

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -7,8 +7,8 @@
   --#{$label}--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$label}--MaxWidth: 100%;
   --#{$label}--MinWidth: calc((var(--#{$label}--FontSize) * var(--pf-t--global--font--line-height--body) + var(--#{$label}--PaddingBlockStart) + var(--#{$label}--PaddingBlockEnd)));
-  --#{$label}--BorderWidth: 0;
-  --#{$label}--BorderColor: transparent;
+  --#{$label}--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$label}--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$label}--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$label}--FontSize: var(--pf-t--global--font--size--body--sm);
 
@@ -17,6 +17,7 @@
   --#{$label}--Color: var(--pf-t--global--text--color--nonstatus--on-gray--default);
   --#{$label}__icon--Color: var(--pf-t--global--icon--color--nonstatus--on-gray--default);
   --#{$label}--m-clickable--hover--BackgroundColor: var(--pf-t--global--color--nonstatus--gray--hover);
+  --#{$label}--m-clickable--hover--BorderWidth: var(--pf-t--global--border--width--action--hover);
   --#{$label}--m-clickable--hover--Color: var(--pf-t--global--text--color--nonstatus--on-gray--hover);
   --#{$label}--m-clickable--hover__icon--Color: var(--pf-t--global--icon--color--nonstatus--on-gray--hover);
   --#{$label}--m-outline--BorderColor: var(--pf-t--global--border--color--nonstatus--gray--default);
@@ -163,8 +164,8 @@
   --#{$label}--m-custom--m-outline--m-clickable--hover__icon--Color: var(--pf-t--global--icon--color--status--custom--hover);
 
   // Clickable
-  --#{$label}--m-clickable--hover--BorderWidth: 0;
-  --#{$label}--m-clickable--hover--BorderColor: transparent;
+  --#{$label}--m-clickable--hover--BorderWidth: var(--pf-t--global--border--width--action--hover);
+  --#{$label}--m-clickable--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$label}--m-clickable__content--Cursor: pointer;
 
   // Filled
@@ -183,8 +184,10 @@
   // Overflow
   --#{$label}--m-overflow--Color: var(--pf-t--global--text--color--brand--default);
   --#{$label}--m-overflow--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$label}--m-overflow--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$label}--m-overflow--hover--Color: var(--pf-t--global--text--color--brand--hover);
   --#{$label}--m-overflow--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --#{$label}--m-overflow--hover--BorderWidth: var(--pf-t--global--border--width--action--hover);
 
   // Add
   --#{$label}--m-add--Color: var(--pf-t--global--text--color--brand--default);
@@ -474,10 +477,12 @@
   &.pf-m-overflow {
     --#{$label}--Color: var(--#{$label}--m-overflow--Color);
     --#{$label}--BackgroundColor: var(--#{$label}--m-overflow--BackgroundColor);
+    --#{$label}--BorderWidth: var(--#{$label}--m-overflow--BorderWidth);
 
     &:is(:hover, :focus) {
       --#{$label}--m-overflow--Color: var(--#{$label}--m-overflow--hover--Color);
       --#{$label}--m-overflow--BackgroundColor: var(--#{$label}--m-overflow--hover--BackgroundColor);
+      --#{$label}--m-overflow--BorderWidth: var(--#{$label}--m-overflow--hover--BorderWidth);
     }
   }
 


### PR DESCRIPTION
Fixes #7618 

Modifies existing pseudoelement border for high-contrast borders.

Backstop report show zero differences.
[Design link](https://www.figma.com/design/iT76DS020Ry1Wswfc0Hmes/branch/wKcOq7IrzfL1gEK2mocd6r/High-Contrast-Exploration?m=auto&node-id=10994-57328&t=6D4lvCu8VnqnM6IQ-1)

Assisted by Cursor autocomplete