### PR TITLE
fix(accordion): fix expanded content height when not expanded

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -116,8 +116,9 @@
   --#{$accordion}__item--m-expanded--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
 
   // expandable content border for high contrast
-  --#{$accordion}__expandable-content--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$accordion}__expandable-content--BorderWidth: 0;
   --#{$accordion}__expandable-content--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$accordion}__item--m-expanded__expandable-content--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
 }
 
 .#{$accordion} {
@@ -191,6 +192,8 @@
     --#{$accordion}__expandable-content--Visibility: var(--#{$accordion}__item--m-expanded__expandable-content--Visibility);
     --#{$accordion}__expandable-content--TransitionDuration--fade: 0s;
     --#{$accordion}__expandable-content--m-fixed--MaxHeight--base: var(--#{$accordion}__expandable-content--m-fixed--MaxHeight);
+    --#{$accordion}__expandable-content--BorderWidth: var(--#{$accordion}__item--m-expanded__expandable-content--BorderWidth);
+
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7792

@lboehling there was a bug that made staging look different than the original PR preview when we added the HC borders. This should fix that. Here's the link to the original HC accordion implementation if you want to compare - https://github.com/patternfly/patternfly/pull/7656