### PR TITLE
chore(backstop): revert desc feature

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -6,10 +6,6 @@ const viewports = [];
 const isDarkTheme = process.argv.includes('--dark');
 const themeSuffix = isDarkTheme ? '_dark' : '';
 
-// check for --desc flag to add a custom description to the report
-const descArg = process.argv.find(arg => arg.startsWith('--desc='));
-const customDescription = descArg ? descArg.split('=')[1].replace(/^["']|["']$/g, '') : null;
-
 config.relativeUrls.map((relativeUrl) => {
   const url = relativeUrl.url || relativeUrl;
   const fullUrl = `${config.baseUrl}${url}`;
@@ -30,12 +26,8 @@ Object.keys(config.viewports).map((viewport) =>
   })
 );
 
-// Generate report title
-const defaultTitle = isDarkTheme ? 'Core - Dark Theme' : 'Core - Light Theme';
-const reportTitle = customDescription || defaultTitle;
-
 module.exports = {
-  id: reportTitle,
+  id: 'pf-core',
   viewports,
   scenarioDefaults: {
     delay: 100, // a small timeout allows wiggle room for the page to fully render. increase as needed if you're getting rendering related false positives.
@@ -68,7 +60,7 @@ module.exports = {
     html_report: `backstop_data/html_report${themeSuffix}`,
     ci_report: 'backstop_data/ci_report'
   },
-  asyncCaptureLimit: 5,
+  asyncCaptureLimit: 3,
   asyncCompareLimit: 50,
   resembleOutputOptions: {
     errorType: 'movementDifferenceIntensity',

--- a/backstop.js
+++ b/backstop.js
@@ -60,7 +60,7 @@ module.exports = {
     html_report: `backstop_data/html_report${themeSuffix}`,
     ci_report: 'backstop_data/ci_report'
   },
-  asyncCaptureLimit: 3,
+  asyncCaptureLimit: 15,
   asyncCompareLimit: 50,
   resembleOutputOptions: {
     errorType: 'movementDifferenceIntensity',


### PR DESCRIPTION
The --desc option caused problems with the reference file names since they also contain the id string. This reverts that feature.
It also sets the asynch capture number back to 3 for possibly a happy medium of speed and reliability. Also it nicely groups the captures of each test in the 3 viewport settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed support for custom report descriptions
  * Standardized report identifier to a fixed value
  * Increased concurrent screenshot capture operations for higher throughput

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->