### PR TITLE
fix(table): fix toggle vertical alignment in thead

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -22,6 +22,7 @@
 
   // * Table thead toggle
   --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$table}__thead__toggle--VerticalAlign: middle;
 
   // * Table body cell
   --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
@@ -191,6 +192,10 @@
   // * Table compact th
   --#{$table}--m-compact__th--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
   --#{$table}--m-compact__th--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+
+  // * Table compact thead toggle
+  --#{$table}--m-compact__thead__tr--VerticalAlign: middle;
+  --#{$table}--m-compact__thead__check--VerticalAlign: middle;
 
   // * Table compact cell
   --#{$table}--m-compact--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -835,6 +840,11 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__toggle--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__toggle--PaddingInlineEnd);
 
+  // Apply vertical alignment for thead toggle in non-compact tables
+  thead:where(.#{$table}__thead) & {
+    vertical-align: var(--#{$table}__thead__toggle--VerticalAlign);
+  }
+
   .#{$button} {
     &.pf-m-expanded .#{$table}__toggle-icon {
       transform: rotate(var(--#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate));
@@ -1131,6 +1141,14 @@
     .#{$table}__toggle {
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__th--PaddingBlockStart);
       --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__th--PaddingBlockEnd);
+    }
+
+    tr:where(.#{$table}__tr) {
+      vertical-align: var(--#{$table}--m-compact__thead__tr--VerticalAlign);
+    }
+
+    .#{$table}__check {
+      vertical-align: var(--#{$table}--m-compact__thead__check--VerticalAlign);
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -16,6 +16,9 @@
   --#{$table}__caption--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$table}__caption--PaddingInlineStart: var(--pf-t--global--spacer--inset--page-chrome);
 
+  // * Table thead
+  --#{$table}__thead--VerticalAlign: bottom;
+
   // * Table thead cell
   --#{$table}__thead--cell--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
@@ -877,6 +880,11 @@
     vertical-align: bottom;
   }
 
+  // Override for compact expandable tables
+  .#{$table}.pf-m-compact.pf-m-expandable thead & {
+    vertical-align: middle;
+  }
+
   .#{$check}.pf-m-standalone,
   .#{$radio}.pf-m-standalone {
     thead & {
@@ -1159,7 +1167,7 @@
   --#{$table}__tr--BorderBlockEndWidth: 0;
   --#{$table}__toggle--PaddingBlockEnd: var(--#{$table}__thead__toggle--PaddingBlockEnd);
 
-  vertical-align: bottom;
+  vertical-align: var(--#{$table}__thead--VerticalAlign);
 
   // - Table nested column header button
   &.pf-m-nested-column-header {
@@ -1185,6 +1193,8 @@
 
 // Table table tbody expandable
 .#{$table}.pf-m-expandable {
+  --#{$table}__thead--VerticalAlign: middle;
+  
   .#{$table}__tr.pf-m-expanded {
     border-block-end: 0;
   }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -26,6 +26,9 @@
   // * Table thead toggle
   --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
 
+  // * Table thead check
+  --#{$table}__thead__check--VerticalAlign: bottom;
+
   // * Table body cell
   --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
   --#{$table}__tbody--cell--PaddingBlockEnd: var(--#{$table}--cell--Padding--base);
@@ -877,12 +880,12 @@
   }
 
   thead & {
-    vertical-align: bottom;
+    vertical-align: var(--#{$table}__thead__check--VerticalAlign);
   }
 
   // Override for compact expandable tables
   .#{$table}.pf-m-compact.pf-m-expandable thead & {
-    vertical-align: middle;
+    --#{$table}__thead__check--VerticalAlign: middle;
   }
 
   .#{$check}.pf-m-standalone,

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -22,7 +22,6 @@
 
   // * Table thead toggle
   --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
-  --#{$table}__thead__toggle--VerticalAlign: middle;
 
   // * Table body cell
   --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
@@ -192,10 +191,6 @@
   // * Table compact th
   --#{$table}--m-compact__th--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
   --#{$table}--m-compact__th--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-
-  // * Table compact thead toggle
-  --#{$table}--m-compact__thead__tr--VerticalAlign: middle;
-  --#{$table}--m-compact__thead__check--VerticalAlign: middle;
 
   // * Table compact cell
   --#{$table}--m-compact--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -840,11 +835,6 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__toggle--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__toggle--PaddingInlineEnd);
 
-  // Apply vertical alignment for thead toggle in non-compact tables
-  thead:where(.#{$table}__thead) & {
-    vertical-align: var(--#{$table}__thead__toggle--VerticalAlign);
-  }
-
   .#{$button} {
     &.pf-m-expanded .#{$table}__toggle-icon {
       transform: rotate(var(--#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate));
@@ -1141,14 +1131,6 @@
     .#{$table}__toggle {
       --#{$table}--cell--PaddingBlockStart: var(--#{$table}--m-compact__th--PaddingBlockStart);
       --#{$table}--cell--PaddingBlockEnd: var(--#{$table}--m-compact__th--PaddingBlockEnd);
-    }
-
-    tr:where(.#{$table}__tr) {
-      vertical-align: var(--#{$table}--m-compact__thead__tr--VerticalAlign);
-    }
-
-    .#{$table}__check {
-      vertical-align: var(--#{$table}--m-compact__thead__check--VerticalAlign);
     }
   }
 


### PR DESCRIPTION
Closes #7699 

This PR fixes alignment issues between the expandable toggle button, selectable checkbox, and column headers in the table thead that affect both expandable tables and expandable & compact tables.  

It adds 2 new variables to set vertical alignment, both default to the existing value of `bottom` and both are changed to `middle` to resolve alignment bugs:
1. `--#{$table}__thead--VerticalAlign: bottom`
    - Updated to `middle` on expandable tables.
2. `--#{$table}__thead__check--VerticalAlign: bottom`
    - Updated to `middle` on tables that are both expandable & compact.