### PR TITLE
fix(notification-drawer): add spacing between header actions

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -18,6 +18,7 @@
   --#{$notification-drawer}__header-status--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$notification-drawer}__header-status--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$notification-drawer}__header-status--Color: var(--pf-t--global--text--color--subtle);
+  --#{$notification-drawer}__header-action--Gap: var(--pf-t--global--spacer--gap--action-to-action--plain);
 
   // Body
   --#{$notification-drawer}__body--ZIndex: var(--pf-t--global--z-index--xs);
@@ -144,6 +145,7 @@
 .#{$notification-drawer}__header-action {
   display: flex;
   align-items: center;
+  gap: var(--#{$notification-drawer}__header-action--Gap);
   margin-inline-start: auto;
 }
 

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -144,8 +144,8 @@
 
 .#{$notification-drawer}__header-action {
   display: flex;
-  align-items: center;
   gap: var(--#{$notification-drawer}__header-action--Gap);
+  align-items: center;
   margin-inline-start: auto;
 }
 


### PR DESCRIPTION
Fixes #7366

Adds the missing spacing token between notification drawer header actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment of notification drawer header actions for more consistent visual rhythm and easier scanning of header controls across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->