### PR TITLE
fix(links): fix decoration color

### DIFF
--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -3,8 +3,8 @@
 @mixin pf-v6-tokens {
   // temporary until we have updates from design 
   // new
-  --pf-t--global--text-decoration--color--default: var(--pf-t--global--text--color--default);
-  --pf-t--global--text-decoration--color--hover: var(--pf-t--global--text--color--hover);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--border--color--default);
+  --pf-t--global--text-decoration--color--hover: currentcolor; // could also use var(--pf-t--global--text--color--link--hover);
   --pf-t--global--text-decoration--offset--hover: calc(var(--pf-t--global--spacer--xs) + 1px);
 
   // changed


### PR DESCRIPTION
Fixes #7959

Changes back to border color for the text decoration, and changes hover color to currentcolor - but kept in a comment on the temporary token saying what token it should be matching, just for reference until the new tokens are added for real.