### PR TITLE
fix(button): support centered progress spinner for block buttons and restore progress animation.

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -339,6 +339,8 @@
   --#{$button}__progress--InsetBlockStart: 50%;
   --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
+  --#{$button}--m-progress--TransitionProperty: padding, color, background, border-color;
+  --#{$button}--m-progress--TransitionDuration: 250ms;
   --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -880,6 +882,8 @@
   &.pf-m-progress {
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
+    --#{$button}--TransitionProperty: var(--#{$button}--m-progress--TransitionProperty);
+    --#{$button}--TransitionDuration: var(--#{$button}--m-progress--TransitionDuration);  
   }
 
   &.pf-m-in-progress {
@@ -952,6 +956,16 @@
 
   .#{$spinner} {
     --#{$spinner}--Color: currentcolor;
+  }
+}
+
+.#{$button}.pf-m-block {
+  --#{$button}--AlignItems: center;
+
+  .#{$button}__progress {
+    position: static;
+    inset: auto;
+    transform: none;
   }
 }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -796,6 +796,10 @@
     width: var(--#{$button}--m-block--Width);
     transition-duration: var(--#{$button}--m-progress--TransitionDuration);
     transition-property: var(--#{$button}--m-progress--TransitionProperty);
+
+    .#{$button}__progress {
+      align-self: center;
+    }
   }
 
   &.pf-m-small {
@@ -1076,7 +1080,6 @@
   position: var(--#{$button}__progress--Position);
   inset-block-start: var(--#{$button}__progress--InsetBlockStart);
   inset-inline-start: var(--#{$button}__progress--InsetInlineStart);
-  align-self: center;
   line-height: 1;
   color: var(--#{$button}__progress--Color);
   transform: translate(var(--#{$button}__progress--TranslateX), var(--#{$button}__progress--TranslateY));

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -394,8 +394,8 @@
   --#{$button}--m-in-progress--m-plain--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$button}--m-in-progress--m-plain__progress--InsetInlineStart: 50%;
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
-  --#{$button}--m-progress--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
-  --#{$button}--m-progress--TransitionProperty: padding;
+  --#{$button}--m-progress--TransitionDuration: var(--#{$button}--TransitionDuration);
+  --#{$button}--m-progress--TransitionProperty: var(--#{$button}--TransitionProperty), padding;
 
   // Settings
   --#{$button}--m-settings__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
@@ -789,6 +789,7 @@
   &.pf-m-block {
     --#{$button}--Display: var(--#{$button}--m-block--Display);
     --#{$button}__progress--Position: relative;
+    --#{$button}__progress--InsetBlockStart: 0;
     --#{$button}__progress--InsetInlineStart: 0;
     --#{$button}__progress--TranslateY: 0;
   

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -24,7 +24,7 @@
   --#{$button}--TransitionDelay: 0s;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$button}--TransitionProperty: color, background, border-color;
+  --#{$button}--TransitionProperty: padding, color, background, border-color;
   --#{$button}--ScaleX: 1;
   --#{$button}--ScaleY: 1;
   --#{$button}--border--offset: 0;
@@ -386,8 +386,7 @@
   --#{$button}__progress--InsetBlockStart: 50%;
   --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
-  --#{$button}--m-progress--TransitionProperty: padding, color, background, border-color;
-  --#{$button}--m-progress--TransitionDuration: 250ms;
+  --#{$button}__progress--position: absolute;
   --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -976,8 +975,6 @@
   &.pf-m-progress {
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
-    --#{$button}--TransitionProperty: var(--#{$button}--m-progress--TransitionProperty);
-    --#{$button}--TransitionDuration: var(--#{$button}--m-progress--TransitionDuration);  
   }
 
   &.pf-m-in-progress {
@@ -1068,9 +1065,10 @@
 }
 
 .#{$button}__progress {
-  position: absolute;
+  position: var(--#{$button}__progress--position);
   inset-block-start: var(--#{$button}__progress--InsetBlockStart);
   inset-inline-start: var(--#{$button}__progress--InsetInlineStart);
+  align-self: center;
   line-height: 1;
   color: var(--#{$button}__progress--Color);
   transform: translate(var(--#{$button}__progress--TranslateX), var(--#{$button}__progress--TranslateY));
@@ -1082,12 +1080,9 @@
 
 .#{$button}.pf-m-block {
   --#{$button}--AlignItems: center;
-
-  .#{$button}__progress {
-    position: static;
-    inset: auto;
-    transform: none;
-  }
+  --#{$button}__progress--position: relative;
+  --#{$button}__progress--InsetInlineStart: 0;
+  --#{$button}__progress--TranslateY: 0;
 }
 
 // enable inline link to have underline when used with truncate

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -24,7 +24,7 @@
   --#{$button}--TransitionDelay: 0s;
   --#{$button}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$button}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$button}--TransitionProperty: padding, color, background, border-color;
+  --#{$button}--TransitionProperty: color, background, border-color;
   --#{$button}--ScaleX: 1;
   --#{$button}--ScaleY: 1;
   --#{$button}--border--offset: 0;
@@ -386,7 +386,7 @@
   --#{$button}__progress--InsetBlockStart: 50%;
   --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
-  --#{$button}__progress--position: absolute;
+  --#{$button}__progress--Position: absolute;
   --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -394,6 +394,8 @@
   --#{$button}--m-in-progress--m-plain--Color: var(--pf-t--global--icon--color--brand--default);
   --#{$button}--m-in-progress--m-plain__progress--InsetInlineStart: 50%;
   --#{$button}--m-in-progress--m-plain__progress--TranslateX: -50%;
+  --#{$button}--m-progress--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$button}--m-progress--TransitionProperty: padding;
 
   // Settings
   --#{$button}--m-settings__icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--long);
@@ -786,8 +788,13 @@
 
   &.pf-m-block {
     --#{$button}--Display: var(--#{$button}--m-block--Display);
- 
+    --#{$button}__progress--Position: relative;
+    --#{$button}__progress--InsetInlineStart: 0;
+    --#{$button}__progress--TranslateY: 0;
+  
     width: var(--#{$button}--m-block--Width);
+    transition-duration: var(--#{$button}--m-progress--TransitionDuration);
+    transition-property: var(--#{$button}--m-progress--TransitionProperty);
   }
 
   &.pf-m-small {
@@ -1065,7 +1072,7 @@
 }
 
 .#{$button}__progress {
-  position: var(--#{$button}__progress--position);
+  position: var(--#{$button}__progress--Position);
   inset-block-start: var(--#{$button}__progress--InsetBlockStart);
   inset-inline-start: var(--#{$button}__progress--InsetInlineStart);
   align-self: center;
@@ -1076,13 +1083,6 @@
   .#{$spinner} {
     --#{$spinner}--Color: currentcolor;
   }
-}
-
-.#{$button}.pf-m-block {
-  --#{$button}--AlignItems: center;
-  --#{$button}__progress--position: relative;
-  --#{$button}__progress--InsetInlineStart: 0;
-  --#{$button}__progress--TranslateY: 0;
 }
 
 // enable inline link to have underline when used with truncate

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -386,6 +386,8 @@
   --#{$button}__progress--InsetBlockStart: 50%;
   --#{$button}__progress--InsetInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}__progress--Color: var(--#{$button}__icon--Color);
+  --#{$button}--m-progress--TransitionProperty: padding, color, background, border-color;
+  --#{$button}--m-progress--TransitionDuration: 250ms;
   --#{$button}--m-progress--PaddingInlineEnd: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-progress--PaddingInlineStart: calc(var(--pf-t--global--spacer--control--horizontal--default) + var(--#{$button}__progress--width) / 2);
   --#{$button}--m-in-progress--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
@@ -974,6 +976,8 @@
   &.pf-m-progress {
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-progress--PaddingInlineEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-progress--PaddingInlineStart);
+    --#{$button}--TransitionProperty: var(--#{$button}--m-progress--TransitionProperty);
+    --#{$button}--TransitionDuration: var(--#{$button}--m-progress--TransitionDuration);  
   }
 
   &.pf-m-in-progress {
@@ -1073,6 +1077,16 @@
 
   .#{$spinner} {
     --#{$spinner}--Color: currentcolor;
+  }
+}
+
+.#{$button}.pf-m-block {
+  --#{$button}--AlignItems: center;
+
+  .#{$button}__progress {
+    position: static;
+    inset: auto;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
Fix spinner layout for `.pf-m-block` buttons so the progress indicator
is centered alongside button text instead of using absolute positioning.

Restore the progress padding animation that was unintentionally removed
when ripple/click animation updates changed transition handling. The
button text now slides to make space for the spinner as in v5 behavior.

Fixes #7732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the button progress indicator’s positioning and centering.
  * Updated progress transitions to use configurable timing and properties for smoother updates.
  * Enhanced block-style button behavior so progress indicators align consistently and respond better to resizing and state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->