### PR TITLE
chore: include/use react-icons svgs

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -112,7 +112,8 @@ const buildPatternflyFromClean = parallel(series(copyReactIcons, buildDocs, mini
 const rebuildPatternfly = parallel(series(buildDocs, minifyCSS), copySourceFiles);
 
 const hasPfIconsDir = fs.existsSync('src/icons/PfIcons');
-export const buildPatternfly = hasPfIconsDir ? rebuildPatternfly : buildPatternflyFromClean;
+const hasReactIconsDir = fs.existsSync('src/icons/react-icons');
+export const buildPatternfly = (hasPfIconsDir && hasReactIconsDir) ? rebuildPatternfly : buildPatternflyFromClean;
 
 export function pfIcons() {
   return definedPfIcons();

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2,7 +2,7 @@ import fs from'fs';
 import path from 'path';
 import gulp from'gulp';
 import { rimraf } from 'rimraf';
-import { copyFA, copySource, copyAssets, copyDocs, watchCopyDocs } from'./scripts/gulp/copy.mjs';
+import { copyFA, copySource, copyAssets, copyDocs, watchCopyDocs, copyReactIcons } from'./scripts/gulp/copy.mjs';
 import { compileSASS, minifyCSS, watchSASS } from'./scripts/gulp/sass.mjs';
 import { pfIconFont as definedPfIconFont, pfIcons as definedPfIcons } from'./scripts/gulp/icons.mjs';
 import { compileHBS, compileMD, watchHBS, watchMD, watchHelpers } from'./scripts/gulp/html.mjs';
@@ -32,6 +32,7 @@ export function clean(cb) {
     '.circleci/css-size-report/package-lock.json',
     '.circleci/css-size-report/report.html',
     'src/icons/PfIcons/',
+    'src/icons/react-icons',
     'static/assets/fontawesome/',
     'static/assets/fonts/',
     'static/assets/pficon/',
@@ -107,8 +108,8 @@ const buildDocs = series(buildSrc, copyDocs);
 const watchAll = parallel(watchSrcSASS, watchSrcHBS, watchSrcMD, watchCopyDocs, watchSrcHelpers, startWebpackDevServer);
 
 // Builds `dist` folder
-const buildPatternflyFromClean = parallel(series(buildDocs, minifyCSS), series(pfIcons, parallel(copyFA, copySourceFiles)));
-const rebuildPatternfly = parallel(series(buildDocs, minifyCSS), pfIcons, copyFA, copySourceFiles);
+const buildPatternflyFromClean = parallel(series(buildDocs, minifyCSS), series(pfIcons, parallel(copyFA, copyReactIcons, copySourceFiles)));
+const rebuildPatternfly = parallel(series(buildDocs, minifyCSS), pfIcons, copyFA, copyReactIcons, copySourceFiles);
 
 const hasPfIconsDir = fs.existsSync('src/icons/PfIcons');
 export const buildPatternfly = hasPfIconsDir ? rebuildPatternfly : buildPatternflyFromClean;

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -108,13 +108,11 @@ const buildDocs = series(buildSrc, copyDocs);
 const watchAll = parallel(watchSrcSASS, watchSrcHBS, watchSrcMD, watchCopyDocs, watchSrcHelpers, startWebpackDevServer);
 
 // Builds `dist` folder
-const buildPatternflyFromClean = parallel(series(buildDocs, minifyCSS), series(pfIcons, parallel(copyFA, copyReactIcons, copySourceFiles)));
-const rebuildPatternfly = parallel(series(buildDocs, minifyCSS), pfIcons, copyFA, copyReactIcons, copySourceFiles);
+const buildPatternflyFromClean = parallel(series(copyReactIcons, buildDocs, minifyCSS), series(pfIcons, copyFA, copySourceFiles));
+const rebuildPatternfly = parallel(series(buildDocs, minifyCSS), copySourceFiles);
 
 const hasPfIconsDir = fs.existsSync('src/icons/PfIcons');
 export const buildPatternfly = hasPfIconsDir ? rebuildPatternfly : buildPatternflyFromClean;
-
-export const build = series(buildPatternfly, buildWebpack); // Builds `dist` and `public` folders
 
 export function pfIcons() {
   return definedPfIcons();

--- a/scripts/gulp/copy.mjs
+++ b/scripts/gulp/copy.mjs
@@ -9,6 +9,11 @@ export function copyFA() {
     .pipe(dest('dist/assets/icons'));
 }
 
+export function copyReactIcons() {
+  return src('node_modules/@patternfly/react-icons/dist/static/**/*.svg', { encoding: false, allowEmpty: true })
+    .pipe(dest('src/icons/react-icons'));
+}
+
 export function copyAssets() {
   return src('src/patternfly/assets/**', { encoding: false }).pipe(dest('static/assets'));
 }

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -373,17 +373,28 @@ export const prefix = function (term) {
 // ======================================================================================
 export const readReactIcon = function (iconName) {
   try {
+    if (typeof iconName !== 'string' || !iconName.trim()) {
+      console.error('[readReactIcon helper] Missing iconName');
+      return '';
+    }
+
+    const baseDir = path.resolve(process.cwd(), 'src/icons/react-icons');
     const fileName = iconName.endsWith('.svg') ? iconName : `${iconName}.svg`;
-    const fullPath = path.join(process.cwd(), 'src/icons/react-icons', fileName);
+    const fullPath = path.resolve(baseDir, fileName);
+
+    if (!fullPath.startsWith(baseDir + path.sep)) {
+      console.error(`[readReactIcon helper] Refusing to read outside icons dir: ${iconName}`);
+      return '';
+    }
 
     if (!fs.existsSync(fullPath)) {
-      console.warn(`[readReactIcon helper] Icon not found: ${fullPath}`);
+      console.error(`[readReactIcon helper] Icon not found: ${fullPath}`);
       return '';
     }
 
     return fs.readFileSync(fullPath, 'utf8');
   } catch (error) {
-    console.error(`[readReactIcon helper] Error reading icon ${iconName}:`, error.message);
+    console.error(`[readReactIcon helper] Error reading icon ${String(iconName)}:`, error);
     return '';
   }
 };

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -1,4 +1,6 @@
 import { patternflyNamespace, patternflyVersion } from './init.mjs';
+import fs from 'fs';
+import path from 'path';
 
 // TODO: TODO: update ternary to not escape chars
 
@@ -359,3 +361,29 @@ export const pfv = (type) => {
 export const prefix = function (term) {
   return pfv('c') + term;
 }
+
+// ======================================================================================
+// readReactIcon: is a helper function that reads a React Icon SVG file from src/icons/react-icons
+// ======================================================================================
+//
+// Usage:
+//   {{readReactIcon 'rh-ui-home'}}
+//   {{readReactIcon icon}}  // where icon is 'rh-ui-home' (without .svg extension)
+//
+// ======================================================================================
+export const readReactIcon = function (iconName) {
+  try {
+    const fileName = iconName.endsWith('.svg') ? iconName : `${iconName}.svg`;
+    const fullPath = path.join(process.cwd(), 'src/icons/react-icons', fileName);
+
+    if (!fs.existsSync(fullPath)) {
+      console.warn(`[readReactIcon helper] Icon not found: ${fullPath}`);
+      return '';
+    }
+
+    return fs.readFileSync(fullPath, 'utf8');
+  } catch (error) {
+    console.error(`[readReactIcon helper] Error reading icon ${iconName}:`, error.message);
+    return '';
+  }
+};

--- a/src/patternfly/components/Icon/pf-icon.hbs
+++ b/src/patternfly/components/Icon/pf-icon.hbs
@@ -1,0 +1,2 @@
+{{{readReactIcon icon}}}
+

--- a/src/patternfly/demos/Compass/compass--card-view.hbs
+++ b/src/patternfly/demos/Compass/compass--card-view.hbs
@@ -1,84 +1,7 @@
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar-start}}
     {{#> compass-main}}
       {{#> compass-main-header}}
         {{#> compass-panel}}
@@ -129,26 +52,6 @@
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar-end}}
   {{/compass}}
 {{/compass--demo-context}}

--- a/src/patternfly/demos/Compass/compass--header.hbs
+++ b/src/patternfly/demos/Compass/compass--header.hbs
@@ -1,0 +1,48 @@
+{{#> compass-header}}
+  {{#> compass-logo}}
+    {{> compass--icons compass--icons--redhat=true}}
+  {{/compass-logo}}
+  {{#> compass-nav}}
+    {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
+      {{#> compass-nav-content}}
+        {{#> compass-nav-home}}
+          {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
+            {{> pf-icon icon="rh-ui-home"}}
+          {{/button}}
+        {{/compass-nav-home}}
+        {{#> compass-nav-main}}
+            {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true"}}
+              {{> __tabs-list}}
+            {{/tabs}}
+        {{/compass-nav-main}}
+        {{#> compass-nav-search}}
+          {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
+            {{> pf-icon icon="rh-ui-search"}}
+          {{/button}}
+        {{/compass-nav-search}}
+      {{/compass-nav-content}}
+    {{/compass-panel}}
+    {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
+      {{#> compass-nav-content}}
+        {{#> compass-nav-main}}
+            {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+              {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
+            {{/tabs}}
+        {{/compass-nav-main}}
+      {{/compass-nav-content}}
+    {{/compass-panel}}
+  {{/compass-nav}}
+  {{#> compass-profile}}
+    {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
+      {{#> menu-toggle-icon}}
+        {{> avatar avatar--modifier="pf-m-md"}}
+      {{/menu-toggle-icon}}
+      {{#> menu-toggle-text}}
+        Ned Username
+      {{/menu-toggle-text}}
+      {{#> menu-toggle-controls}}
+        {{> menu-toggle-toggle-icon}}
+      {{/menu-toggle-controls}}
+    {{/menu-toggle}}
+  {{/compass-profile}}
+{{/compass-header}}

--- a/src/patternfly/demos/Compass/compass--sidebar-end.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar-end.hbs
@@ -2,27 +2,27 @@
   {{#> compass-panel compass-panel--IsPill=true}}
     {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Notifications" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-notification"}}
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="List" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-list"}}
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Zap" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-electricity"}}
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Download" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-download"}}
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-question-mark-circle"}}
         {{/button}}
       {{/action-list-item}}

--- a/src/patternfly/demos/Compass/compass--sidebar-end.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar-end.hbs
@@ -1,0 +1,31 @@
+{{#> compass-sidebar compass-sidebar--IsEnd=true}}
+  {{#> compass-panel compass-panel--IsPill=true}}
+    {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-notification"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-list"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-electricity"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-download"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-question-mark-circle"}}
+        {{/button}}
+      {{/action-list-item}}
+    {{/action-list}}
+  {{/compass-panel}}
+{{/compass-sidebar}}

--- a/src/patternfly/demos/Compass/compass--sidebar-start.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar-start.hbs
@@ -1,0 +1,31 @@
+{{#> compass-sidebar compass-sidebar--IsStart=true}}
+  {{#> compass-panel compass-panel--IsPill=true}}
+    {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-add-square"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-collection"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
+          {{> compass--icons compass--icons--sparkle=true}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-volume-up"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+          {{> pf-icon icon="rh-ui-microphone"}}
+        {{/button}}
+      {{/action-list-item}}
+    {{/action-list}}
+  {{/compass-panel}}
+{{/compass-sidebar}}

--- a/src/patternfly/demos/Compass/compass--sidebar-start.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar-start.hbs
@@ -7,7 +7,7 @@
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Collections" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-collection"}}
         {{/button}}
       {{/action-list-item}}
@@ -17,12 +17,12 @@
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Volume" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-volume-up"}}
         {{/button}}
       {{/action-list-item}}
       {{#> action-list-item}}
-        {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
+        {{#> button button--IsPlain=true button--aria-label="Use microphone" button--IsCircle=true button--IsIcon=true}}
           {{> pf-icon icon="rh-ui-microphone"}}
         {{/button}}
       {{/action-list-item}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -26,85 +26,8 @@ This demo populates the main Compass section with a dashboard, which is often us
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar-start}}
     {{#> compass-main}}
       {{#> compass-hero}}
         {{#> hero}}
@@ -176,27 +99,7 @@ This demo populates the main Compass section with a dashboard, which is often us
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar-end}}
   {{/compass}}
 {{/compass--demo-context}}
 ```
@@ -210,85 +113,8 @@ Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rou
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar-start}}
     {{#> compass-main}}
       {{#> compass-main-header}}
         {{#> compass-panel}}
@@ -353,27 +179,7 @@ Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rou
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar-end}}
   {{/compass}}
 {{/compass--demo-context}}
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -3366,6 +3366,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-icons@npm:6.5.0-prerelease.8":
+  version: 6.5.0-prerelease.8
+  resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.8"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10c0/900d6ad4afd01d32bfed7e521e34b5b8d0907cf0aa090624e50c0beca586d746757e645162fa668451aab7abe1e1e696d0387fbc9241e11a5ac99e05da03d27e
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-icons@npm:^6.4.0":
   version: 6.4.0
   resolution: "@patternfly/react-icons@npm:6.4.0"


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8005

* adds react-icons as a dev dependency
* adds a `copyReactIcons()` gulp function that copies `react-icons/dist/static/*` to `src/icons/react-icons/`
  * This dir is [ignored by git](https://github.com/patternfly/patternfly/blob/414dad4bced8093ff74d12e10ae4a3332142b0d5/.gitignore#L8) so they aren't checked in.
  * These icons are not copied to our dist dir, so they won't be a part of `@patternfly/patternfly`. IMO that's good, I think users can consume `@patternfly/react-icons` (or maybe [`@patternfly/icons`](https://github.com/patternfly/pf-roadmap/issues/280) in the future 😁). However, the "pficons" script generates SVGs and those [pficons are included in the core package](https://app.unpkg.com/@patternfly/patternfly@6.5.0-prerelease.30/files/icons/PfIcons). Any objections to omitting these icons from the core package and pointing folks to `@patternfly/react-icons` if they need them? If we ever reference icons in our CSS (like `background-image: url(/icons/some-react-icon.svg)`) then we can add them to the package, but we are not doing that currently.
* Adds a helper that takes an argument for an icon name and returns `src/icons/react-icons/{icon-name}.svg`
* Adds `pf-icon.hbs` that takes an `icon` parameter that you pass the icon name to. This is how we will include icons.
* Updates the icons in the headers and sidebars in our compass demos to use the rh-ui icons via `{{> pf-icon icon="{icon-name}"}}`
* Creates include files for the compass header and panels used in our demos, so we aren't duplicating that code in each demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PatternFly React icon support added so React SVG icons are available to components.
* **Refactor**
  * Compass demo simplified: header and sidebar extracted into reusable partials, reducing inline layout markup.
* **Chores**
  * Build pipeline adjusted to incorporate the new icon assets and align cleaning/build steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->