### PR TITLE
chore(HelperText): updated how status is conveyed

### DIFF
--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -25,7 +25,7 @@ import './DatePicker.css'
 
 ### Helper text
 ```hbs
-{{#> date-picker date-picker--id="helper-text" helper-text--value="Select a date"}}
+{{#> date-picker date-picker--id="helper-text" helper-text--value="Select a date" helper-text-item--HasNoIcon=true}}
   {{#> input-group}}
     {{#> input-group-item input-group-item--IsFill=true}}
       {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}
@@ -39,7 +39,7 @@ import './DatePicker.css'
 
 ### Invalid
 ```hbs
-{{#> date-picker date-picker--id="invalid" helper-text--value="Invalid date" helper-text-item--IsError="true" helper-text-item--HasIcon=true}}
+{{#> date-picker date-picker--id="invalid" helper-text--value="Invalid date" helper-text-item--IsError=true}}
   {{#> input-group}}
     {{#> input-group-item input-group-item--IsFill=true}}
       {{> form-control controlType="input" input="true" form-control--IsError="true" form-control--attribute=(concat 'aria-invalid="true" type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}

--- a/src/patternfly/components/DatePicker/examples/DatePicker.md
+++ b/src/patternfly/components/DatePicker/examples/DatePicker.md
@@ -25,7 +25,7 @@ import './DatePicker.css'
 
 ### Helper text
 ```hbs
-{{#> date-picker date-picker--id="helper-text" helper-text--value="Select a date" helper-text-item--HasNoIcon=true}}
+{{#> date-picker date-picker--id="helper-text" helper-text--value="Select a date"}}
   {{#> input-group}}
     {{#> input-group-item input-group-item--IsFill=true}}
       {{> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="2020-03-05" id="' date-picker--id '-input" name="' date-picker--id '-input" aria-label="Date picker"')}}

--- a/src/patternfly/components/FileUpload/examples/FileUpload.md
+++ b/src/patternfly/components/FileUpload/examples/FileUpload.md
@@ -187,7 +187,7 @@ cssPrefix: pf-v6-c-file-upload
           file-upload-file-details--attribute='aria-describedby="with-error-example-helper-text" aria-invalid="true"'
           file-upload-file-details--aria-label="Empty text area"}}{{/file-upload-file-details}}
         {{#> file-upload-helper-text}}
-          {{> helper-text helper-text-item--HasIcon=true helper-text--value="Must be a CSV file no larger than 1 KB" helper-text-item--id='with-error-example-helper-text' helper-text-item--IsError=true}}
+          {{> helper-text helper-text--value="Must be a CSV file no larger than 1 KB" helper-text-item--id='with-error-example-helper-text' helper-text-item--IsError=true}}
         {{/file-upload-helper-text}}
       {{/file-upload}}
     {{/form-group-control}}

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -198,7 +198,7 @@ cssPrefix: pf-v6-c-form
     {{#> form-group-control}}
       {{#> form-control controlType="textarea" form-control--modifier='pf-m-resize-both' form-control--IsError='true' form-control--attribute=(concat 'id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}
       {{/form-control}}
-      {{> form-helper-text helper-text--value='This is helper text with an icon.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+      {{> form-helper-text helper-text--value='This is helper text with an icon.' helper-text-item--IsError=true}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/form-helper-text.hbs
+++ b/src/patternfly/components/Form/form-helper-text.hbs
@@ -11,7 +11,7 @@
     {{{form-helper-text--attribute}}}
   {{/if}}>
   {{#if helper-text--value}}
-    {{> helper-text helper-text-item--id=(concat form-group--id '-helper') helper-text-item--HasIcon=true}}
+    {{> helper-text helper-text-item--id=(concat form-group--id '-helper')}}
   {{else if @partial-block}}
     {{> @partial-block}}
   {{/if}}

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -7,7 +7,7 @@ cssPrefix: pf-v6-c-helper-text
 ## Examples
 ### Basic
 ```hbs
-{{> helper-text helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
+{{> helper-text helper-text--value="This is default helper text"}}
 {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true}}
 {{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true}}
 {{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true}}
@@ -20,9 +20,9 @@ You can include multiple `HelperTextItem` components inside a single `HelperText
 
 ```hbs
 {{#> helper-text helper-text--IsList=true}}
-  {{> helper-text-item helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
-  {{> helper-text-item helper-text--value="This is another default helper text in the same block" helper-text-item--HasNoIcon=true}}
-  {{> helper-text-item helper-text--value="And this is more default text in the same block" helper-text-item--HasNoIcon=true}}
+  {{> helper-text-item helper-text--value="This is default helper text"}}
+  {{> helper-text-item helper-text--value="This is another default helper text in the same block"}}
+  {{> helper-text-item helper-text--value="And this is more default text in the same block"}}
 {{/helper-text}}
 ```
 
@@ -32,7 +32,7 @@ If the `HelperTextItem` components are expected or intended to dynamically updat
 
 ```hbs
 {{#> helper-text-wrapper helper-text-item--IsDynamic=true}}
-  {{> helper-text helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
+  {{> helper-text helper-text--value="This is default helper text"}}
   {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true}}
   {{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true}}
   {{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true}}

--- a/src/patternfly/components/HelperText/examples/HelperText.md
+++ b/src/patternfly/components/HelperText/examples/HelperText.md
@@ -5,37 +5,34 @@ cssPrefix: pf-v6-c-helper-text
 ---
 
 ## Examples
-### Static
+### Basic
 ```hbs
-{{> helper-text helper-text--value="This is default helper text"}}
+{{> helper-text helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
 {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true}}
 {{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true}}
 {{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true}}
 {{> helper-text helper-text--value="This is error helper text" helper-text-item--IsError=true}}
 ```
 
-### Icon
-```hbs
-{{> helper-text helper-text--value="This is default helper text" helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-{{> helper-text helper-text--value="This is error helper text" helper-text-item--IsError=true helper-text-item--HasIcon=true}}
-```
+### Multiple items
 
-### Multiple static
+You can include multiple `HelperTextItem` components inside a single `HelperText` container.
+
 ```hbs
-{{#> helper-text}}
-  {{> helper-text-item helper-text--value="This is default helper text"}}
-  {{> helper-text-item helper-text--value="This is another default helper text in the same block"}}
-  {{> helper-text-item helper-text--value="And this is more default text in the same block"}}
+{{#> helper-text helper-text--IsList=true}}
+  {{> helper-text-item helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
+  {{> helper-text-item helper-text--value="This is another default helper text in the same block" helper-text-item--HasNoIcon=true}}
+  {{> helper-text-item helper-text--value="And this is more default text in the same block" helper-text-item--HasNoIcon=true}}
 {{/helper-text}}
 ```
 
 ### Dynamic
+
+If the `HelperTextItem` components are expected or intended to dynamically update in some way, you should use a dynamic `HelperText` container.
+
 ```hbs
-{{#> helper-text-wrapper helper-text-item--IsDynamic=true helper-text-item--HasIcon=true}}
-  {{> helper-text helper-text--value="This is default helper text"}}
+{{#> helper-text-wrapper helper-text-item--IsDynamic=true}}
+  {{> helper-text helper-text--value="This is default helper text" helper-text-item--HasNoIcon=true}}
   {{> helper-text helper-text--value="This is indeterminate helper text" helper-text-item--IsIndeterminate=true}}
   {{> helper-text helper-text--value="This is warning helper text" helper-text-item--IsWarning=true}}
   {{> helper-text helper-text--value="This is success helper text" helper-text-item--IsSuccess=true}}
@@ -45,7 +42,7 @@ cssPrefix: pf-v6-c-helper-text
 
 ### Dynamic list
 ```hbs
-{{#> helper-text helper-text-item--IsDynamic=true helper-text-item--HasIcon=true}}
+{{#> helper-text helper-text-item--IsDynamic=true helper-text--IsList=true}}
   {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsSuccess=true}}
   {{> helper-text-item helper-text--value='Cannot contain any variation of the word "redhat"' helper-text-item--IsError=true}}
   {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols' helper-text-item--IsSuccess=true}}

--- a/src/patternfly/components/HelperText/helper-text-item-icon.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-icon.hbs
@@ -2,7 +2,6 @@
   {{#if helper-text-item-icon--attribute}}
     {{{helper-text-item-icon--attribute}}}
   {{/if}}>
-  {{#if helper-text-item--HasIcon}}
     {{#if helper-text-item--IsIndeterminate}}
       <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
     {{else if helper-text-item--IsWarning}}
@@ -11,12 +10,9 @@
       <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
     {{else if helper-text-item--IsError}}
       <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-    {{else}}
-      <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
+    {{else if @partial-block}}
+      {{> @partial-block}}
+    {{else if helper-text-item-icon--type}}
+      <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
     {{/if}}
-  {{else if @partial-block}}
-    {{> @partial-block}}
-  {{else}}
-    <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
-  {{/if}}
 </span>

--- a/src/patternfly/components/HelperText/helper-text-item-icon.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-icon.hbs
@@ -2,17 +2,17 @@
   {{#if helper-text-item-icon--attribute}}
     {{{helper-text-item-icon--attribute}}}
   {{/if}}>
-    {{#if helper-text-item--IsIndeterminate}}
-      <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
-    {{else if helper-text-item--IsWarning}}
-      <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
-    {{else if helper-text-item--IsSuccess}}
-      <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
-    {{else if helper-text-item--IsError}}
-      <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-    {{else if @partial-block}}
-      {{> @partial-block}}
-    {{else if helper-text-item-icon--type}}
-      <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
-    {{/if}}
+  {{#if helper-text-item--IsIndeterminate}}
+    <i class="fas fa-fw fa-minus" aria-hidden="true"></i>
+  {{else if helper-text-item--IsWarning}}
+    <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
+  {{else if helper-text-item--IsSuccess}}
+    <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
+  {{else if helper-text-item--IsError}}
+    <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+  {{else if @partial-block}}
+    {{> @partial-block}}
+  {{else if helper-text-item-icon--type}}
+    <i class="fas fa-fw fa-{{helper-text-item-icon--type}}" aria-hidden="true"></i>
+  {{/if}}
 </span>

--- a/src/patternfly/components/HelperText/helper-text-item-text.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-text.hbs
@@ -2,6 +2,19 @@
   {{#if helper-text-item-text--attribute}}
     {{{helper-text-item-text--attribute}}}
   {{/if}}>
+  {{#unless helper-text-item--HasNoIcon}}
+    {{#> screen-reader}}
+      {{#if helper-text-item--IsWarning}}
+        Warning: 
+      {{else if helper-text-item--IsSuccess}}
+        Success: 
+      {{else if helper-text-item--IsError}}
+        Error: 
+      {{else}}
+        Indeterminate: 
+      {{/if}}
+    {{/screen-reader}}
+  {{/unless}}
   {{#if helper-text--value}}
     {{{helper-text--value}}}
   {{else if @partial-block}}

--- a/src/patternfly/components/HelperText/helper-text-item-text.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item-text.hbs
@@ -2,7 +2,7 @@
   {{#if helper-text-item-text--attribute}}
     {{{helper-text-item-text--attribute}}}
   {{/if}}>
-  {{#unless helper-text-item--HasNoIcon}}
+  {{#ifAny helper-text-item--IsSuccess helper-text-item--IsError helper-text-item--IsWarning helper-text-item--IsIndeterminate helper-text-item-icon--type}}
     {{#> screen-reader}}
       {{#if helper-text-item--IsWarning}}
         Warning: 
@@ -14,7 +14,7 @@
         Indeterminate: 
       {{/if}}
     {{/screen-reader}}
-  {{/unless}}
+  {{/ifAny}}
   {{#if helper-text--value}}
     {{{helper-text--value}}}
   {{else if @partial-block}}

--- a/src/patternfly/components/HelperText/helper-text-item.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item.hbs
@@ -12,9 +12,9 @@
   {{#if helper-text-item--attribute}}
     {{{helper-text-item--attribute}}}
   {{/if}}>
-  {{#if helper-text-item--HasIcon}}
+  {{#unless helper-text-item--HasNoIcon}}
     {{> helper-text-item-icon}}
-  {{/if}}
+  {{/unless}}
   {{#if helper-text--value}}
     {{> helper-text-item-text}}
   {{else if @partial-block}}

--- a/src/patternfly/components/HelperText/helper-text-item.hbs
+++ b/src/patternfly/components/HelperText/helper-text-item.hbs
@@ -12,12 +12,10 @@
   {{#if helper-text-item--attribute}}
     {{{helper-text-item--attribute}}}
   {{/if}}>
-  {{#unless helper-text-item--HasNoIcon}}
+  {{#ifAny helper-text-item--IsSuccess helper-text-item--IsError helper-text-item--IsWarning helper-text-item--IsIndeterminate helper-text-item-icon--type}}
     {{> helper-text-item-icon}}
-  {{/unless}}
+  {{/ifAny}}
   {{#if helper-text--value}}
     {{> helper-text-item-text}}
-  {{else if @partial-block}}
-    {{> @partial-block}}
   {{/if}}
 </{{#if helper-text--IsList}}li{{else}}div{{/if}}>

--- a/src/patternfly/components/Login/examples/Login.md
+++ b/src/patternfly/components/Login/examples/Login.md
@@ -16,7 +16,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
@@ -55,7 +55,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="invalid-login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute='type="text" id="invalid-login-demo-form-username" name="invalid-login-demo-form-username" aria-invalid="true"'}}{{/form-control}}
@@ -94,7 +94,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
@@ -136,7 +136,7 @@ wrapperTag: div
       {{> __login-main-header}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-helper-text form-helper-text--modifier="pf-m-error pf-m-hidden"}}
             {{#> form-helper-text-icon}}
               <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
@@ -184,7 +184,7 @@ wrapperTag: div
       {{> __login-main-header __login-main-header--HasLangaugeSelector="true"}}
       {{#> login-main-body}}
         {{#> form}}
-          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+          {{> form-helper-text helper-text--value='Invalid login credentials.' helper-text--IsHidden=true helper-text-item--IsError=true}}
           {{#> form-group}}
             {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
             {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--attribute='type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -50,7 +50,7 @@
       {{/form-label}}
     {{/form-group-label}}
     {{#> form-group-control}}
-      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true helper-text-item--HasIcon=true}}
+      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true}}
       {{#> check}}
         {{#> check-input check-input--attribute='type="checkbox" id="alt-checkbox1" name="alt-checkbox1"'}}{{/check-input}}
         {{#> check-label check-label--attribute='for="alt-checkbox1"'}}Follow up via email.{{/check-label}}

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -53,7 +53,7 @@
       {{#> form-label form-label--attribute=(concat 'for="' form-group--id '"') required='true'}}
         How can we contact you?
       {{/form-label}}
-      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--HasIcon=true helper-text-item--IsError=true}}
+      {{> form-helper-text helper-text--value='This is a required field' helper-text-item--IsError=true}}
     {{/form-group-label}}
     {{#> form-group-control form-group-control--modifier="pf-m-inline"}}
       {{#> check}}

--- a/src/patternfly/demos/HelperText/examples/HelperText.md
+++ b/src/patternfly/demos/HelperText/examples/HelperText.md
@@ -42,10 +42,10 @@ section: components
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--IsRequired='true' form-control--IsError='true' form-control--attribute=(concat 'type="text" id="' form-group--id '" name="' form-group--id '" aria-invalid="true" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
-        {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='This criteria has not been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
-          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+        {{#> helper-text helper-text--IsList=true}}
+          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='This criteria has not been met.' helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
+          {{> helper-text-item helper-text--value='This criteria has been met.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -59,7 +59,7 @@ section: components
     {{#> form-group-control}}
       {{#> form-control controlType="input" input="true" form-control--IsSuccess='true' form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form-group--id '" name="' form-group--id '" aria-describedby="' form-group--id '-helper"')}}{{/form-control}}
       {{#> form-helper-text form-helper-text--id=(concat form-group--id '-helper')}}
-        {{> helper-text helper-text--value='This is dynamic helper text with an icon showing success.' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+        {{> helper-text helper-text--value='This is dynamic helper text with an icon showing success.' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
       {{/form-helper-text}}
     {{/form-group-control}}
   {{/form-group}}

--- a/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
+++ b/src/patternfly/demos/PasswordStrength/examples/PasswordStrength.md
@@ -27,9 +27,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true  helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols'  helper-text-item--IsDynamic=true helper-text-item--IsIndeterminate=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -59,9 +59,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsError=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -78,7 +78,7 @@ section: components
             {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
-        {{> helper-text helper-text--value='Weak' helper-text-item--HasIcon=true helper-text-item--IsError=true}}
+        {{> helper-text helper-text--value='Weak' helper-text-item--IsError=true}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
@@ -92,9 +92,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--HasIcon=true helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}
@@ -111,7 +111,7 @@ section: components
         {{#> form-label form-label--attribute=(concat 'for="' form--id form-group--id '"') required="true"}}Password{{/form-label}}
       {{/form-group-label-main}}
       {{#> form-group-label-info}}
-        {{> helper-text helper-text--value="Strong" helper-text-item--HasIcon=true helper-text-item--IsSuccess=true}}
+        {{> helper-text helper-text--value="Strong" helper-text-item--IsSuccess=true}}
       {{/form-group-label-info}}
     {{/form-group-label}}
     {{#> form-group-control}}
@@ -125,9 +125,9 @@ section: components
       {{/input-group}}
       {{#> form-helper-text form-helper-text--type="div"}}
         {{#> helper-text helper-text--type="ul" helper-text-item--type="li"}}
-          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
-          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true helper-text-item--HasIcon=true}}
+          {{> helper-text-item helper-text--value='Must be at least 14 characters' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Cannot contain the word "redhat"' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
+          {{> helper-text-item helper-text--value='Must include at least 3 of the following: lowercase letters, uppercase letters, numbers, symbols' helper-text-item--IsDynamic=true helper-text-item--IsSuccess=true}}
         {{/helper-text}}
       {{/form-helper-text}}
     {{/form-group-control}}


### PR DESCRIPTION
Closes #7282 

- Updated some handlebars logic so that you shouldn't opt into an icon being rendered, rather it's the default for status helper text items.
- For the SR text, I went with something different than what React has: rather than appending "[status] Status" after the visible helper text, I prepended it with "[status]:". In React we currently allow a way to omit the SR text per a product ask at one point, and in the future it may make sense to allow more flexibility with how the SR text is rendered in React (instead of always rendering it at the end of a helper text item, allow consumers to have it at the beginning). I can update Core to match React for now, though, if we'd prefer that.