### PR TITLE
fix(divider): adds border to make visible in forced colors

### DIFF
--- a/src/patternfly/components/Divider/divider.scss
+++ b/src/patternfly/components/Divider/divider.scss
@@ -43,6 +43,8 @@ $pf-v6-c-divider--spacer-map: build-spacer-map("none", "xs", "sm", "md", "lg", "
     flex-basis: var(--#{$divider}--before--FlexBasis);
     content: "";
     background-color: var(--#{$divider}--Color);
+    border-block-start: var(--#{$divider}--Size) solid transparent;
+    border-inline-start: var(--#{$divider}--Size) solid transparent;
   }
 
   // - Divider horizontal


### PR DESCRIPTION
Fixes #7840 

Adds a transparent border to the divider pseudo that is the visible part of the divider, so that it shows up in forced colors.