### PR TITLE
fix(Tabs): updated ariaselected and label attributes

### DIFF
--- a/src/patternfly/components/Tabs/__tabs-all.hbs
+++ b/src/patternfly/components/Tabs/__tabs-all.hbs
@@ -1,36 +1,36 @@
-  {{#> tabs tabs--id=(concat __tabs-all--id "-default-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' default example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-default-example") tabs--modifier="pf-m-scrollable"  tabs--aria-label=(concat __tabs--aria-label-prefix ' default example')}}
+    {{> __tabs-list}}
   {{/tabs}}
 
   <br><br>
 
-  {{#> tabs tabs--id=(concat __tabs-all--id "-box-example") tabs--modifier="pf-m-box pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' box example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-box-example") tabs--modifier="pf-m-box pf-m-scrollable" tabs--aria-label=(concat __tabs--aria-label-prefix ' box example')}}
+    {{> __tabs-list}}
   {{/tabs}}
 
   <br><br>
 
-  {{#> tabs tabs--id=(concat __tabs-all--id "-box-secondary-example") tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' box secondary variant example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-box-secondary-example") tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable" tabs--aria-label=(concat __tabs--aria-label-prefix ' box secondary variant example')}}
+    {{> __tabs-list}}
   {{/tabs}}
 
   <br><br>
 
-  {{#> tabs tabs--id=(concat __tabs-all--id "-icons-text-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with icons example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-icons-text-example") tabs--modifier="pf-m-scrollable" __tabs-list--HasIcons="true" tabs--aria-label=(concat __tabs--aria-label-prefix ' with icons example')}}
+    {{> __tabs-list}}
   {{/tabs}}
 
   <br><br>
 
-  {{#> tabs tabs--id=(concat __tabs-all--id "-filled-example") tabs--modifier="pf-m-fill" __tabs-list--IsScrollable=reset}}
-    {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' filled example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-filled-example") tabs--modifier="pf-m-fill" __tabs-list--IsScrollable=reset __tabs-list--IsShort="true" tabs--aria-label=(concat __tabs--aria-label-prefix ' filled example')}}
+    {{> __tabs-list}}
   {{/tabs}}
 
   <br><br>
 
-  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-primary-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with sub tabs example')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-primary-example") tabs--modifier="pf-m-scrollable" tabs--aria-label=(concat __tabs--aria-label-prefix ' with sub tabs example, primary')}}
+    {{> __tabs-list}}
   {{/tabs}}
-  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-secondary-example") tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true"}}
-    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with sub tabs example, Containers')}}
+  {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-secondary-example") tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true" tabs--aria-label=(concat __tabs--aria-label-prefix ' with sub tabs example, Containers')}}
+    {{> __tabs-list}}
   {{/tabs}}

--- a/src/patternfly/components/Tabs/__tabs-all.hbs
+++ b/src/patternfly/components/Tabs/__tabs-all.hbs
@@ -1,36 +1,36 @@
   {{#> tabs tabs--id=(concat __tabs-all--id "-default-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list}}
+    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' default example')}}
   {{/tabs}}
 
   <br><br>
 
   {{#> tabs tabs--id=(concat __tabs-all--id "-box-example") tabs--modifier="pf-m-box pf-m-scrollable"}}
-    {{> __tabs-list}}
+    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' box example')}}
   {{/tabs}}
 
   <br><br>
 
   {{#> tabs tabs--id=(concat __tabs-all--id "-box-secondary-example") tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable"}}
-    {{> __tabs-list}}
+    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' box secondary variant example')}}
   {{/tabs}}
 
   <br><br>
 
   {{#> tabs tabs--id=(concat __tabs-all--id "-icons-text-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list __tabs-list--HasIcons="true"}}
+    {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with icons example')}}
   {{/tabs}}
 
   <br><br>
 
   {{#> tabs tabs--id=(concat __tabs-all--id "-filled-example") tabs--modifier="pf-m-fill" __tabs-list--IsScrollable=reset}}
-    {{> __tabs-list __tabs-list--IsShort="true"}}
+    {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' filled example')}}
   {{/tabs}}
 
   <br><br>
 
   {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-primary-example") tabs--modifier="pf-m-scrollable"}}
-    {{> __tabs-list}}
+    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with sub tabs example')}}
   {{/tabs}}
   {{#> tabs tabs--id=(concat __tabs-all--id "-secondary-secondary-example") tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true"}}
-    {{> __tabs-list}}
+    {{> __tabs-list __tabs-list--aria-label=(concat __tabs-list--aria-label-prefix ' with sub tabs example, Containers')}}
   {{/tabs}}

--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -26,7 +26,7 @@ __tabs-list--IsCloseDisabled: bool
   {{/if}}
 {{/unless}}
 
-{{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
+{{#> tabs-list tabs-list--aria-label=__tabs-list--aria-label tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
   {{> __tabs-item
     __tabs-item--id="users"
     __tabs-item--icon-name="fas fa-users"

--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -26,7 +26,7 @@ __tabs-list--IsCloseDisabled: bool
   {{/if}}
 {{/unless}}
 
-{{#> tabs-list tabs-list--aria-label=__tabs-list--aria-label tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
+{{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
   {{> __tabs-item
     __tabs-item--id="users"
     __tabs-item--icon-name="fas fa-users"

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -246,18 +246,18 @@ cssPrefix: pf-v6-c-tabs
 
 ### Using the nav element example
 ```hbs
-{{#> tabs tabs--id="using-the-nav-element" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Tabs nav"' tabs-link--isLink="true"}}
+{{#> tabs tabs--id="using-the-nav-element" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--aria-label="Using nav element example" tabs-link--isLink="true"}}
   {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element example"}}
 {{/tabs}}
 ```
 
 ### Sub tabs using the nav element example
 ```hbs
-{{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true" tabs--aria-label="Sub tabs using nav element example"}}
   {{> __tabs-list __tabs-list--aria-label="Using nav element with sub tabs example"}}
 {{/tabs}}
 
-{{#> tabs tabs--id="sub-tabs-using-the-nav-element-subtab" tabs--type="nav" tabs--attribute='aria-label="Tabs subtab nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element-subtab" tabs--type="nav" tabs--attribute='aria-label="Tabs subtab nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab" tabs--aria-label="Sub tabs using nav element example, Containers"}}
   {{> __tabs-list-secondary __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element with sub tabs example, Containers"}}
 {{/tabs}}
 ```
@@ -284,7 +284,8 @@ As sub navigation:
       __tabs-list--IsAction="true"
       __tabs-list--IsScrollable="true"
       __tabs-list--DisabledFirstScrollButton="true"
-      __tabs-list--HasHelp="true" __tabs-list--IsHelpDisabled="true"}}
+      __tabs-list--HasHelp="true" __tabs-list--IsHelpDisabled="true"
+      __tabs-list--aria-label-prefix="Help button"}}
 ```
 
 ### Close button example
@@ -296,7 +297,8 @@ As sub navigation:
       __tabs-list--HasClose="true"
       __tabs-list--IsCloseDisabled="true"
       __tabs-list--IsScrollable="true"
-      __tabs-list--DisabledFirstScrollButton="true"}}
+      __tabs-list--DisabledFirstScrollButton="true"
+      __tabs-list--aria-label-prefix="Close button"}}
 ```
 
 ### Help and close button example
@@ -311,7 +313,8 @@ As sub navigation:
       __tabs-list--HasClose="true"
       __tabs-list--IsHelpDisabled="true"
       __tabs-list--IsCloseDisabled="true"
-      __tabs-list--IsHelpCloseDisabled="true"}}
+      __tabs-list--IsHelpCloseDisabled="true"
+      __tabs-list--aria-label-prefix="Help and close button"}}
 ```
 
 ## Add tab button
@@ -319,22 +322,22 @@ As sub navigation:
 ### Add tab button example
 ```hbs
 {{#> tabs tabs--id="default-tabs-add-tab-button" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button with sub tabs example"}}
 {{/tabs}}
 {{#> tabs tabs--id="default-tabs-add-tab-button-subtab" tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button with sub tabs example, Containers"}}
 {{/tabs}}
 
 <br><br>
 
 {{#> tabs tabs--id="box-tabs-add-tab-button" tabs--modifier="pf-m-box pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button box example"}}
 {{/tabs}}
 
 <br><br>
 
 {{#> tabs tabs--id="box-tabs-add-tab-button-secondary " tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button box secondary variant example"}}
 {{/tabs}}
 ```
 

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -11,7 +11,7 @@ cssPrefix: pf-v6-c-tabs
 ### Default tabs example
 ```hbs
 {{#> tabs tabs--id="default-tabs"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Default example"}}
 {{/tabs}}
 ```
 
@@ -26,7 +26,7 @@ cssPrefix: pf-v6-c-tabs
 ### Overflow beginning of list example
 ```hbs
 {{#> tabs tabs--id="overflow-beginning-of-list" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
+  {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true" __tabs-list--aria-label="Overflow beginning of list example"}}
 {{/tabs}}
 ```
 
@@ -39,21 +39,21 @@ cssPrefix: pf-v6-c-tabs
 ### Horizontal overflow example
 ```hbs
 {{#> tabs tabs--id="horizontal-overflow" __tabs-list--IsOverflow="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow example"}}
 {{/tabs}}
 ```
 
 ### Horizontal overflow expanded example
 ```hbs
 {{#> tabs tabs--id="horizontal-overflow-expanded" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowExpanded="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow expanded example"}}
 {{/tabs}}
 ```
 
 ### Horizontal overflow selected example
 ```hbs
 {{#> tabs tabs--id="horizontal-overflow-selected" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowSelected="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow selected example"}}
 {{/tabs}}
 ```
 
@@ -62,7 +62,7 @@ cssPrefix: pf-v6-c-tabs
 ### Vertical tabs example
 ```hbs
 {{#> tabs tabs--id="vertical-tabs" tabs--IsVertical=true}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Vertical tabs example"}}
 {{/tabs}}
 ```
 
@@ -70,7 +70,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs
 {{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--IsVertical=true}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable example"}}
 {{/tabs}}
 ```
 
@@ -78,7 +78,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs
 {{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--IsVertical=true}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expanded example"}}
 {{/tabs}}
 ```
 
@@ -86,7 +86,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs
 {{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable responsive example"}}
 {{/tabs}}
 ```
 
@@ -94,7 +94,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs isDeprecated
 {{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable deprecated example"}}
 {{/tabs}}
 ```
 
@@ -102,7 +102,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs isDeprecated
 {{#> tabs tabs--id="vertical-expanded-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsExpanded="true" tabs--IsVertical=true}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expanded deprecated example"}}
 {{/tabs}}
 ```
 
@@ -110,7 +110,7 @@ cssPrefix: pf-v6-c-tabs
 ```hbs isDeprecated
 {{#> tabs tabs--id="vertical-expandable-responsive-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable responsive deprecated example"}}
 {{/tabs}}
 ```
 
@@ -119,28 +119,28 @@ cssPrefix: pf-v6-c-tabs
 ### Box tabs example
 ```hbs
 {{#> tabs tabs--id="box-tabs" tabs--modifier="pf-m-box"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box example"}}
 {{/tabs}}
 ```
 
 ### Box overflow example
 ```hbs
 {{#> tabs tabs--id="box-overflow" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true" __tabs-list--aria-label="Box overflow example"}}
 {{/tabs}}
 ```
 
 ### Box vertical example
 ```hbs
 {{#> tabs tabs--id="box-vertical" tabs--IsVertical=true tabs--modifier="pf-m-box"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box vertical example"}}
 {{/tabs}}
 ```
 
 ### Box tabs secondary variant example
 ```hbs
 {{#> tabs tabs--modifier="pf-m-box pf-m-secondary" tabs--id="box-tabs-secondary"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box secondary variant example"}}
 {{/tabs}}
 <div className="tabs-example-block tabs-example-block--m-secondary"></div>
 ```
@@ -150,21 +150,21 @@ cssPrefix: pf-v6-c-tabs
 ### Default tab insets example
 ```hbs
 {{#> tabs tabs--id="default-tab-insets" tabs--modifier="pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
-  {{> __tabs-list}}
+  {{> __tabs-list __tabs-list--aria-label="Default tab insets example"}}
 {{/tabs}}
 ```
 
 ### Box tab insets example
 ```hbs
 {{#> tabs tabs--id="box-tab-insets" tabs--modifier="pf-m-box pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
-  {{> __tabs-list}}
+  {{> __tabs-list __tabs-list--aria-label="Box tab insets example"}}
 {{/tabs}}
 ```
 
 ### Page insets example
 ```hbs
 {{#> tabs tabs--id="page-insets" tabs--modifier="pf-m-page-insets"}}
-  {{> __tabs-list}}
+  {{> __tabs-list __tabs-list--aria-label="Page insets example"}}
 {{/tabs}}
 ```
 
@@ -179,7 +179,7 @@ cssPrefix: pf-v6-c-tabs
 ### Icons and text example
 ```hbs
 {{#> tabs tabs--id="icons-and-text"}}
-  {{> __tabs-list __tabs-list--HasIcons="true"}}
+  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--aria-label="Icons and text example"}}
 {{/tabs}}
 ```
 
@@ -188,22 +188,22 @@ cssPrefix: pf-v6-c-tabs
 ### Tabs with sub tabs example
 ```hbs
 {{#> tabs tabs--id="tabs-with-sub-tabs" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="With sub tabs example, primary"}}
 {{/tabs}}
 
 {{#> tabs tabs--id="tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="With sub tabs example, secondary"}}
 {{/tabs}}
 ```
 
 ### Box tabs with sub tabs example
 ```hbs
 {{#> tabs tabs--id="box-tabs-with-sub-tabs" tabs--modifier="pf-m-box pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="Box with sub tabs example, primary"}}
 {{/tabs}}
 
 {{#> tabs tabs--id="box-tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="Box with sub tabs example, secondary"}}
 {{/tabs}}
 ```
 
@@ -212,28 +212,28 @@ cssPrefix: pf-v6-c-tabs
 ### Filled tabs example
 ```hbs
 {{#> tabs tabs--id="filled-tabs" tabs--modifier="pf-m-fill"}}
-  {{> __tabs-list __tabs-list--IsShort="true"}}
+  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Filled example"}}
 {{/tabs}}
 ```
 
 ### Filled with icons example
 ```hbs
 {{#> tabs tabs--id="filled-with-icons" tabs--modifier="pf-m-fill"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
+  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true" __tabs-list--aria-label="Filled with icons example"}}
 {{/tabs}}
 ```
 
 ### Filled box example
 ```hbs
 {{#> tabs tabs--id="filled-box" tabs--modifier="pf-m-fill pf-m-box"}}
-  {{> __tabs-list __tabs-list--IsShort="true"}}
+  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Filled box example"}}
 {{/tabs}}
 ```
 
 ### Filled box with icons example
 ```hbs
 {{#> tabs tabs--id="filled-box-with-icons" tabs--modifier="pf-m-fill pf-m-box"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
+  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true" __tabs-list--aria-label="Filled box with icons example"}}
 {{/tabs}}
 ```
 
@@ -247,18 +247,18 @@ cssPrefix: pf-v6-c-tabs
 ### Using the nav element example
 ```hbs
 {{#> tabs tabs--id="using-the-nav-element" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--attribute='aria-label="Tabs nav"' tabs-link--isLink="true"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element example"}}
 {{/tabs}}
 ```
 
 ### Sub tabs using the nav element example
 ```hbs
 {{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true"}}
-  {{> __tabs-list}}
+  {{> __tabs-list __tabs-list--aria-label="Using nav element with sub tabs example"}}
 {{/tabs}}
 
 {{#> tabs tabs--id="sub-tabs-using-the-nav-element-subtab" tabs--type="nav" tabs--attribute='aria-label="Tabs subtab nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list-secondary __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element with sub tabs example, Containers"}}
 {{/tabs}}
 ```
 
@@ -347,32 +347,32 @@ To animate the current tab accent, you must set the following variables on the `
 ### Animate default tabs accent
 ```hbs
 {{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
-  {{> __tabs-list __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Animate default example"}}
 {{/tabs}}
 ```
 
 ### Animate sub tabs accent
 ```hbs
 {{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
-  {{> __tabs-list __tabs-list--IsScrollable="true"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="Animate with sub tabs example"}}
 {{/tabs}}
 
 {{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 63px;"'}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="Animate with sub tabs example, Users"}}
 {{/tabs}}
 ```
 
 ### Animate filled tabs accent
 ```hbs
 {{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 253px;"'}}
-  {{> __tabs-list __tabs-list--IsShort="true"}}
+  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Animate filled example"}}
 {{/tabs}}
 ```
 
 ### Animate vertical tabs accent
 ```hbs
 {{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 8px; --pf-v6-c-tabs--link-accent--length: 45px;"'}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Animate vertical example"}}
 {{/tabs}}
 ```
 

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -10,7 +10,7 @@ cssPrefix: pf-v6-c-tabs
 
 ### Default tabs example
 ```hbs
-{{#> tabs tabs--id="default-tabs" tabs--aria-label="Default exampe"}}
+{{#> tabs tabs--id="default-tabs" tabs--aria-label="Default example"}}
   {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```

--- a/src/patternfly/components/Tabs/examples/Tabs.md
+++ b/src/patternfly/components/Tabs/examples/Tabs.md
@@ -10,8 +10,8 @@ cssPrefix: pf-v6-c-tabs
 
 ### Default tabs example
 ```hbs
-{{#> tabs tabs--id="default-tabs"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Default example"}}
+{{#> tabs tabs--id="default-tabs" tabs--aria-label="Default exampe"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
@@ -25,8 +25,8 @@ cssPrefix: pf-v6-c-tabs
 
 ### Overflow beginning of list example
 ```hbs
-{{#> tabs tabs--id="overflow-beginning-of-list" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true" __tabs-list--aria-label="Overflow beginning of list example"}}
+{{#> tabs tabs--id="overflow-beginning-of-list" tabs--modifier="pf-m-scrollable" tabs--aria-label="Overflow beginning of list example"}}
+  {{> __tabs-list __tabs-list--DisabledFirstScrollButton="true" __tabs-list--IsScrollable="true" __tabs-list--IsLong="true" }}
 {{/tabs}}
 ```
 
@@ -38,22 +38,22 @@ cssPrefix: pf-v6-c-tabs
 
 ### Horizontal overflow example
 ```hbs
-{{#> tabs tabs--id="horizontal-overflow" __tabs-list--IsOverflow="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow example"}}
+{{#> tabs tabs--id="horizontal-overflow" __tabs-list--IsOverflow="true" tabs--aria-label="Horizontal overflow example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" }}
 {{/tabs}}
 ```
 
 ### Horizontal overflow expanded example
 ```hbs
-{{#> tabs tabs--id="horizontal-overflow-expanded" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowExpanded="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow expanded example"}}
+{{#> tabs tabs--id="horizontal-overflow-expanded" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowExpanded="true" tabs--aria-label="Horizontal overflow expanded example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" }}
 {{/tabs}}
 ```
 
 ### Horizontal overflow selected example
 ```hbs
-{{#> tabs tabs--id="horizontal-overflow-selected" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowSelected="true"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Horizontal overflow selected example"}}
+{{#> tabs tabs--id="horizontal-overflow-selected" __tabs-list--IsOverflow="true" __tabs-list--IsOverflowSelected="true" tabs--aria-label="Horizontal overflow selected example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" }}
 {{/tabs}}
 ```
 
@@ -61,56 +61,56 @@ cssPrefix: pf-v6-c-tabs
 
 ### Vertical tabs example
 ```hbs
-{{#> tabs tabs--id="vertical-tabs" tabs--IsVertical=true}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Vertical tabs example"}}
+{{#> tabs tabs--id="vertical-tabs" tabs--IsVertical=true tabs--aria-label="Vertical tabs example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" }}
 {{/tabs}}
 ```
 
 ### Vertical expandable example
 ```hbs
-{{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--IsVertical=true}}
+{{#> tabs tabs--id="vertical-expandable" tabs--IsExpandable="true" tabs--IsVertical=true tabs--aria-label="Vertical expandable example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
 ### Vertical expanded example
 ```hbs
-{{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--IsVertical=true}}
+{{#> tabs tabs--id="vertical-expanded" tabs--IsExpandable="true" tabs--IsExpanded="true" tabs--IsVertical=true tabs--aria-label="Vertical expanded example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expanded example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
 ### Vertical expandable responsive example
 ```hbs
-{{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+{{#> tabs tabs--id="vertical-expandable-responsive" tabs--IsExpandable="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl" tabs--aria-label="Vertical expandable responsive example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable responsive example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
 ### Vertical expandable example (deprecated)
 ```hbs isDeprecated
-{{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true}}
+{{#> tabs tabs--id="vertical-expandable-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true tabs--aria-label="Vertical expandable deprecated example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable deprecated example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
 ### Vertical expanded example (deprecated)
 ```hbs isDeprecated
-{{#> tabs tabs--id="vertical-expanded-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsExpanded="true" tabs--IsVertical=true}}
+{{#> tabs tabs--id="vertical-expanded-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsExpanded="true" tabs--IsVertical=true tabs--aria-label="Vertical expanded deprecated example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expanded deprecated example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
 ### Vertical expandable responsive example (deprecated)
 ```hbs isDeprecated
-{{#> tabs tabs--id="vertical-expandable-responsive-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl"}}
+{{#> tabs tabs--id="vertical-expandable-responsive-legacy" tabs--IsExpandable="true" tabs--IsLegacy="true" tabs--IsVertical=true tabs--modifier="pf-m-non-expandable-on-md pf-m-expandable-on-lg pf-m-non-expandable-on-xl" tabs--aria-label="Vertical expandable responsive deprecated example"}}
   {{> tabs-toggle}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--aria-label="Vertical expandable responsive deprecated example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true"}}
 {{/tabs}}
 ```
 
@@ -118,29 +118,29 @@ cssPrefix: pf-v6-c-tabs
 
 ### Box tabs example
 ```hbs
-{{#> tabs tabs--id="box-tabs" tabs--modifier="pf-m-box"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box example"}}
+{{#> tabs tabs--id="box-tabs" tabs--modifier="pf-m-box" tabs--aria-label="Box example"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Box overflow example
 ```hbs
-{{#> tabs tabs--id="box-overflow" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true" __tabs-list--aria-label="Box overflow example"}}
+{{#> tabs tabs--id="box-overflow" tabs--modifier="pf-m-box pf-m-scrollable" __tabs-list--DisabledFirstScrollButton="true" tabs--aria-label="Box overflow example"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsLong="true"}}
 {{/tabs}}
 ```
 
 ### Box vertical example
 ```hbs
-{{#> tabs tabs--id="box-vertical" tabs--IsVertical=true tabs--modifier="pf-m-box"}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box vertical example"}}
+{{#> tabs tabs--id="box-vertical" tabs--IsVertical=true tabs--modifier="pf-m-box" tabs--aria-label="Box vertical example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Box tabs secondary variant example
 ```hbs
-{{#> tabs tabs--modifier="pf-m-box pf-m-secondary" tabs--id="box-tabs-secondary"}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Box secondary variant example"}}
+{{#> tabs tabs--modifier="pf-m-box pf-m-secondary" tabs--id="box-tabs-secondary" tabs--aria-label="Box secondary variant example"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 <div className="tabs-example-block tabs-example-block--m-secondary"></div>
 ```
@@ -149,22 +149,22 @@ cssPrefix: pf-v6-c-tabs
 
 ### Default tab insets example
 ```hbs
-{{#> tabs tabs--id="default-tab-insets" tabs--modifier="pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
-  {{> __tabs-list __tabs-list--aria-label="Default tab insets example"}}
+{{#> tabs tabs--id="default-tab-insets" tabs--modifier="pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl" tabs--aria-label="Default tab insets example"}}
+  {{> __tabs-list}}
 {{/tabs}}
 ```
 
 ### Box tab insets example
 ```hbs
-{{#> tabs tabs--id="box-tab-insets" tabs--modifier="pf-m-box pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl"}}
-  {{> __tabs-list __tabs-list--aria-label="Box tab insets example"}}
+{{#> tabs tabs--id="box-tab-insets" tabs--modifier="pf-m-box pf-m-inset-sm-on-md pf-m-inset-lg-on-lg pf-m-inset-2xl-on-xl" tabs--aria-label="Box tab insets example"}}
+  {{> __tabs-list}}
 {{/tabs}}
 ```
 
 ### Page insets example
 ```hbs
-{{#> tabs tabs--id="page-insets" tabs--modifier="pf-m-page-insets"}}
-  {{> __tabs-list __tabs-list--aria-label="Page insets example"}}
+{{#> tabs tabs--id="page-insets" tabs--modifier="pf-m-page-insets" tabs--aria-label="Page insets example"}}
+  {{> __tabs-list}}
 {{/tabs}}
 ```
 
@@ -178,8 +178,8 @@ cssPrefix: pf-v6-c-tabs
 
 ### Icons and text example
 ```hbs
-{{#> tabs tabs--id="icons-and-text"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--aria-label="Icons and text example"}}
+{{#> tabs tabs--id="icons-and-text" tabs--aria-label="Icons and text example"}}
+  {{> __tabs-list __tabs-list--HasIcons="true"}}
 {{/tabs}}
 ```
 
@@ -187,23 +187,23 @@ cssPrefix: pf-v6-c-tabs
 
 ### Tabs with sub tabs example
 ```hbs
-{{#> tabs tabs--id="tabs-with-sub-tabs" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="With sub tabs example, primary"}}
+{{#> tabs tabs--id="tabs-with-sub-tabs" tabs--modifier="pf-m-scrollable" tabs--aria-label="With sub tabs example, primary"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--id="tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="With sub tabs example, secondary"}}
+{{#> tabs tabs--id="tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--aria-label="With sub tabs example, Containers"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
 ### Box tabs with sub tabs example
 ```hbs
-{{#> tabs tabs--id="box-tabs-with-sub-tabs" tabs--modifier="pf-m-box pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="Box with sub tabs example, primary"}}
+{{#> tabs tabs--id="box-tabs-with-sub-tabs" tabs--modifier="pf-m-box pf-m-scrollable" tabs--aria-label="Box with sub tabs example, primary"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--id="box-tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="Box with sub tabs example, secondary"}}
+{{#> tabs tabs--id="box-tabs-with-sub-tabs-subtab" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--aria-label="Box with sub tabs example, Containers"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
@@ -211,29 +211,29 @@ cssPrefix: pf-v6-c-tabs
 
 ### Filled tabs example
 ```hbs
-{{#> tabs tabs--id="filled-tabs" tabs--modifier="pf-m-fill"}}
-  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Filled example"}}
+{{#> tabs tabs--id="filled-tabs" tabs--modifier="pf-m-fill" tabs--aria-label="Filled example"}}
+  {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
 ### Filled with icons example
 ```hbs
-{{#> tabs tabs--id="filled-with-icons" tabs--modifier="pf-m-fill"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true" __tabs-list--aria-label="Filled with icons example"}}
+{{#> tabs tabs--id="filled-with-icons" tabs--modifier="pf-m-fill" tabs--aria-label="Filled with icons example"}}
+  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
 ### Filled box example
 ```hbs
-{{#> tabs tabs--id="filled-box" tabs--modifier="pf-m-fill pf-m-box"}}
-  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Filled box example"}}
+{{#> tabs tabs--id="filled-box" tabs--modifier="pf-m-fill pf-m-box" tabs--aria-label="Filled box example"}}
+  {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
 ### Filled box with icons example
 ```hbs
-{{#> tabs tabs--id="filled-box-with-icons" tabs--modifier="pf-m-fill pf-m-box"}}
-  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true" __tabs-list--aria-label="Filled box with icons example"}}
+{{#> tabs tabs--id="filled-box-with-icons" tabs--modifier="pf-m-fill pf-m-box" tabs--aria-label="Filled box with icons example"}}
+  {{> __tabs-list __tabs-list--HasIcons="true" __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
@@ -247,29 +247,29 @@ cssPrefix: pf-v6-c-tabs
 ### Using the nav element example
 ```hbs
 {{#> tabs tabs--id="using-the-nav-element" tabs--type="nav" tabs--modifier="pf-m-scrollable" tabs--aria-label="Using nav element example" tabs-link--isLink="true"}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element example"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Sub tabs using the nav element example
 ```hbs
-{{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs--attribute='aria-label="Tabs primary nav"' tabs-link--isLink="true" tabs--aria-label="Sub tabs using nav element example"}}
-  {{> __tabs-list __tabs-list--aria-label="Using nav element with sub tabs example"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element" tabs--type="nav" tabs-link--isLink="true" tabs--aria-label="Using nav element with sub tabs example, primary"}}
+  {{> __tabs-list}}
 {{/tabs}}
 
-{{#> tabs tabs--id="sub-tabs-using-the-nav-element-subtab" tabs--type="nav" tabs--attribute='aria-label="Tabs subtab nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab" tabs--aria-label="Sub tabs using nav element example, Containers"}}
-  {{> __tabs-list-secondary __tabs-list--IsDisabled="true" __tabs-list--aria-label="Using nav element with sub tabs example, Containers"}}
+{{#> tabs tabs--id="sub-tabs-using-the-nav-element-subtab" tabs--type="nav" tabs-link--isLink="true" tabs--modifier="pf-m-subtab" tabs--aria-label="Using nav element with sub tabs example, Containers"}}
+  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Site navigation variation
 ```hbs isBeta
-{{#> tabs tabs--id="nav-tabs" tabs--IsNav=true tabs--attribute='aria-label="Site navigation variation example"'}}
+{{#> tabs tabs--id="nav-tabs" tabs--IsNav=true tabs--aria-label="Site navigation variation example"}}
   {{> __tabs-list }}
 {{/tabs}}
 <br/ >
 As sub navigation:
-{{#> tabs tabs--id="nav-tabs" tabs--IsNav=true tabs--IsSubtab=true tabs--attribute='aria-label="Site sub-navigation variation example"'}}
+{{#> tabs tabs--id="nav-tabs" tabs--IsNav=true tabs--IsSubtab=true tabs--aria-label="Site navigation variation as sub tabs example"}}
   {{> __tabs-list }}
 {{/tabs}}
 ```
@@ -285,7 +285,7 @@ As sub navigation:
       __tabs-list--IsScrollable="true"
       __tabs-list--DisabledFirstScrollButton="true"
       __tabs-list--HasHelp="true" __tabs-list--IsHelpDisabled="true"
-      __tabs-list--aria-label-prefix="Help button"}}
+      __tabs--aria-label-prefix="Help button"}}
 ```
 
 ### Close button example
@@ -298,7 +298,7 @@ As sub navigation:
       __tabs-list--IsCloseDisabled="true"
       __tabs-list--IsScrollable="true"
       __tabs-list--DisabledFirstScrollButton="true"
-      __tabs-list--aria-label-prefix="Close button"}}
+      __tabs--aria-label-prefix="Close button"}}
 ```
 
 ### Help and close button example
@@ -314,30 +314,30 @@ As sub navigation:
       __tabs-list--IsHelpDisabled="true"
       __tabs-list--IsCloseDisabled="true"
       __tabs-list--IsHelpCloseDisabled="true"
-      __tabs-list--aria-label-prefix="Help and close button"}}
+      __tabs--aria-label-prefix="Help and close button"}}
 ```
 
 ## Add tab button
 
 ### Add tab button example
 ```hbs
-{{#> tabs tabs--id="default-tabs-add-tab-button" tabs--modifier="pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button with sub tabs example"}}
+{{#> tabs tabs--id="default-tabs-add-tab-button" tabs--modifier="pf-m-scrollable" tabs--aria-label="Add button with sub tabs example, primary"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
-{{#> tabs tabs--id="default-tabs-add-tab-button-subtab" tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button with sub tabs example, Containers"}}
-{{/tabs}}
-
-<br><br>
-
-{{#> tabs tabs--id="box-tabs-add-tab-button" tabs--modifier="pf-m-box pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button box example"}}
+{{#> tabs tabs--id="default-tabs-add-tab-button-subtab" tabs--modifier="pf-m-scrollable" tabs--IsSubtab="true" tabs--aria-label="Add button with sub tabs example, Containers"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 
 <br><br>
 
-{{#> tabs tabs--id="box-tabs-add-tab-button-secondary " tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable"}}
-  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true" __tabs-list--aria-label="Add button box secondary variant example"}}
+{{#> tabs tabs--id="box-tabs-add-tab-button" tabs--modifier="pf-m-box pf-m-scrollable" tabs--aria-label="Add button box example"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
+{{/tabs}}
+
+<br><br>
+
+{{#> tabs tabs--id="box-tabs-add-tab-button-secondary " tabs--modifier="pf-m-box pf-m-secondary pf-m-scrollable" tabs--aria-label="Add button box secondary variant example"}}
+  {{> __tabs-list __tabs-list--IsAction="true" __tabs-list--HasClose="true" __tabs-list--IsScrollable="true" __tabs-list--DisabledFirstScrollButton="true" __tabs-list--HasAddTab="true"}}
 {{/tabs}}
 ```
 
@@ -349,33 +349,33 @@ To animate the current tab accent, you must set the following variables on the `
 
 ### Animate default tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
-  {{> __tabs-list __tabs-list--IsDisabled="true" __tabs-list--aria-label="Animate default example"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-default" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"' tabs--aria-label="Animate default example"}}
+  {{> __tabs-list __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 
 ### Animate sub tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"'}}
-  {{> __tabs-list __tabs-list--IsScrollable="true" __tabs-list--aria-label="Animate with sub tabs example"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 67px;"' tabs--aria-label="Animate with sub tabs example, primary"}}
+  {{> __tabs-list __tabs-list--IsScrollable="true"}}
 {{/tabs}}
 
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 63px;"'}}
-  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true" __tabs-list--aria-label="Animate with sub tabs example, Users"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-subtabs-sub" tabs--IsSubtab="true" tabs--modifier="pf-m-scrollable" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 63px;"' tabs--aria-label="Animate with sub tabs example, Users"}}
+  {{> __tabs-list-secondary __tabs-list-secondary--IsScrollable="true"}}
 {{/tabs}}
 ```
 
 ### Animate filled tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 253px;"'}}
-  {{> __tabs-list __tabs-list--IsShort="true" __tabs-list--aria-label="Animate filled example"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-filled" tabs--modifier="pf-m-fill" tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 0px; --pf-v6-c-tabs--link-accent--length: 253px;"' tabs--aria-label="Animate filled example"}}
+  {{> __tabs-list __tabs-list--IsShort="true"}}
 {{/tabs}}
 ```
 
 ### Animate vertical tabs accent
 ```hbs
-{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 8px; --pf-v6-c-tabs--link-accent--length: 45px;"'}}
-  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true" __tabs-list--aria-label="Animate vertical example"}}
+{{#> tabs tabs--IsAnimateCurrent=true tabs--id="tabs-animate-current-vertical" tabs--IsVertical=true __tabs-list--HasMultiLine=true tabs--attribute='style="--pf-v6-c-tabs--link-accent--start: 8px; --pf-v6-c-tabs--link-accent--length: 45px;"' tabs--aria-label="Animate vertical example"}}
+  {{> __tabs-list __tabs-list--NoScrollButtons="true" __tabs-list--IsDisabled="true"}}
 {{/tabs}}
 ```
 

--- a/src/patternfly/components/Tabs/tabs-link.hbs
+++ b/src/patternfly/components/Tabs/tabs-link.hbs
@@ -64,6 +64,7 @@
     aria-expanded="true"
   {{/if}}
   role="tab"
+  aria-selected="{{ternary tabs-item--IsCurrent true false}}"
   {{#if tabs-link--attribute}}
     {{{tabs-link--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Tabs/tabs-list.hbs
+++ b/src/patternfly/components/Tabs/tabs-list.hbs
@@ -1,5 +1,8 @@
 <ul class="{{pfv}}tabs__list{{#if tabs-list--modifier}} {{tabs-list--modifier}}{{/if}}"
   role="tablist"
+  {{#if tabs-list--aria-label}}
+    aria-label="{{tabs-list--aria-label}}"
+  {{/if}}
   {{#if tabs-list--attribute}}
     {{{tabs-list--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Tabs/tabs-list.hbs
+++ b/src/patternfly/components/Tabs/tabs-list.hbs
@@ -2,6 +2,8 @@
   role="tablist"
   {{#if tabs-list--aria-label}}
     aria-label="{{tabs-list--aria-label}}"
+  {{else if tabs--aria-label}}
+    aria-label="{{tabs--aria-label}}"
   {{/if}}
   {{#if tabs-list--attribute}}
     {{{tabs-list--attribute}}}

--- a/src/patternfly/components/Tabs/tabs.hbs
+++ b/src/patternfly/components/Tabs/tabs.hbs
@@ -12,7 +12,7 @@
   {{#if tabs--attribute}}
     {{{tabs--attribute}}}
   {{/if}}
-    {{#if tabs--aria-label}}
+  {{#if tabs--aria-label}}
     aria-label="{{tabs--aria-label}}"
   {{/if}}
   {{#if tabs--aria-labelledby}}

--- a/src/patternfly/components/Tabs/tabs.hbs
+++ b/src/patternfly/components/Tabs/tabs.hbs
@@ -12,6 +12,12 @@
   {{#if tabs--attribute}}
     {{{tabs--attribute}}}
   {{/if}}
+    {{#if tabs--aria-label}}
+    aria-label="{{tabs--aria-label}}"
+  {{/if}}
+  {{#if tabs--aria-labelledby}}
+    aria-labelledby="{{tabs--aria-labelledby}}"
+  {{/if}}
   {{#unlessIfEquals tabs--type "nav"}}
     {{#unless tabs--IsNav}}
       {{#if tabs--id}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -537,7 +537,7 @@ import './Card.css'
     {{/card-header-main}}
   {{/card-header}}
   {{#> card-body}}
-    {{#> tabs tabs--id="status-tabs" tabs--modifier="pf-m-fill"}}
+    {{#> tabs tabs--aria-label="Status, tabbed card example" tabs--id="status-tabs" tabs--modifier="pf-m-fill"}}
       {{#> tabs-list}}
         {{> __tabs-item __tabs-item--id="object-1" __tabs-item--aria-label="Object 1" __tabs-item--text="Object 1" __tabs-item--current="true"}}
         {{> __tabs-item __tabs-item--id="object-2" __tabs-item--aria-label="Object 2" __tabs-item--text="Object 2"}}

--- a/src/patternfly/demos/Compass/compass--card-view.hbs
+++ b/src/patternfly/demos/Compass/compass--card-view.hbs
@@ -13,7 +13,7 @@
               {{/button}}
             {{/compass-nav-home}}
             {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true"}}
+                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
                   {{> __tabs-list}}
                 {{/tabs}}
             {{/compass-nav-main}}
@@ -27,7 +27,7 @@
         {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
           {{#> compass-nav-content}}
             {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
                   {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
                 {{/tabs}}
             {{/compass-nav-main}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -42,7 +42,7 @@ wrapperTag: div
         {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
           {{#> compass-nav-content}}
             {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
                   {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
                 {{/tabs}}
             {{/compass-nav-main}}
@@ -207,7 +207,7 @@ wrapperTag: div
               {{/button}}
             {{/compass-nav-home}}
             {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true"}}
+                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
                   {{> __tabs-list}}
                 {{/tabs}}
             {{/compass-nav-main}}
@@ -221,7 +221,7 @@ wrapperTag: div
         {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
           {{#> compass-nav-content}}
             {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Secondary nav"' tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
                   {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
                 {{/tabs}}
             {{/compass-nav-main}}

--- a/src/patternfly/demos/Page/page-template-drawer-panel.hbs
+++ b/src/patternfly/demos/Page/page-template-drawer-panel.hbs
@@ -16,7 +16,7 @@
     {{/l-flex}}
   {{/drawer-head}}
   {{#> drawer-body drawer-body--modifier="pf-m-no-padding"}}
-    {{#> tabs tabs--modifier="pf-m-box pf-m-fill"}}
+    {{#> tabs tabs--aria-label="Drawer panel" tabs--modifier="pf-m-box pf-m-fill"}}
       {{#> tabs-list}}
         {{#> tabs-item tabs-item--IsCurrent="true"}}
           {{#> tabs-link tabs-link--attribute=(concat 'id="' page-template--id '-panel-tabs-tab1-link"')}}

--- a/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
+++ b/src/patternfly/demos/PrimaryDetail/examples/PrimaryDetail.md
@@ -39,7 +39,7 @@ wrapperTag: div
 
           <!-- Tabs -->
           {{#> drawer-body drawer-body--modifier="pf-m-no-padding"}}
-            {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
+            {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--aria-label="Node 2" primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
           {{/drawer-body}}
 
           <!-- Tab content -->
@@ -293,7 +293,7 @@ wrapperTag: div
 
         <!-- Tabs -->
         {{#> drawer-body drawer-body--modifier="pf-m-no-padding"}}
-          {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
+          {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--aria-label="Node 2" primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
         {{/drawer-body}}
 
         <!-- Tab content -->

--- a/src/patternfly/demos/PrimaryDetail/primary-detail-template-panel-tabs.hbs
+++ b/src/patternfly/demos/PrimaryDetail/primary-detail-template-panel-tabs.hbs
@@ -1,4 +1,4 @@
-{{#> tabs tabs--id=(concat primary-detail-template--id '-tabs') tabs--modifier=primary-detail-template-panel-tabs--modifier}}
+{{#> tabs tabs--aria-label=primary-detail-template-panel-tabs--aria-label tabs--id=(concat primary-detail-template--id '-tabs') tabs--modifier=primary-detail-template-panel-tabs--modifier}}
   {{#> tabs-scroll-button tabs-scroll-button--IsLeft="true"}}{{/tabs-scroll-button}}
   {{#> tabs-list}}
     {{> __tabs-item

--- a/src/patternfly/demos/Tabs/examples/Tabs.md
+++ b/src/patternfly/demos/Tabs/examples/Tabs.md
@@ -275,7 +275,7 @@ section: components
 {{#* inline "page-template-section"}}
   {{#> tabs-template tabs-template--id=(concat page-template--id "-tabs")}}
     {{#> page-main-tabs page-main-tabs--IsLimitWidth="true"}}
-      {{#> tabs tabs--id=(concat tabs-template--id '-tabs') tabs--modifier="pf-m-page-insets"}}
+      {{#> tabs tabs--aria-label="Clusters" tabs--id=(concat tabs-template--id '-tabs') tabs--modifier="pf-m-page-insets"}}
         {{#> tabs-list}}
           {{> __tabs-item
             __tabs-item--current="true"
@@ -336,7 +336,7 @@ section: components
           {{#> drawer-panel drawer-panel--modifier="pf-m-width-33 pf-m-width-33-on-xl"}}
             {{> tabs--panel-header tabs--panel-header--title="Node 2" tabs--panel-header--sub-title='<a href="#">siemur/test-space</a>'}}
             {{#> drawer-body drawer-body--modifier="pf-m-no-padding"}}
-              {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
+              {{> primary-detail-template-panel-tabs primary-detail-template-panel-tabs--aria-label="Node 2" primary-detail-template-panel-tabs--modifier="pf-m-box pf-m-fill"}}
             {{/drawer-body}}
             {{#> drawer-body primary-detail-template-template--id=(concat tabs-template--id '-tabs')}}
               {{> primary-detail-template-panel-tab-content progress--modifier="pf-m-sm" primary-detail-template-panel-tab-content--HasLabels="true"}}
@@ -363,7 +363,7 @@ section: components
       {{#> modal-box-body modal-box-body--attribute=(concat 'id="' modal-template--id '-modal-description"')}}
         {{#> grid grid--modifier="pf-m-gutter"}}
           {{#> grid-item}}
-            {{#> tabs tabs--id=(concat modal-template--id '-tabs') tabs--IsSecondary="true" tabs--modifier="pf-m-inset-none"}}
+            {{#> tabs tabs--aria-label="PatternFly" tabs--id=(concat modal-template--id '-tabs') tabs--IsSecondary="true" tabs--modifier="pf-m-inset-none"}}
               {{#> tabs-list}}
                 {{> __tabs-item
                   __tabs-item--current="true"
@@ -432,7 +432,7 @@ section: components
 {{#* inline "page-template-section"}}
   {{#> tabs-template tabs-template--id=(concat page-template--id "-tabs")}}
     {{#> page-main-tabs page-main-tabs--IsLimitWidth="true"}}
-      {{#> tabs tabs--id=(concat tabs-template--id '-tabs') tabs--modifier="pf-m-page-insets"}}
+      {{#> tabs tabs--aria-label="Red Hat Enterprise Linux" tabs--id=(concat tabs-template--id '-tabs') tabs--modifier="pf-m-page-insets"}}
         {{#> tabs-list}}
           {{> __tabs-item
             __tabs-item--id="new"
@@ -470,7 +470,7 @@ section: components
             {{/title}}
           {{/grid-item}}
           {{#> grid-item}}
-            {{#> tabs tabs--id=(concat tabs-template--id '-subtabs') tabs--IsSecondary="true" tabs--modifier="pf-m-inset-none"}}
+            {{#> tabs tabs--aria-label="Get started" tabs--id=(concat tabs-template--id '-subtabs') tabs--IsSecondary="true" tabs--modifier="pf-m-inset-none"}}
               {{#> tabs-list}}
                 {{> __tabs-item
                   __tabs-item--current="true"

--- a/src/patternfly/demos/Tabs/tabs--page-grid-view.hbs
+++ b/src/patternfly/demos/Tabs/tabs--page-grid-view.hbs
@@ -10,7 +10,7 @@
         {{#> wrapper newcontext tabs--page-grid-view--id=(concat tabs--page-grid-view--id "-subtabs")}}
           {{#> l-flex l-flex--modifier="pf-m-column"}}
             {{#> l-flex-item}}
-              {{#> tabs tabs--IsSecondary="true" tabs--id=tabs--page-grid-view--id}}
+              {{#> tabs tabs--aria-label="Cluster 1" tabs--IsSecondary="true" tabs--id=tabs--page-grid-view--id}}
                 {{#> tabs-list}}
                   {{> __tabs-item
                     __tabs-item--current="true"

--- a/src/patternfly/demos/Tabs/tabs-template-pod-tab-list.hbs
+++ b/src/patternfly/demos/Tabs/tabs-template-pod-tab-list.hbs
@@ -1,5 +1,5 @@
 {{#if tabs-template-pod-tab-list--IsSecondary}}
-  {{#> tabs tabs-id=tab-template--id tabs--modifier=(concat "pf-m-secondary " tabs-template-pod-tab-list--modifier) tabs--attribute=tabs-template-pod-tab-list--attribute}}
+  {{#> tabs tabs--aria-label="Pod details" tabs-id=tab-template--id tabs--modifier=(concat "pf-m-secondary " tabs-template-pod-tab-list--modifier) tabs--attribute=tabs-template-pod-tab-list--attribute}}
     {{#> tabs-list}}
       {{> __tabs-item
         __tabs-item--current="true"
@@ -15,7 +15,7 @@
     {{/tabs-list}}
   {{/tabs}}
 {{else}}
-  {{#> tabs tabs-id=tab-template--id tabs--modifier=tabs-template-pod-tab-list--modifier}}
+  {{#> tabs tabs--aria-label="Pod" tabs-id=tab-template--id tabs--modifier=tabs-template-pod-tab-list--modifier}}
     {{#> tabs-list}}
       {{> __tabs-item
         __tabs-item--current="true"


### PR DESCRIPTION
Closes #5795 

To confirm issue is resolved:

- All Tabs usage includes an aria-label on the wrapper `[div|nav].pf-v6-c-tabs` element
- All Tabs usage includes an aria-label on the `ul[role="tabslist"]` element
- Every Tab within a tablist has aria-selected with either a value of true or false; no Tab should have this attribute omitted