### PR TITLE
fix(breadcrumb): ensure inline icons are underlined (#7554)

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -86,6 +86,11 @@
   word-break: break-word;
   background-color: var(--#{$breadcrumb}__link--BackgroundColor);
 
+  > svg,
+  > i {
+    display: inline;
+  }
+
   &:is(:hover, :focus) {
     --#{$breadcrumb}__link--Color: var(--#{$breadcrumb}__link--hover--Color);
     --#{$breadcrumb}__link--TextDecorationLine: var(--#{$breadcrumb}__link--hover--TextDecorationLine);


### PR DESCRIPTION
Fixes #7554 

<img width="803" height="511" alt="Screenshot 2026-03-01 at 12 27 59 AM" src="https://github.com/user-attachments/assets/586d25f8-d049-4cba-8a52-5d7e26a1fde2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved inline icon and text rendering within breadcrumb navigation elements to ensure proper alignment and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->