### PR TITLE
fix(drawer): adjust pill for rtl and widths

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -252,7 +252,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       @include pf-v6-bidirectional-style(
         $prop: transform,
         $ltr-val: translateX(calc(-100% - var(--#{$drawer}--m-expanded__panel--inset))),
-        $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)}),
+        $rtl-val: translateX(#{pf-v6-calc-inverse(calc(-100% - var(--#{$drawer}--m-expanded__panel--inset)))}),
       );
 
       --#{$drawer}__panel--Opacity: var(--#{$drawer}--m-expanded__panel--Opacity);
@@ -712,7 +712,11 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   @include pf-v6-apply-breakpoint($breakpoint) {
     @each $width-value in $pf-v6-c-drawer__panel--list--width {
       .#{$drawer}__panel.pf-m-width-#{$width-value}#{$breakpoint-name} {
-        --#{$drawer}__panel--md--FlexBasis: #{percentage(math.div($width-value, 100))};
+        @if $width-value == 100 {
+          --#{$drawer}__panel--md--FlexBasis: calc(#{percentage(math.div($width-value, 100))} - (2 * var(--#{$drawer}--m-expanded__panel--inset)));
+        } @else {
+          --#{$drawer}__panel--md--FlexBasis: calc(#{percentage(math.div($width-value, 100))} - var(--#{$drawer}--m-expanded__panel--inset));
+        }
       }
     }
   }

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -215,7 +215,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     --#{$drawer}__panel--BackgroundColor: var(--#{$drawer}__panel--m-inline--BackgroundColor);
     --#{$drawer}__panel--BorderInlineStartWidth: var(--#{$drawer}--m-inline__panel--after--Width);
     --#{$drawer}--m-pill__main--Gap: var(--#{$drawer}--m-pill--m-inline__main--Gap);
-    --#{$drawer}--m-pill--m-expanded__panel--inset: 0;
+    --#{$drawer}--m-pill--m-expanded__panel--inset: 0px;
 
     > .#{$drawer}__main > .#{$drawer}__panel:not(.pf-m-no-border, .pf-m-resizable) {
       padding-inline-start: var(--#{$drawer}--m-inline__panel--PaddingInlineStart);
@@ -712,10 +712,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   @include pf-v6-apply-breakpoint($breakpoint) {
     @each $width-value in $pf-v6-c-drawer__panel--list--width {
       .#{$drawer}__panel.pf-m-width-#{$width-value}#{$breakpoint-name} {
+        --#{$drawer}__panel--md--FlexBasis: calc(#{percentage(math.div($width-value, 100))} - (2 * var(--#{$drawer}--m-expanded__panel--inset)));
+        
         @if $width-value == 100 {
-          --#{$drawer}__panel--md--FlexBasis: calc(#{percentage(math.div($width-value, 100))} - (2 * var(--#{$drawer}--m-expanded__panel--inset)));
-        } @else {
-          --#{$drawer}__panel--md--FlexBasis: calc(#{percentage(math.div($width-value, 100))} - var(--#{$drawer}--m-expanded__panel--inset));
+          --#{$drawer}__main--Gap: 0; // Reset gap for width-100 inline pill drawers to prevent misalignment
         }
       }
     }


### PR DESCRIPTION
Fixes #7947 
Uses the pill drawer inset to adjust
- the position of the drawer in RTL (subtract the inset from the translate)
- the width of the drawer when specified 
- for 100% subtract twice the offset so it's offset on both sides

Formula syntax assisted by Claude code