### PR TITLE
fix(button): smooth progress text/indicator motion

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -339,6 +339,7 @@
   --#{$button}__progress--InsetBlockStart: 50%;
   --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
+  --#{$button}--m-progress--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -878,8 +879,15 @@
   }
 
   &.pf-m-progress {
+    --#{$button}--TransitionDuration: var(--#{$button}--m-progress--TransitionDuration);
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
+
+    transition-property: var(--#{$button}--TransitionProperty), padding-inline-start, padding-inline-end;
+
+    &.pf-m-block:not(.pf-m-plain) {
+      transition-timing-function: linear;
+    }
   }
 
   &.pf-m-in-progress {
@@ -888,6 +896,19 @@
     &:not(.pf-m-plain) {
       --#{$button}--PaddingInlineEnd: var(--#{$button}--m-in-progress--PaddingInlineEnd);
       --#{$button}--PaddingInlineStart: var(--#{$button}--m-in-progress--PaddingInlineStart);
+    }
+
+    &.pf-m-block:not(.pf-m-plain) {
+      .#{$button}__progress {
+        position: static;
+        display: inline-flex;
+        flex: none;
+        align-self: center;
+        inline-size: var(--#{$spinner}--m-md--diameter);
+        overflow: hidden;
+        transform: none;
+        animation: #{$button}-progress-reveal var(--#{$button}--m-progress--TransitionDuration) linear both;
+      }
     }
 
     &.pf-m-plain {
@@ -1006,5 +1027,17 @@
 @keyframes #{$button}-icon-favorited {
   50% {
     scale: 1.5;
+  }
+}
+
+@keyframes #{$button}-progress-reveal {
+  from {
+    inline-size: 0;
+    margin-inline-end: calc(var(--#{$button}--Gap) * -1);
+  }
+
+  to {
+    inline-size: var(--#{$spinner}--m-md--diameter);
+    margin-inline-end: 0;
   }
 }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -888,6 +888,12 @@
     &.pf-m-block:not(.pf-m-plain) {
       transition-timing-function: linear;
     }
+
+    &.pf-m-block:not(.pf-m-plain, .pf-m-in-progress) {
+      > :not(.#{$button}__progress) {
+        animation: #{$button}-progress-content-close var(--#{$button}--m-progress--TransitionDuration) linear both;
+      }
+    }
   }
 
   &.pf-m-in-progress {
@@ -899,12 +905,16 @@
     }
 
     &.pf-m-block:not(.pf-m-plain) {
+      --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
+      --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
+
       .#{$button}__progress {
         position: static;
         display: inline-flex;
         flex: none;
         align-self: center;
         inline-size: var(--#{$spinner}--m-md--diameter);
+        width: var(--#{$spinner}--m-md--diameter);
         overflow: hidden;
         transform: none;
         animation: #{$button}-progress-reveal var(--#{$button}--m-progress--TransitionDuration) linear both;
@@ -1032,12 +1042,22 @@
 
 @keyframes #{$button}-progress-reveal {
   from {
-    inline-size: 0;
     margin-inline-end: calc(var(--#{$button}--Gap) * -1);
+    clip-path: inset(0 100% 0 0);
   }
 
   to {
-    inline-size: var(--#{$spinner}--m-md--diameter);
     margin-inline-end: 0;
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes #{$button}-progress-content-close {
+  from {
+    transform: translateX(calc(var(--#{$button}__progress--width) / 2));
+  }
+
+  to {
+    transform: translateX(0);
   }
 }


### PR DESCRIPTION
Fixes #7732 


- Added a shared progress transition duration token so all loading button variants use the same timing: `src/patternfly/components/Button/button.scss:342`.
- Wired `.pf-m-progress` to use that token and animate padding + base button transitions together: `src/patternfly/components/Button/button.scss:881`, `src/patternfly/components/Button/button.scss:882`, `src/patternfly/components/Button/button.scss:886`.
- Scoped linear timing to block progress buttons so click animation behavior is preserved elsewhere: `src/patternfly/components/Button/button.scss:889`.
- For block in-progress buttons, moved spinner layout into inline flow (`static` + `inline-flex`) so spinner stays centered with text during reveal: `src/patternfly/components/Button/button.scss:901`, `src/patternfly/components/Button/button.scss:903`, `src/patternfly/components/Button/button.scss:904`, `src/patternfly/components/Button/button.scss:905`, `src/patternfly/components/Button/button.scss:907`.
- Applied spinner reveal animation to block in-progress state to remove the midpoint hitch: `src/patternfly/components/Button/button.scss:910`.
- Added reveal keyframes (width + negative gap to zero gap) for smooth indicator/text entrance: `src/patternfly/components/Button/button.scss:1033`, `src/patternfly/components/Button/button.scss:1035`, `src/patternfly/components/Button/button.scss:1036`, `src/patternfly/components/Button/button.scss:1040`.


https://github.com/user-attachments/assets/2e63b686-e371-45bf-9e51-c17f05b9d545



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced Button progress visuals with smoother, linear transitions and coordinated reveal/close animations for progress indicators and adjacent content, improving responsiveness and polish during loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->