### PR TITLE
feat(Hero): added Hero component from compasshero

### DIFF
--- a/src/patternfly/components/Compass/compass-hero-body.hbs
+++ b/src/patternfly/components/Compass/compass-hero-body.hbs
@@ -1,6 +1,0 @@
-<div class="{{pfv}}compass__hero-body{{#if compass-hero-body--modifier}} {{compass-hero-body--modifier}}{{/if}}"
-  {{#if compass-hero-body--attribute}}
-    {{{compass-hero-body--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Compass/compass-hero.hbs
+++ b/src/patternfly/components/Compass/compass-hero.hbs
@@ -1,3 +1,6 @@
-{{#> compass-panel compass-panel--IsHero=true compass-panel--modifier=compass-hero--modifier compass-panel--attribute=compass-hero--attribute}}
+<div class="{{pfv}}compass__hero{{#if compass-hero--modifier}} {{compass-hero--modifier}}{{/if}}"
+  {{#if compass-hero--attribute}}
+    {{{compass-hero--attribute}}}
+  {{/if}}>
   {{> @partial-block}}
-{{/compass-panel}}
+</div>

--- a/src/patternfly/components/Compass/compass-panel.hbs
+++ b/src/patternfly/components/Compass/compass-panel.hbs
@@ -4,7 +4,7 @@
     compass-panel--IsPill='pf-m-pill'
     compass-panel--IsFullHeight='pf-m-full-height'
     compass-panel--HasNoBorder='pf-m-no-border'
-    compass-panel--IsHero='pf-v6-c-compass__hero'
+    compass-panel--IsHero='pf-m-hero'
     compass-panel--IsScrollable='pf-m-scrollable'
     compass-panel--modifier=compass-panel--modifier
   }}"

--- a/src/patternfly/components/Compass/compass-panel.hbs
+++ b/src/patternfly/components/Compass/compass-panel.hbs
@@ -4,7 +4,6 @@
     compass-panel--IsPill='pf-m-pill'
     compass-panel--IsFullHeight='pf-m-full-height'
     compass-panel--HasNoBorder='pf-m-no-border'
-    compass-panel--IsHero='pf-m-hero'
     compass-panel--IsScrollable='pf-m-scrollable'
     compass-panel--modifier=compass-panel--modifier
   }}"

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -21,17 +21,6 @@
   --#{$compass}__message-bar--Width: 450px;
   --#{$compass}__message-bar--MinWidth: 300px;
   --#{$compass}__message-bar--MaxWidth: 600px;
-  --#{$compass}__hero--gradient--angle: 109deg;
-  --#{$compass}__hero--gradient--stop-1--light: transparent;
-  --#{$compass}__hero--gradient--stop-2--light: transparent;
-  --#{$compass}__hero--gradient--stop-3--light: transparent;
-  --#{$compass}__hero--gradient--stop-1--dark: transparent;
-  --#{$compass}__hero--gradient--stop-2--dark: transparent;
-  --#{$compass}__hero--gradient--stop-3--dark: transparent;
-  --#{$compass}__hero--BackgroundImage--light: none;
-  --#{$compass}__hero--BackgroundImage--dark: none;
-  --#{$compass}__hero-body--Width: 800px;
-  --#{$compass}__hero-body--MaxWidth: 80%;
 }
 
 .#{$compass} {
@@ -168,36 +157,6 @@
   &.pf-m-scrollable {
     overflow: auto;
   }
-}
-
-.#{$compass}__hero {
-  display: flex;
-  padding-block-start: 32px;
-  padding-block-end: 32px;
-  padding-inline-start: 72px;
-  padding-inline-end: 0;
-  background-image: var(--#{$compass}__hero--BackgroundImage, var(--#{$compass}__hero--BackgroundImage--light)),
-    linear-gradient(
-      var(--#{$compass}__hero--gradient--angle),
-      var(--#{$compass}__hero--gradient--stop-1, var(--#{$compass}__hero--gradient--stop-1--light)) 0%,
-      var(--#{$compass}__hero--gradient--stop-2, var(--#{$compass}__hero--gradient--stop-2--light)) 50%,
-      var(--#{$compass}__hero--gradient--stop-3, var(--#{$compass}__hero--gradient--stop-3--light)) 100%
-    );
-  background-repeat: no-repeat;
-  background-position: right center;
-  background-size: contain;
-  border-radius: 24px 72px;
-
-  :root:where(.pf-v6-theme-dark) & {
-    --#{$compass}__hero--BackgroundImage: var(--#{$compass}__hero--BackgroundImage--dark);
-    --#{$compass}__hero--gradient--stop-1: var(--#{$compass}__hero--gradient--stop-1--dark);
-    --#{$compass}__hero--gradient--stop-2: var(--#{$compass}__hero--gradient--stop-2--dark);
-    --#{$compass}__hero--gradient--stop-3: var(--#{$compass}__hero--gradient--stop-3--dark);
-  }
-}
-
-.#{$compass}__hero-body {
-  width: min(var(--#{$compass}__hero-body--Width), var(--#{$compass}__hero-body--MaxWidth));
 }
 
 :where(.pf-v6-theme-dark) .#{$compass} {

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -18,7 +18,9 @@ import './Compass.css';
   {{/compass-header}}
   {{#> compass-sidebar compass-sidebar--IsStart=true}}sidebar (start){{/compass-sidebar}}
   {{#> compass-main}}
-    {{#> hero}}hero{{/hero}}
+    {{#> compass-hero}}
+      {{#> hero}}hero{{/hero}}
+    {{/compass-hero}}
     {{#> compass-main-header}}main header{{/compass-main-header}}
     {{#> compass-content}}content{{/compass-content}}
   {{/compass-main}}
@@ -43,6 +45,7 @@ import './Compass.css';
 | `.pf-v6-c-compass__main-header` | `<div>` | Initiates the compass main header. |
 | `.pf-v6-c-compass__content` | `<div>` | Initiates the compass content. **Required** |
 | `.pf-v6-c-compass__panel` | `<div>` | Initiates a compass panel. |
+| `.pf-v6-c-compass__hero` | `<div>` | Initiates a compass hero. |
 | `.pf-v6-c-compass__footer` | `<div>` | Initiates the compass footer. **Required** |
 | `.pf-v6-c-compass__message-bar` | `<div>` | Initiates the compass message bar. |
 | `.pf-m-no-glass` | `.pf-v6-c-compass`, `.pf-v6-c-compass__panel` | Modifies all elements or individual panels to remove the glass styles. |

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -18,7 +18,7 @@ import './Compass.css';
   {{/compass-header}}
   {{#> compass-sidebar compass-sidebar--IsStart=true}}sidebar (start){{/compass-sidebar}}
   {{#> compass-main}}
-    {{#> compass-hero}}hero{{/compass-hero}}
+    {{#> hero}}hero{{/hero}}
     {{#> compass-main-header}}main header{{/compass-main-header}}
     {{#> compass-content}}content{{/compass-content}}
   {{/compass-main}}
@@ -40,8 +40,6 @@ import './Compass.css';
 | `.pf-v6-c-compass__profile` | `<div>` | Initiates the compass profile. |
 | `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a compass sidebar. **Required** |
 | `.pf-v6-c-compass__main` | `<div>` | Initiates the compass main wrapper. **Required** |
-| `.pf-v6-c-compass__hero` | `<div>` | Initiates the compass logo hero. |
-| `.pf-v6-c-compass__hero-body` | `<div>` | Initiates the compass hero body. |
 | `.pf-v6-c-compass__main-header` | `<div>` | Initiates the compass main header. |
 | `.pf-v6-c-compass__content` | `<div>` | Initiates the compass content. **Required** |
 | `.pf-v6-c-compass__panel` | `<div>` | Initiates a compass panel. |

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -340,7 +340,7 @@ import './Drawer.css'
 | `.pf-m-static{-on-[lg, xl, 2xl]}` | `.pf-v6-c-drawer` | Modifies the drawer panel state to always show both content and panel at optional [breakpoint](/tokens/all-patternfly-tokens). |
 | `.pf-m-inline{-on-[lg, xl, 2xl]}` | `.pf-v6-c-drawer` | Modifies the drawer so the content element and panel element are displayed side by side. `.pf-m-inline` used without a [breakpoint](/tokens/all-patternfly-tokens) will default to the `md` breakpoint. |
 | `.pf-m-pill` | `.pf-v6-c-drawer` | Modifies the drawer for pill styles. |
-| `.pf-m-no-glass` | `.pf-v6-c-drawer__panel.pf-m-pill` | Modifies the drawer panel remove glass styling when using glass theme. |
+| `.pf-m-no-glass` | `.pf-v6-c-drawer__panel.pf-m-pill` | Modifies the drawer panel to remove glass styling when using glass theme. |
 | `.pf-m-no-border` | `.pf-v6-c-drawer__panel` | Modifies the drawer panel border treatment to disable all border treatment. |
 | `.pf-m-padding` | `.pf-v6-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-v6-c-drawer__body` | Modifies the element to remove padding. |

--- a/src/patternfly/components/Hero/examples/Hero.md
+++ b/src/patternfly/components/Hero/examples/Hero.md
@@ -23,3 +23,4 @@ cssPrefix: pf-v6-c-hero
 | -- | -- | -- |
 | `.pf-v6-c-hero` | `<div>` | Initiates the hero. **Required** |
 | `.pf-v6-c-hero__body` | `<div>` | Initiates the hero body. |
+| `.pf-m-no-glass` | `.pf-v6-c-hero` | Modifies the hero to remove glass styling when using glass theme. |

--- a/src/patternfly/components/Hero/examples/Hero.md
+++ b/src/patternfly/components/Hero/examples/Hero.md
@@ -21,5 +21,5 @@ cssPrefix: pf-v5-c-hero
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v6-c-hero` | `<div>` | Initiates the compass logo hero. **Required** |
-| `.pf-v6-c-hero__body` | `<div>` | Initiates the compass hero body. **Required** |
+| `.pf-v6-c-hero` | `<div>` | Initiates the hero. **Required** |
+| `.pf-v6-c-hero__body` | `<div>` | Initiates the hero body. **Required** |

--- a/src/patternfly/components/Hero/examples/Hero.md
+++ b/src/patternfly/components/Hero/examples/Hero.md
@@ -2,12 +2,12 @@
 id: 'Hero'
 beta: true
 section: components
-cssPrefix: pf-v5-c-hero
+cssPrefix: pf-v6-c-hero
 ---
 
 ## Examples
 ### Basic
-```hbs
+```hbs isBeta
 {{#> hero}}
   {{#> hero-body}}
     Basic hero content
@@ -22,4 +22,4 @@ cssPrefix: pf-v5-c-hero
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-v6-c-hero` | `<div>` | Initiates the hero. **Required** |
-| `.pf-v6-c-hero__body` | `<div>` | Initiates the hero body. **Required** |
+| `.pf-v6-c-hero__body` | `<div>` | Initiates the hero body. |

--- a/src/patternfly/components/Hero/examples/Hero.md
+++ b/src/patternfly/components/Hero/examples/Hero.md
@@ -1,0 +1,25 @@
+---
+id: 'Hero'
+beta: true
+section: components
+cssPrefix: pf-v5-c-hero
+---
+
+## Examples
+### Basic
+```hbs
+{{#> hero}}
+  {{#> hero-body}}
+    Basic hero content
+  {{/hero-body}}
+{{/hero}}
+```
+
+## Documentation
+
+### Usage
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-v6-c-hero` | `<div>` | Initiates the compass logo hero. **Required** |
+| `.pf-v6-c-hero__body` | `<div>` | Initiates the compass hero body. **Required** |

--- a/src/patternfly/components/Hero/hero-body.hbs
+++ b/src/patternfly/components/Hero/hero-body.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}hero__body{{#if hero-body--modifier}} {{hero-body--modifier}}{{/if}}"
+  {{#if hero-body--attribute}}
+    {{{hero-body--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Hero/hero.hbs
+++ b/src/patternfly/components/Hero/hero.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}hero{{#if hero--modifier}} {{hero--modifier}}{{/if}}"
+  {{#if hero--attribute}}
+    {{{hero--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -26,10 +26,10 @@
   --#{$hero}--BorderColor: var(--pf-t--global--border--color--default);
   --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--alt);
   --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--md);
-  --#{$hero}--BorderTopLeftRadius: 24px;
-  --#{$hero}--BorderTopRightRadius: 72px;
-  --#{$hero}--BorderBottomRightRadius: 24px;
-  --#{$hero}--BorderBottomLeftRadius: 72px;
+  --#{$hero}--BorderStartStartRadius: 24px;
+  --#{$hero}--BorderStartEndRadius: 72px;
+  --#{$hero}--BorderEndEndRadius: 24px;
+  --#{$hero}--BorderEndStartRadius: 72px;
   --#{$hero}__body--Width: 800px;
   --#{$hero}__body--MaxWidth: 80%;
 }
@@ -50,15 +50,15 @@
   background-repeat: var(--#{$hero}--BackgroundRepeat);
   background-position: var(--#{$hero}--BackgroundPosition);
   background-size: var(--#{$hero}--BackgroundSize);
+  border-color: var(--#{$hero}--BorderColor);
   border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
   border-block-end-width: var(--#{$hero}--BorderBlockEndWidth);
   border-inline-start-width: var(--#{$hero}--BorderInlineStartWidth);
   border-inline-end-width: var(--#{$hero}--BorderInlineEndWidth);
-  border-color: var(--#{$hero}--BorderColor);
-  border-top-left-radius: var(--#{$hero}--BorderTopLeftRadius);
-  border-top-right-radius: var(--#{$hero}--BorderTopRightRadius);
-  border-bottom-right-radius: var(--#{$hero}--BorderBottomRightRadius);
-  border-bottom-left-radius: var(--#{$hero}--BorderBottomLeftRadius);
+  border-start-start-radius: var(--#{$hero}--BorderStartStartRadius);
+  border-start-end-radius: var(--#{$hero}--BorderStartEndRadius);
+  border-end-start-radius: var(--#{$hero}--BorderEndStartRadius);
+  border-end-end-radius: var(--#{$hero}--BorderEndEndRadius);
 
   :root:where(.pf-v6-theme-dark) & {
     --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -1,0 +1,45 @@
+@use '../../sass-utilities' as *;
+
+@include pf-root($hero) {
+  --#{$hero}--gradient--angle: 109deg;
+  --#{$hero}--gradient--stop-1--light: transparent;
+  --#{$hero}--gradient--stop-2--light: transparent;
+  --#{$hero}--gradient--stop-3--light: transparent;
+  --#{$hero}--gradient--stop-1--dark: transparent;
+  --#{$hero}--gradient--stop-2--dark: transparent;
+  --#{$hero}--gradient--stop-3--dark: transparent;
+  --#{$hero}--BackgroundImage--light: none;
+  --#{$hero}--BackgroundImage--dark: none;
+  --#{$hero}__body--Width: 800px;
+  --#{$hero}__body--MaxWidth: 80%;
+}
+
+.#{$hero} {
+  display: flex;
+  padding-block-start: 32px;
+  padding-block-end: 32px;
+  padding-inline-start: 72px;
+  padding-inline-end: 0;
+  background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
+    linear-gradient(
+      var(--#{$hero}--gradient--angle),
+      var(--#{$hero}--gradient--stop-1, var(--#{$hero}--gradient--stop-1--light)) 0%,
+      var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
+      var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
+    );
+  background-repeat: no-repeat;
+  background-position: right center;
+  background-size: contain;
+  border-radius: 24px 72px;
+
+  :root:where(.pf-v6-theme-dark) & {
+    --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);
+    --#{$hero}--gradient--stop-1: var(--#{$hero}--gradient--stop-1--dark);
+    --#{$hero}--gradient--stop-2: var(--#{$hero}--gradient--stop-2--dark);
+    --#{$hero}--gradient--stop-3: var(--#{$hero}--gradient--stop-3--dark);
+  }
+}
+
+.#{$hero}__body {
+  width: min(var(--#{$hero}__body--Width), var(--#{$hero}__body--MaxWidth));
+}

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -60,14 +60,14 @@
   border-end-start-radius: var(--#{$hero}--BorderEndStartRadius);
   border-end-end-radius: var(--#{$hero}--BorderEndEndRadius);
 
-  :root:where(.pf-v6-theme-dark) & {
+  :root:where(.#{$pf-prefix}theme-dark) & {
     --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);
     --#{$hero}--gradient--stop-1: var(--#{$hero}--gradient--stop-1--dark);
     --#{$hero}--gradient--stop-2: var(--#{$hero}--gradient--stop-2--dark);
     --#{$hero}--gradient--stop-3: var(--#{$hero}--gradient--stop-3--dark);
   }
 
-  :root:where(.pf-v6-theme-glass) & {
+  :root:where(.#{$pf-prefix}theme-glass) & {
     --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
   
     box-shadow: var(--#{$hero}--m-glass--BoxShadow);

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -1,6 +1,10 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($hero) {
+  --#{$hero}--PaddingBlockStart: var(--pf-t--global--spacer--xl);
+  --#{$hero}--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$hero}--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
+  --#{$hero}--PaddingInlineEnd: 0;
   --#{$hero}--gradient--angle: 109deg;
   --#{$hero}--gradient--stop-1--light: transparent;
   --#{$hero}--gradient--stop-2--light: transparent;
@@ -8,18 +12,25 @@
   --#{$hero}--gradient--stop-1--dark: transparent;
   --#{$hero}--gradient--stop-2--dark: transparent;
   --#{$hero}--gradient--stop-3--dark: transparent;
+  --#{$hero}--m-glass--BackgroundColor: var(--pf-t--global--background--color--glass--default);
+  --#{$hero}--m-glass--BackdropFilter: var(--pf-t--global--background--color--glass--filter);
   --#{$hero}--BackgroundImage--light: none;
   --#{$hero}--BackgroundImage--dark: none;
+  --#{$hero}--BackgroundRepeat: no-repeat;
+  --#{$hero}--BackgroundPosition: right center;
+  --#{$hero}--BackgroundSize: contain;
+  --#{$hero}--BorderRadiusTopLeftBottomRight: 24px;
+  --#{$hero}--BorderRadiusTopRightBottomLeft: 72px;
   --#{$hero}__body--Width: 800px;
   --#{$hero}__body--MaxWidth: 80%;
 }
 
 .#{$hero} {
   display: flex;
-  padding-block-start: 32px;
-  padding-block-end: 32px;
-  padding-inline-start: 72px;
-  padding-inline-end: 0;
+  padding-block-start: var(--#{$hero}--PaddingBlockStart);
+  padding-block-end: var(--#{$hero}--PaddingBlockEnd);
+  padding-inline-start: var(--#{$hero}--PaddingInlineStart);
+  padding-inline-end: var(--#{$hero}--PaddingInlineEnd);
   background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
     linear-gradient(
       var(--#{$hero}--gradient--angle),
@@ -27,16 +38,21 @@
       var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
       var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
     );
-  background-repeat: no-repeat;
-  background-position: right center;
-  background-size: contain;
-  border-radius: 24px 72px;
+  background-repeat: var(--#{$hero}--BackgroundRepeat);
+  background-position: var(--#{$hero}--BackgroundPosition);
+  background-size: var(--#{$hero}--BackgroundSize);
+  border-radius: var(--#{$hero}--BorderRadiusTopLeftBottomRight) var(--#{$hero}--BorderRadiusTopRightBottomLeft);
 
   :root:where(.pf-v6-theme-dark) & {
     --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);
     --#{$hero}--gradient--stop-1: var(--#{$hero}--gradient--stop-1--dark);
     --#{$hero}--gradient--stop-2: var(--#{$hero}--gradient--stop-2--dark);
     --#{$hero}--gradient--stop-3: var(--#{$hero}--gradient--stop-3--dark);
+  }
+
+  &:not(.pf-m-no-glass) {
+    background-color: var(--#{$hero}--m-glass--BackgroundColor);
+    backdrop-filter: var(--#{$hero}--m-glass--BackdropFilter);
   }
 }
 

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -4,7 +4,7 @@
   --#{$hero}--PaddingBlockStart: var(--pf-t--global--spacer--xl);
   --#{$hero}--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
   --#{$hero}--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
-  --#{$hero}--PaddingInlineEnd: 0;
+  --#{$hero}--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
   --#{$hero}--gradient--angle: 109deg;
   --#{$hero}--gradient--stop-1--light: transparent;
   --#{$hero}--gradient--stop-2--light: transparent;
@@ -12,15 +12,24 @@
   --#{$hero}--gradient--stop-1--dark: transparent;
   --#{$hero}--gradient--stop-2--dark: transparent;
   --#{$hero}--gradient--stop-3--dark: transparent;
-  --#{$hero}--m-glass--BackgroundColor: var(--pf-t--global--background--color--glass--default);
-  --#{$hero}--m-glass--BackdropFilter: var(--pf-t--global--background--color--glass--filter);
+  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--glass--default);
+  --#{$hero}--BackdropFilter: var(--pf-t--global--background--color--glass--filter);
   --#{$hero}--BackgroundImage--light: none;
   --#{$hero}--BackgroundImage--dark: none;
   --#{$hero}--BackgroundRepeat: no-repeat;
   --#{$hero}--BackgroundPosition: right center;
   --#{$hero}--BackgroundSize: contain;
-  --#{$hero}--BorderRadiusTopLeftBottomRight: 24px;
-  --#{$hero}--BorderRadiusTopRightBottomLeft: 72px;
+  --#{$hero}--BorderBlockStartWidth: var(--pf-t--global--border--width--regular);
+  --#{$hero}--BorderBlockEndWidth: var(--pf-t--global--border--width--regular);
+  --#{$hero}--BorderInlineStartWidth: var(--pf-t--global--border--width--regular);
+  --#{$hero}--BorderInlineEndWidth: var(--pf-t--global--border--width--regular);
+  --#{$hero}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--alt);
+  --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--md);
+  --#{$hero}--BorderTopLeftRadius: 24px;
+  --#{$hero}--BorderTopRightRadius: 72px;
+  --#{$hero}--BorderBottomRightRadius: 24px;
+  --#{$hero}--BorderBottomLeftRadius: 72px;
   --#{$hero}__body--Width: 800px;
   --#{$hero}__body--MaxWidth: 80%;
 }
@@ -41,7 +50,15 @@
   background-repeat: var(--#{$hero}--BackgroundRepeat);
   background-position: var(--#{$hero}--BackgroundPosition);
   background-size: var(--#{$hero}--BackgroundSize);
-  border-radius: var(--#{$hero}--BorderRadiusTopLeftBottomRight) var(--#{$hero}--BorderRadiusTopRightBottomLeft);
+  border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
+  border-block-end-width: var(--#{$hero}--BorderBlockEndWidth);
+  border-inline-start-width: var(--#{$hero}--BorderInlineStartWidth);
+  border-inline-end-width: var(--#{$hero}--BorderInlineEndWidth);
+  border-color: var(--#{$hero}--BorderColor);
+  border-top-left-radius: var(--#{$hero}--BorderTopLeftRadius);
+  border-top-right-radius: var(--#{$hero}--BorderTopRightRadius);
+  border-bottom-right-radius: var(--#{$hero}--BorderBottomRightRadius);
+  border-bottom-left-radius: var(--#{$hero}--BorderBottomLeftRadius);
 
   :root:where(.pf-v6-theme-dark) & {
     --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);
@@ -50,9 +67,15 @@
     --#{$hero}--gradient--stop-3: var(--#{$hero}--gradient--stop-3--dark);
   }
 
+  :root:where(.pf-v6-theme-glass) & {
+    --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
+  
+    box-shadow: var(--#{$hero}--m-glass--BoxShadow);
+  }
+
   &:not(.pf-m-no-glass) {
-    background-color: var(--#{$hero}--m-glass--BackgroundColor);
-    backdrop-filter: var(--#{$hero}--m-glass--BackdropFilter);
+    background-color: var(--#{$hero}--BackgroundColor);
+    backdrop-filter: var(--#{$hero}--BackdropFilter);
   }
 }
 

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -19,6 +19,7 @@
   --#{$hero}--BackgroundRepeat: no-repeat;
   --#{$hero}--BackgroundPosition: right center;
   --#{$hero}--BackgroundSize: contain;
+  --#{$hero}--BorderStyle: solid;
   --#{$hero}--BorderBlockStartWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderBlockEndWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderInlineStartWidth: var(--pf-t--global--border--width--regular);
@@ -51,6 +52,7 @@
   background-position: var(--#{$hero}--BackgroundPosition);
   background-size: var(--#{$hero}--BackgroundSize);
   border-color: var(--#{$hero}--BorderColor);
+  border-style: var(--#{$hero}--BorderStyle);
   border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
   border-block-end-width: var(--#{$hero}--BorderBlockEndWidth);
   border-inline-start-width: var(--#{$hero}--BorderInlineStartWidth);

--- a/src/patternfly/components/_index.scss
+++ b/src/patternfly/components/_index.scss
@@ -32,8 +32,9 @@
 @use "./FileUpload/file-upload";
 @use "./Form/form";
 @use "./FormControl/form-control";
-@use "./Hint/hint";
 @use "./HelperText/helper-text";
+@use "./Hero/hero";
+@use "./Hint/hint";
 @use "./Icon/icon";
 @use "./InlineEdit/inline-edit";
 @use "./InputGroup/input-group";

--- a/src/patternfly/demos/Compass/compass--demo-context.hbs
+++ b/src/patternfly/demos/Compass/compass--demo-context.hbs
@@ -1,10 +1,10 @@
 {{#> wrapper
-  compass-hero--attribute='style="
-      --pf-v6-c-compass__hero--gradient--stop-1--dark: #3d2785;
-      --pf-v6-c-compass__hero--gradient--stop-2--dark: #1b0d33;
-      --pf-v6-c-compass__hero--gradient--stop-3--dark: #000;
-      --pf-v6-c-compass__hero--BackgroundImage--light: url(/assets/images/compass--hero-bg.png);
-      --pf-v6-c-compass__hero--BackgroundImage--dark: url(/assets/images/compass--hero-bg.png);
+  hero--attribute='style="
+      --pf-v6-c-hero--gradient--stop-1--dark: #3d2785;
+      --pf-v6-c-hero--gradient--stop-2--dark: #1b0d33;
+      --pf-v6-c-hero--gradient--stop-3--dark: #000;
+      --pf-v6-c-hero--BackgroundImage--light: url(/assets/images/compass--hero-bg.png);
+      --pf-v6-c-hero--BackgroundImage--dark: url(/assets/images/compass--hero-bg.png);
     "'
     compass--attribute='style="
       --pf-v6-c-compass--BackgroundImage--light: url(/assets/images/compass--wallpaper-light.png);

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -76,30 +76,28 @@ wrapperTag: div
       {{/compass-panel}}
     {{/compass-sidebar}}
     {{#> compass-main}}
-      {{#> compass-panel}}
-        {{#> hero}}
-          {{#> hero-body}}
-            {{#> content}}
-              <h1>Automation that does more</h1>
-              <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
-              {{#> action-list}}
-                {{#> action-list-group}}
-                  {{#> action-list-item}}
-                    {{#> button button--IsPrimary=true}}
-                      Upgrade today
-                    {{/button}}
-                  {{/action-list-item}}
-                  {{#> action-list-item}}
-                    {{#> button button--IsSecondary=true}}
-                      Talk to a Red Hatter
-                    {{/button}}
-                  {{/action-list-item}}
-                {{/action-list-group}}
-              {{/action-list}}
-            {{/content}}
-          {{/hero-body}}
-        {{/hero}}
-      {{/compass-panel}}
+      {{#> hero}}
+        {{#> hero-body}}
+          {{#> content}}
+            <h1>Automation that does more</h1>
+            <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
+            {{#> action-list}}
+              {{#> action-list-group}}
+                {{#> action-list-item}}
+                  {{#> button button--IsPrimary=true}}
+                    Upgrade today
+                  {{/button}}
+                {{/action-list-item}}
+                {{#> action-list-item}}
+                  {{#> button button--IsSecondary=true}}
+                    Talk to a Red Hatter
+                  {{/button}}
+                {{/action-list-item}}
+              {{/action-list-group}}
+            {{/action-list}}
+          {{/content}}
+        {{/hero-body}}
+      {{/hero}}
       {{#> compass-content}}
         {{#> grid grid--modifier="pf-m-gutter" grid--id="compass-dashboard-grid"}}
           {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-6-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:3"'}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -76,28 +76,30 @@ wrapperTag: div
       {{/compass-panel}}
     {{/compass-sidebar}}
     {{#> compass-main}}
-      {{#> hero}}
-        {{#> hero-body}}
-          {{#> content}}
-            <h1>Automation that does more</h1>
-            <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
-            {{#> action-list}}
-              {{#> action-list-group}}
-                {{#> action-list-item}}
-                  {{#> button button--IsPrimary=true}}
-                    Upgrade today
-                  {{/button}}
-                {{/action-list-item}}
-                {{#> action-list-item}}
-                  {{#> button button--IsSecondary=true}}
-                    Talk to a Red Hatter
-                  {{/button}}
-                {{/action-list-item}}
-              {{/action-list-group}}
-            {{/action-list}}
-          {{/content}}
-        {{/hero-body}}
-      {{/hero}}
+      {{#> compass-hero}}
+        {{#> hero}}
+          {{#> hero-body}}
+            {{#> content}}
+              <h1>Automation that does more</h1>
+              <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
+              {{#> action-list}}
+                {{#> action-list-group}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsPrimary=true}}
+                      Upgrade today
+                    {{/button}}
+                  {{/action-list-item}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsSecondary=true}}
+                      Talk to a Red Hatter
+                    {{/button}}
+                  {{/action-list-item}}
+                {{/action-list-group}}
+              {{/action-list}}
+            {{/content}}
+          {{/hero-body}}
+        {{/hero}}
+      {{/compass-hero}}
       {{#> compass-content}}
         {{#> grid grid--modifier="pf-m-gutter" grid--id="compass-dashboard-grid"}}
           {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-6-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:3"'}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -76,28 +76,30 @@ wrapperTag: div
       {{/compass-panel}}
     {{/compass-sidebar}}
     {{#> compass-main}}
-      {{#> compass-hero}}
-        {{#> compass-hero-body}}
-          {{#> content}}
-            <h1>Automation that does more</h1>
-            <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
-            {{#> action-list}}
-              {{#> action-list-group}}
-                {{#> action-list-item}}
-                  {{#> button button--IsPrimary=true}}
-                    Upgrade today
-                  {{/button}}
-                {{/action-list-item}}
-                {{#> action-list-item}}
-                  {{#> button button--IsSecondary=true}}
-                    Talk to a Red Hatter
-                  {{/button}}
-                {{/action-list-item}}
-              {{/action-list-group}}
-            {{/action-list}}
-          {{/content}}
-        {{/compass-hero-body}}
-      {{/compass-hero}}
+      {{#> compass-panel}}
+        {{#> hero}}
+          {{#> hero-body}}
+            {{#> content}}
+              <h1>Automation that does more</h1>
+              <p>Red&nbsp;Hat Ansible Automation Platform offers more capabilities, accessibility, and flexibility, so you can bring the power of automation to the teams, tasks, and environments that need it.</p>
+              {{#> action-list}}
+                {{#> action-list-group}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsPrimary=true}}
+                      Upgrade today
+                    {{/button}}
+                  {{/action-list-item}}
+                  {{#> action-list-item}}
+                    {{#> button button--IsSecondary=true}}
+                      Talk to a Red Hatter
+                    {{/button}}
+                  {{/action-list-item}}
+                {{/action-list-group}}
+              {{/action-list}}
+            {{/content}}
+          {{/hero-body}}
+        {{/hero}}
+      {{/compass-panel}}
       {{#> compass-content}}
         {{#> grid grid--modifier="pf-m-gutter" grid--id="compass-dashboard-grid"}}
           {{#> grid-item grid-item--modifier="pf-m-gutter pf-m-4-col-on-lg pf-m-6-col-on-2xl" grid-item--attribute='style="--pf-v6-l-grid--item--Order-on-lg:3"'}}

--- a/src/patternfly/sass-utilities/namespaces-components.scss
+++ b/src/patternfly/sass-utilities/namespaces-components.scss
@@ -110,6 +110,9 @@ $form-control: #{$pf-prefix} + 'c-form-control';
 // Helper Text
 $helper-text: #{$pf-prefix} + 'c-helper-text';
 
+// Hero
+$hero: #{$pf-prefix} + 'c-hero';
+
 // Hint
 $hint: #{$pf-prefix} + 'c-hint';
 


### PR DESCRIPTION
Closes #7935

Would we want the Hero to be inside a CompassPanel still? If so, would we want to have the border radius (and/or any other styles) live inside CompassPanel when it has a pf-m-hero class? Right now I just moved all hero styles from Compass to the new PF level Hero component, so putting the Hero inside a CompassPanel results in the CompassPanel sticking out like a sore thumb:

<img width="1372" height="391" alt="" src="https://github.com/user-attachments/assets/d20bf00c-40a3-4693-b1b5-6bc56013c896" />
