### PR TITLE
feat(table): add high-contrast borders

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -1407,10 +1407,10 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
 
   {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr table-tr--IsControlRow="true" table-tr--IsExpanded=true}}
-      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--modifier="pf-m-expanded" table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true  table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
         <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;10
       {{/table-td}}
-      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--modifier="pf-m-expanded" table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
         <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
         234
       {{/table-td}}
@@ -1430,18 +1430,18 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
       {{> table-cell-action}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
-        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-1')}}
-        {{/table-expandable-row-content}}
-      {{/table-td}}
-    {{/table-tr}}
-
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
           {{> table-nested table--id=(concat table--id '-nested-table-2')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-expandable-row-content}}
+          234 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -1490,9 +1490,9 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{/table-tr}}
 
     {{#> table-tr table-tr--IsExpandable=true}}
-      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
-        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-5')}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-expandable-row-content}}
+          82 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -1543,7 +1543,186 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-8')}}
+          4 pull requests currently under review.
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-9')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}
+```
+
+### Compound expansion example with nested table
+```hbs
+{{#> table table--id="table-compound-expansion-nested-table" table--IsGrid=true table--modifier="pf-m-grid-md" table--IsExpandable=true table--attribute='aria-label="Compound expandable with nested table example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true table-th--IsSelected="true" table-th--IsAsc="true"}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--IsSortable=true}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+       Workspaces
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+       Last commit
+      {{/table-th}}
+      {{> table-cell-empty table-cell--text='Links'}}
+      {{> table-cell-empty}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
+    {{#> table-tr table-tr--IsControlRow="true" table-tr--IsExpanded=true}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--modifier="pf-m-expanded" table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-1"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;10
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-2"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        234
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-3"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        4
+      {{/table-td}}
+      {{#> table-th table-th--data-label="Workspaces"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        <span>20 minutes</span>
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Action"}}
+        <a href="#">Open in Github</a>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true table-tr--IsExpanded=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-1')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-expandable-row-content}}
+          234 pull requests currently under review.
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-3')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+
+  {{#> table-tbody}}
+    {{#> table-tr table-tr--IsControlRow="true"}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-4"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
+        2
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-5"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        82
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-6"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        1
+      {{/table-td}}
+      {{#> table-th table-th--data-label="Workspaces"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        <span>1 day ago</span>
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Action"}}
+        <a href="#">Open in Github</a>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-4')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          82 pull requests currently under review.
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-6')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+
+  {{#> table-tbody}}
+    {{#> table-tr table-tr--IsControlRow="true"}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Repositories" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-7"')}}
+        <i class="fas fa-code-branch" aria-hidden="true"></i>&nbsp;
+        4
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Branches" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-8"')}}
+        <i class="fas fa-code" aria-hidden="true"></i>&nbsp;
+        4
+      {{/table-td}}
+      {{#> table-td table-td--IsCompoundExpansionToggle=true table-td--data-label="Pull requests" table-td--button--attribute=(concat 'aria-expanded="true" aria-controls="' table--id '-nested-table-9"')}}
+        <i class="fas fa-cube" aria-hidden="true"></i>&nbsp;
+        1
+      {{/table-td}}
+      {{#> table-th table-th--data-label="Workspaces"}}
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        <span>2 days ago</span>
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Action"}}
+        <a href="#">Open in Github</a>
+      {{/table-td}}
+      {{> table-cell-action}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          {{> table-nested table--id=(concat table--id '-nested-table-7')}}
+        {{/table-expandable-row-content}}
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr table-tr--IsExpandable=true}}
+      {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
+        {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
+          4 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -1617,7 +1796,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-2')}}
+          234 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -1664,7 +1843,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-5')}}
+          82 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -1711,7 +1890,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-8')}}
+          4 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -2737,7 +2916,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-2')}}
+          234 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -2785,7 +2964,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-5')}}
+          234 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -2836,7 +3015,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-8')}}
+          82 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}
@@ -2887,7 +3066,7 @@ Note: To apply padding to `.pf-v6-c-table__expandable-row`, wrap the content in 
     {{#> table-tr table-tr--IsExpandable=true}}
       {{#> table-td table-td--attribute='colspan="7"' table-td--modifier="pf-m-no-padding"}}
         {{#> table-expandable-row-content table-expandable-row-content--HasNoBackground=true}}
-          {{> table-nested table--id=(concat table--id '-nested-table-11')}}
+          4 pull requests currently under review.
         {{/table-expandable-row-content}}
       {{/table-td}}
     {{/table-tr}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -96,8 +96,8 @@
   --#{$table}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$table}__button--OutlineOffset: calc(var(--pf-t--global--border--width--strong) * -1);
   --#{$table}__button--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$table}__button--BorderWidth: var(--pf-t--global--high-contrast--border--width--action--default);
-  --#{$table}__button--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--action--hover);
+  --#{$table}__button--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$table}__button--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$table}__button--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$table}__button--hover--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -95,6 +95,9 @@
   --#{$table}__button--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$table}__button--OutlineOffset: calc(var(--pf-t--global--border--width--strong) * -1);
+  --#{$table}__button--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$table}__button--BorderWidth: var(--pf-t--global--high-contrast--border--width--action--default);
+  --#{$table}__button--hover--BorderWidth: var(--pf-t--global--high-contrast--border--width--action--hover);
   --#{$table}__button--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$table}__button--hover--Color: var(--pf-t--global--text--color--regular);
   --#{$table}__button--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
@@ -142,6 +145,8 @@
   --#{$table}__expandable-row-content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$table}__expandable-row-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$table}__expandable-row-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$table}__expandable-row-content--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$table}__expandable-row-content--BorderWidth: 0;
 
   // * Table control row
   --#{$table}__control-row--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -181,12 +186,14 @@
 
   // * Table compound expansion toggle button after
   --#{$table}__compound-expansion-toggle__button--after--BorderColor: var(--pf-t--global--border--color--clicked);
+  --#{$table}__compound-expansion-toggle__button--after--BorderRadius: inherit;
   --#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth: 0;
   --#{$table}__compound-expansion-toggle__button--hover--after--BorderBlockStartWidth: var(--pf-t--global--border--width--strong);
   --#{$table}__compound-expansion-toggle--m-expanded__button--after--BorderBlockStartWidth: var(--pf-t--global--border--width--strong);
 
   // * Compound expandable
   --#{$table}--compound-expansion--m-expanded--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
+  --#{$table}--compound-expansion--m-expanded--BorderWidth: var(--pf-t--global--high-contrast--border--width--regular);
 
   // * Table compact th
   --#{$table}--m-compact__th--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--xs));
@@ -733,6 +740,7 @@
 
 // - Table button
 .#{$table}__button {
+  position: relative;
   width: auto;
   padding-block-start: var(--#{$table}__button--PaddingBlockStart);
   padding-block-end: var(--#{$table}__button--PaddingBlockEnd);
@@ -750,6 +758,15 @@
   border: 0;
   border-radius: var(--#{$table}__button--BorderRadius);
   outline-offset: var(--#{$table}__button--OutlineOffset);
+
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: '';
+    border: var(--#{$table}__button--BorderWidth) solid var(--#{$table}__button--BorderColor);
+    border-radius: inherit;
+  }
 
   // Table table table button
   .#{$table} .#{$table} & {
@@ -968,6 +985,7 @@
     content: '';
     border: 0;
     border-block-start: var(--#{$table}__compound-expansion-toggle__button--after--BorderBlockStartWidth) solid var(--#{$table}__compound-expansion-toggle__button--after--BorderColor);
+    border-radius: var(--#{$table}__compound-expansion-toggle__button--after--BorderRadius);
   }
 
   &:hover,
@@ -1009,6 +1027,7 @@
       --#{$table}__sort-indicator--Color: var(--#{$table}__sort__button--hover__sort-indicator--Color);
       --#{$table}__sort__button__text--Color: var(--#{$table}__sort__button--hover__text--Color);
       --#{$table}__button--BackgroundColor: var(--#{$table}__button--hover--BackgroundColor);
+      --#{$table}__button--BorderWidth: var(--#{$table}__button--hover--BorderWidth);
     }
 
     // - Table text
@@ -1084,17 +1103,29 @@
 
   // - Table expandable row content
   .#{$table}__expandable-row-content {
+    position: relative;
     padding-block-start: var(--#{$table}__expandable-row-content--PaddingBlockStart);
     padding-block-end: var(--#{$table}__expandable-row-content--PaddingBlockEnd);
     padding-inline-start: var(--#{$table}__expandable-row-content--PaddingInlineStart);
     padding-inline-end: var(--#{$table}__expandable-row-content--PaddingInlineEnd);
     background-color: var(--#{$table}__expandable-row-content--BackgroundColor);
+    border: 0;
     border-radius: var(--#{$table}__expandable-row-content--BorderRadius);
 
     &.pf-m-no-background {
       background-color: transparent;
     }
   }
+
+  .#{$table}__td:not(.pf-m-no-padding) > .#{$table}__expandable-row-content::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border: var(--#{$table}__expandable-row-content--BorderWidth) solid var(--#{$table}__expandable-row-content--BorderColor);
+    border-radius: inherit;
+  }
+
 
   // - Table expandable row content expanded
   &.pf-m-expanded {
@@ -1179,6 +1210,8 @@
 
   // TODO: make this a class `compound expansion content`
   .#{$table}__control-row ~ .#{$table}__expandable-row.pf-m-expanded {
+    --#{$table}__expandable-row-content--BorderWidth: var(--#{$table}--compound-expansion--m-expanded--BorderWidth);
+
     background-color: var(--#{$table}--compound-expansion--m-expanded--BackgroundColor);
   }
 }


### PR DESCRIPTION
Fixes #7622 

Regression test on table component was clean (other than examples with a spinner)

[Figma design](https://www.figma.com/design/iT76DS020Ry1Wswfc0Hmes/branch/wKcOq7IrzfL1gEK2mocd6r/High-Contrast-Exploration?m=auto&node-id=10994-65006&t=N9dV6sRf93tCu0aS-1)
Assisted by Cursor autocomplete