### PR TITLE
fix(dual-list-selector): tree to support focus-within, hc border on hover/focus

### DIFF
--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -280,6 +280,11 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor);
     --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderWidth);
 
+    &.pf-m-check {
+      --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: transparent;
+      --#{$dual-list-selector}__list-item-row--BorderWidth: 0;
+    }
+
     .#{$dual-list-selector}__item-text {
       --#{$dual-list-selector}__item-text--Color: var(--#{$dual-list-selector}__list-item-row--m-selected__text--Color);
 
@@ -287,15 +292,14 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
     }
   }
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--hover--BackgroundColor);
     --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--hover--BorderWidth);
   }
 
   &.pf-m-check {
     --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: transparent;
-    --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: transparent;
-    --#{$dual-list-selector}__list-item-row--BorderWidth: revert;
   }
 
   &.pf-m-ghost-row {

--- a/src/patternfly/components/DualListSelector/dual-list-selector.scss
+++ b/src/patternfly/components/DualListSelector/dual-list-selector.scss
@@ -280,11 +280,6 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
     --#{$dual-list-selector}__list-item-row--BackgroundColor: var(--#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor);
     --#{$dual-list-selector}__list-item-row--BorderWidth: var(--#{$dual-list-selector}__list-item-row--m-selected--BorderWidth);
 
-    &.pf-m-check {
-      --#{$dual-list-selector}__list-item-row--m-selected--BorderColor: transparent;
-      --#{$dual-list-selector}__list-item-row--BorderWidth: 0;
-    }
-
     .#{$dual-list-selector}__item-text {
       --#{$dual-list-selector}__item-text--Color: var(--#{$dual-list-selector}__list-item-row--m-selected__text--Color);
 
@@ -300,6 +295,7 @@ $pf-v6-c-dual-list-selector__item--MaxNesting: 10;
 
   &.pf-m-check {
     --#{$dual-list-selector}__list-item-row--m-selected--BackgroundColor: transparent;
+    --#{$dual-list-selector}__list-item-row--m-selected--BorderWidth: 0;
   }
 
   &.pf-m-ghost-row {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7795

* Adds HC border on hover/focus for tree variant
* Adds background color change when focusing on something (either the expand toggle or checkbox) in a tree item - this is a net new style to the default styles, not just HC - @lboehling is that ok? This matches tree view styles.

Previously looks like this:

<img width="537" height="518" alt="Screenshot 2025-09-12 at 2 40 19 PM" src="https://github.com/user-attachments/assets/d060cd96-6b0a-4167-9886-5f431913d7c5" />

Now looks like this:

<img width="610" height="541" alt="Screenshot 2025-09-12 at 2 40 56 PM" src="https://github.com/user-attachments/assets/b3d737b3-123d-42fb-af14-16d5b2d0ca0e" />

For comparison this is tree view, which has the same styling:
<img width="499" height="634" alt="Screenshot 2025-09-12 at 2 48 31 PM" src="https://github.com/user-attachments/assets/5722ed3c-290e-46ca-80fe-0e00765fd1ef" />
