### PR TITLE
fix: fixes for react docked nav

### DIFF
--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -142,6 +142,8 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
   background-color: var(--#{$masthead}--BackgroundColor);
 
   &.pf-m-docked {
+    @include pf-v6-c-masthead--m-display-inline;
+
     --#{$masthead}--BackgroundColor: var(--#{$masthead}--m-docked--BackgroundColor);
     --#{$masthead}--GridTemplateRows: var(--#{$masthead}--m-docked--GridTemplateRows);
     --#{$masthead}--PaddingBlockStart: var(--#{$masthead}--m-docked--PaddingBlockStart);

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -203,7 +203,12 @@
     .#{$nav}__link-icon {
       position: relative;
       align-self: center;
+      text-align: center;
       min-width: 1lh;
+    }
+
+    .#{$nav}__link-text {
+      display: none;
     }
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -203,8 +203,8 @@
     .#{$nav}__link-icon {
       position: relative;
       align-self: center;
-      text-align: center;
       min-width: 1lh;
+      text-align: center;
     }
 
     .#{$nav}__link-text {


### PR DESCRIPTION
1. Centers the nav link icon container in docked nav variant. This was a small bug in core, but more visible in react.
2. Hides link text in docked nav. React can't easily conditionally render that element currently, plus we will want to show that text on small screens when we make responsive updates, so supporting it being in the DOM but not shown via.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Docked navigation: centers icons and hides link text for a more compact appearance.
  * Masthead: enforces inline display in both base and docked states for a consistent inline layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->