### PR TITLE
feat(Button): added circle variant

### DIFF
--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -59,23 +59,3 @@
 
   {{> button button--IsControl=true button--aria-label="Copy input" button--IsIcon=true button--icon="copy"}}
 {{/inline}}
-
-<br><br>
-
-<div><strong>Circle</strong></div>
-
-{{> button button--IsPrimary=true button--aria-label="Add primary circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsSecondary=true button--aria-label="Add secondary circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsTertiary=true button--aria-label="Add tertiary circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsDanger=true button--aria-label="Add danger circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsWarning=true button--aria-label="Add warning circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="plus-circle"}}
-
-{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="times"}}
-
-{{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="copy"}}

--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -64,18 +64,18 @@
 
 <div><strong>Circle</strong></div>
 
-{{> button button--IsPrimary=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsPrimary=true button--aria-label="Add primary circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsSecondary=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsSecondary=true button--aria-label="Add secondary circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsTertiary=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsTertiary=true button--aria-label="Add tertiary circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsDanger=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsDanger=true button--aria-label="Add danger circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsWarning=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsWarning=true button--aria-label="Add warning circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsLink=true button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="plus-circle"}}
 
-{{> button button--IsPlain=true button--IsCircle=true button--icon="times"}}
+{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="times"}}
 
-{{> button button--IsControl=true button--IsCircle=true button--icon="copy"}}
+{{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="copy"}}

--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -59,3 +59,23 @@
 
   {{> button button--IsControl=true button--aria-label="Copy input" button--IsIcon=true button--icon="copy"}}
 {{/inline}}
+
+<br><br>
+
+<div><strong>Circle</strong></div>
+
+{{> button button--IsPrimary=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsSecondary=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsTertiary=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsDanger=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsWarning=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsLink=true button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsPlain=true button--IsCircle=true button--icon="times"}}
+
+{{> button button--IsControl=true button--IsCircle=true button--icon="copy"}}

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -26,6 +26,7 @@
     button--IsBlock='pf-m-block'
     button--IsSettings='pf-m-settings'
     button--IsHamburger='pf-m-hamburger'
+    button--IsCircle='pf-m-circle'
     button--modifier=button--modifier
   }}
   {{#if button--IsDisabled}}

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -376,10 +376,11 @@
   --#{$button}--m-circle--ScaleX: 1.29;
   --#{$button}--m-circle--ScaleY: 1.29;
   --#{$button}--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
-  --#{$button}--m-circle--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$button}--m-circle--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
-  --#{$button}--m-circle--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
-  --#{$button}--m-circle--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--compact);
+  --#{$button}--m-circle--Padding--base: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--m-circle--PaddingBlockStart: var(--#{$button}--m-circle--Padding--base);
+  --#{$button}--m-circle--PaddingInlineEnd: 0;
+  --#{$button}--m-circle--PaddingBlockEnd: var(--#{$button}--m-circle--Padding--base);
+  --#{$button}--m-circle--PaddingInlineStart: 0;
 }
 
 .#{$button} {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -373,6 +373,8 @@
   --#{$button}--m-hamburger__icon--m-expand--ScaleX: -1;
 
   // Circle
+  --#{$button}--m-circle--ScaleX: 1.29;
+  --#{$button}--m-circle--ScaleY: 1.29;
   --#{$button}--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$button}--m-circle--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
   --#{$button}--m-circle--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
@@ -787,6 +789,10 @@
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-circle--PaddingInlineEnd);
     --#{$button}--PaddingBlockEnd: var(--#{$button}--m-circle--PaddingBlockEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-circle--PaddingInlineStart);
+
+    & .pf-v6-c-button__icon {
+      scale: var(--#{$button}--m-circle--ScaleX) var(--#{$button}--m-circle--ScaleY);
+    }
   }
 
   &:hover,

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -371,6 +371,13 @@
   --#{$button}--hamburger-icon--arrow--collapse--path: path("M3,7 L1,5 L3,3");
   --#{$button}--hamburger-icon--bottom--collapse--path: path("M9,9 L5,9");
   --#{$button}--m-hamburger__icon--m-expand--ScaleX: -1;
+
+  // Circle
+  --#{$button}--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
+  --#{$button}--m-circle--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--m-circle--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
+  --#{$button}--m-circle--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
+  --#{$button}--m-circle--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--compact);
 }
 
 .#{$button} {
@@ -772,6 +779,14 @@
     &.pf-m-collapse {
       @include pf-v6-hamburger($collapse: true);
     }
+  }
+
+  &.pf-m-circle {
+    --#{$button}--BorderRadius: var(--#{$button}--m-circle--BorderRadius);
+    --#{$button}--PaddingBlockStart: var(--#{$button}--m-circle--PaddingBlockStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-circle--PaddingInlineEnd);
+    --#{$button}--PaddingBlockEnd: var(--#{$button}--m-circle--PaddingBlockEnd);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-circle--PaddingInlineStart);
   }
 
   &:hover,

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -303,4 +303,4 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-hamburger` | `.pf-v6-c-button.pf-m-plain` | Modifies a plain button to be a hamburger button. |
 | `.pf-m-expand` | `.pf-v6-c-button.pf-m-hamburger` | Modifies a hamburger button to indicate that it will expand a menu. |
 | `.pf-m-collapse` | `.pf-v6-c-button.pf-m-hamburger` | Modifies a hamburger button to indicate that it will collapse a menu. |
-| `.pf-m-circle` | `.pf-v6-c-button` | Modifies a button to have a circular shape, instead of only rounded corners or a pill shape. |
+| `.pf-m-circle` | `.pf-v6-c-button` | Modifies a button to have a circular shape, instead of only rounded corners or a pill shape. Intended for buttons that contain only an icon. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -303,3 +303,4 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-hamburger` | `.pf-v6-c-button.pf-m-plain` | Modifies a plain button to be a hamburger button. |
 | `.pf-m-expand` | `.pf-v6-c-button.pf-m-hamburger` | Modifies a hamburger button to indicate that it will expand a menu. |
 | `.pf-m-collapse` | `.pf-v6-c-button.pf-m-hamburger` | Modifies a hamburger button to indicate that it will collapse a menu. |
+| `.pf-m-circle` | `.pf-v6-c-button` | Modifies a button to have a circular shape, instead of only rounded corners or a pill shape. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -161,6 +161,30 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 {{/button}}
 ```
 
+### Circle buttons
+
+```hbs isBeta
+{{> button button--IsPrimary=true button--aria-label="Add primary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsSecondary=true button--aria-label="Add secondary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsTertiary=true button--aria-label="Add tertiary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsDanger=true button--aria-label="Add danger circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsWarning=true button--aria-label="Add warning circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="plus-circle"}}
+
+{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="times"}}
+
+{{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="copy"}}
+
+{{> button button--IsCircle=true button--IsPlain=true button--aria-label="Upload circle variant" button--IsIcon=true button--icon="upload"}}
+
+{{> button button--IsCircle=true button--IsPlain=true button--IsIcon=true button--icon="upload" button--IsInProgress=true button--progress-text="Uploading circle variant..."}}
+```
+
 ### Counts
 ```hbs
 {{#*inline "button-counts"}}

--- a/src/patternfly/components/MenuToggle/examples/MenuToggle.md
+++ b/src/patternfly/components/MenuToggle/examples/MenuToggle.md
@@ -181,6 +181,15 @@ import './MenuToggle.css'
 {{> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsDisabled="true" menu-toggle--attribute='aria-label="Actions"' menu-toggle--HasKebab=true}}
 ```
 
+### Plain circle
+```hbs isBeta
+{{> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsCircle=true menu-toggle--attribute='aria-label="Circle styled actions"' menu-toggle--HasKebab=true}}
+&nbsp;
+{{> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsCircle=true menu-toggle--IsExpanded=true menu-toggle--attribute='aria-label="Circle and expanded styled actions"' menu-toggle--HasKebab=true}}
+&nbsp;
+{{> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsCircle=true menu-toggle--IsDisabled="true" menu-toggle--attribute='aria-label="Circle and disabled styled actions"' menu-toggle--HasKebab=true}}
+```
+
 ### Plain with text
 ```hbs
 {{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true"}}
@@ -1036,6 +1045,7 @@ Shown with default, primary, and secondary styling
 | `.pf-m-secondary` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the secondary variation. |
 | `.pf-m-text` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the text variation. |
 | `.pf-m-plain` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the plain variation. |
+| `.pf-m-circle` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component to be circular in shape. This is intended to be applied only to a plain menu toggle without any text. |
 | `.pf-m-expanded` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component for the expanded state. |
 | `.pf-m-full-height` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component to full height of parent. |
 | `.pf-m-full-width` | `.pf-v6-c-menu-toggle` | Modifies the menu toggle component to full width of parent. |

--- a/src/patternfly/components/MenuToggle/menu-toggle.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle.hbs
@@ -12,6 +12,7 @@
     menu-toggle--IsDanger='pf-m-danger'
     menu-toggle--IsPlaceholder='pf-m-placeholder'
     menu-toggle--IsSettings='pf-m-settings'
+    menu-toggle--IsCircle='pf-m-circle'
     menu-toggle--modifier=menu-toggle--modifier
   }}
   {{#unless menu-toggle--IsSplitButton}}

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -151,6 +151,7 @@
   --#{$menu-toggle}--m-plain--disabled--BackgroundColor: transparent;
   --#{$menu-toggle}--m-plain--m-small--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--compact);
   --#{$menu-toggle}--m-plain--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--compact);
+  --#{$menu-toggle}--m-plain--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
 
   // Typeahead
   --#{$menu-toggle}--m-typeahead__button--AlignSelf: stretch;
@@ -306,6 +307,10 @@
     --#{$menu-toggle}--disabled--BackgroundColor: var(--#{$menu-toggle}--m-plain--disabled--BackgroundColor);
     --#{$menu-toggle}--m-small--PaddingInlineStart: var(--#{$menu-toggle}--m-plain--m-small--PaddingInlineStart);
     --#{$menu-toggle}--m-small--PaddingInlineEnd: var(--#{$menu-toggle}--m-plain--m-small--PaddingInlineEnd);
+
+    &.pf-m-circle {
+      --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-plain--m-circle--BorderRadius);
+    }
 
     &::before {
       --#{$menu-toggle}--BorderWidth: var(--#{$menu-toggle}--m-plain--BorderWidth);


### PR DESCRIPTION
Closes #7913

The small variant paired with circle buttons looks like it breaks the small styling and it would also break the large/CTA styling, let me know if we would want small and/or large + circle to have decreased/increased padding respectively