### PR TITLE
fix(table): fix toggle vertical alignment

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -838,10 +838,9 @@
 
   @at-root .#{$table}__thead & {
     .#{$button} {
-      --#{$button}--LineHeight: 1lh;
-
       margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
       margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
+      line-height: 1lh; // set line-height instead of --LineHeight to avoid breaking the min-width calc for plain buttons
     }
   }
 
@@ -1008,7 +1007,7 @@
   margin-inline-start: var(--#{$table}__column-help--MarginInlineStart);
 
   .#{$button} {
-    --#{$button}--LineHeight: 1lh;
+    line-height: 1lh; // set line-height instead of --LineHeight to avoid breaking the min-width calc for plain buttons
   }
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -838,9 +838,10 @@
 
   @at-root .#{$table}__thead & {
     .#{$button} {
+      --#{$button}--LineHeight: 1lh;
+
       margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
       margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
-      line-height: 1lh;
     }
   }
 
@@ -1005,6 +1006,10 @@
 .#{$table}__column-help-action {
   align-self: last baseline;
   margin-inline-start: var(--#{$table}__column-help--MarginInlineStart);
+
+  .#{$button} {
+    --#{$button}--LineHeight: 1lh;
+  }
 }
 
 // - Table sort

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -21,7 +21,8 @@
   --#{$table}__thead--cell--FontWeight: var(--pf-t--global--font--weight--body--bold);
 
   // * Table thead toggle
-  --#{$table}__thead__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$table}__thead__toggle--PaddingBlockStart: var(--#{$table}--cell--Padding--base); // TODO - remove thead toggle custom padding in breaking change
+  --#{$table}__thead__toggle--PaddingBlockEnd: var(--#{$table}--cell--Padding--base); // TODO - remove thead toggle custom padding in breaking change
 
   // * Table body cell
   --#{$table}__tbody--cell--PaddingBlockStart: var(--#{$table}--cell--Padding--base);
@@ -835,12 +836,19 @@
   --#{$table}--cell--PaddingInlineStart: var(--#{$table}__toggle--PaddingInlineStart);
   --#{$table}--cell--PaddingInlineEnd: var(--#{$table}__toggle--PaddingInlineEnd);
 
+  @at-root .#{$table}__thead & {
+    .#{$button} {
+      margin-block-start: calc(var(--#{$button}--PaddingBlockStart) * -1);
+      margin-block-end: calc(var(--#{$button}--PaddingBlockEnd) * -1);
+      line-height: 1lh;
+    }
+  }
+
   .#{$button} {
     &.pf-m-expanded .#{$table}__toggle-icon {
       transform: rotate(var(--#{$table}__toggle--c-button--m-expanded__toggle-icon--Rotate));
     }
   }
-
 
   .#{$table}__toggle-icon {
     @include pf-v6-mirror-inline-on-rtl;
@@ -1157,6 +1165,7 @@
 // - Table thead
 .#{$table}__thead {
   --#{$table}__tr--BorderBlockEndWidth: 0;
+  --#{$table}__toggle--PaddingBlockStart: var(--#{$table}__thead__toggle--PaddingBlockStart);
   --#{$table}__toggle--PaddingBlockEnd: var(--#{$table}__thead__toggle--PaddingBlockEnd);
 
   vertical-align: bottom;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7699

The general stragy in this PR:
* Remove the custom padding that is on the `.#{$table}__th.#{$table}__toggle` element (the `<th>` that wraps the toggle button in `<thead>`), so that the padding matches the adjacent `<th>` cells
  https://github.com/patternfly/patternfly/blob/aded963e1259b13b8dcb5383fec8ef3a72383def/src/patternfly/components/Table/table.scss#L24-L25

* Assign negative block margins to the button that are equal to the button's padding, so that only the button's content (the text/icon) takes up space in the cell. This should match other stuff in adjacent `<th>` cells since `<th>` cells either have text or the `.#{$table}__button` element,  which also uses a negative block margin to make it align with adjacent cells.
  https://github.com/patternfly/patternfly/blob/aded963e1259b13b8dcb5383fec8ef3a72383def/src/patternfly/components/Table/table.scss#L839-L842

* Give the button a line-height of `1lh`, which will  make its line-height the computed line-height of its parent. This handles the `font-size` discrepancy between a plain button (`font-size: 14px`) and the `<th>` cells (`font-size: 12px`). Previously the text box in the plain button was 21px (`14px` * 1.5lh), now it's 18px (`12px` * 1.5lh), which matches adjacent cells. The icon is still technically bigger but it doesn't take up more space than smaller text around it.
  https://github.com/patternfly/patternfly/blob/aded963e1259b13b8dcb5383fec8ef3a72383def/src/patternfly/components/Table/table.scss#L843

* Applied the same line-height fix as abive to the column sort help button because it was causing the cell it's in to be slightly misaligned with adjacent cells.

  https://github.com/patternfly/patternfly/blob/3ba39e52aa3f332a02dc6f7ab81cdb03a975a8aa/src/patternfly/components/Table/table.scss#L1010-L1012

----

### I tested the following
1. Regular, non-sortable tables with the expand toggle
1. Sortable tables with the expand toggle
1. 1 & 2  with `.pf-m-compact`. For this you need to be make sure `.pf-m-small` is on the toggle button (reduces the padding) since that variant is used with compact tables. Looks like the [the change to use pf-m-small in react(https://github.com/patternfly/patternfly-react/pull/11947) is going in with the [patch release](https://github.com/patternfly/patternfly-org/issues/4732). It shouldn't matter what size the button is though, it's always offset by its own padding, so it should work with whatever padding is on the button.