### PR TITLE
chore: fix import for add new component script

### DIFF
--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 
 const program = new Command();
 import path from 'path';
-import glob from 'glob';
+import { glob } from 'glob';
 import fs from 'fs-extra';
 
 program
@@ -12,9 +12,9 @@ program
   .option('-f, --folder <folder>', 'Source folder (components, demos, layouts, or utilities)', 'components')
   .action(generateFolders);
 
-const dasherize = s => s.replace(/[A-Z]/g, res => `-${res.toLowerCase()}`).replace(/^-/, ''); // Remove leading -
-const capitalize = s => s[0].toUpperCase() + s.substring(1);
-const titlize = s => capitalize(s.replace(/[A-Z]/g, res => ` ${res.toLowerCase()}`).trim()); // Remove leading space
+const dasherize = (s) => s.replace(/[A-Z]/g, (res) => `-${res.toLowerCase()}`).replace(/^-/, ''); // Remove leading -
+const capitalize = (s) => s[0].toUpperCase() + s.substring(1);
+const titlize = (s) => capitalize(s.replace(/[A-Z]/g, (res) => ` ${res.toLowerCase()}`).trim()); // Remove leading space
 
 import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -23,7 +23,7 @@ function generateFolders(componentName, otherNames, options) {
   const rootPath = path.join(__dirname, '..');
   const templatePath = path.join(__dirname, 'template');
 
-  [componentName].concat(otherNames).forEach(name => {
+  [componentName].concat(otherNames).forEach((name) => {
     const dasherized = dasherize(name);
     const toReplace = [
       [/{folder}/g, options.folder],
@@ -32,7 +32,7 @@ function generateFolders(componentName, otherNames, options) {
       [/{nameTitle}/g, titlize(name)],
       [/{nameBEM}/g, `pf-v5-${options.folder[0]}-${dasherized}`]
     ];
-    const templateReplace = str => {
+    const templateReplace = (str) => {
       let res = str;
       toReplace.forEach(([regex, string]) => {
         res = res.replace(regex, string);
@@ -42,7 +42,7 @@ function generateFolders(componentName, otherNames, options) {
     };
 
     // Write out templated files
-    glob.sync(`${templatePath}/**/*.*`).forEach(file => {
+    glob.sync(`${templatePath}/**/*.*`).forEach((file) => {
       const toPath = templateReplace(file.replace(templatePath, rootPath));
       console.log('Writing', toPath);
       const contents = templateReplace(fs.readFileSync(file, 'utf8'));


### PR DESCRIPTION
`generate CamelCase` creates a new component and was failing with

```
mcoker-computron-3000$ node generate Compass
file:///Users/cmichael/repos/patternfly/scripts/generate.mjs:5
import glob from 'glob';
       ^^^^
SyntaxError: The requested module 'glob' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:146:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:229:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
```