### PR TITLE
chore: add helper for react-icons

### DIFF
--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -387,7 +387,8 @@ export const pfIcon = function (iconName) {
     const svgContent = fs.readFileSync(iconPath, 'utf8');
     return new Handlebars.SafeString(svgContent);
   } catch (error) {
-    console.error(`\x1b[31mError loading icon "${iconName}": ${error.message}\x1b[0m`);
-    return new Handlebars.SafeString(`<!-- Icon "${iconName}" not found -->`);
+    const safeName = (iconName && typeof iconName === 'string') ? path.basename(iconName) : 'unknown';
+    console.error(`\x1b[31mError loading icon "${safeName}": ${error.message}\x1b[0m`);
+    return new Handlebars.SafeString(`<!-- Icon "${safeName}" not found -->`);
   }
 }

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -1,4 +1,7 @@
 import { patternflyNamespace, patternflyVersion } from './init.mjs';
+import fs from 'fs';
+import path from 'path';
+import Handlebars from 'handlebars';
 
 // TODO: TODO: update ternary to not escape chars
 
@@ -358,4 +361,23 @@ export const pfv = (type) => {
 
 export const prefix = function (term) {
   return pfv('c') + term;
+}
+
+// ======================================================================================
+// pfIcon: a helper function to use svg's from @patternfly/react-icons
+// ======================================================================================
+//
+// Usage:
+//   {{pfIcon 'arrow-right'}}
+//
+// ======================================================================================
+export const pfIcon = function (iconName) {
+  try {
+    const iconPath = path.join(process.cwd(), 'node_modules/@patternfly/react-icons/dist/static', `${iconName}.svg`);
+    const svgContent = fs.readFileSync(iconPath, 'utf8');
+    return new Handlebars.SafeString(svgContent);
+  } catch (error) {
+    console.error(`\x1b[31mError loading icon "${iconName}": ${error.message}\x1b[0m`);
+    return new Handlebars.SafeString(`<!-- Icon "${iconName}" not found -->`);
+  }
 }

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -373,7 +373,13 @@ export const prefix = function (term) {
 // ======================================================================================
 export const pfIcon = function (iconName) {
   try {
-    const iconPath = path.join(process.cwd(), 'node_modules/@patternfly/react-icons/dist/static', `${iconName}.svg`);
+  if (!iconName || typeof iconName !== 'string') {
+      console.error(`\x1b[31mInvalid icon name: ${iconName}\x1b[0m`);
+      return new Handlebars.SafeString(`<!-- Invalid icon name -->`);
+    }
+    const baseName = path.basename(iconName);
+    const iconDir = path.join(process.cwd(), 'node_modules/@patternfly/react-icons/dist/static');
+    const iconPath = path.join(iconDir, `${baseName}.svg`);
     const svgContent = fs.readFileSync(iconPath, 'utf8');
     return new Handlebars.SafeString(svgContent);
   } catch (error) {

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -2,6 +2,7 @@ import { patternflyNamespace, patternflyVersion } from './init.mjs';
 import fs from 'fs';
 import path from 'path';
 import Handlebars from 'handlebars';
+import { createRequire } from 'module';
 
 // TODO: TODO: update ternary to not escape chars
 
@@ -373,12 +374,15 @@ export const prefix = function (term) {
 // ======================================================================================
 export const pfIcon = function (iconName) {
   try {
-  if (!iconName || typeof iconName !== 'string') {
+    if (!iconName || typeof iconName !== 'string') {
       console.error(`\x1b[31mInvalid icon name: ${iconName}\x1b[0m`);
       return new Handlebars.SafeString(`<!-- Invalid icon name -->`);
     }
     const baseName = path.basename(iconName);
-    const iconDir = path.join(process.cwd(), 'node_modules/@patternfly/react-icons/dist/static');
+    const require = createRequire(import.meta.url);
+    const packageJsonPath = require.resolve('@patternfly/react-icons/package.json');
+    const packageDir = path.dirname(packageJsonPath);
+    const iconDir = path.join(packageDir, 'dist/static');
     const iconPath = path.join(iconDir, `${baseName}.svg`);
     const svgContent = fs.readFileSync(iconPath, 'utf8');
     return new Handlebars.SafeString(svgContent);

--- a/src/patternfly/demos/Compass/compass--card-view.hbs
+++ b/src/patternfly/demos/Compass/compass--card-view.hbs
@@ -1,84 +1,7 @@
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar--start}}
     {{#> compass-main}}
       {{#> compass-main-header}}
         {{#> compass-panel}}
@@ -129,26 +52,6 @@
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar--end}}
   {{/compass}}
 {{/compass--demo-context}}

--- a/src/patternfly/demos/Compass/compass--header.hbs
+++ b/src/patternfly/demos/Compass/compass--header.hbs
@@ -11,9 +11,9 @@
           {{/button}}
         {{/compass-nav-home}}
         {{#> compass-nav-main}}
-            {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
-              {{> __tabs-list}}
-            {{/tabs}}
+          {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
+            {{> __tabs-list}}
+          {{/tabs}}
         {{/compass-nav-main}}
         {{#> compass-nav-search}}
           {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}

--- a/src/patternfly/demos/Compass/compass--header.hbs
+++ b/src/patternfly/demos/Compass/compass--header.hbs
@@ -25,9 +25,9 @@
     {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
       {{#> compass-nav-content}}
         {{#> compass-nav-main}}
-            {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-              {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-            {{/tabs}}
+          {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+            {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
+          {{/tabs}}
         {{/compass-nav-main}}
       {{/compass-nav-content}}
     {{/compass-panel}}

--- a/src/patternfly/demos/Compass/compass--header.hbs
+++ b/src/patternfly/demos/Compass/compass--header.hbs
@@ -1,0 +1,48 @@
+{{#> compass-header}}
+  {{#> compass-logo}}
+    {{> compass--icons compass--icons--redhat=true}}
+  {{/compass-logo}}
+  {{#> compass-nav}}
+    {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
+      {{#> compass-nav-content}}
+        {{#> compass-nav-home}}
+          {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
+            {{pfIcon "rh-ui-home"}}
+          {{/button}}
+        {{/compass-nav-home}}
+        {{#> compass-nav-main}}
+            {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
+              {{> __tabs-list}}
+            {{/tabs}}
+        {{/compass-nav-main}}
+        {{#> compass-nav-search}}
+          {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
+            {{pfIcon "rh-ui-search"}}
+          {{/button}}
+        {{/compass-nav-search}}
+      {{/compass-nav-content}}
+    {{/compass-panel}}
+    {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
+      {{#> compass-nav-content}}
+        {{#> compass-nav-main}}
+            {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
+              {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
+            {{/tabs}}
+        {{/compass-nav-main}}
+      {{/compass-nav-content}}
+    {{/compass-panel}}
+  {{/compass-nav}}
+  {{#> compass-profile}}
+    {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
+      {{#> menu-toggle-icon}}
+        {{> avatar avatar--modifier="pf-m-md"}}
+      {{/menu-toggle-icon}}
+      {{#> menu-toggle-text}}
+        Ned Username
+      {{/menu-toggle-text}}
+      {{#> menu-toggle-controls}}
+        {{> menu-toggle-toggle-icon}}
+      {{/menu-toggle-controls}}
+    {{/menu-toggle}}
+  {{/compass-profile}}
+{{/compass-header}}

--- a/src/patternfly/demos/Compass/compass--sidebar--end.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar--end.hbs
@@ -1,0 +1,31 @@
+{{#> compass-sidebar compass-sidebar--IsEnd=true}}
+  {{#> compass-panel compass-panel--IsPill=true}}
+    {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Notifications" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-notification"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="List" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-list"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Zap" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-electricity"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Download" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-download"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-question-mark-circle"}}
+        {{/button}}
+      {{/action-list-item}}
+    {{/action-list}}
+  {{/compass-panel}}
+{{/compass-sidebar}}

--- a/src/patternfly/demos/Compass/compass--sidebar--start.hbs
+++ b/src/patternfly/demos/Compass/compass--sidebar--start.hbs
@@ -1,0 +1,31 @@
+{{#> compass-sidebar compass-sidebar--IsStart=true}}
+  {{#> compass-panel compass-panel--IsPill=true}}
+    {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-add-square"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Collections" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-collection"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-ai-experience-fill"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Volume" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-volume-up"}}
+        {{/button}}
+      {{/action-list-item}}
+      {{#> action-list-item}}
+        {{#> button button--IsPlain=true button--aria-label="Use microphone" button--IsCircle=true button--IsIcon=true}}
+          {{pfIcon "rh-ui-microphone"}}
+        {{/button}}
+      {{/action-list-item}}
+    {{/action-list}}
+  {{/compass-panel}}
+{{/compass-sidebar}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -26,85 +26,8 @@ This demo populates the main Compass section with a dashboard, which is often us
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--attribute='aria-label="Primary nav"' tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar--start}}
     {{#> compass-main}}
       {{#> compass-hero}}
         {{#> hero}}
@@ -176,27 +99,7 @@ This demo populates the main Compass section with a dashboard, which is often us
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar--end}}
   {{/compass}}
 {{/compass--demo-context}}
 ```
@@ -210,85 +113,8 @@ Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rou
 ```hbs isFullscreen isBeta
 {{#> compass--demo-context}}
   {{#> compass}}
-    {{#> compass-header}}
-      {{#> compass-logo}}
-        {{> compass--icons compass--icons--redhat=true}}
-      {{/compass-logo}}
-      {{#> compass-nav}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-home}}
-              {{#> button button--IsPlain=true button--aria-label="Home" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--home=true}}
-              {{/button}}
-            {{/compass-nav-home}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="primary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass primary" tabs-link--isLink="true"}}
-                  {{> __tabs-list}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-            {{#> compass-nav-search}}
-              {{#> button button--IsPlain=true button--aria-label="Search" button--IsCircle=true button--IsIcon=true}}
-                {{> compass--icons compass--icons--search=true}}
-              {{/button}}
-            {{/compass-nav-search}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-        {{#> compass-panel compass-panel--HasNoPadding=false compass-panel--IsPill=true}}
-          {{#> compass-nav-content}}
-            {{#> compass-nav-main}}
-                {{#> tabs tabs--id="secondary-nav" tabs--type="nav" tabs--IsNav=true tabs--aria-label="Compass secondary" tabs-link--isLink="true" tabs--modifier="pf-m-subtab"}}
-                  {{> __tabs-list-secondary __tabs-list--IsDisabled="true"}}
-                {{/tabs}}
-            {{/compass-nav-main}}
-          {{/compass-nav-content}}
-        {{/compass-panel}}
-      {{/compass-nav}}
-      {{#> compass-profile}}
-        {{#> menu-toggle menu-toggle--IsPlain=true menu-toggle--IsText=true menu-toggle--IsCircle=true}}
-          {{#> menu-toggle-icon}}
-            {{> avatar avatar--modifier="pf-m-md"}}
-          {{/menu-toggle-icon}}
-          {{#> menu-toggle-text}}
-            Ned Username
-          {{/menu-toggle-text}}
-          {{#> menu-toggle-controls}}
-            {{> menu-toggle-toggle-icon}}
-          {{/menu-toggle-controls}}
-        {{/menu-toggle}}
-      {{/compass-profile}}
-    {{/compass-header}}
-    {{#> compass-sidebar compass-sidebar--IsStart=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Add" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--square-plus=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--modifier=(concat (pfv "unset-prefix") "m-ai-indicator") button--IsPlain=true button--aria-label="AI assistant" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--sparkle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--header}}
+    {{> compass--sidebar--start}}
     {{#> compass-main}}
       {{#> compass-main-header}}
         {{#> compass-panel}}
@@ -353,27 +179,7 @@ Without a `.pf-v6-c-compass__panel` wrapping all of the content, there is no rou
         {{/compass-message-bar}}
       {{/compass-main-footer}}
     {{/compass-main}}
-    {{#> compass-sidebar compass-sidebar--IsEnd=true}}
-      {{#> compass-panel compass-panel--IsPill=true}}
-        {{#> action-list action-list--modifier="pf-m-icons" action-list--IsVertical=true}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Help" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--question-circle=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="User profile" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--user=true}}
-            {{/button}}
-          {{/action-list-item}}
-          {{#> action-list-item}}
-            {{#> button button--IsPlain=true button--aria-label="Send" button--IsCircle=true button--IsIcon=true}}
-              {{> compass--icons compass--icons--paper-plane=true}}
-            {{/button}}
-          {{/action-list-item}}
-        {{/action-list}}
-      {{/compass-panel}}
-    {{/compass-sidebar}}
+    {{> compass--sidebar--end}}
   {{/compass}}
 {{/compass--demo-context}}
 ```


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/8005

Replaces https://github.com/patternfly/patternfly/pull/8022 with a simpler approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public icon helper to load and render SVG icons in templates.
  * New Compass header with navigation, search, and user profile.
  * New start and end sidebar components with accessible icon action buttons.

* **Refactor**
  * Demo layouts simplified to use header/sidebar partials for cleaner composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->