### PR TITLE
Post process backstop report name

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -6,10 +6,6 @@ const viewports = [];
 const isDarkTheme = process.argv.includes('--dark');
 const themeSuffix = isDarkTheme ? '_dark' : '';
 
-// check for --desc flag to add a custom description to the report
-const descArg = process.argv.find(arg => arg.startsWith('--desc='));
-const customDescription = descArg ? descArg.split('=')[1].replace(/^["']|["']$/g, '') : null;
-
 config.relativeUrls.map((relativeUrl) => {
   const url = relativeUrl.url || relativeUrl;
   const fullUrl = `${config.baseUrl}${url}`;
@@ -30,12 +26,8 @@ Object.keys(config.viewports).map((viewport) =>
   })
 );
 
-// Generate report title
-const defaultTitle = isDarkTheme ? 'Core - Dark Theme' : 'Core - Light Theme';
-const reportTitle = customDescription || defaultTitle;
-
 module.exports = {
-  id: reportTitle,
+  id: 'pf-core',
   viewports,
   scenarioDefaults: {
     delay: 100, // a small timeout allows wiggle room for the page to fully render. increase as needed if you're getting rendering related false positives.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "a11y": "patternfly-a11y --config patternfly-a11y.config",
     "backstop:clean": "rimraf -- backstop_data/bitmaps_test backstop_data/html_report",
-    "backstop:test": "backstop test --config='backstop.js'",
-    "backstop:test:dark": "backstop test --config='backstop.js' --dark",
+    "backstop:test": "node scripts/backstop-run.mjs test",
+    "backstop:test:dark": "node scripts/backstop-run.mjs test --dark",
     "backstop:approve": "backstop approve --config='backstop.js'",
     "backstop:approve:dark": "backstop approve --config='backstop.js' --dark",
     "backstop:chrome": "node backstop_data/engine_scripts/puppet/chrome.js",

--- a/scripts/backstop-post-process.mjs
+++ b/scripts/backstop-post-process.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Post-processes BackstopJS HTML reports to inject custom descriptions.
+ * Modifies the config.js file to update the testSuite field without affecting screenshot filenames.
+ */
+
+function parseArguments() {
+  const args = process.argv.slice(2);
+  let customDescription = null;
+  let isDarkTheme = false;
+
+  for (const arg of args) {
+    if (arg.startsWith('--desc=')) {
+      // Extract value and remove surrounding quotes
+      customDescription = arg.substring(7).replace(/^["']|["']$/g, '');
+    } else if (arg === '--dark') {
+      isDarkTheme = true;
+    }
+  }
+
+  return { customDescription, isDarkTheme };
+}
+
+function processConfigFile(configPath, customDescription, isDarkTheme) {
+  // Check if file exists
+  if (!fs.existsSync(configPath)) {
+    console.error(`Error: Config file not found at ${configPath}`);
+    console.error('Make sure BackstopJS has generated the report before running this script.');
+    return false;
+  }
+
+  try {
+    // Read config.js
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    // Extract JSON from JSONP wrapper
+    // Format: report({...JSON...});
+    const match = content.match(/^report\(([\s\S]*)\);?\s*$/);
+    if (!match) {
+      console.error(`Error: Invalid config.js format at ${configPath}`);
+      console.error('Expected JSONP format: report({...});');
+      return false;
+    }
+
+    // Parse JSON
+    const reportData = JSON.parse(match[1]);
+
+    // Update testSuite field
+    const defaultTitle = isDarkTheme ? 'Core - Dark Theme' : 'Core - Light Theme';
+    reportData.testSuite = customDescription || defaultTitle;
+
+    // Regenerate JSONP
+    const jsonString = JSON.stringify(reportData, null, 2);
+    const newContent = `report(${jsonString});`;
+
+    // Write back to file
+    fs.writeFileSync(configPath, newContent, 'utf8');
+
+    return true;
+  } catch (error) {
+    console.error(`Error processing config file: ${error.message}`);
+    return false;
+  }
+}
+
+function main() {
+  const { customDescription, isDarkTheme } = parseArguments();
+
+  // Determine theme suffix and report path
+  const themeSuffix = isDarkTheme ? '_dark' : '';
+  const reportDir = path.join(__dirname, '..', 'backstop_data', `html_report${themeSuffix}`);
+  const configPath = path.join(reportDir, 'config.js');
+
+  // Process the config file
+  const success = processConfigFile(configPath, customDescription, isDarkTheme);
+
+  // Exit with appropriate code
+  process.exit(success ? 0 : 1);
+}
+
+main();

--- a/scripts/backstop-post-process.mjs
+++ b/scripts/backstop-post-process.mjs
@@ -42,7 +42,8 @@ function processConfigFile(configPath, customDescription, isDarkTheme) {
 
     // Extract JSON from JSONP wrapper
     // Format: report({...JSON...});
-    const match = content.match(/^report\(([\s\S]*)\);?\s*$/);
+    const normalized = content.replace(/^\uFEFF/, '');
+    const match = normalized.match(/^\s*report\(([\s\S]*)\);?\s*$/);
     if (!match) {
       console.error(`Error: Invalid config.js format at ${configPath}`);
       console.error('Expected JSONP format: report({...});');

--- a/scripts/backstop-run.mjs
+++ b/scripts/backstop-run.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Wrapper script that coordinates BackstopJS execution and post-processing.
+ * Separates --desc argument for post-processing while passing other args to BackstopJS.
+ */
+
+function parseArguments() {
+  const args = process.argv.slice(2);
+  const backstopArgs = [];
+  let customDescription = null;
+
+  for (const arg of args) {
+    if (arg.startsWith('--desc=')) {
+      // Extract description and remove surrounding quotes
+      customDescription = arg.substring(7).replace(/^["']|["']$/g, '');
+    } else {
+      // Pass all other arguments to BackstopJS
+      backstopArgs.push(arg);
+    }
+  }
+
+  return { backstopArgs, customDescription };
+}
+
+function runBackstop(args) {
+  const backstopCommand = `backstop ${args.join(' ')} --config='backstop.js'`;
+
+  console.log(`Running: ${backstopCommand}`);
+
+  try {
+    execSync(backstopCommand, {
+      stdio: 'inherit', // Show output in real-time
+      cwd: path.join(__dirname, '..') // Run from project root
+    });
+    return true;
+  } catch (error) {
+    console.error('BackstopJS command failed');
+    return false;
+  }
+}
+
+function runPostProcessor(customDescription, isDarkTheme) {
+  const args = [];
+
+  if (customDescription) {
+    args.push(`--desc="${customDescription}"`);
+  }
+
+  if (isDarkTheme) {
+    args.push('--dark');
+  }
+
+  const postProcessCommand = `node ${path.join(__dirname, 'backstop-post-process.mjs')} ${args.join(' ')}`;
+
+  try {
+    execSync(postProcessCommand, {
+      stdio: 'inherit',
+      cwd: path.join(__dirname, '..')
+    });
+    return true;
+  } catch (error) {
+    console.error('Post-processing failed');
+    return false;
+  }
+}
+
+function main() {
+  const { backstopArgs, customDescription } = parseArguments();
+
+  // Check if --dark flag is present (needed for post-processor)
+  const isDarkTheme = backstopArgs.includes('--dark');
+
+  // Run BackstopJS
+  const backstopSuccess = runBackstop(backstopArgs);
+
+  if (!backstopSuccess) {
+    console.error('Stopping due to BackstopJS failure');
+    process.exit(1);
+  }
+
+  // Run post-processor
+  const postProcessSuccess = runPostProcessor(customDescription, isDarkTheme);
+
+  if (!postProcessSuccess) {
+    console.error('Warning: Post-processing failed, but BackstopJS completed successfully');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Backstop doesn't differentiate the id shown at the top of a report from the initial part of the screen capture filenames.
This PR introduces a wrapper script that changes the name at the top of the report after it's created.

Note: in testing, it works well but (probably because the html report is opened in the browser immediately after creation) you need to reload the page to see the changed name.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New test runner CLI that executes visual tests and applies post-processing.
  * Post-processing step can inject a custom report description and apply a dark-theme variant.

* **Chores**
  * Test scripts updated to use the new runner.
  * Reports now use a consistent, fixed report identifier for generated outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->