### PR TITLE
fix(card): use high contrast border for secondary

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -98,6 +98,7 @@
   // Secondary
   --#{$card}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$card}--m-secondary--BorderColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$card}--m-secondary--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
 
   // Full height
   --#{$card}--m-full-height--Height: 100%;
@@ -221,6 +222,7 @@
 
   &.pf-m-secondary {
     --#{$card}--BorderColor: var(--#{$card}--m-secondary--BorderColor);
+    --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
   }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7865

Visual regressions showed no differences. This just uses the more technically correct token for border-width.