### PR TITLE
fix(global): set color-scheme light by default

### DIFF
--- a/src/patternfly/base/normalize.scss
+++ b/src/patternfly/base/normalize.scss
@@ -122,6 +122,10 @@
     cursor: pointer;
   }
 
+  :where(:root) {
+    color-scheme: light;
+  }
+
   :where(.pf-v6-theme-dark) {
     color-scheme: dark;
   }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7720

Since designs intent for default theme is a light theme, and we set `color-scheme` explicitly in the CSS in dark theme, this seems like a safe update to make.

Though ultimately for the type of issue reported in https://github.com/patternfly/patternfly/issues/7720, I'd recommend just not including the `<meta>` tag.