### PR TITLE
fix(compass): add main-footer

### DIFF
--- a/src/patternfly/components/Compass/compass-main-footer.hbs
+++ b/src/patternfly/components/Compass/compass-main-footer.hbs
@@ -1,0 +1,6 @@
+<div class="{{pfv}}compass__main-footer{{#if compass-main-footer--modifier}} {{compass-main-footer--modifier}}{{/if}}"
+  {{#if compass-main-footer--attribute}}
+    {{{compass-main-footer--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -38,10 +38,10 @@
   display: grid;
   grid-template-areas:
     "header header header"
-    "sidebar-start main sidebar-end"
-    "footer footer footer";
-  grid-template-rows: auto 1fr auto;
+    "sidebar-start main sidebar-end";
+  grid-template-rows: auto 1fr;
   grid-template-columns: auto 1fr auto;
+  grid-auto-rows: auto;
   gap: var(--#{$compass}--RowGap) var(--#{$compass}--ColumnGap);
   align-items: center;
   justify-content: center;
@@ -151,6 +151,12 @@
   }
 }
 
+.#{$compass}__main-footer {
+  display: flex;
+  justify-content: center;
+  margin-top: calc(var(--#{$compass}__main--RowGap) * -1 + var(--#{$compass}--RowGap)); // Creates same gap as parent compass grid, mimicking the compass footer
+}
+
 .#{$compass}__sidebar.pf-m-end {
   grid-area: sidebar-end;
   padding: var(--pf-t--global--spacer--sm);
@@ -158,7 +164,7 @@
 
 .#{$compass}__footer {
   display: flex;
-  grid-area: footer;
+  grid-column: 1 / -1;
   justify-content: center;
 }
 

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -154,7 +154,7 @@
 .#{$compass}__main-footer {
   display: flex;
   justify-content: center;
-  margin-top: calc(var(--#{$compass}__main--RowGap) * -1 + var(--#{$compass}--RowGap)); // Creates same gap as parent compass grid, mimicking the compass footer
+  margin-block-start: calc(var(--#{$compass}__main--RowGap) * -1 + var(--#{$compass}--RowGap)); // Creates same gap as parent compass grid, mimicking the compass footer
 }
 
 .#{$compass}__sidebar.pf-m-end {

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -38,10 +38,13 @@ import './Compass.css';
       {{/compass-panel}}
     {{/compass-main-header}}
     {{#> compass-content}}content{{/compass-content}}
+    {{#> compass-main-footer}}
+      {{#> compass-message-bar}}message bar{{/compass-message-bar}}
+    {{/compass-main-footer}}
   {{/compass-main}}
   {{#> compass-sidebar compass-sidebar--IsEnd=true}}sidebar (end){{/compass-sidebar}}
   {{#> compass-footer}}
-    {{#> compass-message-bar}}message bar{{/compass-message-bar}}
+    footer
   {{/compass-footer}}
 {{/compass}}
 ```
@@ -62,13 +65,15 @@ import './Compass.css';
 | `.pf-v6-c-compass__main-header-title` | `<div>` | Initiates a title within the compass main header content. |
 | `.pf-v6-c-compass__main-header-toolbar` | `<div>` | Initiates a toolbar of actions within the compass main header content. |
 | `.pf-v6-c-compass__content` | `<div>` | Initiates the compass content. **Required** |
+| `.pf-v6-c-compass__main-footer` | `<div>` | Initiates the compass main footer. **Required** |
 | `.pf-v6-c-compass__panel` | `<div>` | Initiates a compass panel. |
 | `.pf-v6-c-compass__nav` | `<div>` | Initiates a compass container for site navigation. |
 | `.pf-v6-c-compass__nav-content` | `<div>` | Initiates a compass container for navigation content. |
 | `.pf-v6-c-compass__nav-home` | `<div>` | Initiates a container for compass home button. |
 | `.pf-v6-c-compass__nav-main` | `<div>` | Initiates a container for compass navigation main content. |
 | `.pf-v6-c-compass__nav-search` | `<div>` | Initiates a container for compass search button. |
-| `.pf-v6-c-compass__footer` | `<div>` | Initiates the compass footer. **Required** |
+| `.pf-v6-c-compass__hero` | `<div>` | Initiates a compass hero. |
+| `.pf-v6-c-compass__footer` | `<div>` | Initiates the compass footer. |
 | `.pf-v6-c-compass__message-bar` | `<div>` | Initiates the compass message bar. |
 | `.pf-m-no-glass` | `.pf-v6-c-compass`, `.pf-v6-c-compass__panel` | Modifies all elements or individual panels to remove the glass styles. |
 | `.pf-m-start` | `.pf-v6-c-compass__sidebar` | Modifies a compass sidebar for start styles. **Required** |

--- a/src/patternfly/demos/Compass/compass--card-view.hbs
+++ b/src/patternfly/demos/Compass/compass--card-view.hbs
@@ -121,6 +121,13 @@
           {{/l-flex}}
         {{/compass-panel}}
       {{/compass-content}}
+      {{#> compass-main-footer}}
+        {{#> compass-message-bar}}
+          {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}
+            chatbot message bar
+          {{/compass-panel}}
+        {{/compass-message-bar}}
+      {{/compass-main-footer}}
     {{/compass-main}}
     {{#> compass-sidebar compass-sidebar--IsEnd=true}}
       {{#> compass-panel compass-panel--IsPill=true}}
@@ -143,10 +150,5 @@
         {{/action-list}}
       {{/compass-panel}}
     {{/compass-sidebar}}
-    {{#> compass-footer}}
-      {{#> compass-footer-main}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}chatbot message bar{{/compass-panel}}
-      {{/compass-footer-main}}
-    {{/compass-footer}}
   {{/compass}}
 {{/compass--demo-context}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -157,6 +157,13 @@ wrapperTag: div
           {{/grid-item}}
         {{/grid}}
       {{/compass-content}}
+      {{#> compass-main-footer}}
+        {{#> compass-message-bar}}
+          {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}
+            chatbot message bar
+          {{/compass-panel}}
+        {{/compass-message-bar}}
+      {{/compass-main-footer}}
     {{/compass-main}}
     {{#> compass-sidebar compass-sidebar--IsEnd=true}}
       {{#> compass-panel compass-panel--IsPill=true}}
@@ -179,11 +186,6 @@ wrapperTag: div
         {{/action-list}}
       {{/compass-panel}}
     {{/compass-sidebar}}
-    {{#> compass-footer}}
-      {{#> compass-footer-main}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}chatbot message bar{{/compass-panel}}
-      {{/compass-footer-main}}
-    {{/compass-footer}}
   {{/compass}}
 {{/compass--demo-context}}
 ```
@@ -327,6 +329,13 @@ wrapperTag: div
           {{/compass-panel}}
         {{/grid}}
       {{/compass-content}}
+      {{#> compass-main-footer}}
+        {{#> compass-message-bar}}
+          {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}
+            chatbot message bar
+          {{/compass-panel}}
+        {{/compass-message-bar}}
+      {{/compass-main-footer}}
     {{/compass-main}}
     {{#> compass-sidebar compass-sidebar--IsEnd=true}}
       {{#> compass-panel compass-panel--IsPill=true}}
@@ -349,11 +358,6 @@ wrapperTag: div
         {{/action-list}}
       {{/compass-panel}}
     {{/compass-sidebar}}
-    {{#> compass-footer}}
-      {{#> compass-footer-main}}
-        {{#> compass-panel compass-panel--HasNoPadding=true compass-panel--HasNoBorder=true compass-panel--IsPill=true}}chatbot message bar{{/compass-panel}}
-      {{/compass-footer-main}}
-    {{/compass-footer}}
   {{/compass}}
 {{/compass--demo-context}}
 ```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7938

@lboehling or @andrew-ronaldson for the chatbot message bar, should the space between it and the section above (the row gap) be tighter like this where it matches the space/row-gap between sections in the main area?

<img width="1245" height="637" alt="Screenshot 2025-11-10 at 9 49 57 PM" src="https://github.com/user-attachments/assets/4871bde7-9014-4033-922e-eec774facbc5" />

Or should it have more space, which matches the gap that's used for the main layout
* between the header and content below it
* between the left/right sidebars and the content in the middle

<img width="1240" height="633" alt="Screenshot 2025-11-10 at 9 49 40 PM" src="https://github.com/user-attachments/assets/dfe37d8f-965d-4fc2-a293-434c495dce7e" />
