### PR TITLE
fix(drawer,table): make grid tables responsive to drawer width

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -327,6 +327,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   display: flex;
   flex: 1;
   gap: var(--#{$drawer}__main--Gap, 0);
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -334,9 +335,11 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 .#{$drawer}__content,
 .#{$drawer}__panel,
 .#{$drawer}__panel-main {
+  container-type: inline-size;
   display: flex;
   flex-shrink: 0;
   flex-direction: column;
+  min-width: 0;
   overflow: auto;
 }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -10,10 +10,18 @@
     @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--md)) {
       @content;
     }
+
+    @container (max-width: #{pf-v6-max-width-bp($pf-v6-global--breakpoint--md)}) {
+      @content;
+    }
   }
 
   .pf-m-grid-lg.#{$table} {
     @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--lg)) {
+      @content;
+    }
+
+    @container (max-width: #{pf-v6-max-width-bp($pf-v6-global--breakpoint--lg)}) {
       @content;
     }
   }
@@ -22,10 +30,18 @@
     @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--xl)) {
       @content;
     }
+
+    @container (max-width: #{pf-v6-max-width-bp($pf-v6-global--breakpoint--xl)}) {
+      @content;
+    }
   }
 
   .pf-m-grid-2xl.#{$table} {
     @media screen and (max-width: pf-v6-max-width-bp($pf-v6-global--breakpoint--2xl)) {
+      @content;
+    }
+
+    @container (max-width: #{pf-v6-max-width-bp($pf-v6-global--breakpoint--2xl)}) {
       @content;
     }
   }


### PR DESCRIPTION
Fixes #8001

## Summary
- Adds container-query support to table grid breakpoint modifiers (`pf-m-grid-md/lg/xl/2xl`).
- Makes drawer content/panel containers queryable (`container-type: inline-size`).
- Adds `min-width: 0` to drawer flex containers to avoid overflow-driven width issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Drawer component layout constraints to improve content shrinking and prevent unintended overflow behavior.

* **Enhancements**
  * Improved Table grid responsiveness with container-aware layout queries for better adaptation across different screen sizes and space availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->