### PR TITLE
fix(toggle-group): added forced colors selected borders

### DIFF
--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -14,6 +14,7 @@
   --#{$toggle-group}__button--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
   --#{$toggle-group}__button--hover--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--hover--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toggle-group}__button--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--default);
 
@@ -116,6 +117,7 @@
 
   // forced-colors borders
   &::after {
+    inset: var(--#{$toggle-group}__button--before--BorderWidth);
     border-color: var(--#{$toggle-group}__button--after--BorderColor, transparent);
     border-width: var(--#{$toggle-group}__button--after--BorderWidth, 0);
   }
@@ -124,6 +126,7 @@
     --#{$toggle-group}__button--BackgroundColor: var(--#{$toggle-group}__button--hover--BackgroundColor);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--hover--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--hover--before--BorderColor);
+    --#{$toggle-group}__button--after--BorderWidth: var(--#{$toggle-group}__button--hover--after--BorderWidth);
 
     text-decoration-line: none;
   }

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -31,14 +31,15 @@
   --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--default);
   --#{$toggle-group}__button--m-selected--Color: var(--pf-t--global--text--color--on-brand--default);
   --#{$toggle-group}__button--m-selected--before--BorderColor: var(--pf-t--global--border--color--clicked);
-  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--alt);
   --#{$toggle-group}__button--m-selected--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$toggle-group}__button--m-selected--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--strong);
 
   // disabled
   --#{$toggle-group}__button--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$toggle-group}__button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$toggle-group}__button--disabled--before--BorderColor: var(--pf-t--global--border--color--disabled);
-  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--disabled);
   --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Compact
@@ -68,21 +69,15 @@
 
   &:first-child {
     .#{$toggle-group}__button {
-      &,
-      &::before {
-        border-start-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderStartStartRadius);
-        border-end-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderEndStartRadius);
-      }
+      border-start-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderStartStartRadius);
+      border-end-start-radius: var(--#{$toggle-group}__item--first-child__button--BorderEndStartRadius);
     }
   }
 
   &:last-child {
     .#{$toggle-group}__button {
-      &,
-      &::before {
-        border-start-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderStartEndRadius);
-        border-end-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderEndEndRadius);
-      }
+      border-start-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderStartEndRadius);
+      border-end-end-radius: var(--#{$toggle-group}__item--last-child__button--BorderEndEndRadius);
     }
   }
 }
@@ -101,20 +96,28 @@
   background-color: var(--#{$toggle-group}__button--BackgroundColor);
   border: 0;
 
-  &::before {
+  &::before,
+  &::after {
     position: absolute;
-    inset-block-start: 0;
-    inset-block-end: 0;
-    inset-inline-start: 0;
-    inset-inline-end: 0;
+    inset: 0;
     pointer-events: none;
     content: "";
     border-style: solid;
+    border-radius: inherit;
+  }
+
+  &::before {
     border-width: var(--#{$toggle-group}__button--before--BorderWidth);
     border-block-start-color: var(--#{$toggle-group}__button--before--BorderBlockStartColor, var(--#{$toggle-group}__button--before--BorderColor));
     border-block-end-color: var(--#{$toggle-group}__button--before--BorderBlockEndColor, var(--#{$toggle-group}__button--before--BorderColor));
     border-inline-start-color: var(--#{$toggle-group}__button--before--BorderInlineStartColor, var(--#{$toggle-group}__button--before--BorderColor));
     border-inline-end-color: var(--#{$toggle-group}__button--before--BorderInlineEndColor, var(--#{$toggle-group}__button--before--BorderColor));
+  }
+
+  // forced-colors borders
+  &::after {
+    border-color: var(--#{$toggle-group}__button--after--BorderColor, transparent);
+    border-width: var(--#{$toggle-group}__button--after--BorderWidth, 0);
   }
 
   &:is(:hover, :focus) {
@@ -130,6 +133,7 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--m-selected--Color, inherit);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--m-selected--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--m-selected--before--BorderColor);
+    --#{$toggle-group}__button--after--BorderWidth: var(--#{$toggle-group}__button--m-selected--after--BorderWidth);
   }
 
   &:is(:disabled, .pf-m-disabled) {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7837

@lboehling needs some design feedback on this one. Updated selected toggles to have an additional border. It isn't very visible IMO:

<img width="292" height="287" alt="Screenshot 2025-09-18 at 5 51 52 PM" src="https://github.com/user-attachments/assets/e78b138d-abae-4a39-95eb-88d70d2cd6bd" />

We could add a hover border-width change of 1px and increase the selected state to 2px? Here's what that would look like with "option 1" on the third row hovered

<img width="317" height="282" alt="Screenshot 2025-09-18 at 6 01 18 PM" src="https://github.com/user-attachments/assets/c60eadba-bb7a-412f-b1da-b86f5ea118a3" />

The only thing that looks bad with that is the compact variant, feels kinda squished, but maybe it's ok?

<img width="272" height="167" alt="Screenshot 2025-09-18 at 6 01 29 PM" src="https://github.com/user-attachments/assets/0c4dd245-d658-40c7-a223-8551440f9389" />

----

Also updated the border between 2 selected toggles to use the `border--color--alt` token (like we updated with primary split toggles), and the border between 2 disabled toggles to use the disabled border color. The disabled border has less contrast than the regular border, but seems like the more correct use of the token? That border matches the other borders around the disabled toggles in a toggle group when it didn't before. Curious what you think of those changes

This is before the change in HC:
<img width="312" height="316" alt="Screenshot 2025-09-18 at 4 57 57 PM" src="https://github.com/user-attachments/assets/3c4b75cc-7ce0-4676-9911-60aee47615b1" />

This is after the change:
<img width="296" height="312" alt="Screenshot 2025-09-18 at 4 58 13 PM" src="https://github.com/user-attachments/assets/c71fb7cc-b961-41ee-bf87-3ec92e4ebaa5" />

