### PR TITLE
chore(controls): apply control tokens

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -193,12 +193,12 @@
   --#{$button}--m-plain--m-no-padding--border--offset: calc(#{pf-size-prem(2px)} * -1);
 
   // Control
-  --#{$button}--m-control--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$button}--m-control--BorderRadius: var(--pf-t--global--border--radius--control--form-element);
   --#{$button}--m-control--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}--m-control--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}--m-control--Color: var(--pf-t--global--text--color--regular);
   --#{$button}--m-control--BackgroundColor: var(--pf-t--global--background--color--control--default);
-  --#{$button}--m-control--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$button}--m-control--BorderColor: var(--pf-t--global--border--color--control--default);
   --#{$button}--m-control--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$button}--m-control__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$button}--m-control--hover--Color: var(--pf-t--global--text--color--regular);

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -19,7 +19,7 @@
   --#{$clipboard-copy}__expandable-content--BorderBlockEndWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderInlineStartWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderColor: var(--pf-t--global--border--color--control--default);
-  --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--form-element);
+  --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--control--form-element);
   --#{$clipboard-copy}__expandable-content--OutlineOffset: var(--pf-t--global--spacer--xs);
 
   // Group

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -18,8 +18,8 @@
   --#{$clipboard-copy}__expandable-content--BorderInlineEndWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderBlockEndWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderInlineStartWidth: var(--pf-t--global--border--width--control--default);
-  --#{$clipboard-copy}__expandable-content--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$clipboard-copy}__expandable-content--BorderColor: var(--pf-t--global--border--color--control--default);
+  --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--form-element);
   --#{$clipboard-copy}__expandable-content--OutlineOffset: var(--pf-t--global--spacer--xs);
 
   // Group

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -7,10 +7,10 @@
   --#{$form-control}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$form-control}--Resize: none;
   --#{$form-control}--OutlineOffset: -6px;
-  --#{$form-control}--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$form-control}--BorderRadius: var(--pf-t--global--border--radius--control--form-element);
   --#{$form-control}--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--before--BorderStyle: solid;
-  --#{$form-control}--before--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$form-control}--before--BorderColor: var(--pf-t--global--border--color--control--default);
   --#{$form-control}--before--BorderRadius: var(--#{$form-control}--BorderRadius);
   --#{$form-control}--after--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$form-control}--after--BorderStyle: solid;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -12,7 +12,7 @@
   --#{$menu-toggle}--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$menu-toggle}--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$menu-toggle}--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$menu-toggle}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$menu-toggle}--BorderColor: var(--pf-t--global--border--color--control--default);
   --#{$menu-toggle}--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$menu-toggle}--border--ZIndex: var(--pf-t--global--z-index--xs); // add z-index for toggle border to render above other borders
   --#{$menu-toggle}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -36,7 +36,7 @@
   // Switch toggle
   --#{$switch}__toggle--Height: calc(var(--#{$switch}--FontSize) * var(--#{$switch}--LineHeight));
   --#{$switch}__toggle--BackgroundColor: var(--pf-t--global--background--color--control--default);
-  --#{$switch}__toggle--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$switch}__toggle--BorderColor: var(--pf-t--global--border--color--control--default);
   --#{$switch}__toggle--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$switch}__toggle--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$switch}__toggle--before--Width: calc(var(--#{$switch}--FontSize) - var(--#{$switch}__toggle-icon--Offset));

--- a/src/patternfly/components/TextInputGroup/text-input-group.scss
+++ b/src/patternfly/components/TextInputGroup/text-input-group.scss
@@ -2,7 +2,7 @@
 
 @include pf-root($text-input-group) {
   --#{$text-input-group}--BackgroundColor: var(--pf-t--global--background--color--control--default);
-  --#{$text-input-group}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$text-input-group}--BorderColor: var(--pf-t--global--border--color--control--default);
   --#{$text-input-group}--m-success--BorderColor: var(--pf-t--global--border--color--status--success--default);
   --#{$text-input-group}--m-warning--BorderColor: var(--pf-t--global--border--color--status--warning--default);
   --#{$text-input-group}--m-error--BorderColor: var(--pf-t--global--border--color--status--danger--default);
@@ -26,7 +26,7 @@
   --#{$text-input-group}__main--ColumnGap: var(--pf-t--global--spacer--xs);
 
   // Text wrapper
-  --#{$text-input-group}__text--BorderRadius--base: var(--pf-t--global--border--radius--small);
+  --#{$text-input-group}__text--BorderRadius--base: var(--pf-t--global--border--radius--control--form-element);
   --#{$text-input-group}__text--BorderStartStartRadius: var(--#{$text-input-group}__text--BorderRadius--base);
   --#{$text-input-group}__text--BorderStartEndRadius: var(--#{$text-input-group}__text--BorderRadius--base);
   --#{$text-input-group}__text--BorderEndEndRadius: var(--#{$text-input-group}__text--BorderRadius--base);

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -16,7 +16,7 @@
   --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--border--color--default);
   --#{$toggle-group}__button--hover--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toggle-group}__button--before--BorderWidth: var(--pf-t--global--border--width--control--default);
-  --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--control--default);
 
   // item
   --#{$toggle-group}__item--item--MarginInlineStart: calc(-1 * var(--pf-t--global--border--width--control--default));


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/8018
This covers control buttons, form elements, Switch, input groups toggle group and menu toggles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated default border color and border radius across Button, ClipboardCopy, FormControl, MenuToggle, Switch, TextInputGroup, and ToggleGroup so controls use more specific design tokens, refining the visual appearance of form and control elements without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->