### PR TITLE
feat(nav): add high-contrast border

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -57,6 +57,11 @@
   --#{$nav}__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--hover);
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
+  --#{$nav}__link--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
+  --#{$nav}__link--after--BorderColor: transparent;
+  --#{$nav}__link--hover--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$nav}__link--m-current--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--clicked);
+  --#{$nav}__link--m-current--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // background color transition on hover
   --#{$nav}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--default);
@@ -113,6 +118,8 @@
   // * Nav horizontal subnav
   --#{$nav}--m-horizontal--m-subnav--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$nav}--m-horizontal--m-subnav--BorderRadius: var(--pf-t--global--border--radius--pill);
+  --#{$nav}--m-horizontal--m-subnav--BorderWidth: var(--pf-t--global--high-contrast--border--width--divider--default);
+  --#{$nav}--m-horizontal--m-subnav--BorderColor: var(--pf-t--global--border--color--high-contrast--default);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingInlineStart: var(--pf-t--global--spacer--md);
@@ -290,10 +297,21 @@
   transition-duration: var(--#{$nav}__link--TransitionDuration--background-color), var(--#{$nav}__link--m-current--TransitionDuration--color);
   transition-property: background-color, color;
 
+  &::after {
+    position: absolute;
+    inset: 0;
+    content: "";
+    border: var(--#{$nav}__link--after--BorderWidth) solid var(--#{$nav}__link--after--BorderColor);
+    border-radius: inherit;
+  }
+
+
   // explicitly set background-color prop to avoid affecting child elements settings
   &:hover,
   &.pf-m-hover,
   &:focus {
+    --#{$nav}__link--after--BorderColor: var(--#{$nav}__link--hover--after--BorderColor);
+
     color: var(--#{$nav}__link--hover--Color);
     background-color: var(--#{$nav}__link--hover--BackgroundColor);
   }
@@ -301,6 +319,8 @@
   &.pf-m-current,
   &.pf-m-current:hover {
     --#{$nav}__link-icon--Color: var(--#{$nav}__link--m-current__link-icon--Color);
+    --#{$nav}__link--after--BorderWidth: var(--#{$nav}__link--m-current--after--BorderWidth);
+    --#{$nav}__link--after--BorderColor: var(--#{$nav}__link--m-current--after--BorderColor);
 
     color: var(--#{$nav}__link--m-current--Color);
     background-color: var(--#{$nav}__link--m-current--BackgroundColor);
@@ -428,6 +448,7 @@
     --#{$nav}__link--PaddingBlockStart: var(--#{$nav}--m-horizontal--m-subnav__link--PaddingBlockStart);
     --#{$nav}__link--PaddingBlockEnd: var(--#{$nav}--m-horizontal--m-subnav__link--PaddingBlockEnd);
 
+    border: var(--#{$nav}--m-horizontal--m-subnav--BorderWidth) solid var(--#{$nav}--m-horizontal--m-subnav--BorderColor);
     border-radius: var(--#{$nav}--m-horizontal--m-subnav--BorderRadius);
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -58,9 +58,9 @@
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$nav}__link--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$nav}__link--after--BorderWidth: 0;
-  --#{$nav}__link--hover--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--hover);
-  --#{$nav}__link--m-current--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--clicked);
+  --#{$nav}__link--after--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$nav}__link--hover--after--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$nav}__link--m-current--after--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
 
   // background color transition on hover
   --#{$nav}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--default);
@@ -117,7 +117,7 @@
   // * Nav horizontal subnav
   --#{$nav}--m-horizontal--m-subnav--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$nav}--m-horizontal--m-subnav--BorderRadius: var(--pf-t--global--border--radius--pill);
-  --#{$nav}--m-horizontal--m-subnav--BorderWidth: var(--pf-t--global--high-contrast--border--width--divider--default);
+  --#{$nav}--m-horizontal--m-subnav--BorderWidth: var(--pf-t--global--border--width--divider--default);
   --#{$nav}--m-horizontal--m-subnav--BorderColor: var(--pf-t--global--border--color--high-contrast--default);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockEnd: var(--pf-t--global--spacer--xs);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -300,6 +300,7 @@
   &::after {
     position: absolute;
     inset: 0;
+    pointer-events: none;
     content: "";
     border: var(--#{$nav}__link--after--BorderWidth) solid var(--#{$nav}__link--after--BorderColor);
     border-radius: inherit;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -57,11 +57,10 @@
   --#{$nav}__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--hover);
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
-  --#{$nav}__link--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
-  --#{$nav}__link--after--BorderColor: transparent;
-  --#{$nav}__link--hover--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$nav}__link--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$nav}__link--after--BorderWidth: 0;
+  --#{$nav}__link--hover--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--hover);
   --#{$nav}__link--m-current--after--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--clicked);
-  --#{$nav}__link--m-current--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
 
   // background color transition on hover
   --#{$nav}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--default);
@@ -311,7 +310,7 @@
   &:hover,
   &.pf-m-hover,
   &:focus {
-    --#{$nav}__link--after--BorderColor: var(--#{$nav}__link--hover--after--BorderColor);
+    --#{$nav}__link--after--BorderWidth: var(--#{$nav}__link--hover--after--BorderWidth);
 
     color: var(--#{$nav}__link--hover--Color);
     background-color: var(--#{$nav}__link--hover--BackgroundColor);
@@ -321,7 +320,6 @@
   &.pf-m-current:hover {
     --#{$nav}__link-icon--Color: var(--#{$nav}__link--m-current__link-icon--Color);
     --#{$nav}__link--after--BorderWidth: var(--#{$nav}__link--m-current--after--BorderWidth);
-    --#{$nav}__link--after--BorderColor: var(--#{$nav}__link--m-current--after--BorderColor);
 
     color: var(--#{$nav}__link--m-current--Color);
     background-color: var(--#{$nav}__link--m-current--BackgroundColor);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -57,10 +57,10 @@
   --#{$nav}__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--hover);
   --#{$nav}__link--m-current--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --#{$nav}__link--m-current--Color: var(--pf-t--global--text--color--regular);
-  --#{$nav}__link--after--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$nav}__link--after--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
-  --#{$nav}__link--hover--after--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
-  --#{$nav}__link--m-current--after--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
+  --#{$nav}__link--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$nav}__link--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$nav}__link--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$nav}__link--m-current--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
 
   // background color transition on hover
   --#{$nav}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--default);
@@ -117,8 +117,8 @@
   // * Nav horizontal subnav
   --#{$nav}--m-horizontal--m-subnav--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$nav}--m-horizontal--m-subnav--BorderRadius: var(--pf-t--global--border--radius--pill);
-  --#{$nav}--m-horizontal--m-subnav--BorderWidth: var(--pf-t--global--border--width--divider--default);
-  --#{$nav}--m-horizontal--m-subnav--BorderColor: var(--pf-t--global--border--color--high-contrast--default);
+  --#{$nav}--m-horizontal--m-subnav--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$nav}--m-horizontal--m-subnav--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$nav}--m-horizontal--m-subnav__list--PaddingInlineStart: var(--pf-t--global--spacer--md);
@@ -301,7 +301,7 @@
     inset: 0;
     pointer-events: none;
     content: "";
-    border: var(--#{$nav}__link--after--BorderWidth) solid var(--#{$nav}__link--after--BorderColor);
+    border: var(--#{$nav}__link--BorderWidth) solid var(--#{$nav}__link--BorderColor);
     border-radius: inherit;
   }
 
@@ -310,7 +310,7 @@
   &:hover,
   &.pf-m-hover,
   &:focus {
-    --#{$nav}__link--after--BorderWidth: var(--#{$nav}__link--hover--after--BorderWidth);
+    --#{$nav}__link--BorderWidth: var(--#{$nav}__link--hover--BorderWidth);
 
     color: var(--#{$nav}__link--hover--Color);
     background-color: var(--#{$nav}__link--hover--BackgroundColor);
@@ -319,7 +319,7 @@
   &.pf-m-current,
   &.pf-m-current:hover {
     --#{$nav}__link-icon--Color: var(--#{$nav}__link--m-current__link-icon--Color);
-    --#{$nav}__link--after--BorderWidth: var(--#{$nav}__link--m-current--after--BorderWidth);
+    --#{$nav}__link--BorderWidth: var(--#{$nav}__link--m-current--BorderWidth);
 
     color: var(--#{$nav}__link--m-current--Color);
     background-color: var(--#{$nav}__link--m-current--BackgroundColor);


### PR DESCRIPTION
Fixes #7621 

Adds a border on the ::after of the __link element, because the border width changes when selected.
Adds a border directly on the horizontal secondary nav.

[Full backstop report](https://drive.google.com/file/d/1ei93Hx5qjARfQKxeOg-pRtc8VjLcwKTQ/view?usp=sharing) only showed 6 failures that appear to be the noise on the mobile view. 

[Figma design](https://www.figma.com/design/iT76DS020Ry1Wswfc0Hmes/branch/wKcOq7IrzfL1gEK2mocd6r/High-Contrast-Exploration?m=auto&node-id=10994-64849&t=t9OWnsJOhGHccWv6-1)

Used Cursor autocomplete.