### PR TITLE
feat(drawer): add support for glass panel, add comapss demo

### DIFF
--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -133,5 +133,27 @@
 
   // stylelint-disable custom-property-pattern
   --pf-t--temp--dev--tbd: #BC11E0;
+  // stylelint-enable
 
+  // Compass/glass tokens
+  --pf-t--global--background--color--glass--filter: blur(12.5px);
+  --pf-t--global--background--color--glass--opacity: .85;
+  --pf-t--global--background--color--glass--default: rgba(255, 255, 255, var(--pf-t--global--background--color--glass--opacity));
+  --pf-t--global--dark--background--color--glass--filter: blur(12.5px);
+  --pf-t--global--dark--background--color--glass--opacity: .85;
+  --pf-t--global--dark--background--color--glass--default: rgba(29, 29, 29, var(--pf-t--global--background--color--glass--opacity));
+
+  // Compass/glass dark tokens
+  &:where(.pf-v6-theme-dark) {
+    --pf-t--global--background--color--glass--filter: var(--pf-t--global--dark--background--color--glass--filter);
+    --pf-t--global--background--color--glass--opacity: var(--pf-t--global--dark--background--color--glass--opacity);
+    --pf-t--global--background--color--glass--default: var(--pf-t--global--dark--background--color--glass--default);
+  }
+
+  // no glass theme
+  &:root:where(.pf-m-no-glass) {
+    --pf-t--global--background--color--glass--filter: none;
+    --pf-t--global--background--color--glass--opacity: 1;
+    --pf-t--global--background--color--glass--default: var(--pf-t--global--background--color--primary--default);
+  }
 }

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -10,15 +10,8 @@
   --#{$compass}__nav--RowGap: var(--pf-t--global--spacer--gap--group--vertical);
   --#{$compass}__sidebar--Padding: var(--pf-t--global--spacer--sm);
   --#{$compass}__main--RowGap: var(--pf-t--global--spacer--md);
-  --#{$compass}__panel--BackgroundColor--rgb--light: 255,255,255;
-  --#{$compass}__panel--BackgroundColor--opacity--light: .85;
-  --#{$compass}__panel--BackgroundColor--light: rgba(var(--#{$compass}__panel--BackgroundColor--rgb--light), var(--#{$compass}__panel--BackgroundColor--opacity--light));
-  --#{$compass}__panel--BackgroundColor--rgb--dark: 29,29,29;
-  --#{$compass}__panel--BackgroundColor--opacity--dark: .8;
-  --#{$compass}__panel--BackgroundColor--dark: rgba(var(--#{$compass}__panel--BackgroundColor--rgb--dark), var(--#{$compass}__panel--BackgroundColor--opacity--dark));
-  --#{$compass}__panel--BackdropFilter: var(--#{$compass}__panel--BackdropFilter--light);
-  --#{$compass}__panel--BackdropFilter--light: blur(12.5px);
-  --#{$compass}__panel--BackdropFilter--dark: blur(12.5px);
+  --#{$compass}__panel--BackgroundColor: var(--pf-t--global--background--color--glass--default);
+  --#{$compass}__panel--BackdropFilter: var(--pf-t--global--background--color--glass--filter);
   --#{$compass}__panel--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$compass}__panel--m-pill--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$compass}__panel--Padding: var(--pf-t--global--spacer--inset--page-chrome);
@@ -151,16 +144,11 @@
 
 .#{$compass}__panel {
   padding: var(--#{$compass}__panel--Padding);
-  background-color: var(--#{$compass}__panel--BackgroundColor, var(--#{$compass}__panel--BackgroundColor--light));
-  backdrop-filter: var(--#{$compass}__panel--BackdropFilter, var(--#{$compass}__panel--BackdropFilter--light));
+  background-color: var(--#{$compass}__panel--BackgroundColor);
+  backdrop-filter: var(--#{$compass}__panel--BackdropFilter);
   border: var(--#{$compass}__panel--BorderWidth) solid var(--#{$compass}__panel--BorderColor);
   border-radius: var(--#{$compass}__panel--BorderRadius);
   box-shadow: var(--#{$compass}__panel--BoxShadow);
-
-  :root:where(.pf-v6-theme-dark) & {
-    --#{$compass}__panel--BackdropFilter: var(--#{$compass}__panel--BackdropFilter--dark);
-    --#{$compass}__panel--BackgroundColor: var(--#{$compass}__panel--BackgroundColor--dark);
-  }
 
   &.pf-m-no-border {
     border-width: 0;
@@ -211,13 +199,6 @@
 
 .#{$compass}__hero-body {
   width: min(var(--#{$compass}__hero-body--Width), var(--#{$compass}__hero-body--MaxWidth));
-}
-
-:where(:root.pf-v6-theme-no-glass) .#{$compass} {
-  --#{$compass}--glass--opacity: 100%;
-  --#{$compass}--glass--border: var(--pf-t--global--border--color--default);
-  --#{$compass}--glass--blend-mode: none;
-  --#{$compass}--glass--blend-mode--dark: none;
 }
 
 :where(.pf-v6-theme-dark) .#{$compass} {

--- a/src/patternfly/components/Drawer/drawer-example-panel.hbs
+++ b/src/patternfly/components/Drawer/drawer-example-panel.hbs
@@ -1,4 +1,4 @@
-{{#> drawer-panel}}
+{{#> drawer-panel drawer-panel--IsGlass=drawer-panel-example--IsGlass}}
   {{#> drawer-head}}
     <span>Drawer panel header content</span>
     {{#> drawer-actions}}

--- a/src/patternfly/components/Drawer/drawer-panel.hbs
+++ b/src/patternfly/components/Drawer/drawer-panel.hbs
@@ -1,4 +1,9 @@
-<{{#if drawer-panel--type}}{{{drawer-panel--type}}}{{else}}div{{/if}} class="{{pfv}}drawer__panel{{#if drawer-panel--IsResizable}} pf-m-resizable{{/if}}{{#if drawer-panel--modifier}} {{drawer-panel--modifier}}{{/if}}"
+<{{#if drawer-panel--type}}{{{drawer-panel--type}}}{{else}}div{{/if}} class="{{pfv}}drawer__panel
+  {{setModifiers
+    drawer-panel--IsResizable='pf-m-resizable'
+    drawer-panel--IsGlass='pf-m-glass'
+    drawer-panel--modifier=drawer-panel--modifier
+  }}"
   {{#unless drawer-IsStatic}}
     {{#unless drawer-panel--IsOpen}}
       hidden

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -67,6 +67,9 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}--m-pill__panel--BorderColor: var(--pf-t--global--border--color--default);
   --#{$drawer}--m-pill__panel--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$drawer}--m-pill--m-expanded__panel--inset: var(--pf-t--global--spacer--inset--page-chrome);
+  --#{$drawer}__panel--m-glass--BackgroundColor: var(--pf-t--global--background--color--glass--default);
+  --#{$drawer}__panel--m-glass--BackdropFilter: var(--pf-t--global--background--color--glass--filter);
+  --#{$drawer}__panel--m-glass--BorderColor: var(--pf-t--global--border--color--alt);
 
   @media screen and (prefers-reduced-motion: no-preference) {
     --#{$drawer}__panel--TransitionDuration--slide: var(--pf-t--global--motion--duration--slide-in--short);
@@ -388,6 +391,13 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   &.pf-m-no-background {
     --#{$drawer}__panel--BackgroundColor: transparent;
+  }
+
+  &.pf-m-glass {
+    --#{$drawer}__panel--BackgroundColor: var(--#{$drawer}__panel--m-glass--BackgroundColor);
+    --#{$drawer}__panel--BorderColor: var(--#{$drawer}__panel--m-glass--BorderColor);
+
+    backdrop-filter: var(--#{$drawer}__panel--m-glass--BackdropFilter);
   }
 
   @media screen and (min-width: $pf-v6-global--breakpoint--md) {

--- a/src/patternfly/demos/Compass/compass--card-view.hbs
+++ b/src/patternfly/demos/Compass/compass--card-view.hbs
@@ -1,0 +1,134 @@
+{{#> compass--demo-context}}
+  {{#> compass}}
+    {{#> compass-header}}
+      {{#> compass-logo}}
+        {{> compass--icons compass--icons--redhat=true}}
+      {{/compass-logo}}
+      {{#> compass-nav}}
+        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--IsPill=true}}
+          {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-inset-xl"}}
+            {{> __tabs-list}}
+          {{/tabs}}
+        {{/compass-panel}}
+        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--IsPill=true}}
+          {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab pf-m-inset-xl"}}
+            {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
+          {{/tabs}}
+        {{/compass-panel}}
+      {{/compass-nav}}
+      {{#> compass-profile}}
+        {{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true"}}
+          {{#> menu-toggle-icon}}
+            {{> avatar avatar--modifier="pf-m-md"}}
+          {{/menu-toggle-icon}}
+          {{#> menu-toggle-text}}
+            Ned Username
+          {{/menu-toggle-text}}
+          {{#> menu-toggle-controls}}
+            {{> menu-toggle-toggle-icon}}
+          {{/menu-toggle-controls}}
+        {{/menu-toggle}}
+      {{/compass-profile}}
+    {{/compass-header}}
+    {{#> compass-sidebar compass-sidebar--IsStart=true}}
+      {{#> compass-panel compass-panel--IsPill=true}}
+        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--square-plus=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--question-circle=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--sparkle=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--user=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--paper-plane=true}}
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list}}
+      {{/compass-panel}}
+    {{/compass-sidebar}}
+    {{#> compass-main}}
+      {{#> compass-main-header}}
+        {{#> compass-panel}}
+          {{#> l-flex l-flex--modifier="pf-m-align-items-center"}}
+            {{#> l-flex-item l-flex-item--modifier="pf-m-grow"}}
+              {{#> title titleType="h2" title--modifier="pf-m-h1"}}
+                Page title
+              {{/title}}
+            {{/l-flex-item}}
+            {{#> l-flex-item}}
+              {{#> action-list}}
+                {{#> action-list-group}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsPrimary=true}}
+                      Add integration
+                    {{/button}}
+                  {{/action-list-item}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsSecondary=true}}
+                      Test integration
+                    {{/button}}
+                  {{/action-list-item}}
+                {{/action-list-group}}
+              {{/action-list}}
+            {{/l-flex-item}}
+          {{/l-flex}}
+        {{/compass-panel}}
+      {{/compass-main-header}}
+      {{#> compass-content}}
+        {{#> compass-panel compass-panel--IsScrollable=true}}
+          {{#> l-flex l-flex--modifier="pf-m-column pf-m-gap-md"}}
+            {{> toolbar-template
+              toolbar-template--id=(concat page-template--id '-toolbar')
+              toolbar-template--HasToggleGroup=true
+              toolbar-template--HasBulkSelect=true
+              toolbar-template--HasOverflowMenu=true
+              toolbar-template--HasFilter=true
+            }}
+            {{> card-template-gallery card-template-gallery--id="card-view-basic-example-gallery"}}
+          {{/l-flex}}
+        {{/compass-panel}}
+      {{/compass-content}}
+    {{/compass-main}}
+    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
+      {{#> compass-panel compass-panel--IsPill=true}}
+        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--question-circle=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--user=true}}
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+              {{> compass--icons compass--icons--paper-plane=true}}
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list}}
+      {{/compass-panel}}
+    {{/compass-sidebar}}
+    {{#> compass-footer}}
+      {{#> compass-footer-main}}
+        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}chatbot message bar{{/compass-panel}}
+      {{/compass-footer-main}}
+    {{/compass-footer}}
+  {{/compass}}
+{{/compass--demo-context}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -7,140 +7,7 @@ wrapperTag: div
 ## Examples
 ### Card view
 ```hbs isFullscreen isBeta
-{{#> compass--demo-context}}
-  {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--IsPill=true}}
-          {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-inset-xl"}}
-            {{> __tabs-list}}
-          {{/tabs}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--IsPill=true}}
-          {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab pf-m-inset-xl"}}
-            {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-          {{/tabs}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain="true" menu-toggle--IsText="true"}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
-    {{#> compass-main}}
-      {{#> compass-main-header}}
-        {{#> compass-panel}}
-          {{#> l-flex l-flex--modifier="pf-m-align-items-center"}}
-            {{#> l-flex-item l-flex-item--modifier="pf-m-grow"}}
-              {{#> title titleType="h2" title--modifier="pf-m-h1"}}
-                Page title
-              {{/title}}
-            {{/l-flex-item}}
-            {{#> l-flex-item}}
-              {{#> action-list}}
-                {{#> action-list-group}}
-                  {{#> action-list-item}}
-                    {{#> button button--IsPrimary=true}}
-                      Add integration
-                    {{/button}}
-                  {{/action-list-item}}
-                  {{#> action-list-item}}
-                    {{#> button button--IsSecondary=true}}
-                      Test integration
-                    {{/button}}
-                  {{/action-list-item}}
-                {{/action-list-group}}
-              {{/action-list}}
-            {{/l-flex-item}}
-          {{/l-flex}}
-        {{/compass-panel}}
-      {{/compass-main-header}}
-      {{#> compass-content}}
-        {{#> compass-panel compass-panel--IsScrollable=true}}
-          {{#> l-flex l-flex--modifier="pf-m-column pf-m-gap-md"}}
-            {{> toolbar-template
-              toolbar-template--id=(concat page-template--id '-toolbar')
-              toolbar-template--HasToggleGroup=true
-              toolbar-template--HasBulkSelect=true
-              toolbar-template--HasOverflowMenu=true
-              toolbar-template--HasFilter=true
-            }}
-            {{> card-template-gallery card-template-gallery--id="card-view-basic-example-gallery"}}
-          {{/l-flex}}
-        {{/compass-panel}}
-      {{/compass-content}}
-    {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
-    {{#> compass-footer}}
-      {{#> compass-footer-main}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}chatbot message bar{{/compass-panel}}
-      {{/compass-footer-main}}
-    {{/compass-footer}}
-  {{/compass}}
-{{/compass--demo-context}}
+{{> compass--card-view}}
 ```
 
 ### Dashboard
@@ -450,4 +317,16 @@ wrapperTag: div
     {{/compass-footer}}
   {{/compass}}
 {{/compass--demo-context}}
+```
+
+### With drawer
+```hbs isFullscreen isBeta
+{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsGlass=true}}
+ {{#> drawer-main}}
+    {{#> drawer-content}}
+      {{> compass--card-view}}
+    {{/drawer-content}}
+    {{> drawer-example-panel drawer-panel-example--IsGlass=true}}
+  {{/drawer-main}}
+{{/drawer}}
 ```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7958

This PR does these things:
* Creates a new compass "with drawer" demo
* Creates a `.pf-m-glass` drawer panel variation
* Creates tokens for the panel background attributes - background color, background color opacity, blur. I left the blur token as `--filter` implying you could change that use other filters, too.
  * Also handles dark theme and a "no glass" theme. No glass will likely change this upcoming sprint to "glass", with "no glass" being the new default styles.
* Implements those tokens in the compass panel and the glass drawer panel.