### PR TITLE
feat(ToggleGroup): unified theme updates

### DIFF
--- a/src/patternfly/components/ToggleGroup/examples/toggle-group.md
+++ b/src/patternfly/components/ToggleGroup/examples/toggle-group.md
@@ -91,21 +91,21 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Copy button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-copy" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-copy'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Undo button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-undo'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Share button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-share-square" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-share-alt'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
@@ -117,21 +117,21 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--modifier="pf-m-selected" toggle-group-button--attribute='aria-label="Copy button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-copy" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-copy'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Undo button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-undo'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Share button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-share-square" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-share-alt'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
@@ -143,21 +143,21 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Copy button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-copy" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-copy'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Undo button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-undo'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Share button" disabled'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-share-square" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-share-alt'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
@@ -170,7 +170,7 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-copy" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-copy'}}
       {{/toggle-group-icon}}
       {{#> toggle-group-text}}
         Copy
@@ -180,7 +180,7 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--attribute='aria-label="Undo button"'}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-undo'}}
       {{/toggle-group-icon}}
       {{#> toggle-group-text}}
         Undo
@@ -190,7 +190,7 @@ cssPrefix: pf-v6-c-toggle-group
   {{#> toggle-group-item}}
     {{#> toggle-group-button toggle-group-button--modifier="pf-m-selected"}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-share-square" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-share-alt'}}
       {{/toggle-group-icon}}
       {{#> toggle-group-text}}
         Share
@@ -208,7 +208,7 @@ cssPrefix: pf-v6-c-toggle-group
         Copy
       {{/toggle-group-text}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-copy" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-copy'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
@@ -218,7 +218,7 @@ cssPrefix: pf-v6-c-toggle-group
         Undo
       {{/toggle-group-text}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-undo'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}
@@ -228,7 +228,7 @@ cssPrefix: pf-v6-c-toggle-group
         Share
       {{/toggle-group-text}}
       {{#> toggle-group-icon}}
-        <i class="fas fa-share-square" aria-hidden="true"></i>
+        {{pfIcon 'rh-ui-share-alt'}}
       {{/toggle-group-icon}}
     {{/toggle-group-button}}
   {{/toggle-group-item}}

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -14,7 +14,7 @@
   --#{$toggle-group}__button--hover--Color: var(--pf-t--global--text--color--on-brand--subtle--default);
   --#{$toggle-group}__button--hover--BackgroundColor: var(--pf-t--global--color--brand--subtle--default);
   --#{$toggle-group}__button--hover--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--color--brand--subtle--hover);
+  --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--border--color--brand--subtle--hover);
   --#{$toggle-group}__button--hover--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toggle-group}__button--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--control--default);
@@ -31,7 +31,7 @@
   --#{$toggle-group}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$toggle-group}__icon--hover--Color: var(--pf-t--global--icon--color--on-brand--subtle--default);
   --#{$toggle-group}__icon--m-selected--Color: var(--pf-t--global--icon--color--on-brand--subtle--default);
-  --#{$toggle-group}__icon--m-disabled--Color: var(--pf-t--global--icon--color--on-disabled);
+  --#{$toggle-group}__icon--disabled--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Selected
   --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--subtle--default);
@@ -40,14 +40,14 @@
   --#{$toggle-group}__button--m-selected--before--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toggle-group}__button--m-selected--after--BorderColor: var(--pf-t--global--border--color--brand--subtle--clicked);
   --#{$toggle-group}__button--m-selected--after--BorderWidth: var(--pf-t--global--border--width--control--clicked);
-  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--brand--subtle--clicked);
+  --#{$toggle-group}__button--m-selected--selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--brand--subtle--clicked);
   --#{$toggle-group}__button--m-selected--ZIndex: var(--pf-t--global--z-index--xs);
 
   // disabled
   --#{$toggle-group}__button--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$toggle-group}__button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$toggle-group}__button--disabled--before--BorderColor: var(--pf-t--global--border--color--control--default);
-  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--control--default);
+  --#{$toggle-group}__button--disabled--disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--control--default);
   --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Compact
@@ -71,7 +71,7 @@
 }
 
 .#{$toggle-group}__item {
-  &+& {
+  & + & {
     margin-inline-start: var(--#{$toggle-group}__item--item--MarginInlineStart);
   }
 
@@ -163,13 +163,13 @@
 }
 
 // For consecutive selected items, turn the left border back to what it was
-.#{$toggle-group}__item:has(.pf-m-selected)+.#{$toggle-group}__item:has(.pf-m-selected) {
-  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor);
+.#{$toggle-group}__item:has(.pf-m-selected) + .#{$toggle-group}__item:has(.pf-m-selected) {
+  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--m-selected--selected--before--BorderInlineStartColor);
 }
 
 // For consecutive disabled items, turn the left border back to what it was
-.#{$toggle-group}__item:has(:disabled, .pf-m-disabled)+.#{$toggle-group}__item:has(:disabled, .pf-m-disabled) {
-  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor);
+.#{$toggle-group}__item:has(:disabled, .pf-m-disabled) + .#{$toggle-group}__item:has(:disabled, .pf-m-disabled) {
+  --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled--disabled--before--BorderInlineStartColor);
 }
 
 .#{$toggle-group}__icon {

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -9,38 +9,45 @@
   --#{$toggle-group}__button--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$toggle-group}__button--LineHeight: var(--pf-t--global--font--line-height--body);
   --#{$toggle-group}__button--Color: var(--pf-t--global--text--color--regular);
-  --#{$toggle-group}__button--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$toggle-group}__button--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$toggle-group}__button--ZIndex: auto;
-  --#{$toggle-group}__button--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+  --#{$toggle-group}__button--hover--Color: var(--pf-t--global--text--color--on-brand--subtle--default);
+  --#{$toggle-group}__button--hover--BackgroundColor: var(--pf-t--global--color--brand--subtle--default);
   --#{$toggle-group}__button--hover--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$toggle-group}__button--hover--before--BorderColor: var(--pf-t--global--color--brand--subtle--hover);
   --#{$toggle-group}__button--hover--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toggle-group}__button--before--BorderWidth: var(--pf-t--global--border--width--control--default);
   --#{$toggle-group}__button--before--BorderColor: var(--pf-t--global--border--color--control--default);
 
   // item
   --#{$toggle-group}__item--item--MarginInlineStart: calc(-1 * var(--pf-t--global--border--width--control--default));
-  --#{$toggle-group}__item--first-child__button--BorderStartStartRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--first-child__button--BorderEndStartRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--last-child__button--BorderStartEndRadius: var(--pf-t--global--border--radius--tiny);
-  --#{$toggle-group}__item--last-child__button--BorderEndEndRadius: var(--pf-t--global--border--radius--tiny);
+  --#{$toggle-group}__item--first-child__button--BorderStartStartRadius: var(--pf-t--global--border--radius--control--default);
+  --#{$toggle-group}__item--first-child__button--BorderEndStartRadius: var(--pf-t--global--border--radius--control--default);
+  --#{$toggle-group}__item--last-child__button--BorderStartEndRadius: var(--pf-t--global--border--radius--control--default);
+  --#{$toggle-group}__item--last-child__button--BorderEndEndRadius: var(--pf-t--global--border--radius--control--default);
 
   // icon
   --#{$toggle-group}__icon--text--MarginInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$toggle-group}__icon--Color: var(--pf-t--global--icon--color--regular);
+  --#{$toggle-group}__icon--hover--Color: var(--pf-t--global--icon--color--on-brand--subtle--default);
+  --#{$toggle-group}__icon--m-selected--Color: var(--pf-t--global--icon--color--on-brand--subtle--default);
+  --#{$toggle-group}__icon--m-disabled--Color: var(--pf-t--global--icon--color--on-disabled);
 
   // Selected
-  --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--default);
-  --#{$toggle-group}__button--m-selected--Color: var(--pf-t--global--text--color--on-brand--default);
-  --#{$toggle-group}__button--m-selected--before--BorderColor: var(--pf-t--global--border--color--clicked);
-  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--alt);
+  --#{$toggle-group}__button--m-selected--BackgroundColor: var(--pf-t--global--color--brand--subtle--default);
+  --#{$toggle-group}__button--m-selected--Color: var(--pf-t--global--text--color--on-brand--subtle--default);
+  --#{$toggle-group}__button--m-selected--before--BorderColor: var(--pf-t--global--border--color--brand--subtle--clicked);
+  --#{$toggle-group}__button--m-selected--before--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$toggle-group}__button--m-selected--after--BorderColor: var(--pf-t--global--border--color--brand--subtle--clicked);
+  --#{$toggle-group}__button--m-selected--after--BorderWidth: var(--pf-t--global--border--width--control--clicked);
+  --#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor: var(--pf-t--global--border--color--brand--subtle--clicked);
   --#{$toggle-group}__button--m-selected--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$toggle-group}__button--m-selected--after--BorderWidth: var(--pf-t--global--border--width--high-contrast--strong);
 
   // disabled
   --#{$toggle-group}__button--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
   --#{$toggle-group}__button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$toggle-group}__button--disabled--before--BorderColor: var(--pf-t--global--border--color--disabled);
-  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--disabled);
+  --#{$toggle-group}__button--disabled--before--BorderColor: var(--pf-t--global--border--color--control--default);
+  --#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor: var(--pf-t--global--border--color--control--default);
   --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Compact
@@ -64,7 +71,7 @@
 }
 
 .#{$toggle-group}__item {
-  & + & {
+  &+& {
     margin-inline-start: var(--#{$toggle-group}__item--item--MarginInlineStart);
   }
 
@@ -124,9 +131,11 @@
 
   &:is(:hover, :focus) {
     --#{$toggle-group}__button--BackgroundColor: var(--#{$toggle-group}__button--hover--BackgroundColor);
+    --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--hover--Color);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--hover--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--hover--before--BorderColor);
     --#{$toggle-group}__button--after--BorderWidth: var(--#{$toggle-group}__button--hover--after--BorderWidth);
+    --#{$toggle-group}__icon--Color: var(--#{$toggle-group}__icon--hover--Color);
 
     text-decoration-line: none;
   }
@@ -136,7 +145,10 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--m-selected--Color, inherit);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--m-selected--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--m-selected--before--BorderColor);
+    --#{$toggle-group}__button--before--BorderWidth: var(--#{$toggle-group}__button--m-selected--before--BorderWidth);
+    --#{$toggle-group}__button--after--BorderColor: var(--#{$toggle-group}__button--m-selected--after--BorderColor);
     --#{$toggle-group}__button--after--BorderWidth: var(--#{$toggle-group}__button--m-selected--after--BorderWidth);
+    --#{$toggle-group}__icon--Color: var(--#{$toggle-group}__icon--m-selected--Color);
   }
 
   &:is(:disabled, .pf-m-disabled) {
@@ -144,23 +156,27 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--disabled--Color);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--disabled--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--disabled--before--BorderColor);
+    --#{$toggle-group}__icon--Color: var(--#{$toggle-group}__icon--m-disabled--Color);
 
     pointer-events: none;
   }
 }
 
 // For consecutive selected items, turn the left border back to what it was
-.#{$toggle-group}__item:has(.pf-m-selected) + .#{$toggle-group}__item:has(.pf-m-selected) {
+.#{$toggle-group}__item:has(.pf-m-selected)+.#{$toggle-group}__item:has(.pf-m-selected) {
   --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--m-selected-selected--before--BorderInlineStartColor);
 }
 
 // For consecutive disabled items, turn the left border back to what it was
-.#{$toggle-group}__item:has(:disabled, .pf-m-disabled) + .#{$toggle-group}__item:has(:disabled, .pf-m-disabled) {
+.#{$toggle-group}__item:has(:disabled, .pf-m-disabled)+.#{$toggle-group}__item:has(:disabled, .pf-m-disabled) {
   --#{$toggle-group}__button--before--BorderInlineStartColor: var(--#{$toggle-group}__button--disabled-disabled--before--BorderInlineStartColor);
 }
 
-.#{$toggle-group}__icon + .#{$toggle-group}__text,
-.#{$toggle-group}__text + .#{$toggle-group}__icon {
-  margin-inline-start: var(--#{$toggle-group}__icon--text--MarginInlineStart);
+.#{$toggle-group}__icon {
+  color: var(--#{$toggle-group}__icon--Color);
 }
 
+.#{$toggle-group}__icon+.#{$toggle-group}__text,
+.#{$toggle-group}__text+.#{$toggle-group}__icon {
+  margin-inline-start: var(--#{$toggle-group}__icon--text--MarginInlineStart);
+}

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -156,7 +156,7 @@
     --#{$toggle-group}__button--Color: var(--#{$toggle-group}__button--disabled--Color);
     --#{$toggle-group}__button--ZIndex: var(--#{$toggle-group}__button--disabled--ZIndex);
     --#{$toggle-group}__button--before--BorderColor: var(--#{$toggle-group}__button--disabled--before--BorderColor);
-    --#{$toggle-group}__icon--Color: var(--#{$toggle-group}__icon--m-disabled--Color);
+    --#{$toggle-group}__icon--Color: var(--#{$toggle-group}__icon--disabled--Color);
 
     pointer-events: none;
   }


### PR DESCRIPTION
Closes #8059.

Updates for unified theme & docs update to use RH icons.

Need to open follow up bug for pre-existing border layer issue (hovering over a toggle group item whose left sibling is selected cuts into the selected border color).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated toggle group examples to use the design-system icon helper for icons, preserving structure and accessibility while aligning examples with current standards.

* **Style**
  * Overhauled toggle group styles: refined background, text and border colors; introduced explicit icon color tokens; improved hover, selected and disabled states, spacing, radii and adjacent-item edge-case behavior for more consistent interactive feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->