### PR TITLE
chore(backstop): script to work with puppeteer chrome version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ backstop_data/bitmaps_test*
 backstop_data/html_report*
 backstop_data/reports
 .history
+chrome

--- a/backstop_data/engine_scripts/puppet/chrome.js
+++ b/backstop_data/engine_scripts/puppet/chrome.js
@@ -1,0 +1,21 @@
+const puppeteer = require('puppeteer');
+
+console.log('');
+console.log('To make changes to the chrome version puppeteer uses, reference \x1B[1mhttps://pptr.dev/browsers-api\x1B[22m');
+console.log('For a list of the current "Chromium for Testing" versions, reference \x1B[1mhttps://googlechromelabs.github.io/chrome-for-testing/\x1B[22m');
+console.log('');
+console.log('Some common commands:');
+console.log('- \x1B[1mnpx @puppeteer/browsers list\x1B[22m # lists all installed browsers');
+console.log('- \x1B[1mnpx @puppeteer/browsers clear\x1B[22m # removes all installed browsers');
+console.log('- \x1B[1mnpx @puppeteer/browsers install chrome@stable\x1B[22m # install specific chromium version');
+console.log(' - Available options are: \x1B[1mstable\x1B[22m, \x1B[1mbeta\x1B[22m, \x1B[1mdev\x1B[22m, \x1B[1mcanary\x1B[22m, and a specific version \(eg, \x1B[1m139.0.7258.154\x1B[22m\)');
+
+// Spits out version of chromium puppeteer is currently using
+(async () => {
+  const browser = await puppeteer.launch();
+  const version = await browser.version();
+  console.log('');
+  console.log(`Puppeteer is using: ${version}`);
+  console.log('');
+  await browser.close();
+})();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "backstop:test:dark": "backstop test --config='backstop.js' --dark",
     "backstop:approve": "backstop approve --config='backstop.js'",
     "backstop:approve:dark": "backstop approve --config='backstop.js' --dark",
+    "backstop:chrome": "node backstop_data/engine_scripts/puppet/chrome.js",
     "build-patternfly": "gulp buildPatternfly",
     "build": "gulp build",
     "build:docs": "gulp buildWebpack",


### PR DESCRIPTION
This spits out the version of chrome that puppeteer uses, which can be a little difficult to suss out, and gives some handy commands to update that version. Here's the output:


```console
$ yarn backstop:chrome

To make changes to the chrome version puppeteer uses, reference https://pptr.dev/browsers-api
For a list of the current "Chromium for Testing" versions, reference https://googlechromelabs.github.io/chrome-for-testing/

Some common commands:
- npx @puppeteer/browsers list # lists all installed browsers
- npx @puppeteer/browsers clear # removes all installed browsers
- npx @puppeteer/browsers install chrome@stable # install specific chromium version
 - Available options are: stable, beta, dev, canary, and a specific version (eg, 139.0.7258.154)

Puppeteer is using: Chrome/139.0.7258.68

```