### PR TITLE
fix(progress): Fixed to use fa-exclamation-circle for failure/danger status

### DIFF
--- a/src/patternfly/components/Progress/progress-status.hbs
+++ b/src/patternfly/components/Progress/progress-status.hbs
@@ -16,6 +16,6 @@
     {{#> progress-status-icon progress-status-icon--type="exclamation-triangle"}}{{/progress-status-icon}}
   {{/if}}
   {{#if progress--danger}}
-    {{#> progress-status-icon progress-status-icon--type="times-circle"}}{{/progress-status-icon}}
+    {{#> progress-status-icon progress-status-icon--type="exclamation-circle"}}{{/progress-status-icon}}
   {{/if}}
 </div>


### PR DESCRIPTION
Fixed to use fa-exclamation-circle for failure/danger status

closes: #7773 