### PR TITLE
fix: import gray45, red05

### DIFF
--- a/src/patternfly/base/tokens/tokens-palette.scss
+++ b/src/patternfly/base/tokens/tokens-palette.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 10 Sep 2025 19:58:14 GMT
+// Generated on Wed, 11 Feb 2026 20:28:14 GMT
 
 @mixin pf-v6-tokens {
   --pf-t--color--black: #000000;
@@ -16,6 +16,7 @@
   --pf-t--color--gray--20: #e0e0e0;
   --pf-t--color--gray--30: #c7c7c7;
   --pf-t--color--gray--40: #a3a3a3;
+  --pf-t--color--gray--45: #8c8c8c;
   --pf-t--color--gray--50: #707070;
   --pf-t--color--gray--60: #4d4d4d;
   --pf-t--color--gray--70: #383838;
@@ -46,6 +47,7 @@
   --pf-t--color--purple--60: #3d2785;
   --pf-t--color--purple--70: #21134d;
   --pf-t--color--purple--80: #1b0d33;
+  --pf-t--color--red--05: #fef0f0;
   --pf-t--color--red--10: #fce3e3;
   --pf-t--color--red--20: #fbc5c5;
   --pf-t--color--red--30: #f9a8a8;


### PR DESCRIPTION
grabs the latest from design tokens repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new color tokens to the design system palette: a gray neutral shade (#8c8c8c) and a light red tone (#fef0f0). These tokens expand the available color options for consistent design implementation across components and layouts, providing enhanced flexibility for design composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->