### PR TITLE
fix(modal): change 2 icons to new ones

### DIFF
--- a/src/patternfly/components/ModalBox/examples/ModalBox.md
+++ b/src/patternfly/components/ModalBox/examples/ModalBox.md
@@ -172,7 +172,7 @@ import './ModalBox.css'
   {{#> modal-box modal-box--attribute=(concat 'aria-labelledby="' modal-example--id '-title" aria-describedby="' modal-example--id '-description"')}}
     {{> modal-box-close}}
     {{#> modal-box-header}}
-      {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"') modal-box-title-icon--type="bullhorn"}}
+      {{#> modal-box-title modal-box-title--IsIcon="true" modal-box-title--attribute=(concat 'id="' modal-example--id '-title"') modal-box-title-icon--type="rh-standard-megaphone"}}
         Modal with icon title
       {{/modal-box-title}}
     {{/modal-box-header}}

--- a/src/patternfly/components/ModalBox/modal-box-header-help.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header-help.hbs
@@ -2,5 +2,5 @@
   {{#if modal-box-header-help--attribute}}
     {{{modal-box-header-help--attribute}}}
   {{/if}}>
-  {{> button button--IsPlain=true button--icon-template="icon-help" button--IsIcon=true button--attribute='aria-label="Help"'}}
+  {{> button button--IsPlain=true button--icon="rh-ui-question-mark-circle" button--IsIcon=true button--attribute='aria-label="Help"'}}
 </div>


### PR DESCRIPTION
Fixes #8129 

No change to the background token needed. Most icons were fixed in global PRs, and this cleans up the custom icon and help icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icons in ModalBox component headers and examples for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->