### PR TITLE
feat(glass): added glass theme

### DIFF
--- a/src/patternfly/base/tokens/tokens-local.scss
+++ b/src/patternfly/base/tokens/tokens-local.scss
@@ -1,3 +1,5 @@
+@import '../../sass-utilities/init';
+
 // LOCAL TOKENS
 
 @mixin pf-v6-tokens {
@@ -135,25 +137,57 @@
   --pf-t--temp--dev--tbd: #BC11E0;
   // stylelint-enable
 
-  // Compass/glass tokens
-  --pf-t--global--background--color--glass--filter: blur(12.5px);
-  --pf-t--global--background--color--glass--opacity: .85;
-  --pf-t--global--background--color--glass--default: rgba(255, 255, 255, var(--pf-t--global--background--color--glass--opacity));
-  --pf-t--global--dark--background--color--glass--filter: blur(12.5px);
-  --pf-t--global--dark--background--color--glass--opacity: .85;
-  --pf-t--global--dark--background--color--glass--default: rgba(29, 29, 29, var(--pf-t--global--background--color--glass--opacity));
+  // Glass theme  tokens
+  // Glass theme off base. These are reused.
+  --pf-t--global--background--color--glass--filter--base: none;
+  --pf-t--global--background--color--glass--opacity--base: 1;
+  --pf-t--global--background--color--glass--default--base: var(--pf-t--global--background--color--primary--default);
 
-  // Compass/glass dark tokens
-  &:where(.pf-v6-theme-dark) {
+  // Glass theme off defaults
+  --pf-t--global--background--color--glass--filter: var(--pf-t--global--background--color--glass--filter--base);
+  --pf-t--global--background--color--glass--opacity: var(--pf-t--global--background--color--glass--opacity--base);
+  --pf-t--global--background--color--glass--default: var(--pf-t--global--background--color--glass--default--base);
+  --pf-t--global--dark--background--color--glass--filter: var(--pf-t--global--background--color--glass--filter--base);
+  --pf-t--global--dark--background--color--glass--opacity: var(--pf-t--global--background--color--glass--opacity--base);
+  --pf-t--global--dark--background--color--glass--default: var(--pf-t--global--background--color--glass--default--base);
+
+  // Glass theme on. In the root scope so they can be themed on :root
+  --pf-t--global--light--glass--background--color--glass--color: #ffffff;
+  --pf-t--global--light--glass--background--color--glass--filter: blur(12.5px);
+  --pf-t--global--light--glass--background--color--glass--opacity: 85%;
+  --pf-t--global--light--glass--background--color--glass--default: color-mix(in srgb, var(--pf-t--global--light--glass--background--color--glass--color) var(--pf-t--global--light--glass--background--color--glass--opacity), transparent );
+  --pf-t--global--dark--glass--background--color--glass--color: #1d1d1d;
+  --pf-t--global--dark--glass--background--color--glass--filter: blur(12.5px);
+  --pf-t--global--dark--glass--background--color--glass--opacity: 85%;
+  --pf-t--global--dark--glass--background--color--glass--default: color-mix(in srgb, var(--pf-t--global--dark--glass--background--color--glass--color) var(--pf-t--global--dark--glass--background--color--glass--opacity), transparent );
+
+  // Dark theme
+  &:where(.#{$pf-prefix}theme-dark) {
     --pf-t--global--background--color--glass--filter: var(--pf-t--global--dark--background--color--glass--filter);
     --pf-t--global--background--color--glass--opacity: var(--pf-t--global--dark--background--color--glass--opacity);
     --pf-t--global--background--color--glass--default: var(--pf-t--global--dark--background--color--glass--default);
   }
 
-  // no glass theme
-  &:root:where(.pf-m-no-glass) {
-    --pf-t--global--background--color--glass--filter: none;
-    --pf-t--global--background--color--glass--opacity: 1;
-    --pf-t--global--background--color--glass--default: var(--pf-t--global--background--color--primary--default);
+  // Glass theme
+  &:where(.#{$pf-prefix}theme-glass) {
+    --pf-t--global--background--color--glass--filter: var(--pf-t--global--light--glass--background--color--glass--filter);
+    --pf-t--global--background--color--glass--opacity: var(--pf-t--global--light--glass--background--color--glass--opacity);
+    --pf-t--global--background--color--glass--default: var(--pf-t--global--light--glass--background--color--glass--default);
+  }
+
+  // Glass dark theme
+  &:where(.#{$pf-prefix}theme-glass.#{$pf-prefix}theme-dark) {
+    --pf-t--global--background--color--glass--filter: var(--pf-t--global--dark--glass--background--color--glass--filter);
+    --pf-t--global--background--color--glass--opacity: var(--pf-t--global--dark--glass--background--color--glass--opacity);
+    --pf-t--global--background--color--glass--default: var(--pf-t--global--dark--glass--background--color--glass--default);
+  }
+
+  // High contrast
+  &:where(.#{$pf-prefix}theme-high-contrast) {
+    --pf-t--global--background--color--glass--filter: var(--pf-t--global--background--color--glass--filter--base);
+    --pf-t--global--background--color--glass--opacity: var(--pf-t--global--background--color--glass--opacity--base);
+    --pf-t--global--background--color--glass--default: var(--pf-t--global--background--color--glass--default--base);
   }
 }
+
+

--- a/src/patternfly/components/Drawer/drawer-panel.hbs
+++ b/src/patternfly/components/Drawer/drawer-panel.hbs
@@ -1,7 +1,6 @@
 <{{#if drawer-panel--type}}{{{drawer-panel--type}}}{{else}}div{{/if}} class="{{pfv}}drawer__panel
   {{setModifiers
     drawer-panel--IsResizable='pf-m-resizable'
-    drawer-panel--IsGlass='pf-m-glass'
     drawer-panel--modifier=drawer-panel--modifier
   }}"
   {{#unless drawer-IsStatic}}

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -293,6 +293,16 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
         border-block-end-width: var(--#{$drawer}--m-pill__panel--BorderBlockEndWidth);
         border-inline-start-width: var(--#{$drawer}--m-pill__panel--BorderInlineStartWidth);
         border-inline-end-width: var(--#{$drawer}--m-pill__panel--BorderInlineEndWidth);
+
+        // This won't apply background overrides if glass is disabled, allowing secondary backgrounds to work
+        // stylelint-disable max-nesting-depth
+        &:not(.pf-m-no-glass) {
+          --#{$drawer}__panel--BackgroundColor: var(--#{$drawer}__panel--m-glass--BackgroundColor);
+          --#{$drawer}__panel--BorderColor: var(--#{$drawer}__panel--m-glass--BorderColor);
+
+          backdrop-filter: var(--#{$drawer}__panel--m-glass--BackdropFilter);
+        }
+        // stylelint-enable
       }
     }
   }
@@ -391,13 +401,6 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   &.pf-m-no-background {
     --#{$drawer}__panel--BackgroundColor: transparent;
-  }
-
-  &.pf-m-glass {
-    --#{$drawer}__panel--BackgroundColor: var(--#{$drawer}__panel--m-glass--BackgroundColor);
-    --#{$drawer}__panel--BorderColor: var(--#{$drawer}__panel--m-glass--BorderColor);
-
-    backdrop-filter: var(--#{$drawer}__panel--m-glass--BackdropFilter);
   }
 
   @media screen and (min-width: $pf-v6-global--breakpoint--md) {

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -282,7 +282,7 @@ import './Drawer.css'
 ```
 
 ### Pill
-```hbs
+```hbs isBeta
 {{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
@@ -294,7 +294,7 @@ import './Drawer.css'
 ```
 
 ### Pill inline
-```hbs
+```hbs isBeta
 {{#> drawer drawer--id="pill--inline" drawer--IsInline=true drawer--IsPill=true drawer-panel--IsOpen=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
@@ -340,6 +340,7 @@ import './Drawer.css'
 | `.pf-m-static{-on-[lg, xl, 2xl]}` | `.pf-v6-c-drawer` | Modifies the drawer panel state to always show both content and panel at optional [breakpoint](/tokens/all-patternfly-tokens). |
 | `.pf-m-inline{-on-[lg, xl, 2xl]}` | `.pf-v6-c-drawer` | Modifies the drawer so the content element and panel element are displayed side by side. `.pf-m-inline` used without a [breakpoint](/tokens/all-patternfly-tokens) will default to the `md` breakpoint. |
 | `.pf-m-pill` | `.pf-v6-c-drawer` | Modifies the drawer for pill styles. |
+| `.pf-m-no-glass` | `.pf-v6-c-drawer__panel.pf-m-pill` | Modifies the drawer panel remove glass styling when using glass theme. |
 | `.pf-m-no-border` | `.pf-v6-c-drawer__panel` | Modifies the drawer panel border treatment to disable all border treatment. |
 | `.pf-m-padding` | `.pf-v6-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-v6-c-drawer__body` | Modifies the element to remove padding. |

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -321,7 +321,7 @@ wrapperTag: div
 
 ### With drawer
 ```hbs isFullscreen isBeta
-{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsGlass=true}}
+{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
       {{> compass--card-view}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7972. I listed some acceptance criteria in the description of https://github.com/patternfly/patternfly/issues/7972 if you want to reference.

Compass with drawer demo to test - **https://pf-pr-7973.surge.sh/components/compass/html-demos/with-drawer/**

This adds
* `.pf-v6-theme-glass` - added to `<html>`, turns on the glass theme
* `.pf-v6-c-drawer__panel.pf-m-no-glass` - added to a pill drawer variant, disables glass styling when glass theme is enabled.

This PR creates these 4 tokens that can be used for theming
* `--pf-t--global--[light/dark]--glass--background--color--glass--color`
  * glass background color base. Takes any kind of color (uses `color-mix()`)
* `--pf-t--global--[light/dark]--glass--background--color--glass--opacity`
  * glass background color opacity
* `--pf-t--global--[light/dark]--glass--background--color--glass--filter`
  * glass background (backdrop) filter(s)
* `--pf-t--global--[light/dark]--glass--background--color--glass--default`
  * this is used to set the combo of `--color` and `--opacity` above. If you theme it, it will override the `--color` and `--opacity` above. Maybe useful if you wanted to pass your own color function or something.

I used these values to test (you have to disable the `--default` vars for `--color` and `--opacity` to work)
```
--pf-t--global--light--glass--background--color--glass--color: red;
--pf-t--global--light--glass--background--color--glass--opacity: 50%;
--pf-t--global--light--glass--background--color--glass--filter: blur(5px) hue-rotate(180deg);
--pf-t--global--light--glass--background--color--glass--default: rgb(255, 255, 0, 0.5);
--pf-t--global--dark--glass--background--color--glass--color: green;
--pf-t--global--dark--glass--background--color--glass--opacity: 10%;
--pf-t--global--dark--glass--background--color--glass--filter: blur(2px) hue-rotate(90deg);
--pf-t--global--dark--glass--background--color--glass--default: purple;
```

<img width="1383" height="1310" alt="Screenshot 2025-11-05 at 6 46 35 PM" src="https://github.com/user-attachments/assets/57ea7000-981e-40c5-8dee-07f7473df50f" />
<img width="1383" height="1310" alt="Screenshot 2025-11-05 at 6 46 43 PM" src="https://github.com/user-attachments/assets/5632fe83-baaa-407b-a325-b98e23e9c11b" />

