### PR TITLE
feat(menu): add high-contrast border

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -777,27 +777,27 @@ import './Menu.css'
 
 ### Drilldown level two
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-2" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 165px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-2" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 166px;"'}}
 ```
 
 ### Drilldown level three
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-3" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 202px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-3" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 204px;"'}}
 ```
 
 ### Drilldown level four
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-4" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--IsDrilledIn--list-3="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 165px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-4" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--IsDrilledIn--list-3="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 168px;"'}}
 ```
 
 ### Scrollable drilldown
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-default" menu--Drilldown--menu--modifier="pf-m-scrollable" menu--Drilldown--menu--attribute='style="--pf-v6-c-menu__content--MaxHeight: 180px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-default" menu--Drilldown--menu--modifier="pf-m-scrollable" menu--Drilldown--menu--attribute='style="--pf-v6-c-menu__content--MaxHeight: 182px;"'}}
 ```
 
 ### Width modified drilldown
 ```hbs
-{{> menu--Drilldown menu--Drilldown--menu--attribute='style="--pf-v6-c-menu--Width: 350px;"'}}
+{{> menu--Drilldown menu--Drilldown--menu--attribute='style="--pf-v6-c-menu--Width: 352px;"'}}
 ```
 
 ### Drilldown with breadcrumbs - level 1
@@ -809,7 +809,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 2
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-2" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 74px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-2" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 76px;"'}}
   {{> menu-breadcrumbs--Drilldown menu-breadcrumbs--Drilldown--IsLevel2="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true"}}
 {{/menu}}
@@ -817,7 +817,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 3
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-3" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 111px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-3" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 113px;"'}}
   {{> menu-breadcrumbs--Drilldown menu-breadcrumbs--Drilldown--IsLevel3="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true" menu-content--Breadcrumbs--level3="true"}}
 {{/menu}}
@@ -825,7 +825,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 4
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-4" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 185px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-4" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 188px;"'}}
   {{> menu-breadcrumbs--Drilldown breadcrumb--id="drilldown-with-breadcrumbs-level-4" menu-breadcrumbs--Drilldown--IsLevel4="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true" menu-content--Breadcrumbs--level3="true" menu-content--Breadcrumbs--level4="true"}}
 {{/menu}}

--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -777,27 +777,27 @@ import './Menu.css'
 
 ### Drilldown level two
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-2" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 166px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-2" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 165px;"'}}
 ```
 
 ### Drilldown level three
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-3" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 204px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-3" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 202px;"'}}
 ```
 
 ### Drilldown level four
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-level-4" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--IsDrilledIn--list-3="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 168px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-level-4" menu--Drilldown--IsDrilledIn--list-1="true" menu--Drilldown--IsDrilledIn--list-2="true" menu--Drilldown--IsDrilledIn--list-3="true" menu--Drilldown--menu__content--attribute='style="--pf-v6-c-menu__content--Height: 165px;"'}}
 ```
 
 ### Scrollable drilldown
 ```hbs
-{{> menu--Drilldown menu--Drilldown--id="drilldown-default" menu--Drilldown--menu--modifier="pf-m-scrollable" menu--Drilldown--menu--attribute='style="--pf-v6-c-menu__content--MaxHeight: 182px;"'}}
+{{> menu--Drilldown menu--Drilldown--id="drilldown-default" menu--Drilldown--menu--modifier="pf-m-scrollable" menu--Drilldown--menu--attribute='style="--pf-v6-c-menu__content--MaxHeight: 180px;"'}}
 ```
 
 ### Width modified drilldown
 ```hbs
-{{> menu--Drilldown menu--Drilldown--menu--attribute='style="--pf-v6-c-menu--Width: 352px;"'}}
+{{> menu--Drilldown menu--Drilldown--menu--attribute='style="--pf-v6-c-menu--Width: 350px;"'}}
 ```
 
 ### Drilldown with breadcrumbs - level 1
@@ -809,7 +809,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 2
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-2" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 76px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-2" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 74px;"'}}
   {{> menu-breadcrumbs--Drilldown menu-breadcrumbs--Drilldown--IsLevel2="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true"}}
 {{/menu}}
@@ -817,7 +817,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 3
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-3" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 113px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-3" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 111px;"'}}
   {{> menu-breadcrumbs--Drilldown menu-breadcrumbs--Drilldown--IsLevel3="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true" menu-content--Breadcrumbs--level3="true"}}
 {{/menu}}
@@ -825,7 +825,7 @@ import './Menu.css'
 
 ### Drilldown with breadcrumbs - level 4
 ```hbs
-{{#> menu menu--id="drilldown-with-breadcrumbs-level-4" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 188px;"'}}
+{{#> menu menu--id="drilldown-with-breadcrumbs-level-4" menu--modifier="pf-m-drilldown pf-m-drilled-in" menu--attribute='style="--pf-v6-c-menu__content--Height: 185px;"'}}
   {{> menu-breadcrumbs--Drilldown breadcrumb--id="drilldown-with-breadcrumbs-level-4" menu-breadcrumbs--Drilldown--IsLevel4="true"}}
   {{> menu-content--Breadcrumbs menu-content--Breadcrumbs--level2="true" menu-content--Breadcrumbs--level3="true" menu-content--Breadcrumbs--level4="true"}}
 {{/menu}}

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -225,6 +225,7 @@
   // TODO: Explore this fallback method
   // padding-block-start: var(--#{$menu}--PaddingBlockStart, var(--#{$menu}--PaddingBlock));
   // padding-block-end: var(--#{$menu}--PaddingBlockEnd, var(--#{$menu}--PaddingBlock));
+  box-sizing: content-box;
   display: grid;
   row-gap: var(--#{$menu}--RowGap);
   width: var(--#{$menu}--Width);

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -46,9 +46,9 @@
   // * Menu list item
   --#{$menu}__list-item--Color: var(--pf-t--global--text--color--regular);
   --#{$menu}__list-item--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$menu}__list-item--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
-  --#{$menu}__list-item--BorderColor: transparent;
-  --#{$menu}__list-item--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$menu}__list-item--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$menu}__list-item--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$menu}__list-item--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$menu}__list-item--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
   --#{$menu}__list-item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$menu}__list-item--TransitionProperty: background-color;
@@ -225,7 +225,6 @@
   // TODO: Explore this fallback method
   // padding-block-start: var(--#{$menu}--PaddingBlockStart, var(--#{$menu}--PaddingBlock));
   // padding-block-end: var(--#{$menu}--PaddingBlockEnd, var(--#{$menu}--PaddingBlock));
-  box-sizing: content-box;
   display: grid;
   row-gap: var(--#{$menu}--RowGap);
   width: var(--#{$menu}--Width);
@@ -299,6 +298,7 @@
 
     :where(.#{$menu}) {
       padding: 0;
+      border: 0;
     }
 
     &.pf-m-drilled-in {
@@ -528,7 +528,7 @@
   &:focus-within,
   &:has(> :hover) {
     --#{$menu}__list-item--BackgroundColor: var(--#{$menu}__list-item--hover--BackgroundColor);
-    --#{$menu}__list-item--BorderColor: var(--#{$menu}__list-item--hover--BorderColor);
+    --#{$menu}__list-item--BorderWidth: var(--#{$menu}__list-item--hover--BorderWidth);
 
     .#{$menu}__item-select-icon,
     .#{$menu}__item-external-icon {

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -10,6 +10,8 @@
   --#{$menu}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$menu}--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$menu}--Color: var(--pf-t--global--text--color--regular);
+  --#{$menu}--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
+  --#{$menu}--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$menu}--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$menu}--OutlineOffset: calc(var(--pf-t--global--border--width--control--default) * -3);
   --#{$menu}--ZIndex: var(--pf-t--global--z-index--sm);
@@ -44,6 +46,9 @@
   // * Menu list item
   --#{$menu}__list-item--Color: var(--pf-t--global--text--color--regular);
   --#{$menu}__list-item--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$menu}__list-item--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
+  --#{$menu}__list-item--BorderColor: transparent;
+  --#{$menu}__list-item--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$menu}__list-item--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
   --#{$menu}__list-item--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$menu}__list-item--TransitionProperty: background-color;
@@ -195,6 +200,7 @@
     --#{$menu}__item-description--Color: var(--#{$menu}--icon--disabled--Color);
     --#{$menu}__list-item--BackgroundColor: transparent;
     --#{$menu}__list-item--hover--BackgroundColor: transparent;
+    --#{$menu}__list-item--hover--BorderColor: transparent;
   }
 
   &:is(.pf-m-disabled, :disabled) {
@@ -219,6 +225,7 @@
   // TODO: Explore this fallback method
   // padding-block-start: var(--#{$menu}--PaddingBlockStart, var(--#{$menu}--PaddingBlock));
   // padding-block-end: var(--#{$menu}--PaddingBlockEnd, var(--#{$menu}--PaddingBlock));
+  position: relative;
   display: grid;
   row-gap: var(--#{$menu}--RowGap);
   width: var(--#{$menu}--Width);
@@ -235,6 +242,15 @@
   transition-duration: var(--#{$menu}--TransitionDuration) !important; // Note that this duration is overriding whatever value is supplied as a prop to Popper
   // stylelint-enable declaration-no-important
 
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$menu}--BorderWidth) solid var(--#{$menu}--BorderColor);
+    border-radius: inherit;
+  }
+    
   .#{$menu} {
     min-width: 100%;
   }
@@ -482,6 +498,8 @@
     inset: 0;
     content: "";
     background-color: var(--#{$menu}__list-item--BackgroundColor);
+    border-block-start: var(--#{$menu}__list-item--BorderWidth) solid var(--#{$menu}__list-item--BorderColor);
+    border-block-end: var(--#{$menu}__list-item--BorderWidth) solid var(--#{$menu}__list-item--BorderColor);
     transition: inherit;
   }
 
@@ -518,6 +536,7 @@
   &:focus-within,
   &:has(> :hover) {
     --#{$menu}__list-item--BackgroundColor: var(--#{$menu}__list-item--hover--BackgroundColor);
+    --#{$menu}__list-item--BorderColor: var(--#{$menu}__list-item--hover--BorderColor);
 
     .#{$menu}__item-select-icon,
     .#{$menu}__item-external-icon {

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -10,7 +10,7 @@
   --#{$menu}--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$menu}--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$menu}--Color: var(--pf-t--global--text--color--regular);
-  --#{$menu}--BorderWidth: var(--pf-t--global--high-contrast--border--width--control--default);
+  --#{$menu}--BorderWidth: var(--pf-t--global--high-contrast--border--width--box--default);
   --#{$menu}--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$menu}--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$menu}--OutlineOffset: calc(var(--pf-t--global--border--width--control--default) * -3);
@@ -225,7 +225,6 @@
   // TODO: Explore this fallback method
   // padding-block-start: var(--#{$menu}--PaddingBlockStart, var(--#{$menu}--PaddingBlock));
   // padding-block-end: var(--#{$menu}--PaddingBlockEnd, var(--#{$menu}--PaddingBlock));
-  position: relative;
   display: grid;
   row-gap: var(--#{$menu}--RowGap);
   width: var(--#{$menu}--Width);
@@ -235,21 +234,13 @@
   overflow: hidden;
   color: var(--#{$menu}--Color);
   background-color: var(--#{$menu}--BackgroundColor);
+  border: var(--#{$menu}--BorderWidth) solid var(--#{$menu}--BorderColor);
   border-radius: var(--#{$menu}--BorderRadius);
   box-shadow: var(--#{$menu}--BoxShadow);
   // stylelint-disable declaration-no-important
   transition-timing-function: var(--#{$menu}--TransitionTimingFunction) !important; // Note that this timing function is overriding the default that Popper is using
   transition-duration: var(--#{$menu}--TransitionDuration) !important; // Note that this duration is overriding whatever value is supplied as a prop to Popper
   // stylelint-enable declaration-no-important
-
-  &::after {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    content: "";
-    border: var(--#{$menu}--BorderWidth) solid var(--#{$menu}--BorderColor);
-    border-radius: inherit;
-  }
     
   .#{$menu} {
     min-width: 100%;


### PR DESCRIPTION
Fixes #7600 

Added border to existing pseudoelement on the menu item
Added border to a new ::after on the menu - used the pseudo because otherwise the drilldown calculation of the size was off by the amount of the border.

Note - The nav with drilldown menu items have a slight border radius that touches the menu's border. I'm not sure if this is right or not.
<img width="307" height="325" alt="image" src="https://github.com/user-attachments/assets/06354716-e707-4ce6-8a66-ca5edcf0400c" />
