### PR TITLE
feat(table): use container queries

### DIFF
--- a/src/patternfly/base/patternfly-common.scss
+++ b/src/patternfly/base/patternfly-common.scss
@@ -129,7 +129,7 @@
   }
 
   container-type: inline-size;
-  container-name: viewport;
+  container-name: #{$pf-prefix}contain-viewport #{$pf-prefix}contain-table;
 }
 
 // Register the property type for the custom property to be animatable

--- a/src/patternfly/base/patternfly-common.scss
+++ b/src/patternfly/base/patternfly-common.scss
@@ -127,6 +127,9 @@
   @media screen and (prefers-reduced-motion: no-preference) {
     --#{$pf-global}--thinking-active--Animation--Duration: 2s;
   }
+
+  container-type: inline-size;
+  container-name: viewport;
 }
 
 // Register the property type for the custom property to be animatable

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -135,7 +135,7 @@ import './Table.css'
 
 ## Responsive table behavior
 ### Responsive layout modifier usage
-These classes can be used to ensure that the table changes between the tabular and grid-based layout at an appropriate screen width. 
+These classes can be used to ensure that the table changes between the tabular and grid-based layout at an appropriate screen width.
 **Note:** If a wrapping element creates an `inline-size` or `size` container with the container name `pf-v6-contain-table`, the breakpoints will apply to the container's width.
 
 | Class | Applied to | Outcome |

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -135,7 +135,8 @@ import './Table.css'
 
 ## Responsive table behavior
 ### Responsive layout modifier usage
-These classes can be used to ensure that the table changes between the tabular and grid-based layout at an appropriate screen width.
+These classes can be used to ensure that the table changes between the tabular and grid-based layout at an appropriate screen width. 
+**Note:** If a wrapping element creates an `inline-size` or `size` container with the container name `pf-v6-contain-table`, the breakpoints will apply to the container's width.
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -7,25 +7,25 @@
   }
 
   .pf-m-grid-md.#{$table} {
-    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--md)) {
+    @container viewport (max-width: #{$pf-v6-global--breakpoint--md}) {
       @content;
     }
   }
 
   .pf-m-grid-lg.#{$table} {
-    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--lg)) {
+    @container viewport (max-width: #{$pf-v6-global--breakpoint--lg}) {
       @content;
     }
   }
 
   .pf-m-grid-xl.#{$table} {
-    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--xl)) {
+    @container viewport (max-width: #{$pf-v6-global--breakpoint--xl}) {
       @content;
     }
   }
 
   .pf-m-grid-2xl.#{$table} {
-    @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--2xl)) {
+    @container viewport (max-width: #{$pf-v6-global--breakpoint--2xl}) {
       @content;
     }
   }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -7,25 +7,25 @@
   }
 
   .pf-m-grid-md.#{$table} {
-    @container viewport (max-width: #{$pf-v6-global--breakpoint--md}) {
+    @container #{$pf-prefix}contain-table (max-width: #{$pf-v6-global--breakpoint--md}) {
       @content;
     }
   }
 
   .pf-m-grid-lg.#{$table} {
-    @container viewport (max-width: #{$pf-v6-global--breakpoint--lg}) {
+    @container #{$pf-prefix}contain-table (max-width: #{$pf-v6-global--breakpoint--lg}) {
       @content;
     }
   }
 
   .pf-m-grid-xl.#{$table} {
-    @container viewport (max-width: #{$pf-v6-global--breakpoint--xl}) {
+    @container #{$pf-prefix}contain-table (max-width: #{$pf-v6-global--breakpoint--xl}) {
       @content;
     }
   }
 
   .pf-m-grid-2xl.#{$table} {
-    @container viewport (max-width: #{$pf-v6-global--breakpoint--2xl}) {
+    @container #{$pf-prefix}contain-table (max-width: #{$pf-v6-global--breakpoint--2xl}) {
       @content;
     }
   }

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -487,7 +487,7 @@ Note that the table in the main content area uses the `pf-m-grid-lg` modifier an
                 toolbar-template--HasBulkSelect=true
                 toolbar-template--HasSearchFilter=true
               }}
-            {{> table-simple-table}}
+            {{> table-simple-table table-simple-table--modifier="pf-m-grid-lg"}}
             {{> table-pagination-footer}}
           {{/drawer-body}}
         {{/drawer-content}}
@@ -507,7 +507,7 @@ Note that the table in the main content area uses the `pf-m-grid-lg` modifier an
                 toolbar-template--HasBulkSelect=true
                 toolbar-template--HasSearchFilter=true
               }}
-            {{> table-simple-table table-simple-table--modifier="pf-m-grid-lg"}}
+            {{> table-simple-table}}
             {{> table-pagination-footer}}
           {{/drawer-body}}
         {{/drawer-panel}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -464,3 +464,55 @@ By default, table cell alignment is set to baseline. This retains vertical align
   {{/page-main-section}}
 {{/inline}}
 ```
+
+### Container query with drawer
+
+This demo shows how tables can use container queries to respond to the size of their container. The drawer panel is defined as a container using `container-type: inline-size; container-name: pf-v6-contain-table`. This allows the table in the drawer to respond to the panel's width rather than the viewport width.
+
+Because the table in the main content area does not have a specific container around it, its responsive behavior defaults to the container specified on the `:root` element.
+
+Note that the table in the main content area uses the `pf-m-grid-lg` modifier and will change between the stacked and grid layout when the viewport reaches the large breakpoint. The table in the drawer uses the medium breakpoint, but changes from stacked to grid layout when its container (the drawer) reaches the medium breakpoint.
+
+```hbs isFullscreen
+{{> page-template page-template--id="table-drawer-container"}}
+
+{{#*inline "page-template-section"}}
+  {{#> page-main-section page-main-section--modifier="pf-m-no-padding"}}
+    {{#> drawer drawer--id="table-drawer" drawer--modifier="pf-m-expanded pf-m-inline"}}
+      {{#> drawer-main}}
+        {{#> drawer-content}}
+          {{#> drawer-body drawer-body--modifier="pf-m-padding"}}
+            {{> toolbar-template
+                toolbar-template--id=(concat page--id '-main-toolbar')
+                toolbar-template--HasBulkSelect=true
+                toolbar-template--HasSearchFilter=true
+              }}
+            {{> table-simple-table}}
+            {{> table-pagination-footer}}
+          {{/drawer-body}}
+        {{/drawer-content}}
+
+        {{#> drawer-panel drawer-panel--modifier="pf-m-width-50"
+            drawer-panel--attribute='style="container-type: inline-size; container-name: pf-v6-contain-table;"'}}
+          {{#> drawer-head}}
+            <h2 class="pf-v6-c-title pf-m-2xl">Drawer as a container</h2>
+            {{#> drawer-actions}}
+              {{> drawer-close}}
+            {{/drawer-actions}}
+          {{/drawer-head}}
+
+          {{#> drawer-body}}
+            {{> toolbar-template
+                toolbar-template--id=(concat page--id '-drawer-toolbar')
+                toolbar-template--HasBulkSelect=true
+                toolbar-template--HasSearchFilter=true
+              }}
+            {{> table-simple-table table-simple-table--modifier="pf-m-grid-lg"}}
+            {{> table-pagination-footer}}
+          {{/drawer-body}}
+        {{/drawer-panel}}
+      {{/drawer-main}}
+    {{/drawer}}
+  {{/page-main-section}}
+{{/inline}}
+```


### PR DESCRIPTION
This PR adds a container to the :root for use as a fallback container for the table (and generic viewport) container queries.

The table component is now using `@container` in place of `@media` for changing the table layout from a stacked to grid layout at given breakpoints. The `@container` query uses the same breakpoint values as the `@media` query did.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables now use container-query based responsiveness so they adapt to their container width (not just the viewport), improving behavior in constrained or embedded layouts.
  * Root-level container metadata added to enable container-based sizing and naming.

* **Documentation**
  * Updated table docs with guidance for container queries.
  * Added a demo showing container-query behavior with a drawer-panel layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->