### PR TITLE
fix(label-group): adjust close icon color

### DIFF
--- a/src/patternfly/components/Label/label-group-close.hbs
+++ b/src/patternfly/components/Label/label-group-close.hbs
@@ -2,5 +2,5 @@
   {{#if label-group-close--attribute}}
     {{{label-group-close--attribute}}}
   {{/if}}>
-  {{> button button--IsPlain=true button--HasNoPadding=true button--IsIcon=true button--icon="times" button--attribute=(concat 'aria-labelledby="' label-group--id '-button ' label-group--id '-label" aria-label="Close label group" id="' label-group--id '-button"')}}
+  {{> button button--IsPlain=true button--IsSmall=true button--IsIcon=true button--icon="times" button--attribute=(concat 'aria-labelledby="' label-group--id '-button ' label-group--id '-label" aria-label="Close label group" id="' label-group--id '-button"')}}
 </div>

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -41,6 +41,7 @@
   --#{$label-group}__label--MaxWidth: 18ch;
 
   // Close
+  --#{$label-group}__close--c-button--Color: var(--pf-t--global--icon--color--regular);
   --#{$label-group}__close--c-button--FontSize: var(--pf-t--global--icon--size--font--body--sm);
   --#{$label-group}__close--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$label-group}__close--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
@@ -146,8 +147,9 @@
   display: flex;
   align-self: flex-start;
 
-  .#{$button} {
+  .#{$button}.pf-m-plain.pf-m-no-padding {
     --#{$button}--FontSize: var(--#{$label-group}__close--c-button--FontSize);
+    --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$label-group}__close--c-button--Color);
     --#{$button}--m-plain--m-no-padding--PaddingBlockStart: var(--#{$label-group}__close--c-button--PaddingBlockStart);
     --#{$button}--m-plain--m-no-padding--PaddingInlineEnd: var(--#{$label-group}__close--c-button--PaddingInlineEnd);
     --#{$button}--m-plain--m-no-padding--PaddingBlockEnd: var(--#{$label-group}__close--c-button--PaddingBlockEnd);

--- a/src/patternfly/components/Label/label-group.scss
+++ b/src/patternfly/components/Label/label-group.scss
@@ -41,7 +41,6 @@
   --#{$label-group}__label--MaxWidth: 18ch;
 
   // Close
-  --#{$label-group}__close--c-button--Color: var(--pf-t--global--icon--color--regular);
   --#{$label-group}__close--c-button--FontSize: var(--pf-t--global--icon--size--font--body--sm);
   --#{$label-group}__close--c-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$label-group}__close--c-button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
@@ -147,9 +146,8 @@
   display: flex;
   align-self: flex-start;
 
-  .#{$button}.pf-m-plain.pf-m-no-padding {
+  .#{$button} {
     --#{$button}--FontSize: var(--#{$label-group}__close--c-button--FontSize);
-    --#{$button}--m-plain--m-no-padding__icon--Color: var(--#{$label-group}__close--c-button--Color);
     --#{$button}--m-plain--m-no-padding--PaddingBlockStart: var(--#{$label-group}__close--c-button--PaddingBlockStart);
     --#{$button}--m-plain--m-no-padding--PaddingInlineEnd: var(--#{$label-group}__close--c-button--PaddingInlineEnd);
     --#{$button}--m-plain--m-no-padding--PaddingBlockEnd: var(--#{$label-group}__close--c-button--PaddingBlockEnd);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7676

~~This fixes the color.~~ After chatting with @lboehling, we decided to use a small button here, which has a black icon by default.

Opened a follow-up issue in react to fix the icon - https://github.com/patternfly/patternfly-react/issues/11941

