### PR TITLE
fix(button): run favorite icon animation only on click or keyboard activation.

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -325,6 +325,7 @@
   --#{$button}--m-favorited--hover__icon--Color: var(--pf-t--global--color--favorite--hover);
   --#{$button}--m-favorited__icon--AnimationDuration: var(--pf-t--global--motion--duration--icon--long);
   --#{$button}--m-favorited__icon--AnimationTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$button}--m-favorited__icon--AnimationFillMode: both;
   --#{$button}__icon--favorite--Opacity: 1;
   --#{$button}__icon--favorited--Opacity: 0;
   --#{$button}--m-favorited__icon--favorite--Opacity: 0;
@@ -764,11 +765,19 @@
     --#{$button}__icon--favorited--Opacity: var(--#{$button}--m-favorited__icon--favorited--Opacity);
   }
 
-  // Favorite button will run an animation when favorited
-  &.pf-m-favorited:focus .#{$button}__icon {
+  // Keep animation definition on favorited state so focus toggles don't reapply animation-name
+  &.pf-m-favorited .#{$button}__icon {
     animation-name: #{$button}-icon-favorited;
     animation-duration: var(--#{$button}--m-favorited__icon--AnimationDuration);
+    animation-play-state: paused;
     animation-timing-function: var(--#{$button}--m-favorited__icon--AnimationTimingFunction);
+    animation-fill-mode: var(--#{$button}--m-favorited__icon--AnimationFillMode);
+  }
+
+  // Run animation while the favorited button is keyboard focused or actively pressed
+  &.pf-m-favorited:focus .#{$button}__icon,
+  &.pf-m-favorited:active .#{$button}__icon {
+    animation-play-state: running;
   }
 
   &.pf-m-settings {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -765,7 +765,7 @@
   }
 
   // Favorite button will run an animation when favorited
-  &.pf-m-favorited .#{$button}__icon {
+  &.pf-m-favorited:focus .#{$button}__icon {
     animation-name: #{$button}-icon-favorited;
     animation-duration: var(--#{$button}--m-favorited__icon--AnimationDuration);
     animation-timing-function: var(--#{$button}--m-favorited__icon--AnimationTimingFunction);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -774,8 +774,14 @@
     animation-fill-mode: var(--#{$button}--m-favorited__icon--AnimationFillMode);
   }
 
-  // Run animation while the favorited button is keyboard focused or actively pressed
-  &.pf-m-favorited:focus .#{$button}__icon,
+  // Run favorite animation when interaction logic applies a one-shot class.
+  // Keep non-scripted fallback triggers for existing integrations:
+  // - :focus-visible supports keyboard activation flows (e.g. React click on key release).
+  // - :focus:not(:focus-visible) covers pointer focus.
+  // - :active covers press interactions.
+  &.pf-m-is-animating .#{$button}__icon,
+  &.pf-m-favorited:focus-visible .#{$button}__icon,
+  &.pf-m-favorited:focus:not(:focus-visible) .#{$button}__icon,
   &.pf-m-favorited:active .#{$button}__icon {
     animation-play-state: running;
   }

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -252,23 +252,11 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 ```
 
 ### Favorite
-A favorite button should use a plain button with the star icon. Applying `.pf-m-favorited` indicates that the item is favorited. Applying `.pf-m-clicked` with `.pf-m-favorited` shows the clicked animation state.
+A favorite button should use a plain button with the star icon. Applying `.pf-m-favorited` to the button initiates a microanimation and indicates that the item is favorited.
 ```hbs
 {{#> button button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--aria-label="not starred"}}
 {{/button}}
 {{#> button button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--IsFavorited=true button--aria-label="starred"}}
-{{/button}}
-```
-
-### Favorite demo (interactive)
-Click the button to toggle favorite and test the animation.
-```hbs
-{{#> button
-  button--IsPlain=true
-  button--IsIcon=true
-  button--IsFavorite=true
-  button--aria-label="not starred"
-  button--attribute='aria-pressed="false" onclick="var isFavorited = this.classList.toggle(&#39;pf-m-favorited&#39;); this.setAttribute(&#39;aria-pressed&#39;, isFavorited ? &#39;true&#39; : &#39;false&#39;); this.setAttribute(&#39;aria-label&#39;, isFavorited ? &#39;starred&#39; : &#39;not starred&#39;); var button = this; setTimeout(function(){ button.classList.remove(&#39;pf-m-clicked&#39;); }, 300);"'}}
 {{/button}}
 ```
 

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -252,11 +252,23 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 ```
 
 ### Favorite
-A favorite button should use a plain button with the star icon. Applying `.pf-m-favorited` to the button initiates a microanimation and indicates that the item is favorited.
+A favorite button should use a plain button with the star icon. Applying `.pf-m-favorited` indicates that the item is favorited. Applying `.pf-m-clicked` with `.pf-m-favorited` shows the clicked animation state.
 ```hbs
 {{#> button button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--aria-label="not starred"}}
 {{/button}}
 {{#> button button--IsPlain=true button--IsIcon=true button--IsFavorite=true button--IsFavorited=true button--aria-label="starred"}}
+{{/button}}
+```
+
+### Favorite demo (interactive)
+Click the button to toggle favorite and test the animation.
+```hbs
+{{#> button
+  button--IsPlain=true
+  button--IsIcon=true
+  button--IsFavorite=true
+  button--aria-label="not starred"
+  button--attribute='aria-pressed="false" onclick="var isFavorited = this.classList.toggle(&#39;pf-m-favorited&#39;); this.setAttribute(&#39;aria-pressed&#39;, isFavorited ? &#39;true&#39; : &#39;false&#39;); this.setAttribute(&#39;aria-label&#39;, isFavorited ? &#39;starred&#39; : &#39;not starred&#39;); var button = this; setTimeout(function(){ button.classList.remove(&#39;pf-m-clicked&#39;); }, 300);"'}}
 {{/button}}
 ```
 


### PR DESCRIPTION
Fixes #7894 

- Updated the favorite icon animation selector in `src/patternfly/components/Button/button.scss:765` from `.pf-m-favorited` to `.pf-m-favorited:focus`.
- Restricts the animation to focused favorited buttons, preventing unintended animation on initial load/non-focus states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the Favorite button icon animation so it only runs when the button is favorited and then focused or actively pressed, aligning animation with user interactions.
  * Added an animation fill-mode setting and set the animation to be paused by default so the animation is defined but not played until triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->