### PR TITLE
fix(drawer): fix primary-detail pattern drawer header

### DIFF
--- a/src/patternfly/components/Drawer/drawer-body.hbs
+++ b/src/patternfly/components/Drawer/drawer-body.hbs
@@ -1,6 +1,6 @@
 <div class="{{pfv}}drawer__body
   {{~#if drawer-body--HasPadding}}
-    pf-m-paddinng
+    pf-m-padding
   {{/if}}
   {{~#if drawer-body--modifier}}
     {{drawer-body--modifier}}

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -185,7 +185,7 @@ import './Drawer.css'
       {{#> drawer-body}}
         Drawer panel body content
       {{/drawer-body}}
-      {{#> drawer-body drawer-body--HasPadding=true drawer-body--attribute="style='--pf-v6-c-drawer__panel__body--PaddingInlineStart: 48px;'"}}
+      {{#> drawer-body drawer-body--attribute="style='--pf-v6-c-drawer__panel__body--PaddingInlineStart: 48px;'"}}
         Drawer panel body content with modified inline start padding
       {{/drawer-body}}
     {{/drawer-panel}}

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -194,15 +194,14 @@ import './Wizard.css'
               {{/wizard-main-body}}
             {{/drawer-content}}
             {{#> drawer-panel drawer-panel--modifier="pf-m-width-33"}}
+              {{#> drawer-head}}
+                drawer-panel
+                {{#> drawer-actions}}
+                  {{> drawer-close}}
+                {{/drawer-actions}}
+              {{/drawer-head}}
               {{#> drawer-body}}
-                {{#> drawer-head}}
-                  {{#> drawer-actions}}
-                    {{> drawer-close}}
-                  {{/drawer-actions}}
-                  {{#> drawer-header}}
-                    drawer-panel
-                  {{/drawer-header}}
-                {{/drawer-head}}
+                drawer-body
               {{/drawer-body}}
             {{/drawer-panel}}
           {{/drawer-main}}

--- a/src/patternfly/demos/Page/page-template-drawer-panel.hbs
+++ b/src/patternfly/demos/Page/page-template-drawer-panel.hbs
@@ -1,22 +1,20 @@
 {{#> drawer-panel drawer-panel--modifier="pf-m-width-33-on-lg"}}
-  {{#> drawer-body}}
-    {{#> drawer-head}}
-      {{#> drawer-actions}}
-        {{> menu-toggle menu-toggle--IsPlain=true menu-toggle--HasKebab=true menu-toggle--id=(dasherize page-template--id 'toggle')}}
-        {{> drawer-close}}
-      {{/drawer-actions}}
-      {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
-        {{#> l-flex-item}}
-          {{> label label--id="default-blue" label--color="blue" label-text--value="DC" label--IsCompact=true}}
-        {{/l-flex-item}}
-        {{#> l-flex-item}}
-          {{#> title titleType="h2" title--modifier="pf-m-xl" title--attribute=(concat 'id="' page-template--id '-drawer-label"')}}
-            mary-test
-          {{/title}}
-        {{/l-flex-item}}
-      {{/l-flex}}
-    {{/drawer-head}}
-  {{/drawer-body}}
+  {{#> drawer-head}}
+    {{#> drawer-actions}}
+      {{> menu-toggle menu-toggle--IsPlain=true menu-toggle--HasKebab=true menu-toggle--id=(dasherize page-template--id 'toggle')}}
+      {{> drawer-close}}
+    {{/drawer-actions}}
+    {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+      {{#> l-flex-item}}
+        {{> label label--id="default-blue" label--color="blue" label-text--value="DC" label--IsCompact=true}}
+      {{/l-flex-item}}
+      {{#> l-flex-item}}
+        {{#> title titleType="h2" title--modifier="pf-m-xl" title--attribute=(concat 'id="' page-template--id '-drawer-label"')}}
+          mary-test
+        {{/title}}
+      {{/l-flex-item}}
+    {{/l-flex}}
+  {{/drawer-head}}
   {{#> drawer-body drawer-body--modifier="pf-m-no-padding"}}
     {{#> tabs tabs--modifier="pf-m-box pf-m-fill"}}
       {{#> tabs-list}}

--- a/src/patternfly/demos/PrimaryDetail/primary-detail-template-panel-header.hbs
+++ b/src/patternfly/demos/PrimaryDetail/primary-detail-template-panel-header.hbs
@@ -1,21 +1,17 @@
-{{#> drawer-body}}
-  {{#> l-flex l-flex--modifier="pf-m-column"}}
-    {{#> l-flex-item}}
-      {{#> drawer-head}}
-        {{#> drawer-actions}}
-          {{#unless drawer-panel--NoCloseButton}}
-            {{> drawer-close}}
-          {{/unless}}
-        {{/drawer-actions}}
-        {{#> title titleType="h2" title--modifier="pf-m-lg" title--attribute=(concat 'id="' primary-detail-template--id '-drawer-label"')}}
-          {{{primary-detail-template-panel-header--title}}}
-        {{/title}}
-      {{/drawer-head}}
-    {{/l-flex-item}}
-    {{#if primary-detail-template-panel-header--sub-title}}
-      {{#> l-flex-item}}
-        {{{primary-detail-template-panel-header--sub-title}}}
-      {{/l-flex-item}}
-    {{/if}}
-  {{/l-flex}}
-{{/drawer-body}}
+{{#> drawer-head}}
+  {{#> drawer-actions}}
+    {{#unless drawer-panel--NoCloseButton}}
+      {{> drawer-close}}
+    {{/unless}}
+  {{/drawer-actions}}
+  {{#> title titleType="h2" title--modifier="pf-m-lg" title--attribute=(concat 'id="' primary-detail-template--id '-drawer-label"')}}
+    {{{primary-detail-template-panel-header--title}}}
+  {{/title}}
+{{/drawer-head}}
+
+{{#if primary-detail-template-panel-header--sub-title}}
+  {{#> drawer-description}}
+    {{{primary-detail-template-panel-header--sub-title}}}
+  {{/drawer-description}}
+{{/if}}
+

--- a/src/patternfly/demos/Wizard/examples/Wizard.md
+++ b/src/patternfly/demos/Wizard/examples/Wizard.md
@@ -207,13 +207,13 @@ wrapperTag: div
                   {{/wizard-main-body}}
                 {{/drawer-content}}
                 {{#> drawer-panel drawer-panel--modifier="pf-m-width-33"}}
+                  {{#> drawer-head}}
+                    {{> title titleType="h2" title--modifier="pf-m-xl" title--text="Register with Red Hat connector"}}
+                    {{#> drawer-actions}}
+                      {{> drawer-close}}
+                    {{/drawer-actions}}
+                  {{/drawer-head}}
                   {{#> drawer-body}}
-                    {{#> drawer-head}}
-                      {{> title titleType="h2" title--modifier="pf-m-xl" title--text="Register with Red Hat connector"}}
-                      {{#> drawer-actions}}
-                        {{> drawer-close}}
-                      {{/drawer-actions}}
-                    {{/drawer-head}}
                   {{/drawer-body}}
                   {{#> drawer-body}}
                     {{#> content}}
@@ -288,14 +288,12 @@ wrapperTag: div
                   {{/wizard-main-body}}
                 {{/drawer-content}}
                 {{#> drawer-panel drawer-panel--modifier="pf-m-width-33"}}
-                  {{#> drawer-body}}
-                    {{#> drawer-head}}
-                      {{> title titleType="h2" title--modifier="pf-m-xl" title--text="Register with Red Hat connector"}}
-                      {{#> drawer-actions}}
-                        {{> drawer-close}}
-                      {{/drawer-actions}}
-                    {{/drawer-head}}
-                  {{/drawer-body}}
+                  {{#> drawer-head}}
+                    {{> title titleType="h2" title--modifier="pf-m-xl" title--text="Register with Red Hat connector"}}
+                    {{#> drawer-actions}}
+                      {{> drawer-close}}
+                    {{/drawer-actions}}
+                  {{/drawer-head}}
                   {{#> drawer-body}}
                     {{#> content}}
                       <p>


### PR DESCRIPTION
Fixes #7803 

• **Fixed CSS typo**: `pf-m-paddinng` → `pf-m-padding` in drawer-body.hbs
• **Removed unnecessary attribute**: `drawer-body--HasPadding=true` from Drawer.md example
• **Fixed drawer nesting**: Moved `drawer-head` out of `drawer-body` in page-template-drawer-panel.hbs
• **Simplified header structure**: Removed unnecessary flex layout in primary-detail-template-panel-header.hbs. It now uses `drawer-head` and `drawer-description` elements properly.

Just the description generated by cursor 😺 