### PR TITLE
fix(button): apply unified tokens and new icons

### DIFF
--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -3,12 +3,12 @@
 <br><br>
 
 <div><strong>Icon</strong></div>
-{{> button-list button--icon="plus-circle"}}
+{{> button-list button--icon="rh-ui-add-circle"}}
 
 <br><br>
 
 <div><strong>Icon end</strong></div>
-{{> button-list button-icon--IsEnd=true button--icon="plus-circle"}}
+{{> button-list button-icon--IsEnd=true button--icon="rh-ui-add-circle"}}
 
 {{#*inline "button-list"}}
   {{#> button button--IsPrimary=true}}
@@ -49,7 +49,7 @@
     Inline link
   {{/button}}
 
-  {{> button button--IsPlain=true button--aria-label="Remove" button--IsIcon=true button--icon="times"}}
+  {{> button button--IsPlain=true button--aria-label="Remove" button--IsIcon=true button--icon="rh-ui-close"}}
 
   <br><br>
 
@@ -57,5 +57,5 @@
     Control
   {{/button}}
 
-  {{> button button--IsControl=true button--aria-label="Copy input" button--IsIcon=true button--icon="copy"}}
+  {{> button button--IsControl=true button--aria-label="Copy input" button--IsIcon=true button--icon="rh-ui-copy"}}
 {{/inline}}

--- a/src/patternfly/components/Button/button--variations.hbs
+++ b/src/patternfly/components/Button/button--variations.hbs
@@ -49,7 +49,7 @@
     Inline link
   {{/button}}
 
-  {{> button button--IsPlain=true button--aria-label="Remove" button--IsIcon=true button--icon="rh-ui-close"}}
+  {{> button button--IsPlain=true button--aria-label="Remove" button--IsIcon=true button--icon="rh-microns-close"}}
 
   <br><br>
 

--- a/src/patternfly/components/Button/button-icon.hbs
+++ b/src/patternfly/components/Button/button-icon.hbs
@@ -10,11 +10,11 @@
     <span class="{{pfv}}button__icon-favorite">{{> icon-outlined-star}}</span>
     <span class="{{pfv}}button__icon-favorited">{{> icon-star}}</span>
   {{else if button--IsSettings}}
-    <i class="fas fa-cog" aria-hidden="true"></i>
+    {{pfIcon "rh-ui-settings"}}
   {{else if button--IsHamburger}}
     {{> hamburger-icon}}
   {{else if button--icon}}
-    <i class="fas fa-{{button--icon}}" aria-hidden="true"></i>
+    {{pfIcon button--icon}}
   {{else if button--icon-template}}
     {{! renders a hbs partial if passed as the value for button--icon-template}}
     {{> (lookup . "button--icon-template")}}

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -44,6 +44,10 @@
   --#{$button}--m-clicked--BackgroundColor: transparent;
   --#{$button}--m-clicked--BorderColor: transparent;
   --#{$button}--m-clicked--BorderWidth: var(--pf-t--global--border--width--action--clicked);
+  --#{$button}--m-clicked--TextDecorationLine: none;
+  --#{$button}--m-clicked--TextDecorationStyle: none;
+  --#{$button}--m-clicked--TextDecorationColor: currentcolor;
+  --#{$button}--m-clicked--TextUnderlineOffset: var(--pf-t--global--text-decoration--offset--default);
 
   // Primary
   --#{$button}--m-primary--Color: var(--pf-t--global--text--color--on-brand--default);
@@ -285,6 +289,10 @@
   --#{$button}--m-display-lg--hover--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
   --#{$button}--m-display-lg--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
   --#{$button}--m-display-lg--hover--TextUnderlineOffset: var(--pf-t--global--text-decoration--offset--hover);
+  --#{$button}--m-display-lg--m-clicked--TextDecorationColor: var(--pf-t--global--border--color--control--default);
+  --#{$button}--m-display-lg--m-clicked--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
+  --#{$button}--m-display-lg--m-clicked--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
+  --#{$button}--m-display-lg--m-clicked--TextUnderlineOffset: var(--pf-t--global--text-decoration--offset--hover);
 
   // CTA primary
   --#{$button}--m-display-lg--m-primary--Color: var(--pf-t--global--text--color--on-brand--accent--default);
@@ -297,6 +305,7 @@
   --#{$button}--m-display-lg--m-primary--m-clicked--BackgroundColor: var(--pf-t--global--color--brand--accent--clicked);
   --#{$button}--m-display-lg--m-primary--m-clicked__icon--Color: var(--pf-t--global--icon--color--on-brand--accent--clicked);
   --#{$button}--m-display-lg--m-primary--hover--TextDecorationColor: currentcolor;
+  --#{$button}--m-display-lg--m-primary--m-clicked--TextDecorationColor: currentcolor;
 
   // CTA Secondary
   --#{$button}--m-display-lg--m-secondary--Color: var(--pf-t--global--text--color--regular);
@@ -782,6 +791,10 @@
     --#{$button}--hover--TextDecorationLine: var(--#{$button}--m-display-lg--hover--TextDecorationLine);
     --#{$button}--hover--TextDecorationStyle: var(--#{$button}--m-display-lg--hover--TextDecorationStyle);
     --#{$button}--hover--TextUnderlineOffset: var(--#{$button}--m-display-lg--hover--TextUnderlineOffset);
+    --#{$button}--m-clicked--TextDecorationColor: var(--#{$button}--m-display-lg--m-clicked--TextDecorationColor);
+    --#{$button}--m-clicked--TextDecorationLine: var(--#{$button}--m-display-lg--m-clicked--TextDecorationLine);
+    --#{$button}--m-clicked--TextDecorationStyle: var(--#{$button}--m-display-lg--m-clicked--TextDecorationStyle);
+    --#{$button}--m-clicked--TextUnderlineOffset: var(--#{$button}--m-display-lg--m-clicked--TextUnderlineOffset);
     --#{$button}--m-primary--Color: var(--#{$button}--m-display-lg--m-primary--Color);
     --#{$button}--m-primary--BackgroundColor: var(--#{$button}--m-display-lg--m-primary--BackgroundColor);
     --#{$button}--m-primary__icon--Color: var(--#{$button}--m-display-lg--m-primary__icon--Color);
@@ -805,6 +818,7 @@
 
     &.pf-m-primary {
       --#{$button}--hover--TextDecorationColor: var(--#{$button}--m-display-lg--m-primary--hover--TextDecorationColor);
+      --#{$button}--m-clicked--TextDecorationColor: var(--#{$button}--m-display-lg--m-primary--m-clicked--TextDecorationColor);
     }
   }
 
@@ -902,6 +916,11 @@
     --#{$button}--BorderWidth: var(--#{$button}--m-clicked--BorderWidth);
     --#{$button}--BorderColor: var(--#{$button}--m-clicked--BorderColor);
     --#{$button}__icon--Color: var(--#{$button}--m-clicked__icon--Color);
+
+    text-decoration-line: var(--#{$button}--m-clicked--TextDecorationLine);
+    text-decoration-style: var(--#{$button}--m-clicked--TextDecorationStyle);
+    text-decoration-color: var(--#{$button}--m-clicked--TextDecorationColor);
+    text-underline-offset: var(--#{$button}--m-clicked--TextUnderlineOffset);
   }
 
   &:active {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -36,6 +36,7 @@
   --#{$button}--hover--TextDecorationLine: none;
   --#{$button}--hover--TextDecorationStyle: none;
   --#{$button}--hover--TextDecorationColor: currentcolor;
+  --#{$button}--hover--TextUnderlineOffset: var(--pf-t--global--text-decoration--offset--hover);
   --#{$button}--hover--ScaleX: 1;
   --#{$button}--hover--ScaleY: 1;
 
@@ -89,7 +90,7 @@
   --#{$button}--m-tertiary--m-clicked__icon--Color: var(--pf-t--global--icon--color--brand--clicked);
 
   // Link
-  --#{$button}--m-link--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$button}--m-link--BorderRadius: var(--pf-t--global--border--radius--action--plain--default);
   --#{$button}--m-link--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$button}--m-link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$button}--m-link--Color: var(--pf-t--global--text--color--brand--default);
@@ -273,13 +274,44 @@
   --#{$button}--m-danger--m-clicked--BackgroundColor: var(--pf-t--global--color--status--danger--clicked);
   --#{$button}--m-danger--m-clicked__icon--Color: var(--pf-t--global--icon--color--status--on-danger--clicked);
 
-  // CTA
+  // CTA (display large)
   --#{$button}--m-display-lg--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--spacious);
   --#{$button}--m-display-lg--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--spacious);
   --#{$button}--m-display-lg--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--spacious);
   --#{$button}--m-display-lg--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--spacious);
   --#{$button}--m-display-lg--FontWeight: var(--pf-t--global--font--weight--body--bold);
-  --#{$button}--m-link--m-display-lg--FontSize: var(--pf-t--global--font--size--body--lg);
+  --#{$button}--m-link--m-display-lg--FontSize: var(--pf-t--global--font--size--body--default);
+  --#{$button}--m-display-lg--hover--TextDecorationColor: var(--pf-t--global--border--color--control--default);
+  --#{$button}--m-display-lg--hover--TextDecorationLine: var(--pf-t--global--text-decoration--link--line--hover);
+  --#{$button}--m-display-lg--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
+  --#{$button}--m-display-lg--hover--TextUnderlineOffset: var(--pf-t--global--text-decoration--offset--hover);
+
+  // CTA primary
+  --#{$button}--m-display-lg--m-primary--Color: var(--pf-t--global--text--color--on-brand--accent--default);
+  --#{$button}--m-display-lg--m-primary--BackgroundColor: var(--pf-t--global--color--brand--accent--default);
+  --#{$button}--m-display-lg--m-primary__icon--Color: var(--pf-t--global--icon--color--on-brand--accent--default);
+  --#{$button}--m-display-lg--m-primary--hover--Color: var(--pf-t--global--text--color--on-brand--accent--hover);
+  --#{$button}--m-display-lg--m-primary--hover--BackgroundColor: var(--pf-t--global--color--brand--accent--hover);
+  --#{$button}--m-display-lg--m-primary--hover__icon--Color: var(--pf-t--global--icon--color--on-brand--accent--hover);
+  --#{$button}--m-display-lg--m-primary--m-clicked--Color: var(--pf-t--global--text--color--on-brand--accent--clicked);
+  --#{$button}--m-display-lg--m-primary--m-clicked--BackgroundColor: var(--pf-t--global--color--brand--accent--clicked);
+  --#{$button}--m-display-lg--m-primary--m-clicked__icon--Color: var(--pf-t--global--icon--color--on-brand--accent--clicked);
+  --#{$button}--m-display-lg--m-primary--TextDecorationColor: currentcolor;
+
+  // CTA Secondary
+  --#{$button}--m-display-lg--m-secondary--Color: var(--pf-t--global--text--color--regular);
+  --#{$button}--m-display-lg--m-secondary--BorderColor: var(--pf-t--global--border--color--brand--accent--default);
+  --#{$button}--m-display-lg--m-secondary__icon--Color: var(--pf-t--global--icon--color--brand--accent--default);
+  --#{$button}--m-display-lg--m-secondary--hover--Color: var(--pf-t--global--text--color--regular);
+  --#{$button}--m-display-lg--m-secondary--hover--BorderColor: var(--pf-t--global--border--color--brand--accent--hover);
+  --#{$button}--m-display-lg--m-secondary--hover__icon--Color: var(--pf-t--global--icon--color--brand--accent--hover);
+  --#{$button}--m-display-lg--m-secondary--m-clicked--Color: var(--pf-t--global--text--color--regular);
+  --#{$button}--m-display-lg--m-secondary--m-clicked--BorderColor: var(--pf-t--global--border--color--brand--accent--clicked);
+  --#{$button}--m-display-lg--m-secondary--m-clicked__icon--Color: var(--pf-t--global--icon--color--brand--accent--clicked);
+
+  // CTA Tertiary
+  --#{$button}--m-display-lg--m-tertiary--hover--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$button}--m-display-lg--m-tertiary--m-clicked--BorderColor: var(--pf-t--global--border--color--default);
 
   // Small
   --#{$button}--m-small--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
@@ -553,6 +585,7 @@
       --#{$button}--hover--TextDecorationLine: var(--#{$button}--m-link--m-inline--hover--TextDecorationLine);
       --#{$button}--hover--TextDecorationStyle: var(--#{$button}--m-link--m-inline--hover--TextDecorationStyle);
       --#{$button}--hover--TextDecorationColor: var(--#{$button}--m-link--m-inline--hover--TextDecorationColor);
+      --#{$button}--hover--TextUnderlineOffset: var(--#{$button}--m-link--m-inline--TextUnderlineOffset);
       --#{$button}--m-link--hover--Color: var(--#{$button}--m-link--m-inline--hover--Color);
       --#{$button}--m-link--hover__icon--Color: var(--#{$button}--m-link--m-inline--hover__icon--Color);
       --#{$button}--BorderWidth: 0;
@@ -745,6 +778,34 @@
     --#{$button}--PaddingBlockEnd: var(--#{$button}--m-display-lg--PaddingBlockEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-display-lg--PaddingInlineStart);
     --#{$button}--FontSize: var(--#{$button}--m-display-lg--FontSize);
+    --#{$button}--hover--TextDecorationColor: var(--#{$button}--m-display-lg--hover--TextDecorationColor);
+    --#{$button}--hover--TextDecorationLine: var(--#{$button}--m-display-lg--hover--TextDecorationLine);
+    --#{$button}--hover--TextDecorationStyle: var(--#{$button}--m-display-lg--hover--TextDecorationStyle);
+    --#{$button}--hover--TextUnderlineOffset: var(--#{$button}--m-display-lg--hover--TextUnderlineOffset);
+    --#{$button}--m-primary--Color: var(--#{$button}--m-display-lg--m-primary--Color);
+    --#{$button}--m-primary--BackgroundColor: var(--#{$button}--m-display-lg--m-primary--BackgroundColor);
+    --#{$button}--m-primary__icon--Color: var(--#{$button}--m-display-lg--m-primary__icon--Color);
+    --#{$button}--m-primary--hover--Color: var(--#{$button}--m-display-lg--m-primary--hover--Color);
+    --#{$button}--m-primary--hover--BackgroundColor: var(--#{$button}--m-display-lg--m-primary--hover--BackgroundColor);
+    --#{$button}--m-primary--hover__icon--Color: var(--#{$button}--m-display-lg--m-primary--hover__icon--Color);
+    --#{$button}--m-primary--m-clicked--Color: var(--#{$button}--m-display-lg--m-primary--m-clicked--Color);
+    --#{$button}--m-primary--m-clicked--BackgroundColor: var(--#{$button}--m-display-lg--m-primary--m-clicked--BackgroundColor);
+    --#{$button}--m-primary--m-clicked__icon--Color: var(--#{$button}--m-display-lg--m-primary--m-clicked__icon--Color);
+    --#{$button}--m-secondary--Color: var(--#{$button}--m-display-lg--m-secondary--Color);
+    --#{$button}--m-secondary--BorderColor: var(--#{$button}--m-display-lg--m-secondary--BorderColor);
+    --#{$button}--m-secondary__icon--Color: var(--#{$button}--m-display-lg--m-secondary__icon--Color);
+    --#{$button}--m-secondary--hover--Color: var(--#{$button}--m-display-lg--m-secondary--hover--Color);
+    --#{$button}--m-secondary--hover--BorderColor: var(--#{$button}--m-display-lg--m-secondary--hover--BorderColor);
+    --#{$button}--m-secondary--hover__icon--Color: var(--#{$button}--m-display-lg--m-secondary--hover__icon--Color);
+    --#{$button}--m-secondary--m-clicked--Color: var(--#{$button}--m-display-lg--m-secondary--m-clicked--Color);
+    --#{$button}--m-secondary--m-clicked--BorderColor: var(--#{$button}--m-display-lg--m-secondary--m-clicked--BorderColor);
+    --#{$button}--m-secondary--m-clicked__icon--Color: var(--#{$button}--m-display-lg--m-secondary--m-clicked__icon--Color);
+    --#{$button}--m-tertiary--hover--BorderColor: var(--#{$button}--m-display-lg--m-tertiary--hover--BorderColor);
+    --#{$button}--m-tertiary--m-clicked--BorderColor: var(--#{$button}--m-display-lg--m-tertiary--m-clicked--BorderColor);
+
+    &.pf-m-primary {
+      --#{$button}--hover--TextDecorationColor: var(--#{$button}--m-display-lg--m-primary--hover--TextDecorationColor);
+    }
   }
 
   &.pf-m-favorite .#{$button}__icon {
@@ -830,6 +891,7 @@
     text-decoration-line: var(--#{$button}--hover--TextDecorationLine);
     text-decoration-style: var(--#{$button}--hover--TextDecorationStyle);
     text-decoration-color: var(--#{$button}--hover--TextDecorationColor);
+    text-underline-offset: var(--#{$button}--hover--TextUnderlineOffset);
     outline-offset: var(--pf-t--global--focus-ring--position--offset);
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -296,7 +296,7 @@
   --#{$button}--m-display-lg--m-primary--m-clicked--Color: var(--pf-t--global--text--color--on-brand--accent--clicked);
   --#{$button}--m-display-lg--m-primary--m-clicked--BackgroundColor: var(--pf-t--global--color--brand--accent--clicked);
   --#{$button}--m-display-lg--m-primary--m-clicked__icon--Color: var(--pf-t--global--icon--color--on-brand--accent--clicked);
-  --#{$button}--m-display-lg--m-primary--TextDecorationColor: currentcolor;
+  --#{$button}--m-display-lg--m-primary--hover--TextDecorationColor: currentcolor;
 
   // CTA Secondary
   --#{$button}--m-display-lg--m-secondary--Color: var(--pf-t--global--text--color--regular);

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -63,11 +63,11 @@ import './Button.css'
 ```hbs
 <strong>Plain</strong>
 <br>
-{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--IsIcon=true button--icon="rh-ui-close"}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--IsIcon=true button--icon="rh-microns-close"}}
 <br><br>
 <strong>Plain no padding</strong>
 <br>
-{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--HasNoPadding=true button--IsIcon=true button--icon="rh-ui-close"}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--HasNoPadding=true button--IsIcon=true button--icon="rh-microns-close"}}
 <br><br>
 <strong>Inline link</strong>
 <br>
@@ -176,7 +176,7 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 
 {{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="rh-ui-close"}}
+{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="rh-microns-close"}}
 
 {{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="rh-ui-copy"}}
 

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -63,11 +63,11 @@ import './Button.css'
 ```hbs
 <strong>Plain</strong>
 <br>
-{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--IsIcon=true button--icon="times"}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--IsIcon=true button--icon="rh-ui-close"}}
 <br><br>
 <strong>Plain no padding</strong>
 <br>
-{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--HasNoPadding=true button--IsIcon=true button--icon="times"}}
+{{> button button--aria-label="Remove" button--IsSpan=true button--IsPlain=true button--HasNoPadding=true button--IsIcon=true button--icon="rh-ui-close"}}
 <br><br>
 <strong>Inline link</strong>
 <br>
@@ -115,11 +115,11 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
     Call to action
   {{/button}}
 
-  {{#> button button--IsLink=true button--IsDisplayLg=true button--icon="arrow-right" button-icon--IsEnd=true}}
+  {{#> button button--IsLink=true button--IsDisplayLg=true button--icon="rh-ui-arrow-right" button-icon--IsEnd=true}}
     Call to action
   {{/button}}
 
-  {{#> button button--IsLink=true button--IsInline=true button--IsDisplayLg=true button--icon="arrow-right" button-icon--IsEnd=true}}
+  {{#> button button--IsLink=true button--IsInline=true button--IsDisplayLg=true button--icon="rh-ui-arrow-right" button-icon--IsEnd=true}}
     Call to action
   {{/button}}
 {{/inline}}
@@ -148,9 +148,9 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
   Secondary loading
 {{/button}}
 <br/>
-{{> button button--IsPlain=true button--aria-label="Upload" button--IsIcon=true button--icon="upload"}}
+{{> button button--IsPlain=true button--aria-label="Upload" button--IsIcon=true button--icon="rh-ui-upload"}}
 
-{{> button button--IsPlain=true button--IsIcon=true button--icon="upload" button--IsInProgress=true button--progress-text="Uploading..."}}
+{{> button button--IsPlain=true button--IsIcon=true button--icon="rh-ui-upload" button--IsInProgress=true button--progress-text="Uploading..."}}
 <br/>
 {{#> button button--IsLink=true button--IsInline=true button--IsProgress=true}}
   Inline loader
@@ -164,25 +164,25 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 ### Circle buttons
 
 ```hbs isBeta
-{{> button button--IsPrimary=true button--aria-label="Add primary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsPrimary=true button--aria-label="Add primary circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsSecondary=true button--aria-label="Add secondary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsSecondary=true button--aria-label="Add secondary circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsTertiary=true button--aria-label="Add tertiary circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsTertiary=true button--aria-label="Add tertiary circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsDanger=true button--aria-label="Add danger circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsDanger=true button--aria-label="Add danger circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsWarning=true button--aria-label="Add warning circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsWarning=true button--aria-label="Add warning circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="plus-circle"}}
+{{> button button--IsLink=true button--aria-label="Add link circle variant" button--IsCircle=true button--icon="rh-ui-add-circle"}}
 
-{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="times"}}
+{{> button button--IsPlain=true button--aria-label="Remove plain circle variant" button--IsCircle=true button--icon="rh-ui-close"}}
 
-{{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="copy"}}
+{{> button button--IsControl=true button--aria-label="Copy control circle variant" button--IsCircle=true button--icon="rh-ui-copy"}}
 
-{{> button button--IsCircle=true button--IsPlain=true button--aria-label="Upload circle variant" button--IsIcon=true button--icon="upload"}}
+{{> button button--IsCircle=true button--IsPlain=true button--aria-label="Upload circle variant" button--IsIcon=true button--icon="rh-ui-upload"}}
 
-{{> button button--IsCircle=true button--IsPlain=true button--IsIcon=true button--icon="upload" button--IsInProgress=true button--progress-text="Uploading circle variant..."}}
+{{> button button--IsCircle=true button--IsPlain=true button--IsIcon=true button--icon="rh-ui-upload" button--IsInProgress=true button--progress-text="Uploading circle variant..."}}
 ```
 
 ### Counts
@@ -211,18 +211,18 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
 
 ### Plain with no padding
 ```hbs
-For when a plain/icon button is placed inline with text {{> button button--IsPlain=true button--HasNoPadding=true button--aria-label="More info" button--IsIcon=true button--icon-template="icon-help"}}.
+For when a plain/icon button is placed inline with text {{> button button--IsPlain=true button--HasNoPadding=true button--aria-label="More info" button--IsIcon=true button--icon="rh-ui-question-mark-circle"}}.
 ```
 
 ### Stateful
 ```hbs
 <strong>Read</strong>
 <br>
-{{#> button button--IsStateful=true button--IsRead=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsRead=true button--icon="rh-ui-notification-fill"}}
   10 {{#> screen-reader}}items{{/screen-reader}}
 {{/button}}
 
-{{#> button button--IsStateful=true button--IsRead=true button--IsClicked=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsRead=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
   10 {{#> screen-reader}}items{{/screen-reader}}
 {{/button}}
 
@@ -230,11 +230,11 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 <strong>Unread</strong>
 <br>
-{{#> button button--IsStateful=true button--IsUnread=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsUnread=true button--icon="rh-ui-notification-fill"}}
   10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
-{{#> button button--IsStateful=true button--IsUnread=true button--IsClicked=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsUnread=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
   10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
@@ -242,11 +242,11 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 <strong>Attention</strong>
 <br>
-{{#> button button--IsStateful=true button--IsAttention=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsAttention=true button--icon="rh-ui-attention-bell-fill"}}
   10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 
-{{#> button button--IsStateful=true button--IsAttention=true button--IsClicked=true button--icon="bell"}}
+{{#> button button--IsStateful=true button--IsAttention=true button--IsClicked=true button--icon="rh-ui-attention-bell-fill"}}
   10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 ```


### PR DESCRIPTION
Fixes #8019 

Figma link: https://www.figma.com/design/qRn3S225WwGHIdgGZX0LTC/Unified-Theme--Design-Tokens--Styles---Specs?node-id=9736-17135&t=JCmoeoZfuJ2yaOcj-1

Adjusts button border radius for unified, and some colors mainly in the CTA button. Also replaces the icons in the button examples with ones from the new icon set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized button icons to a consistent rh-ui set and unified icon rendering across button types
  * Improved hover and pressed text-decoration (color, style, underline offset) and expanded display‑large CTA styling for consistent visuals across primary, secondary, tertiary, link, and plain variants

* **Documentation**
  * Updated button examples to reflect new icons and rendering behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->