### PR TITLE
fix(expandable-section): align nested indented content

### DIFF
--- a/src/patternfly/components/ExpandableSection/expandable-section.scss
+++ b/src/patternfly/components/ExpandableSection/expandable-section.scss
@@ -60,6 +60,7 @@
 
   // Indented
   --#{$expandable-section}--m-indented__content--PaddingInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) + var(--pf-t--global--spacer--gap--text-to-element--default) + var(--#{$expandable-section}__toggle-icon--MinWidth));
+  --#{$expandable-section}--m-indented--nested--Offset: var(--pf-t--global--spacer--action--horizontal--plain--default);
 
   // Truncate
   --#{$expandable-section}--m-truncate__content--LineClamp: 3;
@@ -179,5 +180,9 @@
     transition-duration: var(--#{$expandable-section}__content--TransitionDuration--fade), var(--#{$expandable-section}__content--TransitionDuration--slide), 0s, 0s;
     transition-property: opacity, translate, visibility, max-height;
     translate: 0 var(--#{$expandable-section}__content--TranslateY);
+  }
+
+  > .#{$expandable-section}.pf-m-indented {
+    margin-inline-start: calc(var(--#{$expandable-section}--m-indented--nested--Offset) * -1);
   }
 }


### PR DESCRIPTION
Fixes #7881 

Implements a component-level fix to resolve misalignment of nested indented expandable sections.

- Added a new token:
  `--pf-v6-c-expandable-section--m-indented--nested--Offset`
  derived from the link-button plain horizontal padding token.

- Added a nested-specific alignment rule so direct child indented
  expandable sections inside `.pf-v6-c-expandable-section__content`
  apply a negative `margin-inline-start` to offset the invisible
  link-button start padding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation handling for nested expandable sections, ensuring proper visual alignment when using the indented style variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->