### PR TITLE
fix(alert): fix hover styles, HC borders

### DIFF
--- a/src/patternfly/components/Alert/alert-group-overflow-button.hbs
+++ b/src/patternfly/components/Alert/alert-group-overflow-button.hbs
@@ -1,11 +1,13 @@
-<button class="{{pfv}}alert-group__overflow-button{{#if alert-group-overflow-button--modifier}} {{alert-group-overflow-button--modifier}}{{/if}}"
-  {{#if alert-group-overflow-button--attribute}}
-    {{{alert-group-overflow-button--attribute}}}
-  {{/if}}>
-  {{#if alert-group-overflow-button--text}}
-    {{{alert-group-overflow-button--text}}}
-  {{/if}}
-  {{#if @partial-block}}
-    {{> @partial-block}}
-  {{/if}}
-</button>
+<li>
+  <button class="{{pfv}}alert-group__overflow-button{{#if alert-group-overflow-button--modifier}} {{alert-group-overflow-button--modifier}}{{/if}}"
+    {{#if alert-group-overflow-button--attribute}}
+      {{{alert-group-overflow-button--attribute}}}
+    {{/if}}>
+    {{#if alert-group-overflow-button--text}}
+      {{{alert-group-overflow-button--text}}}
+    {{/if}}
+    {{#if @partial-block}}
+      {{> @partial-block}}
+    {{/if}}
+  </button>
+</li>

--- a/src/patternfly/components/Alert/alert-group.scss
+++ b/src/patternfly/components/Alert/alert-group.scss
@@ -90,7 +90,7 @@
   --#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition: initial;
 
     // Overflow button
-  --#{$alert-group}__overflow-button--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
+  --#{$alert-group}__overflow-button--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$alert-group}__overflow-button--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$alert-group}__overflow-button--BorderRadius: var(--pf-t--global--border--radius--medium);
   --#{$alert-group}__overflow-button--PaddingBlockStart: var(--pf-t--global--spacer--md);
@@ -100,9 +100,11 @@
   --#{$alert-group}__overflow-button--Color: var(--pf-t--global--text--color--link--default);
   --#{$alert-group}__overflow-button--BoxShadow: var(--pf-t--global--box-shadow--lg);
   --#{$alert-group}__overflow-button--BackgroundColor: var(--pf-t--global--background--color--floating--default);
-  --#{$alert-group}__overflow-button--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$alert-group}__overflow-button--hover--BorderWidth: var(--pf-t--global--border--width--high-contrast--strong);
   --#{$alert-group}__overflow-button--hover--Color: var(--pf-t--global--text--color--link--hover);
   --#{$alert-group}__overflow-button--hover--BackgroundColor: var(--pf-t--global--background--color--floating--hover);
+
+  // TODO - remove this block in breaking change, not used
   --#{$alert-group}__overflow-button--hover--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
   --#{$alert-group}__overflow-button--focus--Color: var(--pf-t--global--text--color--link--hover);
   --#{$alert-group}__overflow-button--focus--BoxShadow: var(--pf-t--global--box-shadow--lg), var(--pf-t--global--box-shadow--lg--bottom);
@@ -152,6 +154,8 @@
   &:hover,
   &:focus {
     --#{$alert-group}__overflow-button--BorderWidth: var(--#{$alert-group}__overflow-button--hover--BorderWidth);
+    --#{$alert-group}__overflow-button--BackgroundColor: var(--#{$alert-group}__overflow-button--hover--BackgroundColor);
+    --#{$alert-group}__overflow-button--Color: var(--#{$alert-group}__overflow-button--hover--Color);
   }
 }
 
@@ -277,21 +281,5 @@
           transition: var(--#{$alert-group}--m-toast__item--m-offstage-right--c-alert--Transition, var(--#{$alert-group}--m-toast__item--m-outgoing--c-alert--Transition));
         }
     }
-  }
-
-  &:hover {
-    --#{$alert-group}__overflow-button--Color: var(--#{$alert-group}__overflow-button--hover--Color);
-    --#{$alert-group}__overflow-button--BackgroundColor: var(--#{$alert-group}__overflow-button--hover--BackgroundColor);
-    --#{$alert-group}__overflow-button--BoxShadow: var(--#{$alert-group}__overflow-button--hover--BoxShadow);
-  }
-
-  &:focus {
-    --#{$alert-group}__overflow-button--Color: var(--#{$alert-group}__overflow-button--focus--Color);
-    --#{$alert-group}__overflow-button--BoxShadow: var(--#{$alert-group}__overflow-button--focus--BoxShadow);
-  }
-
-  &:active {
-    --#{$alert-group}__overflow-button--Color: var(--#{$alert-group}__overflow-button--active--Color);
-    --#{$alert-group}__overflow-button--BoxShadow: var(--#{$alert-group}__overflow-button--active--BoxShadow);
   }
 }

--- a/src/patternfly/components/Alert/examples/Alert.md
+++ b/src/patternfly/components/Alert/examples/Alert.md
@@ -487,10 +487,7 @@ For sighted users, interactive elements can be included in this message in one o
       {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
-
-  {{#> alert-item}}
-    {{> alert-group-overflow-button alert-group-overflow-button--text="View 3 more notifications"}}
-  {{/alert-item}}
+  {{> alert-group-overflow-button alert-group-overflow-button--text="View 3 more notifications"}}
 {{/alert-group}}
 ```
 


### PR DESCRIPTION
Goes toward https://github.com/patternfly/patternfly/issues/7796

But I also noticed we had `:hover/focus/active` styles on the alert-group-item (an `<li>` that isn't interactive/focusable) instead of on the overflow button so I 1) removed those styles and 2) put the appropriate changes on the overflow button. 

Also in react, a plain ol' `<li>` wraps the overflow button, not a `li.pf-v6-c-alert-group__item`, so the `:hover` styles I removed weren't working. That should be fixed with the changes above, but I also wrapped the overflow button in an `<li>` in the core docs to match react. 