### PR TITLE
fix(notification-drawer): prevent list item layout shift when marking as read

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -37,6 +37,7 @@
   --#{$notification-drawer}__list-item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$notification-drawer}__list-item--BorderWidth: var(--pf-t--global--border--width--box--status--default);
   --#{$notification-drawer}__list-item--BorderRadius: var(--pf-t--global--border--radius--medium);
+  --#{$notification-drawer}__list-item--focus--OutlineOffset: #{pf-size-prem(-4px)};
 
   // List item modifiers
   --#{$notification-drawer}__list-item--m-info__list-item-header-icon--Color: var(--pf-t--global--icon--color--status--info--default);
@@ -220,6 +221,10 @@
     &:focus {
       background-color: var(--#{$notification-drawer}__list-item--m-hoverable--hover--BackgroundColor);
     }
+
+    &:focus-visible {
+      outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
+    }
   }
 }
 
@@ -322,4 +327,3 @@
     transform: rotate(var(--#{$notification-drawer}__group--m-expanded__group-toggle-icon--Rotate));
   }
 }
-

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -171,8 +171,16 @@
   padding-inline-start: var(--#{$notification-drawer}__list-item--PaddingInlineStart);
   padding-inline-end: var(--#{$notification-drawer}__list-item--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__list-item--BackgroundColor);
-  border: var(--#{$notification-drawer}__list-item--BorderWidth) solid var(--#{$notification-drawer}__list-item--BorderColor);
   border-radius: var(--#{$notification-drawer}__list-item--BorderRadius);
+
+  &::before {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: '';
+    border: var(--#{$notification-drawer}__list-item--BorderWidth) solid var(--#{$notification-drawer}__list-item--BorderColor);
+    border-radius: inherit;
+  }
 
   &.pf-m-info {
     --#{$notification-drawer}__list-item--BorderColor: var(--#{$notification-drawer}__list-item--m-info__list-item--BorderColor);
@@ -203,8 +211,6 @@
     --#{$notification-drawer}__list-item--BorderWidth: var(--#{$notification-drawer}__list-item--m-read--BorderWidth);
     --#{$notification-drawer}__list-item--BackgroundColor: var(--#{$notification-drawer}__list-item--m-read--BackgroundColor);
     --#{$notification-drawer}__list-item--BorderColor: var(--#{$notification-drawer}__list-item--m-read--BorderColor);
-
-    position: relative;
   }
 
   &.pf-m-hoverable {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -37,7 +37,7 @@
   --#{$notification-drawer}__list-item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$notification-drawer}__list-item--BorderWidth: var(--pf-t--global--border--width--box--status--default);
   --#{$notification-drawer}__list-item--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$notification-drawer}__list-item--focus--OutlineOffset: #{pf-size-prem(-4px)};
+  --#{$notification-drawer}__list-item--OutlineOffset: #{pf-size-prem(-4px)};
 
   // List item modifiers
   --#{$notification-drawer}__list-item--m-info__list-item-header-icon--Color: var(--pf-t--global--icon--color--status--info--default);

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -173,6 +173,7 @@
   padding-inline-end: var(--#{$notification-drawer}__list-item--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__list-item--BackgroundColor);
   border-radius: var(--#{$notification-drawer}__list-item--BorderRadius);
+  outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
 
   &::before {
     position: absolute;
@@ -181,10 +182,6 @@
     content: '';
     border: var(--#{$notification-drawer}__list-item--BorderWidth) solid var(--#{$notification-drawer}__list-item--BorderColor);
     border-radius: inherit;
-  }
-
-  &:focus-visible {
-    outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
   }
 
   &.pf-m-info {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -183,6 +183,10 @@
     border-radius: inherit;
   }
 
+  &:focus-visible {
+    outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
+  }
+
   &.pf-m-info {
     --#{$notification-drawer}__list-item--BorderColor: var(--#{$notification-drawer}__list-item--m-info__list-item--BorderColor);
     --#{$notification-drawer}__list-item-header-icon--Color: var(--#{$notification-drawer}__list-item--m-info__list-item-header-icon--Color);
@@ -220,10 +224,6 @@
     &:hover,
     &:focus {
       background-color: var(--#{$notification-drawer}__list-item--m-hoverable--hover--BackgroundColor);
-    }
-
-    &:focus-visible {
-      outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
     }
   }
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -173,7 +173,7 @@
   padding-inline-end: var(--#{$notification-drawer}__list-item--PaddingInlineEnd);
   background-color: var(--#{$notification-drawer}__list-item--BackgroundColor);
   border-radius: var(--#{$notification-drawer}__list-item--BorderRadius);
-  outline-offset: var(--#{$notification-drawer}__list-item--focus--OutlineOffset);
+  outline-offset: var(--#{$notification-drawer}__list-item--OutlineOffset);
 
   &::before {
     position: absolute;


### PR DESCRIPTION
Fixes #8091.

Prevents Notification Drawer layout shift when unread items are marked read by moving the list-item border from the element itself to a `::before` pseudo-element. Visual styles remain the same; box size no longer changes.

Assisted-by: GitHub Copilot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Notification drawer list-item borders now render via a layered overlay for more consistent visuals and preserved corner radii.
  * Removed direct borders from list items and adjusted read-state positioning to align with the overlay approach.
  * Added an adjustable focus outline offset to improve keyboard focus visuals.
  * Preserved existing state-specific border colors (info, warning, danger, success, custom, read).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->