### PR TITLE
feat(high-contrast): use variable for high-contrast

### DIFF
--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -4,6 +4,7 @@ module.exports = {
   hasFooter: false,
   hasVersionSwitcher: false,
   hasThemeSwitcher: true,
+  hasHighContrastSwitcher: true,
   hasRTLSwitcher: true,
   sideNavItems: [
     { section: 'get-started' },

--- a/src/patternfly/base/patternfly-variables.scss
+++ b/src/patternfly/base/patternfly-variables.scss
@@ -17,24 +17,12 @@
   @include dark.pf-v6-tokens;
 }
 
-// :root:where(.pf-v6-theme-high-contrast) {
-//   @include highcontrast.pf-v6-tokens;
-// }
-
-@media (prefers-contrast: more) {
-  :root {
-    @include highcontrast.pf-v6-tokens;
-  }
+:root:where(.pf-v6-theme-high-contrast) {
+  @include highcontrast.pf-v6-tokens;
 }
 
-// :root:where(.pf-v6-theme-high-contrast.pf-v6-theme-dark) {
-//   @include highcontrast-dark.pf-v6-tokens;
-// }
-
-@media (prefers-contrast: more) {
-  :root:where(.pf-v6-theme-dark) {
-    @include highcontrast-dark.pf-v6-tokens;
-  }
+:root:where(.pf-v6-theme-high-contrast.pf-v6-theme-dark) {
+  @include highcontrast-dark.pf-v6-tokens;
 }
 
 @include pf-v6-rtl(false) {

--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -143,7 +143,7 @@
   --pf-t--global--high-contrast--border--width--regular: 0;
   --pf-t--global--high-contrast--border--width--strong: 0;
 
-  @media (prefers-contrast: more) {
+  &:where(.pf-v6-theme-high-contrast) {
     --pf-t--global--high-contrast--border--width--action--clicked: var(--pf-t--global--border--width--action--clicked);
     --pf-t--global--high-contrast--border--width--action--default: var(--pf-t--global--border--width--action--default);
     --pf-t--global--high-contrast--border--width--action--hover: var(--pf-t--global--border--width--action--hover);


### PR DESCRIPTION
Fixes #7774 

Turns on the high-contrast switcher in docs framework
Removes media queries for prefers-contrast: more and replaces it with the `.pf-v6-theme-high-contrast` variable.