### PR TITLE
docs(compass): content review and edits

### DIFF
--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -87,7 +87,7 @@ In a basic Compass layout, the page structure is defined by the order of element
 | `.pf-v6-c-compass` | `<div>` | Initiates the Compass component. **Required** |
 | `.pf-v6-c-compass__header` | `<div>` | Initiates the Compass header. **Required** |
 | `.pf-v6-c-compass__logo` | `<div>` | Initiates the Compass logo header. |
-| `.pf-v6-c-compass__dock` | `<div>` | Initiates the compass dock. |
+| `.pf-v6-c-compass__dock` | `<div>` | Initiates the Compass dock. |
 | `.pf-v6-c-compass__profile` | `<div>` | Initiates the Compass profile. |
 | `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a Compass sidebar. **Required** |
 | `.pf-v6-c-compass__main` | `<div>` | Initiates the Compass main wrapper. **Required** |

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -13,10 +13,10 @@ import './Compass.css';
 
 In a basic Compass layout, the page structure is defined by the order of elements nested within the main `.pf-v6-c-compass` container:
 - Header: Content rendered at the top of the page (`.pf-v6-c-compass__header`), typically containing a logo (`.pf-v6-c-compass__logo`), middle navigation (`.pf-v6-c-compass__nav`), and profile (`.pf-v6-c-compass__profile`).
-- Start sidebar: Content rendered at the horizontal start of the page (by default, the left side). In this example, a `pf-v6-c-compass__sidebar` with the `.pf-m-start` modifier.
+- Start sidebar: Content rendered at the horizontal start of the page (by default, the left side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-start` modifier.
 - Main: Content rendered in the center of the page. The `.pf-v6-c-compass__main` wrapper contains the hero (`.pf-v6-c-compass__hero`), the main header (`.pf-v6-c-compass__main-header`), the content area (`.pf-v6-c-compass__content`), and the main footer (`.pf-v6-c-compass__main-footer`) with the message bar.
 - End sidebar: Content rendered at the horizontal end of the page (by default, the right side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-end modifier`.
-- Footer: Content rendered at the bottom of the page (.pf-v6-c-compass__footer`).
+- Footer: Content rendered at the bottom of the page (`.pf-v6-c-compass__footer`).
 
 ```hbs isBeta
 {{#> compass}}

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -12,11 +12,11 @@ import './Compass.css';
 ### Basic
 
 In a basic Compass layout, the page structure is defined by the order of elements nested within the main `.pf-v6-c-compass` container:
-- Header: Content rendered at the top of the page (`.pf-v6-c-compass__header`), typically containing a logo (`.pf-v6-c-compass__logo`), middle navigation (`.pf-v6-c-compass__nav`), and profile (`.pf-v6-c-compass__profile`).
-- Start sidebar: Content rendered at the horizontal start of the page (by default, the left side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-start` modifier.
-- Main: Content rendered in the center of the page. The `.pf-v6-c-compass__main` wrapper contains the hero (`.pf-v6-c-compass__hero`), the main header (`.pf-v6-c-compass__main-header`), the content area (`.pf-v6-c-compass__content`), and the main footer (`.pf-v6-c-compass__main-footer`) with the message bar.
-- End sidebar: Content rendered at the horizontal end of the page (by default, the right side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-end modifier`.
-- Footer: Content rendered at the bottom of the page (`.pf-v6-c-compass__footer`).
+- **Header:** Content rendered at the top of the page (`.pf-v6-c-compass__header`), typically containing a logo (`.pf-v6-c-compass__logo`), middle navigation (`.pf-v6-c-compass__nav`), and profile (`.pf-v6-c-compass__profile`).
+- **Start sidebar:** Content rendered at the horizontal start of the page (by default, the left side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-start` modifier.
+- **Main:** Content rendered in the center of the page. The `.pf-v6-c-compass__main` wrapper contains a [hero component](/components/hero), the main header (`.pf-v6-c-compass__main-header`), the content area (`.pf-v6-c-compass__content`), and the main footer (`.pf-v6-c-compass__main-footer`) with the message bar.
+- **End sidebar:** Content rendered at the horizontal end of the page (by default, the right side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-end` modifier.
+- **Footer:** Content rendered at the bottom of the page (`.pf-v6-c-compass__footer`).
 
 ```hbs isBeta
 {{#> compass}}
@@ -87,7 +87,7 @@ In a basic Compass layout, the page structure is defined by the order of element
 | `.pf-v6-c-compass` | `<div>` | Initiates the Compass component. **Required** |
 | `.pf-v6-c-compass__header` | `<div>` | Initiates the Compass header. **Required** |
 | `.pf-v6-c-compass__logo` | `<div>` | Initiates the Compass logo header. |
-| `.pf-v6-c-compass__nav` | `<div>` | Initiates the Compass nav. |
+| `.pf-v6-c-compass__dock` | `<div>` | Initiates the compass dock. |
 | `.pf-v6-c-compass__profile` | `<div>` | Initiates the Compass profile. |
 | `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a Compass sidebar. **Required** |
 | `.pf-v6-c-compass__main` | `<div>` | Initiates the Compass main wrapper. **Required** |
@@ -103,9 +103,9 @@ In a basic Compass layout, the page structure is defined by the order of element
 | `.pf-v6-c-compass__nav-home` | `<div>` | Initiates a container for Compass home button. |
 | `.pf-v6-c-compass__nav-main` | `<div>` | Initiates a container for Compass navigation main content. |
 | `.pf-v6-c-compass__nav-search` | `<div>` | Initiates a container for Compass search button. |
-| `.pf-v6-c-compass__hero` | `<div>` | Initiates a Compass hero. |
 | `.pf-v6-c-compass__footer` | `<div>` | Initiates the Compass footer. |
 | `.pf-v6-c-compass__message-bar` | `<div>` | Initiates the Compass message bar. |
+| `.pf-m-dock` | `.pf-v6-c-compass` | Modifies for dock layout. |
 | `.pf-m-no-glass` | `.pf-v6-c-compass`, `.pf-v6-c-compass__panel` | Modifies all elements or individual panels to remove the glass styles. |
 | `.pf-m-start` | `.pf-v6-c-compass__sidebar` | Modifies a Compass sidebar for start styles. **Required** |
 | `.pf-m-end` | `.pf-v6-c-compass__sidebar` | Modifies a Compass sidebar for end styles. **Required** |

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -112,6 +112,6 @@ In a basic Compass layout, the page structure is defined by the order of element
 | `.pf-m-no-border` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to remove the border. |
 | `.pf-m-no-padding` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to remove the padding. |
 | `.pf-m-full-height` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to be full height. |
-| `.pf-m-pill` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to have a pill shaped border radius. |
+| `.pf-m-pill` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to have a pill-shaped border radius. |
 | `.pf-m-scrollable` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to scroll its overflow. |
 | `.pf-m-expanded` | `.pf-v6-c-compass__header`, `.pf-v6-c-compass__sidebar`, `.pf-v6-c-compass__main-footer`, `.pf-v6-c-compass__footer` | Modifies a Compass section for expanded styles. |

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -10,6 +10,14 @@ import './Compass.css';
 
 ## Examples
 ### Basic
+
+In a basic Compass layout, the page structure is defined by the order of elements nested within the main `.pf-v6-c-compass` container:
+- Header: Content rendered at the top of the page (`.pf-v6-c-compass__header`), typically containing a logo (`.pf-v6-c-compass__logo`), middle navigation (`.pf-v6-c-compass__nav`), and profile (`.pf-v6-c-compass__profile`).
+- Start sidebar: Content rendered at the horizontal start of the page (by default, the left side). In this example, a `pf-v6-c-compass__sidebar` with the `.pf-m-start` modifier.
+- Main: Content rendered in the center of the page. The `.pf-v6-c-compass__main` wrapper contains the hero (`.pf-v6-c-compass__hero`), the main header (`.pf-v6-c-compass__main-header`), the content area (`.pf-v6-c-compass__content`), and the main footer (`.pf-v6-c-compass__main-footer`) with the message bar.
+- End sidebar: Content rendered at the horizontal end of the page (by default, the right side). In this example, a `.pf-v6-c-compass__sidebar` with the `.pf-m-end modifier`.
+- Footer: Content rendered at the bottom of the page (.pf-v6-c-compass__footer`).
+
 ```hbs isBeta
 {{#> compass}}
   {{#> compass-header}}
@@ -53,34 +61,34 @@ import './Compass.css';
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v6-c-compass` | `<div>` | Initiates the compass component. **Required** |
-| `.pf-v6-c-compass__header` | `<div>` | Initiates the compass header. **Required** |
-| `.pf-v6-c-compass__logo` | `<div>` | Initiates the compass logo header. |
-| `.pf-v6-c-compass__nav` | `<div>` | Initiates the compass nav. |
-| `.pf-v6-c-compass__profile` | `<div>` | Initiates the compass profile. |
-| `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a compass sidebar. **Required** |
-| `.pf-v6-c-compass__main` | `<div>` | Initiates the compass main wrapper. **Required** |
-| `.pf-v6-c-compass__main-header` | `<div>` | Initiates the compass main header. |
-| `.pf-v6-c-compass__main-header-content` | `<div>` | Initiates the compass main header content. This should be passed into a `.pf-v6-c-compass__panel` component. |
-| `.pf-v6-c-compass__main-header-title` | `<div>` | Initiates a title within the compass main header content. |
-| `.pf-v6-c-compass__main-header-toolbar` | `<div>` | Initiates a toolbar of actions within the compass main header content. |
-| `.pf-v6-c-compass__content` | `<div>` | Initiates the compass content. **Required** |
-| `.pf-v6-c-compass__main-footer` | `<div>` | Initiates the compass main footer. **Required** |
-| `.pf-v6-c-compass__panel` | `<div>` | Initiates a compass panel. |
-| `.pf-v6-c-compass__nav` | `<div>` | Initiates a compass container for site navigation. |
-| `.pf-v6-c-compass__nav-content` | `<div>` | Initiates a compass container for navigation content. |
-| `.pf-v6-c-compass__nav-home` | `<div>` | Initiates a container for compass home button. |
-| `.pf-v6-c-compass__nav-main` | `<div>` | Initiates a container for compass navigation main content. |
-| `.pf-v6-c-compass__nav-search` | `<div>` | Initiates a container for compass search button. |
-| `.pf-v6-c-compass__hero` | `<div>` | Initiates a compass hero. |
-| `.pf-v6-c-compass__footer` | `<div>` | Initiates the compass footer. |
-| `.pf-v6-c-compass__message-bar` | `<div>` | Initiates the compass message bar. |
+| `.pf-v6-c-compass` | `<div>` | Initiates the Compass component. **Required** |
+| `.pf-v6-c-compass__header` | `<div>` | Initiates the Compass header. **Required** |
+| `.pf-v6-c-compass__logo` | `<div>` | Initiates the Compass logo header. |
+| `.pf-v6-c-compass__nav` | `<div>` | Initiates the Compass nav. |
+| `.pf-v6-c-compass__profile` | `<div>` | Initiates the Compass profile. |
+| `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a Compass sidebar. **Required** |
+| `.pf-v6-c-compass__main` | `<div>` | Initiates the Compass main wrapper. **Required** |
+| `.pf-v6-c-compass__main-header` | `<div>` | Initiates the Compass main header. |
+| `.pf-v6-c-compass__main-header-content` | `<div>` | Initiates the Compass main header content. This should be passed into a `.pf-v6-c-compass__panel` component. |
+| `.pf-v6-c-compass__main-header-title` | `<div>` | Initiates a title within the Compass main header content. |
+| `.pf-v6-c-compass__main-header-toolbar` | `<div>` | Initiates a toolbar of actions within the Compass main header content. |
+| `.pf-v6-c-compass__content` | `<div>` | Initiates the Compass content. **Required** |
+| `.pf-v6-c-compass__main-footer` | `<div>` | Initiates the Compass main footer. **Required** |
+| `.pf-v6-c-compass__panel` | `<div>` | Initiates a Compass panel. |
+| `.pf-v6-c-compass__nav` | `<div>` | Initiates a Compass container for site navigation. |
+| `.pf-v6-c-compass__nav-content` | `<div>` | Initiates a Compass container for navigation content. |
+| `.pf-v6-c-compass__nav-home` | `<div>` | Initiates a container for Compass home button. |
+| `.pf-v6-c-compass__nav-main` | `<div>` | Initiates a container for Compass navigation main content. |
+| `.pf-v6-c-compass__nav-search` | `<div>` | Initiates a container for Compass search button. |
+| `.pf-v6-c-compass__hero` | `<div>` | Initiates a Compass hero. |
+| `.pf-v6-c-compass__footer` | `<div>` | Initiates the Compass footer. |
+| `.pf-v6-c-compass__message-bar` | `<div>` | Initiates the Compass message bar. |
 | `.pf-m-no-glass` | `.pf-v6-c-compass`, `.pf-v6-c-compass__panel` | Modifies all elements or individual panels to remove the glass styles. |
-| `.pf-m-start` | `.pf-v6-c-compass__sidebar` | Modifies a compass sidebar for start styles. **Required** |
-| `.pf-m-end` | `.pf-v6-c-compass__sidebar` | Modifies a compass sidebar for end styles. **Required** |
-| `.pf-m-no-border` | `.pf-v6-c-compass__panel` | Modifies a compass panel to remove the border. |
-| `.pf-m-no-padding` | `.pf-v6-c-compass__panel` | Modifies a compass panel to remove the padding. |
-| `.pf-m-full-height` | `.pf-v6-c-compass__panel` | Modifies a compass panel to be full height. |
-| `.pf-m-pill` | `.pf-v6-c-compass__panel` | Modifies a compass panel to have a pill shaped border radius. |
-| `.pf-m-scrollable` | `.pf-v6-c-compass__panel` | Modifies a compass panel to scroll its overflow. |
-| `.pf-m-expanded` | `.pf-v6-c-compass__header`, `.pf-v6-c-compass__sidebar`, `.pf-v6-c-compass__main-footer`, `.pf-v6-c-compass__footer` | Modifies a compass section for expanded styles. |
+| `.pf-m-start` | `.pf-v6-c-compass__sidebar` | Modifies a Compass sidebar for start styles. **Required** |
+| `.pf-m-end` | `.pf-v6-c-compass__sidebar` | Modifies a Compass sidebar for end styles. **Required** |
+| `.pf-m-no-border` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to remove the border. |
+| `.pf-m-no-padding` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to remove the padding. |
+| `.pf-m-full-height` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to be full height. |
+| `.pf-m-pill` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to have a pill shaped border radius. |
+| `.pf-m-scrollable` | `.pf-v6-c-compass__panel` | Modifies a Compass panel to scroll its overflow. |
+| `.pf-m-expanded` | `.pf-v6-c-compass__header`, `.pf-v6-c-compass__sidebar`, `.pf-v6-c-compass__main-footer`, `.pf-v6-c-compass__footer` | Modifies a Compass section for expanded styles. |

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -8,7 +8,9 @@ wrapperTag: div
 ## Examples
 ### Card view
 
-This demo places a card view within the main Compass section. 
+This demo populates the main Compass section with a card view, which is one of the more common page types used within a Compass layout. In this demo, the page includes:
+- A `.pf-v6-c-compass__main-header` that contains the page title, any toolbar, or action items.
+- A `.pf-v6-c-compass__content`, which contains a `.pf-v6-c-compass__panel` to create a rounded-rectangle container that serves as the main content background.
 
 ```hbs isFullscreen isBeta
 {{> compass--card-view}}
@@ -16,7 +18,10 @@ This demo places a card view within the main Compass section.
 
 ### Dashboard
 
-This demo places a dashboard within the main Compass section. 
+This demo populates the main Compass section with a dashboard, which is often used as the landing page within a Compass layout. This demo page includes:
+
+- A `.pf-v6-c-hero` element positioned between the top navigation and the main page content, containing promotional or introductory content with important CTAs.
+- A `.pf-v6-c-compass__content` without a `.pf-v6-c-compass__panel` wrapping all of the contents. This removes the rounded-rectangle container that typically serves as the main content background. Instead, the content area is a dashboard (a grid of cards), and each card is individually wrapped in`.pf-v6-c-compass__panel` to provide the rounded-rectangle styling.
 
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
@@ -200,6 +205,8 @@ This demo places a dashboard within the main Compass section.
 
 This demo places multiple sections within the main Compass section, with each section containing a card view. 
 
+Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rounded-rectangle container as the main content background. Instead, the `.pf-v6-c-compass__content` is a grid with 2 independently scrollable `.pf-v6-c-compass__panel` elements. 
+
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
@@ -373,7 +380,7 @@ This demo places multiple sections within the main Compass section, with each se
 
 ### With drawer
 
-This demo showcases how you can position a side-panel drawer on top of the other Compass elements. 
+This demo showcases how you can position a side-panel drawer on top of the other Compass elements.
 
 ```hbs isFullscreen isBeta
 {{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -7,11 +7,17 @@ wrapperTag: div
 
 ## Examples
 ### Card view
+
+This demo places a card view within the main Compass section. 
+
 ```hbs isFullscreen isBeta
 {{> compass--card-view}}
 ```
 
 ### Dashboard
+
+This demo places a dashboard within the main Compass section. 
+
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
@@ -191,6 +197,9 @@ wrapperTag: div
 ```
 
 ### Multiple sections
+
+This demo places multiple sections within the main Compass section, with each section containing a card view. 
+
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
@@ -363,6 +372,9 @@ wrapperTag: div
 ```
 
 ### With drawer
+
+This demo showcases how you can position a side-panel drawer on top of the other Compass elements. 
+
 ```hbs isFullscreen isBeta
 {{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}
  {{#> drawer-main}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -9,7 +9,7 @@ wrapperTag: div
 ### Card view
 
 This demo populates the main Compass section with a card view, which is one of the more common page types used within a Compass layout. In this demo, the page includes:
-- A `.pf-v6-c-compass__main-header` that contains the page title, any toolbar, or action items.
+- A `.pf-v6-c-compass__main-header` that contains the page title and toolbar with action items.
 - A `.pf-v6-c-compass__content`, which contains a `.pf-v6-c-compass__panel` to create a rounded-rectangle container that serves as the main content background.
 
 ```hbs isFullscreen isBeta
@@ -20,7 +20,7 @@ This demo populates the main Compass section with a card view, which is one of t
 
 This demo populates the main Compass section with a dashboard, which is often used as the landing page within a Compass layout. This demo page includes:
 
-- A `.pf-v6-c-hero` element positioned between the top navigation and the main page content, containing promotional or introductory content with important CTAs.
+- A `.pf-v6-c-hero` component positioned between the top navigation and the main page content, containing promotional or introductory content with important CTAs.
 - A `.pf-v6-c-compass__content` without a `.pf-v6-c-compass__panel` wrapping all of the contents. This removes the rounded-rectangle container that typically serves as the main content background. Instead, the content area is a dashboard (a grid of cards), and each card is individually wrapped in`.pf-v6-c-compass__panel` to provide the rounded-rectangle styling.
 
 ```hbs isFullscreen isBeta

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -203,9 +203,9 @@ This demo populates the main Compass section with a dashboard, which is often us
 
 ### Multiple sections
 
-This demo places multiple sections within the main Compass section, with each section containing a card view. 
+This demo places multiple sections within the main Compass section, with each section containing a card view.
 
-Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rounded-rectangle container as the main content background. Instead, the `.pf-v6-c-compass__content` is a grid with 2 independently scrollable `.pf-v6-c-compass__panel` elements. 
+Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rounded-rectangle container as the main content background. Instead, the `.pf-v6-c-compass__content` is a grid with 2 independently scrollable `.pf-v6-c-compass__panel` elements.
 
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}


### PR DESCRIPTION
Closes [#8003](https://github.com/patternfly/patternfly/issues/8003)

Some small, simple things. Also tried to mirror the React docs, but open to building off of this however we want

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed "Default" to "Basic" and added a descriptive overview of the Compass layout (header, sidebars, main, panels, footer, message bar)
  * Revised public selector and modifier docs to new Compass naming, marked key layout elements as required, and clarified modifier behavior
  * Added documentation entries for header, logo, dock, profile, navigation, sidebars, main areas, panels, footer, and message bar
  * Expanded demo narratives for Card view, Dashboard, Multiple sections, and With drawer

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->