### PR TITLE
feat(wizard): add warning step variation

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -479,6 +479,15 @@ import './Wizard.css'
 {{> wizard--status wizard--status--IsExpanded=true  wizard--status--id="success-on-step-nav-expanded" wizard--status--IsSuccess=true}}
 ```
 
+### Warning on step
+```hbs isFullscreen
+{{> wizard--status wizard--status--id="warning-on-step" wizard--status--IsWarning=true}}
+```
+
+### Nav expanded with warning (mobile)
+```hbs isFullscreen
+{{> wizard--status wizard--status--IsExpanded=true  wizard--status--id="warning-on-step-nav-expanded" wizard--status--IsWarning=true}}
+```
 
 ## Documentation
 ### Accessibility
@@ -534,5 +543,6 @@ import './Wizard.css'
 | `.pf-m-current` | `.pf-v6-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |
 | `.pf-m-disabled` | `.pf-v6-c-wizard__nav-link` | Modifies a step link for the disabled state. |
 | `.pf-m-success` | `.pf-v6-c-wizard__nav-link`, `.pf-v6-c-wizard__toggle-list-item` | Modifies a step link to indicate success status. |
+| `.pf-m-warning` | `.pf-v6-c-wizard__nav-link`, `.pf-v6-c-wizard__toggle-list-item` | Modifies a step link to indicate warning status. |
 | `.pf-m-danger` | `.pf-v6-c-wizard__nav-link`, `.pf-v6-c-wizard__toggle-list-item` | Modifies a step link to indicate danger status. |
 | `.pf-m-no-padding` | `.pf-v6-c-wizard__main-body` | Modifies the main container body to remove the padding. |

--- a/src/patternfly/components/Wizard/wizard--status.hbs
+++ b/src/patternfly/components/Wizard/wizard--status.hbs
@@ -8,7 +8,7 @@
   {{/wizard-header}}
   {{#> wizard-toggle}}
     {{#> wizard-toggle-list}}
-      {{#> wizard-toggle-list-item wizard-toggle-list-item--IsSuccess=wizard--status--IsSuccess wizard-toggle-list-item--IsDanger=wizard--status--IsDanger}}
+      {{#> wizard-toggle-list-item wizard-toggle-list-item--IsSuccess=wizard--status--IsSuccess wizard-toggle-list-item--IsDanger=wizard--status--IsDanger wizard-toggle-list-item--IsWarning=wizard--status--IsWarning}}
         Configuration
         {{> wizard-toggle-separator}}
       {{/wizard-toggle-list-item}}
@@ -27,7 +27,7 @@
                 Information
               {{/wizard-nav-link}}
             {{/wizard-nav-item}}
-            {{#> wizard-nav-item wizard-nav-item--IsExpandable="true" wizard-nav-item--IsExpanded="true" wizard-nav-item--IsSuccess=wizard--status--IsSuccess wizard-nav-item--IsDanger=wizard--status--IsDanger}}
+            {{#> wizard-nav-item wizard-nav-item--IsExpandable="true" wizard-nav-item--IsExpanded="true" wizard-nav-item--IsSuccess=wizard--status--IsSuccess wizard-nav-item--IsDanger=wizard--status--IsDanger wizard-nav-item--IsWarning=wizard--status--IsWarning}}
               {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
                 Configuration
               {{/wizard-nav-link}}

--- a/src/patternfly/components/Wizard/wizard-nav-link-status-icon.hbs
+++ b/src/patternfly/components/Wizard/wizard-nav-link-status-icon.hbs
@@ -2,5 +2,5 @@
   {{#if wizard-nav-link-status-icon--attribute}}
     {{{wizard-nav-link-status-icon--attribute}}}
   {{/if}}>
-  <i class="fas fa-{{ternary wizard-nav-item--IsSuccess 'check-circle' 'exclamation-circle'}}" aria-hidden="true"></i>
+  <i class="fas fa-{{ternary wizard-nav-item--IsSuccess 'check-circle' (ternary wizard-nav-item--IsWarning 'exclamation-triangle' 'exclamation-circle')}}" aria-hidden="true"></i>
 </span>

--- a/src/patternfly/components/Wizard/wizard-nav-link.hbs
+++ b/src/patternfly/components/Wizard/wizard-nav-link.hbs
@@ -5,6 +5,9 @@
   {{~#if wizard-nav-item--IsSuccess}}
     pf-m-success
   {{/if}}
+  {{~#if wizard-nav-item--IsWarning}}
+    pf-m-warning
+  {{/if}}
   {{~#if wizard-nav-item--IsDanger}}
     pf-m-danger
   {{/if}}
@@ -40,7 +43,7 @@
   {{#if wizard-nav-link--attribute}}
     {{{wizard-nav-link--attribute}}}
   {{/if}}>
-  {{#ifAny wizard-nav-item--IsSuccess wizard-nav-item--IsDanger}}
+  {{#ifAny wizard-nav-item--IsSuccess wizard-nav-item--IsDanger wizard-nav-item--IsWarning}}
     {{> wizard-nav-link-status-icon}}
   {{/ifAny}}
   {{#> wizard-nav-link-main}}

--- a/src/patternfly/components/Wizard/wizard-toggle-list-item.hbs
+++ b/src/patternfly/components/Wizard/wizard-toggle-list-item.hbs
@@ -1,11 +1,12 @@
 <span class="{{pfv}}wizard__toggle-list-item
 {{#if wizard-toggle-list-item--IsSuccess}} pf-m-success{{/if}}
+{{#if wizard-toggle-list-item--IsWarning}} pf-m-warning{{/if}}
 {{#if wizard-toggle-list-item--IsDanger}} pf-m-danger{{/if}}
 {{#if wizard-toggle-list-item--modifier}} {{wizard-toggle-list-item--modifier}}{{/if}}"
   {{#if wizard-toggle-list-item--attribute}}
     {{{wizard-toggle-list-item--attribute}}}
   {{/if}}>
-  {{#ifAny wizard-toggle-list-item--IsSuccess wizard-toggle-list-item--IsDanger}}
+  {{#ifAny wizard-toggle-list-item--IsSuccess wizard-toggle-list-item--IsDanger wizard-toggle-list-item--IsWarning}}
     {{> wizard-toggle-status-icon}}
   {{/ifAny}}
   {{> @partial-block}}

--- a/src/patternfly/components/Wizard/wizard-toggle-status-icon.hbs
+++ b/src/patternfly/components/Wizard/wizard-toggle-status-icon.hbs
@@ -2,5 +2,5 @@
   {{#if wizard-toggle-status-icon--attribute}}
     {{{wizard-toggle-status-icon--attribute}}}
   {{/if}}>
-  <i class="fas fa-{{ternary wizard-toggle-list-item--IsSuccess 'check-circle' 'exclamation-circle'}}" aria-hidden="true"></i>
+  <i class="fas fa-{{ternary wizard-toggle-list-item--IsSuccess 'check-circle' (ternary wizard-toggle-list-item--IsWarning 'exclamation-triangle' 'exclamation-circle')}}" aria-hidden="true"></i>
 </span>

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -84,6 +84,7 @@
   // Nav link status icon
   --#{$wizard}__nav-link-status-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$wizard}__nav-link--m-danger__nav-link-status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
+  --#{$wizard}__nav-link--m-warning__nav-link-status-icon--Color: var(--pf-t--global--icon--color--status--warning--default);
   --#{$wizard}__nav-link--m-success__nav-link-status-icon--Color: var(--pf-t--global--icon--color--status--success--default);
   --#{$wizard}__nav-link-status-icon--InsetBlockStart: 4px; // not spacer-based but needed to align
   --#{$wizard}__nav-link-status-icon--FontSize: var(--pf-t--global--icon--size--font--xl);
@@ -110,6 +111,7 @@
   --#{$wizard}__nav-link-status-icon--LineHeight: 1;
   --#{$wizard}__toggle-status-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$wizard}__toggle-list-item--m-danger__status-icon--Color: var(--pf-t--global--icon--color--status--danger--default);
+  --#{$wizard}__toggle-list-item--m-warning__status-icon--Color: var(--pf-t--global--icon--color--status--warning--default);
   --#{$wizard}__toggle-list-item--m-success__status-icon--Color: var(--pf-t--global--icon--color--status--success--default);
   --#{$wizard}__toggle-status-icon--InsetBlockStart: 2px; // not spacer-based but needed to align
   --#{$wizard}__toggle-status-icon--FontSize: var(--pf-t--global--icon--size--font--xl);
@@ -302,6 +304,10 @@
     --#{$wizard}__toggle-status-icon--Color: var(--#{$wizard}__toggle-list-item--m-danger__status-icon--Color);
   }
 
+  &.pf-m-warning {
+    --#{$wizard}__toggle-status-icon--Color: var(--#{$wizard}__toggle-list-item--m-warning__status-icon--Color);
+  }
+
   &.pf-m-success {
     --#{$wizard}__toggle-status-icon--Color: var(--#{$wizard}__toggle-list-item--m-success__status-icon--Color);
   }
@@ -480,7 +486,7 @@
     }
   }
 
-  &:is(.pf-m-success, .pf-m-danger) {
+  &:is(.pf-m-success, .pf-m-warning, .pf-m-danger) {
     &::before {
       display: none;
     }
@@ -488,6 +494,10 @@
 
   &.pf-m-success {
     --#{$wizard}__nav-link-status-icon--Color: var(--#{$wizard}__nav-link--m-success__nav-link-status-icon--Color);
+  }
+
+  &.pf-m-warning {
+    --#{$wizard}__nav-link-status-icon--Color: var(--#{$wizard}__nav-link--m-warning__nav-link-status-icon--Color);
   }
 
   &.pf-m-danger {


### PR DESCRIPTION
Fixes #7490 

Adds a variation of the wizard step for a warning state, to match the success and danger states that already exist.

Assisted by Cursor autocomplete