### PR TITLE
feat(simpleList): added high contrast border for hover/focus/current

### DIFF
--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -18,7 +18,11 @@
   // Simple list item link
   --#{$simple-list}__item-link--m-link--Color: var(--pf-t--global--text--color--link--default);
   --#{$simple-list}__item-link--m-link--m-current--Color: var(--pf-t--global--text--color--link--hover);
+  --#{$simple-list}__item-link--m-link--m-current--BorderWidth: var(--pf-t--global--border--width--strong);
+  --#{$simple-list}__item-link--m-link--m-current--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$simple-list}__item-link--m-link--hover--Color: var(--pf-t--global--text--color--link--hover);
+  --#{$simple-list}__item-link--m-link--hover--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$simple-list}__item-link--m-link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // Simple list title
   --#{$simple-list}__title--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -58,12 +62,35 @@
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--hover--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--hover--Color);
 
+    position:relative;
     text-decoration-line: none;
+
+    &::after {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      content: "";
+      background-color: inherit;
+      border: var(--#{$simple-list}__item-link--m-link--hover--BorderWidth) solid var(--#{$simple-list}__item-link--m-link--hover--BorderColor);
+      border-radius: inherit;
+    }
   }
 
   &.pf-m-current {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--m-current--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-current--Color);
+
+    position: relative;
+    
+    &::after {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      content: "";
+      background-color: inherit;
+      border: var(--#{$simple-list}__item-link--m-link--m-current--BorderWidth) solid var(--#{$simple-list}__item-link--m-link--m-current--BorderColor);
+      border-radius: inherit;
+    }
   }
 }
 

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -14,7 +14,11 @@
   --#{$simple-list}__item-link--hover--Color: var(--pf-t--global--text--color--subtle);
   --#{$simple-list}__item-link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$simple-list}__item-link--BorderRadius: var(--pf-t--global--border--radius--tiny);
-
+  --#{$simple-list}__item-link--BorderWidth: 0;
+  --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$simple-list}__item-link--hover--BorderWidth: var(--pf-t--global--border--width--regular);
+  --#{$simple-list}__item-link--current--BorderWidth: var(--pf-t--global--border--width--strong);
+  
   // Simple list item link
   --#{$simple-list}__item-link--m-link--Color: var(--pf-t--global--text--color--link--default);
   --#{$simple-list}__item-link--m-link--m-current--Color: var(--pf-t--global--text--color--link--hover);
@@ -67,8 +71,7 @@
   &:is(:hover, :focus) {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--hover--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--hover--Color);
-    --#{$simple-list}__item-link--BorderWidth: var(--pf-t--global--border--width--regular);
-    --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
+    --#{$simple-list}__item-link--BorderWidth: var(--#{$simple-list}__item-link--hover--BorderWidth);
 
     text-decoration-line: none;
   }
@@ -76,8 +79,7 @@
   &.pf-m-current {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--m-current--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-current--Color);
-    --#{$simple-list}__item-link--BorderWidth: var(--pf-t--global--border--width--strong);
-    --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
+    --#{$simple-list}__item-link--BorderWidth: var(--#{$simple-list}__item-link--current--BorderWidth);
   }
 }
 

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -18,11 +18,7 @@
   // Simple list item link
   --#{$simple-list}__item-link--m-link--Color: var(--pf-t--global--text--color--link--default);
   --#{$simple-list}__item-link--m-link--m-current--Color: var(--pf-t--global--text--color--link--hover);
-  --#{$simple-list}__item-link--m-link--m-current--BorderWidth: var(--pf-t--global--border--width--strong);
-  --#{$simple-list}__item-link--m-link--m-current--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$simple-list}__item-link--m-link--hover--Color: var(--pf-t--global--text--color--link--hover);
-  --#{$simple-list}__item-link--m-link--hover--BorderWidth: var(--pf-t--global--border--width--regular);
-  --#{$simple-list}__item-link--m-link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // Simple list title
   --#{$simple-list}__title--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -38,6 +34,7 @@
 }
 
 .#{$simple-list}__item-link {
+  position:relative;
   display: block;
   width: 100%;
   padding-block-start: var(--#{$simple-list}__item-link--PaddingBlockStart);
@@ -52,6 +49,15 @@
   border: none;
   border-radius: var(--#{$simple-list}__item-link--BorderRadius);
 
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$simple-list}__item-link--BorderWidth) solid var(--#{$simple-list}__item-link--BorderColor);
+    border-radius: inherit;
+  }
+
   &.pf-m-link {
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-link--Color);
     --#{$simple-list}__item-link--hover--Color: var(--#{$simple-list}__item-link--m-link--m-current--Color);
@@ -61,36 +67,17 @@
   &:is(:hover, :focus) {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--hover--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--hover--Color);
+    --#{$simple-list}__item-link--BorderWidth: var(--pf-t--global--border--width--regular);
+    --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
-    position:relative;
     text-decoration-line: none;
-
-    &::after {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      content: "";
-      background-color: inherit;
-      border: var(--#{$simple-list}__item-link--m-link--hover--BorderWidth) solid var(--#{$simple-list}__item-link--m-link--hover--BorderColor);
-      border-radius: inherit;
-    }
   }
 
   &.pf-m-current {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--m-current--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-current--Color);
-
-    position: relative;
-    
-    &::after {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      content: "";
-      background-color: inherit;
-      border: var(--#{$simple-list}__item-link--m-link--m-current--BorderWidth) solid var(--#{$simple-list}__item-link--m-link--m-current--BorderColor);
-      border-radius: inherit;
-    }
+    --#{$simple-list}__item-link--BorderWidth: var(--pf-t--global--border--width--strong);
+    --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
   }
 }
 

--- a/src/patternfly/components/SimpleList/simple-list.scss
+++ b/src/patternfly/components/SimpleList/simple-list.scss
@@ -16,13 +16,13 @@
   --#{$simple-list}__item-link--BorderRadius: var(--pf-t--global--border--radius--tiny);
   --#{$simple-list}__item-link--BorderWidth: 0;
   --#{$simple-list}__item-link--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$simple-list}__item-link--hover--BorderWidth: var(--pf-t--global--border--width--regular);
-  --#{$simple-list}__item-link--current--BorderWidth: var(--pf-t--global--border--width--strong);
+  --#{$simple-list}__item-link--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
   
   // Simple list item link
   --#{$simple-list}__item-link--m-link--Color: var(--pf-t--global--text--color--link--default);
   --#{$simple-list}__item-link--m-link--m-current--Color: var(--pf-t--global--text--color--link--hover);
   --#{$simple-list}__item-link--m-link--hover--Color: var(--pf-t--global--text--color--link--hover);
+  --#{$simple-list}__item-link--m-current--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
 
   // Simple list title
   --#{$simple-list}__title--PaddingBlockStart: var(--pf-t--global--spacer--sm);
@@ -38,7 +38,7 @@
 }
 
 .#{$simple-list}__item-link {
-  position:relative;
+  position: relative;
   display: block;
   width: 100%;
   padding-block-start: var(--#{$simple-list}__item-link--PaddingBlockStart);
@@ -79,7 +79,7 @@
   &.pf-m-current {
     --#{$simple-list}__item-link--BackgroundColor: var(--#{$simple-list}__item-link--m-current--BackgroundColor);
     --#{$simple-list}__item-link--Color: var(--#{$simple-list}__item-link--m-current--Color);
-    --#{$simple-list}__item-link--BorderWidth: var(--#{$simple-list}__item-link--current--BorderWidth);
+    --#{$simple-list}__item-link--BorderWidth: var(--#{$simple-list}__item-link--m-current--BorderWidth);
   }
 }
 


### PR DESCRIPTION
Commented in bit about `:root:where(.pf-v6-theme-high-contrast) {` and added it to root to check.

https://pf-pr-7703.surge.sh/components/simple-list

Selected:

| Before | After |
|-|-|
|<img width="846" height="116" alt="Screenshot 2025-07-30 at 12 43 43 PM" src="https://github.com/user-attachments/assets/dc47d68b-a034-4ad9-9996-d2c98deef9fd" />|<img width="773" height="110" alt="Screenshot 2025-07-30 at 12 45 58 PM" src="https://github.com/user-attachments/assets/9949a5e4-15de-4728-b843-ceb254e971dd" />



| Before | After |
|-|-|
|<img width="849" height="116" alt="Screenshot 2025-07-30 at 12 43 37 PM" src="https://github.com/user-attachments/assets/b2733dc5-7350-48d1-a067-c8295c1014a3" />|<img width="772" height="107" alt="Screenshot 2025-07-30 at 12 45 52 PM" src="https://github.com/user-attachments/assets/b9a9beec-5231-4bdf-887d-87f944361606" />



