### PR TITLE
fix(drawer): add top border in high contrast

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -154,6 +154,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-wizard--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$page}__main-wizard--BorderBlockStartColor: var(--pf-t--global--border--color--default);
   --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--action--default);
+
+  // Drawer section
+  --#{$page}__drawer--c-drawer--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$page}__drawer--c-drawer--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
 }
 
 .#{$page} {
@@ -568,10 +572,15 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   flex-shrink: 0;
 }
 
-.#{$page}__drawer .#{$page}__main-container {
-  align-self: revert;
+.#{$page}__drawer {
+  > .#{$drawer} > .#{$drawer}__main > .#{$drawer}__panel {
+    border-block-start: var(--#{$page}__drawer--c-drawer--BorderBlockStartWidth) solid var(--#{$page}__drawer--c-drawer--BorderBlockStartColor);
+  }
+  .#{$page}__main-container {
+    align-self: revert;
 
-  &.pf-m-fill {
-    flex-grow: 1;
+    &.pf-m-fill {
+      flex-grow: 1;
+    }
   }
 }


### PR DESCRIPTION
~~@lboehling this adds a top border to all drawer panels. This would mean there would be a double border with the panel open if there were already a top border added in the UI, but I wonder if that's worth the trade-off of this adding a border to places there is not currently a border between the drawer and whatever is above it (like the notification drawer)~~

Adds a top border to drawer panels when the HTML structure is attached to the page layout - most common use of this layout is with a notification drawer. This is also the HTML structure generated when using `<Page notificationDrawer={...} />`

fixes https://github.com/patternfly/patternfly/issues/7805