### PR TITLE
fix(expandable-section): hide overflow when not expanded

### DIFF
--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -130,8 +130,6 @@
   &.pf-m-truncate {
     --#{$expandable-section}--Gap: var(--#{$expandable-section}--m-truncate--Gap);
     --#{$expandable-section}__content--TransitionDelay--hide: 0s;
-    --#{$expandable-section}__content--Opacity: 1;
-    --#{$expandable-section}__content--TranslateY: 0;
 
     &:not(.pf-m-expanded) .#{$expandable-section}__content {
       // stylelint-disable
@@ -167,7 +165,7 @@
     display: revert;
   }
 
-  .#{$expandable-section}:where(:not(.pf-m-truncate)) & {
+  .#{$expandable-section}:where(:not(.pf-m-truncate)) > & {
     max-height: var(--#{$expandable-section}__content--MaxHeight, 0);
     overflow: var(--#{$expandable-section}__content--Overflow, hidden);
     visibility: var(--#{$expandable-section}__content--Visibility, hidden);

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -129,6 +129,7 @@
 
   &.pf-m-truncate {
     --#{$expandable-section}--Gap: var(--#{$expandable-section}--m-truncate--Gap);
+    --#{$expandable-section}__content--TransitionDelay--hide: 0s;
 
     &:not(.pf-m-expanded) .#{$expandable-section}__content {
       // stylelint-disable

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -23,6 +23,7 @@
   --#{$expandable-section}__content--TransitionDelay--hide: var(--#{$expandable-section}__content--TransitionDuration--fade);
   --#{$expandable-section}__content--Opacity: 0;
   --#{$expandable-section}__content--TranslateY: 0;
+  --#{$expandable-section}__content--PaddingInlineStart: 0;
   --#{$expandable-section}--m-expand-top__content--TranslateY: 0;
   --#{$expandable-section}--m-expand-bottom__content--TranslateY: 0;
   --#{$expandable-section}--m-expanded__content--Opacity: 1;
@@ -158,8 +159,8 @@
 
 .#{$expandable-section}__content {
   max-width: var(--#{$expandable-section}__content--MaxWidth);
-  padding-block-end: var(--#{$expandable-section}__content--PaddingBlockEnd, 0);
-  padding-inline-start: var(--#{$expandable-section}__content--PaddingInlineStart, 0);
+  padding-block-end: var(--#{$expandable-section}__content--PaddingBlockEnd, 0); // TODO remove in breaking change
+  padding-inline-start: var(--#{$expandable-section}__content--PaddingInlineStart);
 
   &:where([hidden]) {
     display: revert;

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -130,6 +130,8 @@
   &.pf-m-truncate {
     --#{$expandable-section}--Gap: var(--#{$expandable-section}--m-truncate--Gap);
     --#{$expandable-section}__content--TransitionDelay--hide: 0s;
+    --#{$expandable-section}__content--Opacity: 1;
+    --#{$expandable-section}__content--TranslateY: 0;
 
     &:not(.pf-m-expanded) .#{$expandable-section}__content {
       // stylelint-disable

--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -79,6 +79,7 @@
     --#{$expandable-section}__content--Opacity: var(--#{$expandable-section}--m-expanded__content--Opacity);
     --#{$expandable-section}__content--TranslateY: var(--#{$expandable-section}--m-expanded__content--TranslateY);
     --#{$expandable-section}__content--Visibility: auto;
+    --#{$expandable-section}__content--Overflow: visible;
     --#{$expandable-section}__content--MaxHeight: 99999px;
     --#{$expandable-section}__content--TransitionDelay--hide: 0s;
 
@@ -165,6 +166,7 @@
 
   .#{$expandable-section}:where(:not(.pf-m-truncate)) & {
     max-height: var(--#{$expandable-section}__content--MaxHeight, 0);
+    overflow: var(--#{$expandable-section}__content--Overflow, hidden);
     visibility: var(--#{$expandable-section}__content--Visibility, hidden);
     opacity: var(--#{$expandable-section}__content--Opacity);
     transition-delay: 0s, 0s, var(--#{$expandable-section}__content--TransitionDelay--hide, 0s), var(--#{$expandable-section}__content--TransitionDelay--hide, 0s);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7746
fixes https://github.com/patternfly/patternfly/issues/7767

You can replicate the bug by adding `overflow: auto` to `.ws-preview-html` (the element that wraps examples) on the docs site. Validated in react that the animations still work as expected and it doesn't conflict with `overflow: hidden` needed in the truncate/line-clamp variation.

Also addressed nested truncated issues from https://github.com/patternfly/patternfly/issues/7767. There were 2 issues:
* nested truncate variant's content had `opacity: 0` so content didn't show up unless it was expanded
* content was offset with `translateY` when not expanded

Also addressed 2 small bugs:
* In truncate variation, when you collapse the expandable section, the `gap` is removed but only after a delay. Disabled that transition-delay for truncate since it doesn't animate open/closed.
* Fixed issue where `isIndented` was being inherited by nested expandable sections and shouldn't be.