### PR TITLE
fix(Button): updated AriaExpanded to apply correctly

### DIFF
--- a/src/patternfly/components/Alert/alert-toggle.hbs
+++ b/src/patternfly/components/Alert/alert-toggle.hbs
@@ -5,7 +5,7 @@
   {{> button
     button--IsPlain=true
     button--IsIcon=true
-    button--AriaExpanded=alert--IsExpanded
+    button--AriaExpanded=(ternary alert--IsExpanded alert--IsExpanded false)
     button--id=(concat alert--id '-toggle')
     button--aria-label="Details"
     button--aria-labelledby=(concat alert--id '-title ' alert--id '-toggle')

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -43,7 +43,10 @@
       type="button"
     {{/unless}}
   {{/if}}
-  {{#if button--AriaExpanded}}
+  {{!-- For now we need to concat this for cases where a boolean true or boolean false are passed
+  to button--AriaExpanded, so that aria-expanded gets set correctly, and where passing a string "false"
+  may cause other hbs attributes (e.g. jump-links--IsExpanded) to render a pf-m-expanded class incorrectly. --}}
+  {{#if (concat button--AriaExpanded)}}
     aria-expanded="{{button--AriaExpanded}}"
   {{/if}}
   {{#if button--role}}

--- a/src/patternfly/components/Button/notification-badge.hbs
+++ b/src/patternfly/components/Button/notification-badge.hbs
@@ -1,5 +1,5 @@
 {{#> button
-  button--AriaExpanded=notification-badge--IsExpanded
+  button--AriaExpanded=(ternary notification-badge--IsExpanded notification-badge--IsExpanded false)
   button--IsClicked=notification-badge--IsExpanded
   button--IsStateful=true
   button--aria-label=notification-badge--aria-label

--- a/src/patternfly/components/ExpandableSection/expandable-section-toggle.hbs
+++ b/src/patternfly/components/ExpandableSection/expandable-section-toggle.hbs
@@ -5,7 +5,7 @@
   {{#> button
     button--IsLink=true
     button--IsInline=expandable-section--IsTruncate
-    button--AriaExpanded=expandable-section--IsExpanded
+    button--AriaExpanded=(ternary expandable-section--IsExpanded expandable-section--IsExpanded false)
     button--aria-controls=(ternary expandable-section--id (concat expandable-section--id '-content') null)
     button--id=(concat expandable-section--id '-toggle')
     button--icon-template=(ternary expandable-section--IsTruncate null "expandable-section-toggle-icon")}}

--- a/src/patternfly/components/Form/form-field-group-toggle-button.hbs
+++ b/src/patternfly/components/Form/form-field-group-toggle-button.hbs
@@ -6,7 +6,7 @@
     button--IsPlain=true
     button--IsIcon=true
     button--icon-template="form-field-group-toggle-icon"
-    button--AriaExpanded=form-field-group--IsExpanded
+    button--AriaExpanded=(ternary form-field-group--IsExpanded form-field-group--IsExpanded false)
     button--aria-label="Details"
     button--aria-labelledby=(concat form-field-group--id '-title ' form-field-group--id '-toggle')
     button--id=(concat form-field-group--id '-toggle')}}

--- a/src/patternfly/components/JumpLinks/jump-links-header.hbs
+++ b/src/patternfly/components/JumpLinks/jump-links-header.hbs
@@ -4,7 +4,7 @@
   {{/if}}>
   {{#if jump-links--IsExpandable}}
     {{#> jump-links-toggle}}
-      {{#> button button--IsPlain=true button--icon-template="jump-links-toggle-icon" button--IsAriaExpanded=jump-links--IsExpanded}}
+      {{#> button button--IsPlain=true button--icon-template="jump-links-toggle-icon" button--AriaExpanded=(ternary jump-links--IsExpanded jump-links--IsExpanded false)}}
         {{#if @partial-block}}
           {{> @partial-block}}
         {{else}}

--- a/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
+++ b/src/patternfly/components/Table/TableCells/table-cell-toggle.hbs
@@ -4,7 +4,7 @@
     button--IsPlain=true
     button--IsIcon=true
     button--icon-template="table-toggle-icon"
-    button--AriaExpanded=table-tr--IsExpanded
+    button--AriaExpanded=(ternary table-tr--IsExpanded table-tr--IsExpanded false)
     button--modifier=(ternary table-tr--IsExpanded "pf-m-expanded" "")
     button--aria-describedby=table-tr--IsExpanded
     button--aria-label=(ternary IsThead 'Toggle all rows' 'Toggle row')

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -44,7 +44,7 @@
           button--IsPlain=true
           button--IsIcon=true
           button--icon-template="table-toggle-icon"
-          button--AriaExpanded=table-tr--IsExpanded
+          button--AriaExpanded=(ternary table-tr--IsExpanded table-tr--IsExpanded false)
           button--modifier=(ternary table-tr--IsExpanded "pf-m-expanded" "")
           button--id=(concat table--id '-expandable-toggle-' table-td--row-index)
           button--aria-label="Details"

--- a/src/patternfly/components/Table/table-tree-view-details-toggle.hbs
+++ b/src/patternfly/components/Table/table-tree-view-details-toggle.hbs
@@ -5,7 +5,7 @@
   {{> button
     button--IsPlain=true
     button--IsIcon=true
-    button--AriaExpanded=table-tr--details--IsExpanded
+    button--AriaExpanded=(ternary table-tr--details--IsExpanded table-tr--details--IsExpanded false)
     button--icon-template="table-details-toggle-icon"
     button--aria-label=(concat table--id '-' table-tr--tree--index '--tree-table--details-toggle')}}
 </span>

--- a/src/patternfly/components/Tabs/tabs-toggle-button.hbs
+++ b/src/patternfly/components/Tabs/tabs-toggle-button.hbs
@@ -7,8 +7,8 @@
     button--icon-template="tabs-toggle-icon"
     button--IsIcon=tabs--IsLegacy
     button--aria-label="Details"
-    button--AriaExpanded=tabs--IsExpanded
-    button--attribute=(concat 'aria-label="Details" aria-expanded="true" id="' tabs--id '-toggle-button" aria-labelledby="' tabs--id '-toggle-text ' tabs--id '-toggle-button"')}}
+    button--AriaExpanded=(ternary tabs--IsExpanded tabs--IsExpanded false)
+    button--attribute=(concat 'aria-label="Details" id="' tabs--id '-toggle-button" aria-labelledby="' tabs--id '-toggle-text ' tabs--id '-toggle-button"')}}
     {{#unless tabs--IsLegacy}}
       {{> tabs-toggle-text}}
     {{/unless}}


### PR DESCRIPTION
Closes #7892

Tried going for the quicker solution for now:

- Updated Button hbs so that the `if` block for button--AriaExpanded uses the concat helper; this should apply aria-expanded correctly when button--AriaExpanded is passed a boolean false value as well as a truthy value
- Added ternary helpers to components using button--AriaExpanded to have false as a fallback

Just need douible checked in reivew:

- aria-expanded is set with a true or false value for expandable ~things~ (true when expanded, false when collapsed)
- aria-expanded isn't incorrectly rendered if the ~thing~ isn't expandable (e.g. a basic primary button shouldn't have aria-expanded)

I also added a comment for the concat helper I added for now, I think we could probably have a followup to clean up how we're passing in button--AriaExpanded based on other component attributes (e.g. jump-links--IsExpanded is explicitly passed a stringy "true", but needs to be passed a boolean `false` otherwise a stringy "false" will set `pf-m-expanded` on the jump links.