### PR TITLE
fix(DragDrop): Updated to use grab cursor for draggable items by default

### DIFF
--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -1,7 +1,7 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($draggable) {
-  --#{$draggable}--Cursor: auto;
+  --#{$draggable}--Cursor: grab;
   --#{$draggable}--m-dragging--Cursor: grabbing;
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$draggable}--m-dragging--BackgroundColor: transparent;


### PR DESCRIPTION
Updated to use `grab` cursor for draggable items by default.  Use `grabbing` only when `pf-m-dragging` modifier is applied.

closes: #7882 