### PR TITLE
fix(Card): Update card with header wrap example to include .pf-v6-c-card__header-main`  wrapper around title

### DIFF
--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -87,7 +87,9 @@ import './Card.css'
       {{#> button button--modifier="pf-m-secondary"}}Secondary action{{/button}}
       {{#> button button--modifier="pf-m-tertiary"}}Tertiary action{{/button}}
     {{/card-actions}}
-    {{> card-title card-title-text--value="This is a longer card title that takes up more space"}}
+    {{#> card-header-main}}
+      {{> card-title card-title-text--value="This is a longer card title that takes up more space"}}
+    {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
     This is the card body


### PR DESCRIPTION
Update card with header wrap example to include `.pf-v6-c-card__header-main`  wrapper around title.

closes: #7474