### PR TITLE
feat(action-list): create vertical variant

### DIFF
--- a/src/patternfly/components/ActionList/action-list.hbs
+++ b/src/patternfly/components/ActionList/action-list.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}action-list{{#if action-list--modifier}} {{action-list--modifier}}{{/if}}"
+<div class="{{pfv}}action-list{{#if action-list--modifier}} {{action-list--modifier}}{{/if}}{{#if action-list--isVertical}} pf-m-vertical{{/if}}"
   {{#if action-list--attribute}}
     {{{action-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/ActionList/action-list.scss
+++ b/src/patternfly/components/ActionList/action-list.scss
@@ -6,6 +6,7 @@
 
   // * Action list group
   --#{$action-list}__group--ColumnGap: var(--pf-t--global--spacer--gap--action-to-action--default);
+  --#{$action-list}--m-vertical--RowGap: var(--pf-t--global--spacer--gap--group-to-group--vertical--default);
 
   // * Action list icons
   --#{$action-list}--m-icons--ColumnGap: var(--pf-t--global--spacer--gap--action-to-action--plain);
@@ -33,6 +34,11 @@
   &.pf-m-vertical,
   &.pf-m-vertical .#{$action-list}__group {
     flex-direction: column;
+  }
+
+  &.pf-m-vertical {
+    row-gap: var(--#{$action-list}--m-vertical--RowGap);
+  }
   }
 }
 

--- a/src/patternfly/components/ActionList/action-list.scss
+++ b/src/patternfly/components/ActionList/action-list.scss
@@ -39,7 +39,6 @@
   &.pf-m-vertical {
     row-gap: var(--#{$action-list}--m-vertical--RowGap);
   }
-  }
 }
 
 // - Action list group

--- a/src/patternfly/components/ActionList/action-list.scss
+++ b/src/patternfly/components/ActionList/action-list.scss
@@ -29,6 +29,11 @@
 
     column-gap: var(--#{$action-list}--m-icons--ColumnGap); // update prop: val to prevent potential inheritance conflicts
   }
+
+  &.pf-m-vertical,
+  &.pf-m-vertical .#{$action-list}__group {
+    flex-direction: column;
+  }
 }
 
 // - Action list group

--- a/src/patternfly/components/ActionList/examples/ActionList.md
+++ b/src/patternfly/components/ActionList/examples/ActionList.md
@@ -144,6 +144,58 @@ In wizards
 {{/action-list}}
 ```
 
+
+### Vertical action list
+```hbs
+Multiple groups
+{{#> action-list action-list--isVertical="true"}}
+  {{#> action-list-group}}
+    {{#> action-list-item}}
+      {{#> button button--IsPrimary=true}}
+        Next
+      {{/button}}
+    {{/action-list-item}}
+    {{#> action-list-item}}
+      {{#> button button--IsSecondary=true}}
+        Back
+      {{/button}}
+    {{/action-list-item}}
+  {{/action-list-group}}
+  {{#> action-list-group}}
+    {{#> action-list-item}}
+      {{#> button button--IsPrimary=true}}
+        Submit
+      {{/button}}
+    {{/action-list-item}}
+    {{#> action-list-item}}
+      {{#> button button--IsLink=true}}
+        Cancel
+      {{/button}}
+    {{/action-list-item}}
+  {{/action-list-group}}
+{{/action-list}}
+<br/ >
+Icons, in two groups
+{{#> action-list action-list--isVertical="true"}}
+  {{#> action-list-group action-list-group--modifier="pf-m-icons"}}
+    {{#> action-list-item}}
+      {{> button button--IsPlain=true button--aria-label="Close" button--icon="times"}}
+    {{/action-list-item}}
+    {{#> action-list-item}}
+      {{> button button--IsPlain=true button--aria-label="Toggle" button--IsIcon=true button--icon="check"}}
+    {{/action-list-item}}
+  {{/action-list-group}}
+  {{#> action-list-group action-list-group--modifier="pf-m-icons"}}
+    {{#> action-list-item}}
+      {{> button button--IsPlain=true button--aria-label="Close" button--IsIcon=true button--icon="times"}}
+    {{/action-list-item}}
+    {{#> action-list-item}}
+      {{> button button--IsPlain=true button--aria-label="Toggle" button--IsIcon=true button--icon="check"}}
+    {{/action-list-item}}
+  {{/action-list-group}}
+{{/action-list}}
+```
+
 ### Overview
 
 ### Usage
@@ -153,3 +205,4 @@ In wizards
 | `.pf-v6-c-action-list__item` | `<div>` | Initiates the action list item container. |
 | `.pf-v6-c-action-list__group` | `<div>` | Initiates the action list group container. |
 | `.pf-m-icons` | `.pf-v6-c-action-list`, `.pf-v6-c-action-list__group` | Modifies the action list and/or group to support icon buttons. If applied to `.pf-v6-c-action-list`, all nested groups will inherit this modification. |
+| `.pf-m-vertical` | `.pf-v6-c-action-list` | Modifies the action list to display vertically. |

--- a/src/patternfly/components/ActionList/examples/ActionList.md
+++ b/src/patternfly/components/ActionList/examples/ActionList.md
@@ -146,7 +146,7 @@ In wizards
 
 
 ### Vertical action list
-```hbs
+```hbs isBeta
 Multiple groups
 {{#> action-list action-list--isVertical="true"}}
   {{#> action-list-group}}


### PR DESCRIPTION
Fixes #7905 

Adds a `.pf-m-vertical` variant. Spacing between groups is provided. Vertical items are inline-start aligned (by default).