### PR TITLE
fix(button): remove border width animation

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -24,7 +24,7 @@
   --#{$button}--TransitionDelay: 0s;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$button}--TransitionProperty: color, background, border-width, border-color;
+  --#{$button}--TransitionProperty: color, background, border-color;
   --#{$button}--ScaleX: 1;
   --#{$button}--ScaleY: 1;
   --#{$button}--border--offset: 0;
@@ -168,7 +168,7 @@
   --#{$button}--m-plain--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$button}--m-plain--m-clicked--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
   --#{$button}--m-plain--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
-  --#{$button}--m-plain--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$button}--m-plain--BorderColor: transparent;
   --#{$button}--m-plain--m-clicked--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$button}--m-plain--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
 


### PR DESCRIPTION
Fixes #7743

After experimentation, it seems that the perceived jankiness in the plain button hover animation was because we are animating in a 1px border. Because it's simply going from 0 to 1px, there is very room for intermediate states and so it seems jumpy. I've removed border-width from the transition properties. Now the plain button (and other) button borders will animate in based just on the color, but this seems to have a smoother feel.