### PR TITLE
feat(Panel): add high-contrast border to panel

### DIFF
--- a/src/patternfly/components/Panel/panel.scss
+++ b/src/patternfly/components/Panel/panel.scss
@@ -10,17 +10,20 @@
 
   // border
   --#{$panel}--before--BorderWidth: 0;
-  --#{$panel}--before--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$panel}--before--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // secondary modifier
   --#{$panel}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$panel}--m-secondary--before--BorderWidth: var(--pf-t--global--border--width--box--default);
 
   // bordered
   --#{$panel}--m-bordered--before--BorderWidth: var(--pf-t--global--border--width--box--default);
+  --#{$panel}--m-bordered--before--BorderColor: var(--pf-t--global--border--color--default);
 
   // raised
   --#{$panel}--m-raised--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$panel}--m-raised--BackgroundColor: var(--pf-t--global--background--color--floating--default);
+  --#{$panel}--m-raised--before--BorderWidth: var(--pf-t--global--border--width--box--default);
 
   // header
   --#{$panel}__header--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -73,15 +76,18 @@
 
   &.pf-m-bordered {
     --#{$panel}--before--BorderWidth: var(--#{$panel}--m-bordered--before--BorderWidth);
+    --#{$panel}--before--BorderColor: var(--#{$panel}--m-bordered--before--BorderColor);
   }
 
   &.pf-m-secondary {
     --#{$panel}--BackgroundColor: var(--#{$panel}--m-secondary--BackgroundColor);
+    --#{$panel}--before--BorderWidth: var(--#{$panel}--m-secondary--before--BorderWidth);
   }
 
   &.pf-m-raised {
     --#{$panel}--BackgroundColor: var(--#{$panel}--m-raised--BackgroundColor);
     --#{$panel}--BoxShadow: var(--#{$panel}--m-raised--BoxShadow);
+    --#{$panel}--before--BorderWidth: var(--#{$panel}--m-raised--before--BorderWidth);
   }
 
   &.pf-m-scrollable {


### PR DESCRIPTION
Closes #7602

[figma](https://www.figma.com/design/wKcOq7IrzfL1gEK2mocd6r/Semantic-dimension-border-width----font-weight-adjustment-test?node-id=10994-65001)

Convenience link: https://pf-pr-7710.surge.sh/components/panel#secondary

Since with `pf-m-bordered` it still needs to use the default border color I wasn't sure if I should update the color of `--#{$panel}--before--BorderColor` to high contrast and set it back to default with the bordered modifier, or leave the default as default and update the color when secondary and raised, so I just took a stab at it. If I guessed wrong my apologies 😅 