### PR TITLE
fix(wizard): adjust z-index for nav shadow bug on mobile viewport

### DIFF
--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -136,7 +136,8 @@
   --#{$wizard}__toggle--m-expanded__toggle-icon--Rotate: 180deg;
 
   // Nav
-  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--sm);
+  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$wizard}__nav--mobile--ZIndex: var(--pf-t--global--z-index--md);
   --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}__nav--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$wizard}__nav--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
@@ -179,7 +180,7 @@
 
   // Footer
   --#{$wizard}__footer--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$wizard}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
@@ -376,7 +377,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--#{$wizard}__nav--ZIndex);
+  z-index: var(--#{$wizard}__nav--mobile--ZIndex);
   display: none;
   width: var(--#{$wizard}__nav--Width);
   max-height: 100%;
@@ -394,6 +395,10 @@
     display: block;
     height: 100%;
     border-inline-end: var(--#{$wizard}__nav--lg--BorderInlineEndWidth) solid var(--#{$wizard}__nav--lg--BorderInlineEndColor);
+  }
+
+  @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
+    z-index: var(--#{$wizard}__nav--ZIndex);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -138,8 +138,7 @@
   --#{$wizard}__toggle--m-expanded__toggle-icon--Rotate: 180deg;
 
   // Nav
-  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$wizard}__nav--mobile--ZIndex: var(--pf-t--global--z-index--md);
+  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$wizard}--m-plain__nav--BackgroundColor: transparent;
   --#{$wizard}__nav--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
@@ -397,7 +396,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--#{$wizard}__nav--mobile--ZIndex);
+  z-index: var(--#{$wizard}__nav--ZIndex);
   display: none;
   width: var(--#{$wizard}__nav--Width);
   max-height: 100%;
@@ -415,10 +414,6 @@
     display: block;
     height: 100%;
     border-inline-end: var(--#{$wizard}__nav--lg--BorderInlineEndWidth) solid var(--#{$wizard}__nav--lg--BorderInlineEndColor);
-  }
-
-  @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-    z-index: var(--#{$wizard}__nav--ZIndex);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -138,7 +138,8 @@
   --#{$wizard}__toggle--m-expanded__toggle-icon--Rotate: 180deg;
 
   // Nav
-  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--sm);
+  --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$wizard}__nav--mobile--ZIndex: var(--pf-t--global--z-index--md);
   --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$wizard}--m-plain__nav--BackgroundColor: transparent;
   --#{$wizard}__nav--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
@@ -186,7 +187,7 @@
   // Footer
   --#{$wizard}__footer--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}--m-plain__footer--BackgroundColor: transparent;
-  --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$wizard}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
@@ -396,7 +397,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--#{$wizard}__nav--ZIndex);
+  z-index: var(--#{$wizard}__nav--mobile--ZIndex);
   display: none;
   width: var(--#{$wizard}__nav--Width);
   max-height: 100%;
@@ -414,6 +415,10 @@
     display: block;
     height: 100%;
     border-inline-end: var(--#{$wizard}__nav--lg--BorderInlineEndWidth) solid var(--#{$wizard}__nav--lg--BorderInlineEndColor);
+  }
+
+  @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
+    z-index: var(--#{$wizard}__nav--ZIndex);
   }
 }
 


### PR DESCRIPTION
Fixes #7225

When the navigation bar touches the footer, a shadow will be visible on screens with a width less than 576px.  This shadow will be hidden on screens wider than 576px.

<img width="416" height="546" alt="Screenshot 2026-03-05 at 1 36 52 PM" src="https://github.com/user-attachments/assets/a08d757e-1a1e-4587-8698-825245f4015d" />


<img width="504" height="550" alt="Screenshot 2026-03-05 at 1 37 06 PM" src="https://github.com/user-attachments/assets/98ba2782-076f-4918-83d8-9db566e0a945" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized wizard component rendering on mobile devices with improved responsive layering and element stacking.
  * Enhanced footer positioning for better visibility across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->