### PR TITLE
fix(wizard): nav item horizontal alignment fixes

### DIFF
--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -452,6 +452,7 @@
   &::before {
     position: relative;
     display: inline-flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: center;
     width: var(--#{$wizard}__nav-link--before--Width);
@@ -514,12 +515,9 @@
   }
 }
 
-.#{$wizard}__nav-link-text {
-  flex-grow: 1;
-}
-
 .#{$wizard}__nav-link-main {
   display: flex;
+  flex-grow: 1;
   justify-content: space-between;
   padding-block-start: var(--#{$wizard}__nav-link-main--PaddingBlockStart);
   padding-block-end: var(--#{$wizard}__nav-link-main--PaddingBlockEnd);


### PR DESCRIPTION
Fixes #7687 

Fixes step number by setting flex-shrink to 0
Fixes the item width by moving flex-grow to the item main rather than the text.

<img width="1177" height="847" alt="image" src="https://github.com/user-attachments/assets/a7e11af3-90df-4401-b736-cd2c3e20357a" />
