### PR TITLE
feat(tree-view): add high-contrast border

### DIFF
--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -18,10 +18,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node--Color: var(--pf-t--global--text--color--subtle);
   --#{$tree-view}__node--BackgroundColor: transparent;
   --#{$tree-view}__node--BorderRadius: var(--#{$tree-view}__content--BorderRadius);
-  --#{$tree-view}__node--BorderWidth: 0;
   --#{$tree-view}__node--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$tree-view}__node--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
-  --#{$tree-view}__node--m-current--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
+  --#{$tree-view}__node--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$tree-view}__node--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$tree-view}__node--m-current--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
   --#{$tree-view}__node--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$tree-view}__node--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$tree-view}__node--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
@@ -248,7 +248,6 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--PaddingBlockEnd);
     --#{$tree-view}__node-container--Display: var(--#{$tree-view}--m-compact__node-container--Display);
     --#{$tree-view}__node--hover--BackgroundColor: transparent;
-    --#{$tree-view}__node--hover--BorderWidth: 0;
     --#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--InsetBlockStart);
 
     // Level 1

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -17,6 +17,11 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node--PaddingInlineStart: var(--#{$tree-view}__node--indent--base);
   --#{$tree-view}__node--Color: var(--pf-t--global--text--color--subtle);
   --#{$tree-view}__node--BackgroundColor: transparent;
+  --#{$tree-view}__node--BorderRadius: var(--#{$tree-view}__content--BorderRadius);
+  --#{$tree-view}__node--BorderWidth: 0;
+  --#{$tree-view}__node--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$tree-view}__node--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
+  --#{$tree-view}__node--m-current--BorderWidth: var(--pf-t--global--high-contrast--border--width--strong);
   --#{$tree-view}__node--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$tree-view}__node--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$tree-view}__node--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
@@ -243,6 +248,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}__node--PaddingBlockEnd: var(--#{$tree-view}--m-compact__node--PaddingBlockEnd);
     --#{$tree-view}__node-container--Display: var(--#{$tree-view}--m-compact__node-container--Display);
     --#{$tree-view}__node--hover--BackgroundColor: transparent;
+    --#{$tree-view}__node--hover--BorderWidth: 0;
     --#{$tree-view}__list-item__list-item__node-toggle--InsetBlockStart: var(--#{$tree-view}--m-compact__list-item__list-item__node-toggle--InsetBlockStart);
 
     // Level 1
@@ -407,8 +413,18 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   color: var(--#{$tree-view}__node--Color);
   background-color: var(--#{$tree-view}__node--BackgroundColor);
 
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$tree-view}__node--BorderWidth) solid var(--#{$tree-view}__node--BorderColor);
+    border-radius: var(--#{$tree-view}__node--BorderRadius);
+  }
+
   &.pf-m-current {
     --#{$tree-view}__node--Color: var(--#{$tree-view}__node--m-current--Color);
+    --#{$tree-view}__node--BorderWidth: var(--#{$tree-view}__node--m-current--BorderWidth);
   }
 
   .#{$tree-view}__node-count {
@@ -514,6 +530,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
 .#{$tree-view}__content:hover,
 .#{$tree-view}__content:focus-within {
+  --#{$tree-view}__node--BorderWidth: var(--#{$tree-view}__node--hover--BorderWidth);
+
   background-color: var(--#{$tree-view}__node--hover--BackgroundColor);
 }
 


### PR DESCRIPTION
Fixes #7608 

Adds border as ::after on the __node.
For compact variation, sets the border width to 0 so that the borders don't show, since the hover does not cause highlighting. 

However, questions for @lboehling -
1. In the compact variation, do you want hover to show borders?
2. In the compact variation with a background, do you want to show borders around each node?
^^ answered in slack - ok to go with no borders

[Figma link](https://www.figma.com/design/iT76DS020Ry1Wswfc0Hmes/branch/wKcOq7IrzfL1gEK2mocd6r/High-Contrast-Exploration?m=auto&node-id=10994-65004&t=DSuEchl5SfZjfWQy-1)