### PR TITLE
feat(Pagination): updated top mobile view

### DIFF
--- a/src/patternfly/components/Pagination/examples/Pagination.md
+++ b/src/patternfly/components/Pagination/examples/Pagination.md
@@ -8,6 +8,7 @@ cssPrefix: pf-v6-c-pagination
 ### Top
 ```hbs
 {{#> pagination}}
+  {{> pagination-total-items-content}}
   {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-top-example"}}
   {{> pagination-nav-content pagination-nav--aria-label="Pagination nav - top example"}}
 {{/pagination}}
@@ -95,8 +96,18 @@ cssPrefix: pf-v6-c-pagination
 ### Compact
 ```hbs
 {{#> pagination pagination--IsCompact="true"}}
+  {{> pagination-total-items-content}}
   {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-compact-example"}}
   {{> pagination-nav-content pagination-nav--aria-label="Pagination nav - compact example"}}
+{{/pagination}}
+```
+
+### Compact on mobile
+```hbs
+{{#> pagination pagination--modifier="pf-m-compact-on-mobile"}}
+  {{> pagination-total-items-content}}
+  {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-compact-mobile-example"}}
+  {{> pagination-nav-content pagination-nav--aria-label="Pagination nav - compact on mobile example"}}
 {{/pagination}}
 ```
 
@@ -170,6 +181,7 @@ cssPrefix: pf-v6-c-pagination
 | `.pf-m-display-full{-on-[breakpoint]}` | `.pf-v6-c-pagination` | Modifies for full display pagination component styles at optional [breakpoint](/tokens/all-patternfly-tokens). |
 | `.pf-m-bottom` | `.pf-v6-c-pagination` | Modifies for bottom pagination component styles. |
 | `.pf-m-compact` | `.pf-v6-c-pagination` | Modifies for compact pagination component styles. |
+| `.pf-m-compact-on-mobile` | `.pf-v6-c-pagination` | Modifies for compact pagination component styles on mobile only. |
 | `.pf-m-static` | `.pf-v6-c-pagination.pf-m-bottom` | Modifies bottom pagination to not be positioned sticky on summary. |
 | `.pf-m-sticky` | `.pf-v6-c-pagination` | Modifies the pagination to be sticky to its container. It will be sticky to the top of the container by default, and sticky to the bottom of the container when applied to `.pf-v6-c-pagination.pf-m-bottom`. |
 | `.pf-m-inset-{none, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-v6-c-pagination` | Modifies pagination horizontal padding at optional [breakpoint](/tokens/all-patternfly-tokens). |

--- a/src/patternfly/components/Pagination/examples/Pagination.md
+++ b/src/patternfly/components/Pagination/examples/Pagination.md
@@ -8,7 +8,6 @@ cssPrefix: pf-v6-c-pagination
 ### Top
 ```hbs
 {{#> pagination}}
-  {{> pagination-total-items-content}}
   {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-top-example"}}
   {{> pagination-nav-content pagination-nav--aria-label="Pagination nav - top example"}}
 {{/pagination}}
@@ -87,7 +86,7 @@ cssPrefix: pf-v6-c-pagination
 ### Top disabled
 ```hbs
 {{#> pagination}}
-  {{> pagination-total-items-content}}
+  {{> pagination-total-items-content pagination-menu-toggle--IsDisabled=true pagination-nav-content--IsDisabled=true }}
   {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-top-disabled-example" pagination-menu-toggle--IsDisabled=true}}
   {{> pagination-nav-content pagination-nav-content--IsDisabled="true"  pagination-nav--aria-label="Pagination nav - top disabled example"}}
 {{/pagination}}
@@ -96,7 +95,6 @@ cssPrefix: pf-v6-c-pagination
 ### Compact
 ```hbs
 {{#> pagination pagination--IsCompact="true"}}
-  {{> pagination-total-items-content}}
   {{> pagination-menu-toggle pagination-menu-toggle--id="pagination-menu-toggle-compact-example"}}
   {{> pagination-nav-content pagination-nav--aria-label="Pagination nav - compact example"}}
 {{/pagination}}

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -17,29 +17,26 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}__nav--Display: none;
   --#{$pagination}--m-compact-mobile__nav--Display: inline-flex;
   --#{$pagination}--m-display-summary__nav--Display: none;
-  --#{$pagination}--m-compact__nav--Display: inline-flex;
   --#{$pagination}--m-display-full__nav--Display: inline-flex;
   --#{$pagination}__nav--ColumnGap: var(--pf-t--global--spacer--sm);
 
   // nav control
-  --#{$pagination}__nav-control--m-first--Display: none;
-  --#{$pagination}__nav-control--m-first--md--Display: block;
-  --#{$pagination}__nav-control--m-last--Display: none;
-  --#{$pagination}__nav-control--m-last--md--Display: block;
+  --#{$pagination}--m-compact-mobile__nav-control--m-first--Display: none;
+  --#{$pagination}--m-compact-mobile__nav-control--m-last--Display: none;
 
   // nav page select
-  --#{$pagination}__nav-page-select--Display: none;
-  --#{$pagination}__nav-page-select--md--Display: flex;
   --#{$pagination}__nav-page-select--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$pagination}__nav-page-select--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$pagination}__nav-page-select--c-form-control--width-base: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--border--width--control--default) * 2);
   --#{$pagination}__nav-page-select--c-form-control--width-chars: 2;
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
+  --#{$pagination}--m-compact-mobile__nav-page-select--Display: none;
 
   // total items
   --#{$pagination}__total-items--Display: block;
   --#{$pagination}--m-display-summary__total-items--Display: block;
   --#{$pagination}--m-display-full__total-items--Display: none;
+  --#{$pagination}--m-compact-mobile__total-items--Display: none;
 
   // top
   --#{$pagination}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -82,9 +79,6 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
     --#{$pagination}__page-menu--Display: var(--#{$pagination}__page-menu--md--Display);
     --#{$pagination}__nav--Display: inline-flex;
-    --#{$pagination}__nav-page-select--Display: var(--#{$pagination}__nav-page-select--md--Display);
-    --#{$pagination}__nav-control--m-first--Display: var(--#{$pagination}__nav-control--m-first--md--Display);
-    --#{$pagination}__nav-control--m-last--Display: var(--#{$pagination}__nav-control--m-last--md--Display);
     --#{$pagination}__total-items--Display: none;
   }
 
@@ -106,13 +100,14 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   border-block-end-width: var(--#{$pagination}--BorderBlockEndWidth);
 
   &.pf-m-compact-on-mobile {
-    --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-compact-mobile__page-menu--Display);
-    --#{$pagination}__nav--Display: var(--#{$pagination}--m-compact-mobile__nav--Display);
-  }
-
-  &.pf-m-compact:not(.pf-m-compact-on-mobile) {
-    --#{$pagination}__nav--Display: inline-flex;
-    --#{$pagination}__page-menu--Display: block;
+    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--md)) {
+      --#{$pagination}__total-items--Display: var(--#{$pagination}--m-compact-mobile__total-items--Display);
+      --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-compact-mobile__page-menu--Display);
+      --#{$pagination}__nav--Display: var(--#{$pagination}--m-compact-mobile__nav--Display);
+      --#{$pagination}__nav-page-select--Display: var(--#{$pagination}--m-compact-mobile__nav-page-select--Display);
+      --#{$pagination}__nav-control--m-first--Display: var(--#{$pagination}--m-compact-mobile__nav-control--m-first--Display);
+      --#{$pagination}__nav-control--m-last--Display: var(--#{$pagination}--m-compact-mobile__nav-control--m-last--Display);
+    }
   }
 
   .#{$pagination}__page-menu {
@@ -226,17 +221,17 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   @include pf-v6-mirror-inline-on-rtl;
 
   &.pf-m-first {
-    display: var(--#{$pagination}__nav-control--m-first--Display)
+    display: var(--#{$pagination}__nav-control--m-first--Display, revert);
   }
 
   &.pf-m-last {
-    display: var(--#{$pagination}__nav-control--m-last--Display)
+    display: var(--#{$pagination}__nav-control--m-last--Display, revert);
   }
 }
 
 // nav page element
 .#{$pagination}__nav-page-select {
-  display: var(--#{$pagination}__nav-page-select--Display);
+  display: var(--#{$pagination}__nav-page-select--Display, flex);
   column-gap: var(--#{$pagination}__nav-page-select--ColumnGap);
   align-items: center;
 
@@ -265,12 +260,14 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
     @include pf-v6-apply-breakpoint($breakpoint) {
+      // TODO - remove in breaking change
       &.pf-m-display-summary#{$breakpoint-name} {
         --#{$pagination}__nav--Display: var(--#{$pagination}--m-display-summary__nav--Display);
         --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-display-summary__page-menu--Display);
         --#{$pagination}__total-items--Display: var(--#{$pagination}--m-display-summary__total-items--Display);
       }
 
+      // TODO - remove in breaking change
       &.pf-m-display-full#{$breakpoint-name} {
         --#{$pagination}__nav--Display: var(--#{$pagination}--m-display-full__nav--Display);
         --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-display-full__page-menu--Display);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -14,12 +14,21 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-page-insets--inset: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--border--width--main--default));
 
   // nav
-  --#{$pagination}__nav--Display: none;
+  --#{$pagination}__nav--Display: inline-flex;
   --#{$pagination}--m-display-summary__nav--Display: none;
+  --#{$pagination}--m-compact__nav--Display: inline-flex;
   --#{$pagination}--m-display-full__nav--Display: inline-flex;
   --#{$pagination}__nav--ColumnGap: var(--pf-t--global--spacer--sm);
 
+  // nav control
+  --#{$pagination}__nav-control--m-first--Display: none;
+  --#{$pagination}__nav-control--m-first--md--Display: block;
+  --#{$pagination}__nav-control--m-last--Display: none;
+  --#{$pagination}__nav-control--m-last--md--Display: block;
+
   // nav page select
+  --#{$pagination}__nav-page-select--Display: none;
+  --#{$pagination}__nav-page-select--md--Display: flex;
   --#{$pagination}__nav-page-select--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$pagination}__nav-page-select--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$pagination}__nav-page-select--c-form-control--width-base: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--spacer--control--horizontal--default) + var(--pf-t--global--border--width--control--default) * 2);
@@ -27,8 +36,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
 
   // total items
-  --#{$pagination}__total-items--Display: block;
-  --#{$pagination}--m-display-summary__total-items--Display: block;
+  --#{$pagination}__total-items--Display: flex;
+  --#{$pagination}--m-display-summary__total-items--Display: flex;
   --#{$pagination}--m-display-full__total-items--Display: none;
 
   // top
@@ -60,7 +69,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   // page menu
   --#{$pagination}__page-menu--Display--base: block;
-  --#{$pagination}__page-menu--Display: none;
+  --#{$pagination}__page-menu--Display: block;
   --#{$pagination}--m-display-summary__page-menu--Display: none;
   --#{$pagination}--m-display-full__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
   --#{$pagination}--m-bottom__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
@@ -71,6 +80,9 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     --#{$pagination}--m-bottom--BorderBlockStartWidth: 0;
     --#{$pagination}__page-menu--Display: var(--#{$pagination}__page-menu--md--Display);
     --#{$pagination}__nav--Display: inline-flex;
+    --#{$pagination}__nav-page-select--Display: var(--#{$pagination}__nav-page-select--md--Display);
+    --#{$pagination}__nav-control--m-first--Display: var(--#{$pagination}__nav-control--m-first--md--Display);
+    --#{$pagination}__nav-control--m-last--Display: var(--#{$pagination}__nav-control--m-last--md--Display);
     --#{$pagination}__total-items--Display: none;
   }
 
@@ -200,11 +212,19 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 // nav control
 .#{$pagination}__nav-control {
   @include pf-v6-mirror-inline-on-rtl;
+
+  &.pf-m-first {
+    display: var(--#{$pagination}__nav-control--m-first--Display)
+  }
+
+  &.pf-m-last {
+    display: var(--#{$pagination}__nav-control--m-last--Display)
+  }
 }
 
 // nav page element
 .#{$pagination}__nav-page-select {
-  display: flex;
+  display: var(--#{$pagination}__nav-page-select--Display);
   column-gap: var(--#{$pagination}__nav-page-select--ColumnGap);
   align-items: center;
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -14,7 +14,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-page-insets--inset: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--border--width--main--default));
 
   // nav
-  --#{$pagination}__nav--Display: inline-flex;
+  --#{$pagination}__nav--Display: none;
+  --#{$pagination}--m-compact-mobile__nav--Display: inline-flex;
   --#{$pagination}--m-display-summary__nav--Display: none;
   --#{$pagination}--m-compact__nav--Display: inline-flex;
   --#{$pagination}--m-display-full__nav--Display: inline-flex;
@@ -36,8 +37,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}__nav-page-select--c-form-control--Width: calc(var(--#{$pagination}__nav-page-select--c-form-control--width-base) + (var(--#{$pagination}__nav-page-select--c-form-control--width-chars) * 1ch));
 
   // total items
-  --#{$pagination}__total-items--Display: flex;
-  --#{$pagination}--m-display-summary__total-items--Display: flex;
+  --#{$pagination}__total-items--Display: block;
+  --#{$pagination}--m-display-summary__total-items--Display: block;
   --#{$pagination}--m-display-full__total-items--Display: none;
 
   // top
@@ -69,7 +70,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   // page menu
   --#{$pagination}__page-menu--Display--base: block;
-  --#{$pagination}__page-menu--Display: block;
+  --#{$pagination}__page-menu--Display: none;
+  --#{$pagination}--m-compact-mobile__page-menu--Display: block;
   --#{$pagination}--m-display-summary__page-menu--Display: none;
   --#{$pagination}--m-display-full__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
   --#{$pagination}--m-bottom__page-menu--Display: var(--#{$pagination}__page-menu--Display--base);
@@ -102,6 +104,11 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   border: 0 solid var(--#{$pagination}--BorderColor);
   border-block-start-width: var(--#{$pagination}--BorderBlockStartWidth);
   border-block-end-width: var(--#{$pagination}--BorderBlockEndWidth);
+
+  &.pf-m-compact-on-mobile {
+    --#{$pagination}__page-menu--Display: var(--#{$pagination}--m-compact-mobile__page-menu--Display);
+    --#{$pagination}__nav--Display: var(--#{$pagination}--m-compact-mobile__nav--Display);
+  }
 
   .#{$pagination}__page-menu {
     display: var(--#{$pagination}__page-menu--Display);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -110,6 +110,11 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
     --#{$pagination}__nav--Display: var(--#{$pagination}--m-compact-mobile__nav--Display);
   }
 
+  &.pf-m-compact:not(.pf-m-compact-on-mobile) {
+    --#{$pagination}__nav--Display: inline-flex;
+    --#{$pagination}__page-menu--Display: block;
+  }
+
   .#{$pagination}__page-menu {
     display: var(--#{$pagination}__page-menu--Display);
   }


### PR DESCRIPTION
Closes #7852 

Draft for now as there's some css cleanup and example updates still to be made if this looks good.

I'm leveraging the existing css media queries to show/hide stuff as needed to visually achieve the compact view of Pagination. This ends up making the `__total-items` container not needed - unless we want to allow a consumer to opt into this new display. If we want that instead, we could maybe add a modifier class (`pf-m-compact-on-mobile` or something,.

I have things setup so that the applicable pagination controls have display none for mobile viewports, so nothing is being repeated in the DOM, and this should trickle down to React where any additional props a consumer is passing in will remain on the applicable controls.
