### PR TITLE
feat: expand clickable area for standalone radio and checkbox

### DIFF
--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -4,6 +4,7 @@
   --#{$check}--GridGap: var(--pf-t--global--spacer--gap--group--vertical) var(--pf-t--global--spacer--gap--text-to-element--default);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
   --#{$check}--m-standalone--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
+
   // Expanded clickable area for standalone checkbox; provides 44x44px minimum touch target per WCAG guidelines
   --#{$check}--m-standalone--before--Inset: -12px;
 
@@ -40,10 +41,10 @@
 
     // Expanded clickable area using pseudo-element
     &::before {
-      content: '';
       position: absolute;
       inset: var(--#{$check}--m-standalone--before--Inset);
       pointer-events: auto;
+      content: '';
     }
 
     .#{$check}__input {

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -4,6 +4,8 @@
   --#{$check}--GridGap: var(--pf-t--global--spacer--gap--group--vertical) var(--pf-t--global--spacer--gap--text-to-element--default);
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
   --#{$check}--m-standalone--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
+  // Expanded clickable area for standalone checkbox; provides 44x44px minimum touch target per WCAG guidelines
+  --#{$check}--m-standalone--before--Inset: -12px;
 
   // TODO: update to `--#{$check}--FontSize` `--#{$check}--LineHeight`
   --#{$check}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -31,9 +33,18 @@
   accent-color: var(--#{$check}--AccentColor);
 
   &.pf-m-standalone {
+    position: relative;
     display: inline-grid;
     grid-template-columns: auto;
     min-height: var(--#{$check}--m-standalone--MinHeight);
+
+    // Expanded clickable area using pseudo-element
+    &::before {
+      content: '';
+      position: absolute;
+      inset: var(--#{$check}--m-standalone--before--Inset);
+      pointer-events: auto;
+    }
 
     .#{$check}__input {
       align-self: center;

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -6,7 +6,7 @@
   --#{$check}--m-standalone--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
 
   // Standalone
-  --#{$check}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--md) * -1);
+  --#{$check}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--sm) * -1);
 
   // TODO: update to `--#{$check}--FontSize` `--#{$check}--LineHeight`
   --#{$check}__label--disabled--Color: var(--pf-t--global--text--color--disabled);

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -5,8 +5,8 @@
   --#{$check}--AccentColor: var(--pf-t--global--color--brand--default);
   --#{$check}--m-standalone--MinHeight: calc(var(--#{$check}__label--FontSize) * var(--#{$check}__label--LineHeight));
 
-  // Expanded clickable area for standalone checkbox; provides 44x44px minimum touch target per WCAG guidelines
-  --#{$check}--m-standalone--before--Inset: -12px;
+  // Standalone
+  --#{$check}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--md) * -1);
 
   // TODO: update to `--#{$check}--FontSize` `--#{$check}--LineHeight`
   --#{$check}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -39,7 +39,6 @@
     grid-template-columns: auto;
     min-height: var(--#{$check}--m-standalone--MinHeight);
 
-    // Expanded clickable area using pseudo-element
     &::before {
       position: absolute;
       inset: var(--#{$check}--m-standalone--before--Inset);

--- a/src/patternfly/components/Check/check.scss
+++ b/src/patternfly/components/Check/check.scss
@@ -44,6 +44,7 @@
       position: absolute;
       inset: var(--#{$check}--m-standalone--before--Inset);
       pointer-events: auto;
+      cursor: inherit;
       content: '';
     }
 

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -4,6 +4,8 @@
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
   --#{$radio}--m-standalone--MinHeight: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
+  // Expanded clickable area for standalone radio; provides 44x44px minimum touch target per WCAG guidelines
+  --#{$radio}--m-standalone--before--Inset: -12px;
 
   // TODO: update to `--#{$radio}--FontSize` `--#{$radio}--LineHeight`
   --#{$radio}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -32,9 +34,18 @@
   accent-color: var(--#{$radio}--AccentColor);
 
   &.pf-m-standalone {
+    position: relative;
     display: inline-grid;
     grid-template-columns: auto;
     min-height: var(--#{$radio}--m-standalone--MinHeight);
+
+    // Expanded clickable area using pseudo-element
+    &::before {
+      content: '';
+      position: absolute;
+      inset: var(--#{$radio}--m-standalone--before--Inset);
+      pointer-events: auto;
+    }
 
     .#{$radio}__input {
       align-self: center;

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -4,6 +4,7 @@
   --#{$radio}--GridGap: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--sm);
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
   --#{$radio}--m-standalone--MinHeight: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
+
   // Expanded clickable area for standalone radio; provides 44x44px minimum touch target per WCAG guidelines
   --#{$radio}--m-standalone--before--Inset: -12px;
 
@@ -41,10 +42,10 @@
 
     // Expanded clickable area using pseudo-element
     &::before {
-      content: '';
       position: absolute;
       inset: var(--#{$radio}--m-standalone--before--Inset);
       pointer-events: auto;
+      content: '';
     }
 
     .#{$radio}__input {

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -5,8 +5,8 @@
   --#{$radio}--AccentColor: var(--pf-t--global--icon--color--brand--default);
   --#{$radio}--m-standalone--MinHeight: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
 
-  // Expanded clickable area for standalone radio; provides 44x44px minimum touch target per WCAG guidelines
-  --#{$radio}--m-standalone--before--Inset: -12px;
+  // Standalone
+  --#{$radio}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--md) * -1);
 
   // TODO: update to `--#{$radio}--FontSize` `--#{$radio}--LineHeight`
   --#{$radio}__label--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -40,7 +40,6 @@
     grid-template-columns: auto;
     min-height: var(--#{$radio}--m-standalone--MinHeight);
 
-    // Expanded clickable area using pseudo-element
     &::before {
       position: absolute;
       inset: var(--#{$radio}--m-standalone--before--Inset);

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -45,6 +45,7 @@
       position: absolute;
       inset: var(--#{$radio}--m-standalone--before--Inset);
       pointer-events: auto;
+      cursor: inherit;
       content: '';
     }
 

--- a/src/patternfly/components/Radio/radio.scss
+++ b/src/patternfly/components/Radio/radio.scss
@@ -6,7 +6,7 @@
   --#{$radio}--m-standalone--MinHeight: calc(var(--#{$radio}__label--FontSize) * var(--#{$radio}__label--LineHeight));
 
   // Standalone
-  --#{$radio}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--md) * -1);
+  --#{$radio}--m-standalone--before--Inset: calc(var(--pf-t--global--spacer--sm) * -1);
 
   // TODO: update to `--#{$radio}--FontSize` `--#{$radio}--LineHeight`
   --#{$radio}__label--disabled--Color: var(--pf-t--global--text--color--disabled);


### PR DESCRIPTION
Implement 44x44px minimum touch target for standalone radio and checkbox components using ::before pseudo-element approach. This improves accessibility and usability on mobile devices while maintaining the original visual layout and shape of the components.

The expanded clickable area is achieved through a CSS pseudo-element with an inset of -12px on all sides, providing an invisible but clickable expansion area. The table component inherits this improvement automatically.

- Add --pf-v6-c-radio--m-standalone--before--Inset component variable
- Add --pf-v6-c-check--m-standalone--before--Inset component variable
- Add position: relative to .pf-m-standalone radio and checkbox
- Add ::before pseudo-element with expanded inset for clickable area

Assisted-by: GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the interactive hit area for standalone checkboxes and radio buttons to make them easier to select.
  * Added configurable spacing tokens and an overlay element so the clickable region is larger while preserving layout and cursor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->