### PR TITLE
fix(form): prevent no-header field group toggle overlap

### DIFF
--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -129,7 +129,9 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   // Field group toggle
   --#{$form}__field-group--GridTemplateColumns--toggle: calc(var(--pf-t--global--spacer--md) * 2 + var(--#{$form}__field-group-toggle-icon--MinWidth) + var(--pf-t--global--spacer--xs)); // based off of the expected width of the group toggle, for use to define a column when the toggle is not present
   --#{$form}__field-group-toggle--PaddingBlockStart: var(--#{$form}__field-group-header--PaddingBlockStart);
+  --#{$form}__field-group-toggle--PaddingBlockEnd: 0;
   --#{$form}__field-group-toggle--PaddingInlineEnd: var(--pf-t--global--spacer--xs);
+  --#{$form}__field-group-toggle--MinBlockSize: calc(var(--#{$form}__field-group-toggle--PaddingBlockStart) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body)) + var(--#{$form}__field-group-header--PaddingBlockEnd));
   --#{$form}__field-group__field-group__field-group-toggle--PaddingBlockStart: var(--pf-t--global--spacer--lg); // remove in breaking change
   --#{$form}__field-group-header-toggle--BorderWidth--base: var(--pf-t--global--border--width--divider--default);
   --#{$form}__field-group__field-group--field-group__field-group-toggle--after--BorderBlockStartWidth: var(--#{$form}__field-group-header-toggle--BorderWidth--base);
@@ -400,6 +402,14 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
     .#{$form}__field-group-toggle ~ .#{$form}__field-group-body {
       --#{$form}__field-group-body--GridColumn: var(--#{$form}__field-group__field-group__field-group-toggle--field-group-body--GridColumn);
     }
+
+    // Nested expandable groups without a header keep body content on row 1,
+    // so add top padding to preserve the expected gap from the group border.
+    // Match at the group level so this still applies when accessibility content
+    // exists between toggle and body.
+    &:has(> .#{$form}__field-group-toggle):not(:has(> .#{$form}__field-group-header)) > .#{$form}__field-group-body {
+      --#{$form}__field-group-body--PaddingBlockStart: var(--#{$form}__field-group-header--PaddingBlockStart);
+    }
   }
 
   &.pf-m-expanded {
@@ -423,8 +433,15 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 .#{$form}__field-group-toggle {
   grid-row: 1 / 2;
   grid-column: 1 / 2;
+  min-block-size: var(--#{$form}__field-group-toggle--MinBlockSize);
   padding-block-start: var(--#{$form}__field-group-toggle--PaddingBlockStart);
+  padding-block-end: var(--#{$form}__field-group-toggle--PaddingBlockEnd);
   padding-inline-end: var(--#{$form}__field-group-toggle--PaddingInlineEnd);
+
+  // Without a header row, preserve vertical space for the toggle by mirroring header block-end padding.
+  &:not(:has(+ .#{$form}__field-group-header)) {
+    --#{$form}__field-group-toggle--PaddingBlockEnd: var(--#{$form}__field-group-header--PaddingBlockEnd);
+  }
 
   + .#{$form}__field-group-header {
     --#{$form}__field-group-header--GridColumn: var(--#{$form}__field-group-toggle--field-group-header--GridColumn);
@@ -504,8 +521,10 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
 
   > .#{$form}__field-group {
     &:first-child {
-      --#{$form}__field-group-toggle--PaddingBlockStart: 0;
-      --#{$form}__field-group-header--PaddingBlockStart: 0;
+      &:has(> .#{$form}__field-group-header) {
+        --#{$form}__field-group-header--PaddingBlockStart: 0;
+        --#{$form}__field-group-toggle--PaddingBlockStart: 0;
+      }
     }
 
     &:last-child {
@@ -513,4 +532,3 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
     }
   }
 }
-


### PR DESCRIPTION

Fixes patternfly/patternfly-react#12611 

**Summary**
- Fixes a layout bug where `FormFieldGroupExpandable` without a header could render the toggle/caret overlapping the divider line.
- Adds explicit toggle sizing/spacing tokens so no-header groups still reserve vertical space (`src/patternfly/components/Form/form.scss:132`, `src/patternfly/components/Form/form.scss:134`).
- Applies no-header toggle block-end padding via `:not(:has(+ .pf-...__field-group-header))` so spacing matches headered groups (`src/patternfly/components/Form/form.scss:442`).
- Handles nested no-header groups by adding top body padding when toggle exists and header is absent, even with accessibility content between elements (`src/patternfly/components/Form/form.scss:410`).
- Restricts first-child top-padding reset to groups that actually have a header, preventing unintended spacing collapse in no-header cases (`src/patternfly/components/Form/form.scss:524`).

Toggle Off
<img width="867" height="176" alt="Screenshot 2026-02-22 at 11 08 25 PM" src="https://github.com/user-attachments/assets/89a37aca-a66f-44b6-b1ef-12979ac83d61" />

Toggle On
<img width="865" height="320" alt="Screenshot 2026-02-22 at 11 17 38 PM" src="https://github.com/user-attachments/assets/11af3ef5-48a1-4533-805e-bd7ad322e288" />


Assisted by: GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced form component spacing and layout for improved visual alignment and accessibility
  * Refined padding and sizing adjustments for nested form groups to better preserve vertical spacing and content hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->