### PR TITLE
chore(backstop): add custom description and reset params

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -6,6 +6,10 @@ const viewports = [];
 const isDarkTheme = process.argv.includes('--dark');
 const themeSuffix = isDarkTheme ? '_dark' : '';
 
+// check for --desc flag to add a custom description to the report
+const descArg = process.argv.find(arg => arg.startsWith('--desc='));
+const customDescription = descArg ? descArg.split('=')[1].replace(/^["']|["']$/g, '') : null;
+
 config.relativeUrls.map((relativeUrl) => {
   const url = relativeUrl.url || relativeUrl;
   const fullUrl = `${config.baseUrl}${url}`;
@@ -26,11 +30,15 @@ Object.keys(config.viewports).map((viewport) =>
   })
 );
 
+// Generate report title
+const defaultTitle = isDarkTheme ? 'Core - Dark Theme' : 'Core - Light Theme';
+const reportTitle = customDescription || defaultTitle;
+
 module.exports = {
-  id: 'pf-core',
+  id: reportTitle,
   viewports,
   scenarioDefaults: {
-    delay: 250, // a small timeout allows wiggle room for the page to fully render. increase as needed if you're getting rendering related false positives.
+    delay: 100, // a small timeout allows wiggle room for the page to fully render. increase as needed if you're getting rendering related false positives.
     readySelector: '.page-loaded',
     removeSelectors: ['.ws-full-page-utils'],
     misMatchThreshold: 0.001
@@ -60,7 +68,7 @@ module.exports = {
     html_report: `backstop_data/html_report${themeSuffix}`,
     ci_report: 'backstop_data/ci_report'
   },
-  asyncCaptureLimit: 1,
+  asyncCaptureLimit: 5,
   asyncCompareLimit: 50,
   resembleOutputOptions: {
     errorType: 'movementDifferenceIntensity',


### PR DESCRIPTION
This sets the timeout back to 100, async captures to 5, and adds a command line parameter `--desc="custom description"` that will put the description at the top of the report. I added it so that we can more easily differentiate different runs.