### PR TITLE
feat(treeview): allow a list item to look disabled

### DIFF
--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -37,9 +37,9 @@ cssPrefix: pf-v6-c-tree-view
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
-        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--text="Application 2"}}
+            {{> tree-view-node tree-view-node--text="Application 2 (disabled item)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -42,12 +42,13 @@ cssPrefix: pf-v6-c-tree-view
             {{> tree-view-node 
               tree-view-node--text="Application 2 (disabled item and toggle)"
               tree-view-node--IsDisabled="true"
-              tree-view-node-toggle--IsDisabled='true'}}
+              tree-view-node-toggle--IsDisabled="true"
+              tree-view-node--type='div'}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--text="Settings"}}
+                {{> tree-view-node tree-view-node--text="Settings" tree-view-node--type='div'}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
@@ -401,7 +402,7 @@ A search input can be used to filter tree view items. It is recommended that a t
         {{/tree-view-list-item}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--IsDisabled="true" tree-view-node--text="Application 2 (disabled item but expansion toggle enabled)"}}
+            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--IsDisabled="true" tree-view-node-toggle--IsDisabled="true" tree-view-node--text="Application 2 (disabled item and toggle)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
@@ -797,9 +798,9 @@ A search input can be used to filter tree view items. It is recommended that a t
                 {{> tree-view-node tree-view-node--text="Options"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
-            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-node--id=(concat tree-view--id '-3')}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-node-toggle--IsDisabled="true" tree-view-node--id=(concat tree-view--id '-3')}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--text="Loader"}}
+                {{> tree-view-node tree-view-node--text="Loader (toggle disabled)"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
           {{/tree-view-list}}
@@ -819,14 +820,14 @@ A search input can be used to filter tree view items. It is recommended that a t
                 {{> tree-view-node tree-view-node--text="Settings"}}
               {{/tree-view-content}}
             {{/tree-view-list-item}}
-            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-list-item--IsExpanded="true" tree-view-node--id=(concat tree-view--id '-6')}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-list-item--IsExpanded="true" tree-view-node--IsDisabled="true" tree-view-node--id=(concat tree-view--id '-6')}}
               {{#> tree-view-content}}
-                {{> tree-view-node tree-view-node--text="Loader"}}
+                {{> tree-view-node tree-view-node--text="Loader (disabled item but toggle is enabled)"}}
               {{/tree-view-content}}
               {{#> tree-view-list newcontext tree-view--id=tree-view--id}}
                 {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-list-item--IsSelected=true tree-view-node-toggle--IsDisabled="true" tree-view-node--IsDisabled="true" tree-view-node--id=(concat tree-view--id '-7')}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--text="Loader app 1 (disabled item and toggle button)"}}
+                    {{> tree-view-node tree-view-node--text="Loader app 1 (disabled item and toggle)"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -39,7 +39,10 @@ cssPrefix: pf-v6-c-tree-view
         {{/tree-view-list-item}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node  tree-view-node--modifier="pf-m-disabled" tree-view-node--text="Application 2 (disabled item)"}}
+            {{> tree-view-node 
+              tree-view-node--text="Application 2 (disabled item and toggle)"
+              tree-view-node--IsDisabled="true"
+              tree-view-node-toggle--IsDisabled='true'}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}
@@ -398,7 +401,7 @@ A search input can be used to filter tree view items. It is recommended that a t
         {{/tree-view-list-item}}
         {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--modifier="pf-m-disabled" tree-view-node--text="Application 2 (disabled item)"}}
+            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--IsDisabled="true" tree-view-node--text="Application 2 (disabled item but expansion toggle enabled)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
@@ -821,9 +824,9 @@ A search input can be used to filter tree view items. It is recommended that a t
                 {{> tree-view-node tree-view-node--text="Loader"}}
               {{/tree-view-content}}
               {{#> tree-view-list newcontext tree-view--id=tree-view--id}}
-                {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-list-item--IsSelected=true tree-view-node--id=(concat tree-view--id '-7')}}
+                {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsSelectable="true" tree-view-list-item--IsSelected=true tree-view-node-toggle--IsDisabled="true" tree-view-node--IsDisabled="true" tree-view-node--id=(concat tree-view--id '-7')}}
                   {{#> tree-view-content}}
-                    {{> tree-view-node tree-view-node--text="Loader app 1"}}
+                    {{> tree-view-node tree-view-node--text="Loader app 1 (disabled item and toggle button)"}}
                   {{/tree-view-content}}
                 {{/tree-view-list-item}}
                 {{#> tree-view-list-item}}
@@ -989,4 +992,5 @@ A search input can be used to filter tree view items. It is recommended that a t
 | `.pf-m-current` | `.pf-v6-c-tree-view__node` | Modifies the tree view node to be current. |
 | `.pf-m-selectable` | `.pf-v6-c-tree-view__node` | For use on nodes that are expandable and selectable, when the default click action on the node selects it instead of expanding it. |
 | `.pf-m-disabled` | `.pf-v6-c-tree-view__node` | Modifies the tree view node to display as disabled. |
+| `.pf-m-disabled` | `.pf-v6-c-tree-view__node-toggle` | Modifies the tree view node toggle to display as disabled. |
 | `.pf-m-truncate` | `.pf-v6-c-tree-view`, `.pf-v6-c-tree-view__node-title`, `.pf-v6-c-tree-view__node-text` | Modifies the tree view title or text to truncate. |

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -989,3 +989,4 @@ A search input can be used to filter tree view items. It is recommended that a t
 | `.pf-m-current` | `.pf-v6-c-tree-view__node` | Modifies the tree view node to be current. |
 | `.pf-m-selectable` | `.pf-v6-c-tree-view__node` | For use on nodes that are expandable and selectable, when the default click action on the node selects it instead of expanding it. |
 | `.pf-m-truncate` | `.pf-v6-c-tree-view`, `.pf-v6-c-tree-view__node-title`, `.pf-v6-c-tree-view__node-text` | Modifies the tree view title or text to truncate. |
+| `.pf-m-disabled` | `.pf-v6-c-tree-view__list-item` | Modifies the tree view list item to display as disabled. |

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -396,9 +396,9 @@ A search input can be used to filter tree view items. It is recommended that a t
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
-        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--text="Application 2"}}
+            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--text="Application 2 (disabled item)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}

--- a/src/patternfly/components/TreeView/examples/TreeView.md
+++ b/src/patternfly/components/TreeView/examples/TreeView.md
@@ -37,9 +37,9 @@ cssPrefix: pf-v6-c-tree-view
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
-        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--text="Application 2 (disabled item)"}}
+            {{> tree-view-node  tree-view-node--modifier="pf-m-disabled" tree-view-node--text="Application 2 (disabled item)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item}}
@@ -396,9 +396,9 @@ A search input can be used to filter tree view items. It is recommended that a t
             {{/tree-view-list-item}}
           {{/tree-view-list}}
         {{/tree-view-list-item}}
-        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
+        {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
           {{#> tree-view-content}}
-            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--text="Application 2 (disabled item)"}}
+            {{> tree-view-node tree-view-node--HasFolderIcon="true" tree-view-node--modifier="pf-m-disabled" tree-view-node--text="Application 2 (disabled item)"}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true"}}
@@ -988,5 +988,5 @@ A search input can be used to filter tree view items. It is recommended that a t
 | `.pf-m-no-background` | `.pf-v6-c-tree-view.pf-m-compact` | Modifies the tree view compact variant node containers to have a transparent background. |
 | `.pf-m-current` | `.pf-v6-c-tree-view__node` | Modifies the tree view node to be current. |
 | `.pf-m-selectable` | `.pf-v6-c-tree-view__node` | For use on nodes that are expandable and selectable, when the default click action on the node selects it instead of expanding it. |
+| `.pf-m-disabled` | `.pf-v6-c-tree-view__node` | Modifies the tree view node to display as disabled. |
 | `.pf-m-truncate` | `.pf-v6-c-tree-view`, `.pf-v6-c-tree-view__node-title`, `.pf-v6-c-tree-view__node-text` | Modifies the tree view title or text to truncate. |
-| `.pf-m-disabled` | `.pf-v6-c-tree-view__list-item` | Modifies the tree view list item to display as disabled. |

--- a/src/patternfly/components/TreeView/tree-view--base.hbs
+++ b/src/patternfly/components/TreeView/tree-view--base.hbs
@@ -30,7 +30,7 @@
     {{/tree-view-list-item}}
     {{#> tree-view-list-item}}
       {{#> tree-view-content}}
-        {{#> tree-view-node tree-view-node--modifier="pf-m-disabled"}}
+        {{#> tree-view-node tree-view-node--IsDisabled="true"}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
               metadata (disabled item)
@@ -142,10 +142,10 @@
           {{#> tree-view-list newcontext}}
             {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
               {{#> tree-view-content}}
-                {{#> tree-view-node tree-view-node--modifier="pf-m-disabled"}}
+                {{#> tree-view-node tree-view-node--IsDisabled="true" tree-view-node-toggle--IsDisabled="true"}}
                   {{#> tree-view-node-content}}
                     {{#> tree-view-node-title}}
-                      matchExpressions (disabled item)
+                      matchExpressions (disabled item and toggle)
                     {{/tree-view-node-title}}
                     {{#> tree-view-node-text}}
                       matchExpressions is a list of the label selector requirements. The requirements and ANDed.

--- a/src/patternfly/components/TreeView/tree-view--base.hbs
+++ b/src/patternfly/components/TreeView/tree-view--base.hbs
@@ -28,9 +28,9 @@
         {{/tree-view-node}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
-    {{#> tree-view-list-item tree-view-list-item--modifier="pf-m-disabled"}}
+    {{#> tree-view-list-item}}
       {{#> tree-view-content}}
-        {{#> tree-view-node}}
+        {{#> tree-view-node tree-view-node--modifier="pf-m-disabled"}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
               metadata (disabled item)
@@ -140,9 +140,9 @@
             {{/tree-view-node}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
-            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
               {{#> tree-view-content}}
-                {{#> tree-view-node}}
+                {{#> tree-view-node tree-view-node--modifier="pf-m-disabled"}}
                   {{#> tree-view-node-content}}
                     {{#> tree-view-node-title}}
                       matchExpressions (disabled item)

--- a/src/patternfly/components/TreeView/tree-view--base.hbs
+++ b/src/patternfly/components/TreeView/tree-view--base.hbs
@@ -28,12 +28,12 @@
         {{/tree-view-node}}
       {{/tree-view-content}}
     {{/tree-view-list-item}}
-    {{#> tree-view-list-item}}
+    {{#> tree-view-list-item tree-view-list-item--modifier="pf-m-disabled"}}
       {{#> tree-view-content}}
         {{#> tree-view-node}}
           {{#> tree-view-node-content}}
             {{#> tree-view-node-title}}
-              metadata
+              metadata (disabled item)
             {{/tree-view-node-title}}
             {{#> tree-view-node-text}}
               Standard object metadata
@@ -140,12 +140,12 @@
             {{/tree-view-node}}
           {{/tree-view-content}}
           {{#> tree-view-list newcontext}}
-            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true"}}
+            {{#> tree-view-list-item tree-view-list-item--IsExpandable="true" tree-view-list-item--IsExpanded="true" tree-view-list-item--modifier="pf-m-disabled"}}
               {{#> tree-view-content}}
                 {{#> tree-view-node}}
                   {{#> tree-view-node-content}}
                     {{#> tree-view-node-title}}
-                      matchExpressions
+                      matchExpressions (disabled item)
                     {{/tree-view-node-title}}
                     {{#> tree-view-node-text}}
                       matchExpressions is a list of the label selector requirements. The requirements and ANDed.

--- a/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
@@ -1,8 +1,9 @@
-<{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}} class="{{pfv}}tree-view__node-toggle{{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
+<{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}} class="{{pfv}}tree-view__node-toggle {{#if tree-view-node-toggle--IsDisabled}}pf-m-disabled{{/if}} {{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
   {{#if tree-view-node-toggle--IsToggle}}
     id="toggle-{{tree-view-node--id}}"
     aria-label="Toggle"
     aria-labelledby="toggle-{{tree-view-node--id}} text-{{tree-view-node--id}}"
+    {{#if tree-view-node-toggle--IsDisabled}}disabled{{/if}}
   {{/if}}
   {{#if tree-view-node-toggle--attribute}}
     {{{tree-view-node-toggle--attribute}}}

--- a/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle.hbs
@@ -1,4 +1,4 @@
-<{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}} class="{{pfv}}tree-view__node-toggle {{#if tree-view-node-toggle--IsDisabled}}pf-m-disabled{{/if}} {{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
+<{{#if tree-view-node-toggle--IsToggle}}button{{else}}span{{/if}} class="{{pfv}}tree-view__node-toggle{{#if tree-view-node-toggle--IsDisabled}} pf-m-disabled{{/if}} {{#if tree-view-node-toggle--modifier}} {{tree-view-node-toggle--modifier}}{{/if}}"
   {{#if tree-view-node-toggle--IsToggle}}
     id="toggle-{{tree-view-node--id}}"
     aria-label="Toggle"

--- a/src/patternfly/components/TreeView/tree-view-node.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node.hbs
@@ -12,6 +12,7 @@
     {{#unless tree-view-list-item--HasCheckbox}}
       {{#if tree-view-list-item--IsSelected}} pf-m-current{{/if}}
     {{/unless}}
+    {{#if tree-view-node--IsDisabled}} pf-m-disabled{{/if}}
     {{#if tree-view-node--modifier}} {{tree-view-node--modifier}}{{/if}}"
     {{#if tree-view-node--type}}
       tabindex="0"

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -97,7 +97,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   // Disabled
   --#{$tree-view}__node--m-disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$tree-view}__node-icon--m-disabled--Color: var(--pf-t--global--icon--color--disabled);
-  
+  --#{$tree-view}__node-toggle--m-disabled--Color: var(--pf-t--global--icon--color--disabled);
+
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
 
@@ -187,6 +188,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
   --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
+  --#{$tree-view}--m-compact__node-toggle--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-toggle--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Background transparent
   --#{$tree-view}--m-no-background__node-container--BackgroundColor: transparent;
@@ -315,6 +318,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         .#{$tree-view}__node-toggle {
           margin-inline-start: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart);
           margin-inline-end: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd);
+          color: var(--#{$tree-view}--m-compact__node-toggle--nested--Color);
         }
 
         .#{$tree-view}__node-icon {
@@ -362,6 +366,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--#{$tree-view}--m-no-background__node-container--BackgroundColor);
     --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: inherit;
     --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: inherit;
+    --#{$tree-view}--m-compact__node-toggle--m-disabled--nested--Color: inherit;
   }
 }
 
@@ -497,6 +502,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     $ltr-val: translateX(var(--#{$tree-view}__list-item__list-item__node-toggle--TranslateX)),
     $rtl-val: translateX(#{pf-v6-calc-inverse(var(--#{$tree-view}__list-item__list-item__node-toggle--TranslateX))})
   );
+
+  &.pf-m-disabled {
+    --#{$tree-view}__node-toggle--Color: var(--#{$tree-view}__node-toggle--m-disabled--Color);
+  }
 }
 
 .#{$tree-view}__node-title,

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -96,12 +96,13 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Disabled
   --#{$tree-view}__list-item--m-disabled__node--Color: var(--pf-t--global--text--color--disabled);
-  --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
   --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
+
+  --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
   --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
-
+  
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
 
@@ -360,8 +361,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   &.pf-m-no-background {
     --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--#{$tree-view}--m-no-background__node-container--BackgroundColor);
-    --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
-    --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color);
+    --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: inherit;
+    --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: inherit;
   }
 }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -184,11 +184,11 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBlockEnd: 0;
-  --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-container--nested--Color: initial;
   --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-icon--nested--Color: initial;
   --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
-  --#{$tree-view}--m-compact__node-toggle--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-toggle--nested--Color: initial;
   --#{$tree-view}--m-compact__node-toggle--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Background transparent
@@ -310,7 +310,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
           padding-block-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockEnd);
           padding-inline-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart);
           padding-inline-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineEnd);
-          color: var(--#{$tree-view}--m-compact__node-container--nested--Color);
+          color: var(--#{$tree-view}--m-compact__node-container--nested--Color, inherit);
           background-color: var(--#{$tree-view}--m-compact__node-container--nested--BackgroundColor);
         }
 
@@ -318,11 +318,11 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
         .#{$tree-view}__node-toggle {
           margin-inline-start: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart);
           margin-inline-end: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd);
-          color: var(--#{$tree-view}--m-compact__node-toggle--nested--Color);
+          color: var(--#{$tree-view}--m-compact__node-toggle--nested--Color, inherit);
         }
 
         .#{$tree-view}__node-icon {
-          color: var(--#{$tree-view}--m-compact__node-icon--nested--Color);
+          color: var(--#{$tree-view}--m-compact__node-icon--nested--Color, inherit);
         }
         // stylelint-enable
       }
@@ -364,9 +364,9 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   &.pf-m-no-background {
     --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--#{$tree-view}--m-no-background__node-container--BackgroundColor);
-    --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: inherit;
-    --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: inherit;
-    --#{$tree-view}--m-compact__node-toggle--m-disabled--nested--Color: inherit;
+    --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: initial;
+    --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: initial;
+    --#{$tree-view}--m-compact__node-toggle--m-disabled--nested--Color: initial;
   }
 }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -95,8 +95,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: 90deg;
 
   // Disabled
-  --#{$tree-view}__list-item--m-disabled__node--Color: var(--pf-t--global--text--color--disabled);
-  --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
+  --#{$tree-view}__node--m-disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$tree-view}__node-icon--m-disabled--Color: var(--pf-t--global--icon--color--disabled);
   
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
@@ -445,9 +445,9 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     margin-inline-start: var(--#{$tree-view}__node-count--MarginInlineStart);
   }
 
-  .pf-m-disabled > .#{$tree-view}__content > & {
-    --#{$tree-view}__node--Color: var(--#{$tree-view}__list-item--m-disabled__node--Color);
-    --#{$tree-view}__node-icon--Color: var(--#{$tree-view}__list-item--m-disabled__node-icon--Color);
+  &.pf-m-disabled {
+    --#{$tree-view}__node--Color: var(--#{$tree-view}__node--m-disabled--Color);
+    --#{$tree-view}__node-icon--Color: var(--#{$tree-view}__node-icon--m-disabled--Color);
     --#{$tree-view}--m-compact__node-container--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
     --#{$tree-view}--m-compact__node-icon--nested--Color: var(--#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color);
   }

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -94,6 +94,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__node-toggle-icon--Rotate: var(--#{$tree-view}__node-toggle-icon--base--Rotate);
   --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: 90deg;
 
+  // Disabled
+  --#{$tree-view}__list-item--m-disabled__node--Color: var(--pf-t--global--text--color--disabled);
+  --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
+
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
 
@@ -428,6 +432,11 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   .#{$tree-view}__node-count {
     margin-inline-start: var(--#{$tree-view}__node-count--MarginInlineStart);
+  }
+
+  .pf-m-disabled > .#{$tree-view}__content > & {
+    --#{$tree-view}__node--Color: var(--#{$tree-view}__list-item--m-disabled__node--Color);
+    --#{$tree-view}__node-icon--Color: var(--#{$tree-view}__list-item--m-disabled__node-icon--Color);
   }
 }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -99,6 +99,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
   --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
   --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
+  --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
@@ -305,14 +307,18 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
           padding-block-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingBlockEnd);
           padding-inline-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart);
           padding-inline-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineEnd);
-          background-color: var(--#{$tree-view}--m-compact__node-container--nested--BackgroundColor);
           color: var(--#{$tree-view}--m-compact__node-container--nested--Color);
+          background-color: var(--#{$tree-view}--m-compact__node-container--nested--BackgroundColor);
         }
 
         // add margins to align item text flush left and offset gap between toggle and text
         .#{$tree-view}__node-toggle {
           margin-inline-start: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineStart);
           margin-inline-end: var(--#{$tree-view}--m-compact__node-toggle--nested--MarginInlineEnd);
+        }
+
+        .#{$tree-view}__node-icon {
+          color: var(--#{$tree-view}--m-compact__node-icon--nested--Color);
         }
         // stylelint-enable
       }
@@ -355,6 +361,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   &.pf-m-no-background {
     --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--#{$tree-view}--m-no-background__node-container--BackgroundColor);
     --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
+    --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color);
   }
 }
 
@@ -442,6 +449,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
     --#{$tree-view}__node--Color: var(--#{$tree-view}__list-item--m-disabled__node--Color);
     --#{$tree-view}__node-icon--Color: var(--#{$tree-view}__list-item--m-disabled__node-icon--Color);
     --#{$tree-view}--m-compact__node-container--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
+    --#{$tree-view}--m-compact__node-icon--nested--Color: var(--#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color);
   }
 }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -97,6 +97,8 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   // Disabled
   --#{$tree-view}__list-item--m-disabled__node--Color: var(--pf-t--global--text--color--disabled);
   --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
+  --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
 
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
@@ -304,6 +306,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
           padding-inline-start: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart);
           padding-inline-end: var(--#{$tree-view}--m-compact__node-container--nested--PaddingInlineEnd);
           background-color: var(--#{$tree-view}--m-compact__node-container--nested--BackgroundColor);
+          color: var(--#{$tree-view}--m-compact__node-container--nested--Color);
         }
 
         // add margins to align item text flush left and offset gap between toggle and text
@@ -351,6 +354,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   &.pf-m-no-background {
     --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--#{$tree-view}--m-no-background__node-container--BackgroundColor);
+    --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
   }
 }
 
@@ -437,6 +441,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   .pf-m-disabled > .#{$tree-view}__content > & {
     --#{$tree-view}__node--Color: var(--#{$tree-view}__list-item--m-disabled__node--Color);
     --#{$tree-view}__node-icon--Color: var(--#{$tree-view}__list-item--m-disabled__node-icon--Color);
+    --#{$tree-view}--m-compact__node-container--nested--Color: var(--#{$tree-view}--m-compact__node-container--m-disabled--nested--Color);
   }
 }
 

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -96,12 +96,7 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
 
   // Disabled
   --#{$tree-view}__list-item--m-disabled__node--Color: var(--pf-t--global--text--color--disabled);
-  --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
-  --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
-
   --#{$tree-view}__list-item--m-disabled__node-icon--Color: var(--pf-t--global--icon--color--disabled);
-  --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
-  --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
   
   // Text
   --#{$tree-view}__node-text--max-lines: 1;
@@ -188,6 +183,10 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   --#{$tree-view}--m-compact__node-container--nested--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$tree-view}--m-compact__node-container--nested--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$tree-view}--m-compact__list-item--m-expanded__node-container--PaddingBlockEnd: 0;
+  --#{$tree-view}--m-compact__node-container--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-container--m-disabled--nested--Color: var(--pf-t--global--text--color--on-disabled);
+  --#{$tree-view}--m-compact__node-icon--nested--Color: inherit;
+  --#{$tree-view}--m-compact__node-icon--m-disabled--nested--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Background transparent
   --#{$tree-view}--m-no-background__node-container--BackgroundColor: transparent;


### PR DESCRIPTION
 Fixes #7996 

Adds .pf-m-disabled to the tree view list item to change the appearance.
Note: Actions should be disabled separately. 
Also, the compact version with a background color has further reduced contrast of disabled items, so it may not be desirable to use these options together.

Note: I added some disabled items for ease of testing - we can remove them if needed.
See it here: 
[basic tree view](https://pf-pr-8030.surge.sh/components/tree-view#single-selectable)
[compact](https://pf-pr-8030.surge.sh/components/tree-view#compact)
[compact no background](https://pf-pr-8030.surge.sh/components/tree-view#compact-no-background)
[With icons](https://pf-pr-8030.surge.sh/components/tree-view#with-icons), then add pf-m-compact to see that, then add pf-m-no-background to see that version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TreeView items and expansion toggles support a disabled state; visuals and interactions reflect disabled styling and non-interactivity across base, compact, no-background, and nested contexts.
  * Disabled toggles render and behave as non-interactive so disabled nodes cannot be expanded or collapsed.

* **Documentation**
  * Examples and docs updated to show the disabled modifier and revised example labels indicating disabled items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->