### PR TITLE
fix(form-control): add transition styles

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -332,6 +332,7 @@
   // Disabled
   --#{$button}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$button}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$button}--disabled--BackgroundSurface: var(--#{$button}--BackgroundSurface);
   --#{$button}--disabled--TextDecorationColor: currentcolor;
   --#{$button}--disabled--BorderColor: transparent;
   --#{$button}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
@@ -587,6 +588,7 @@
       --#{$button}--hover--BackgroundColor: transparent;
       --#{$button}--m-clicked--BackgroundColor: transparent;
       --#{$button}--disabled--BackgroundColor: transparent;
+      --#{$button}--disabled--BackgroundSurface: none;
       --#{$button}--disabled--Color: var(--#{$button}--m-link--m-inline--disabled--Color);
       --#{$button}--disabled__icon--Color: var(--#{$button}--m-link--m-inline--disabled__icon--Color);
       --#{$button}--m-link--Color: var(--#{$button}--m-link--m-inline--Color);
@@ -748,6 +750,7 @@
     --#{$button}--disabled--Color: var(--#{$button}--m-plain--disabled--Color);
     --#{$button}--disabled__icon--Color: var(--#{$button}--m-plain--disabled__icon--Color);
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
+    --#{$button}--disabled--BackgroundSurface: none;
     --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-small--PaddingInlineEnd);
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-small--PaddingInlineStart);
 
@@ -941,7 +944,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--BackgroundSurface);
+    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--disabled--BackgroundSurface, none);
 
     &::after {
       border-color: transparent;

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -15,6 +15,7 @@
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$button}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$button}--BackgroundColor: transparent;
+  --#{$button}--BackgroundSurface: radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
   --#{$button}--BorderColor: transparent;
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
@@ -454,7 +455,7 @@
   -webkit-user-select: none;
   user-select: none;
   // stylelint-enable property-no-vendor-prefix
-  background: var(--#{$button}--BackgroundColor) radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
+  background: var(--#{$button}--BackgroundColor) var(--#{$button}--BackgroundSurface);
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -940,7 +941,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background: var(--#{$button}--disabled--BackgroundColor);
+    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--BackgroundSurface);
 
     &::after {
       border-color: transparent;

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -15,7 +15,6 @@
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$button}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$button}--BackgroundColor: transparent;
-  --#{$button}--BackgroundSurface: radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
   --#{$button}--BorderColor: transparent;
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
@@ -332,7 +331,6 @@
   // Disabled
   --#{$button}--disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$button}--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
-  --#{$button}--disabled--BackgroundSurface: var(--#{$button}--BackgroundSurface);
   --#{$button}--disabled--TextDecorationColor: currentcolor;
   --#{$button}--disabled--BorderColor: transparent;
   --#{$button}--disabled__icon--Color: var(--pf-t--global--icon--color--on-disabled);
@@ -456,7 +454,7 @@
   -webkit-user-select: none;
   user-select: none;
   // stylelint-enable property-no-vendor-prefix
-  background: var(--#{$button}--BackgroundColor) var(--#{$button}--BackgroundSurface);
+  background: var(--#{$button}--BackgroundColor) radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -588,7 +586,6 @@
       --#{$button}--hover--BackgroundColor: transparent;
       --#{$button}--m-clicked--BackgroundColor: transparent;
       --#{$button}--disabled--BackgroundColor: transparent;
-      --#{$button}--disabled--BackgroundSurface: none;
       --#{$button}--disabled--Color: var(--#{$button}--m-link--m-inline--disabled--Color);
       --#{$button}--disabled__icon--Color: var(--#{$button}--m-link--m-inline--disabled__icon--Color);
       --#{$button}--m-link--Color: var(--#{$button}--m-link--m-inline--Color);
@@ -750,7 +747,6 @@
     --#{$button}--disabled--Color: var(--#{$button}--m-plain--disabled--Color);
     --#{$button}--disabled__icon--Color: var(--#{$button}--m-plain--disabled__icon--Color);
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
-    --#{$button}--disabled--BackgroundSurface: none;
     --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-small--PaddingInlineEnd);
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-small--PaddingInlineStart);
 
@@ -944,7 +940,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--disabled--BackgroundSurface, none);
+    background: var(--#{$button}--disabled--BackgroundColor);
 
     &::after {
       border-color: transparent;

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -18,6 +18,10 @@
   --#{$form-control}--after--BorderRadius: var(--#{$form-control}--BorderRadius);
   --#{$form-control}--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$form-control}--Width: 100%;
+  --#{$form-control}--TransitionDelay: 0s;
+  --#{$form-control}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
+  --#{$form-control}--TransitionDuration: var(--pf-t--global--motion--duration--md);
+  --#{$form-control}--TransitionProperty: color, background, border-color;
 
   // padding
   --#{$form-control}--inset--base: var(--pf-t--global--spacer--control--horizontal--default);
@@ -161,6 +165,10 @@
   resize: var(--#{$form-control}--Resize);
   background-color: var(--#{$form-control}--BackgroundColor);
   border-radius: var(--#{$form-control}--BorderRadius);
+  transition-delay: var(--#{$form-control}--TransitionDelay);
+  transition-timing-function: var(--#{$form-control}--TransitionTimingFunction);
+  transition-duration: var(--pf-t--global--motion--duration--fade--default);
+  transition-property: var(--#{$form-control}--TransitionProperty);
 
   &::before,
   &::after {
@@ -168,6 +176,7 @@
     inset: 0;
     pointer-events: none;
     content: "";
+    transition: inherit;
   }
 
   &::before {
@@ -195,6 +204,7 @@
     border: none;
     border-radius: var(--#{$form-control}--BorderRadius);
     outline-offset: var(--#{$form-control}--OutlineOffset);
+    transition: inherit;
   }
 
   > ::placeholder {
@@ -441,6 +451,7 @@
 .#{$form-control}__icon {
   font-size: var(--#{$form-control}__icon--FontSize);
   color: var(--#{$form-control}__icon--Color);
+  transition: inherit;
 
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
@@ -456,6 +467,7 @@
   font-size: var(--#{$form-control}__toggle-icon--FontSize);
   color: var(--#{$form-control}__toggle-icon--Color);
   pointer-events: none;
+  transition: inherit;
 }
 
 .#{$form-control}__utilities {

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -20,8 +20,12 @@
   --#{$form-control}--Width: 100%;
   --#{$form-control}--TransitionDelay: 0s;
   --#{$form-control}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
-  --#{$form-control}--TransitionDuration: var(--pf-t--global--motion--duration--md);
-  --#{$form-control}--TransitionProperty: color, background, border-color;
+  --#{$form-control}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
+  --#{$form-control}--TransitionProperty: color, background-color, border-color;
+  --#{$form-control}__control--TransitionDelay: 0s;
+  --#{$form-control}__control--TransitionTimingFunction: auto;
+  --#{$form-control}__control--TransitionDuration: 0s;
+  --#{$form-control}__control--TransitionProperty: none;
 
   // padding
   --#{$form-control}--inset--base: var(--pf-t--global--spacer--control--horizontal--default);
@@ -134,6 +138,10 @@
   // Form control icon
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
+  --#{$form-control}__icon--TransitionDelay: 0s;
+  --#{$form-control}__icon--TransitionTimingFunction: auto;
+  --#{$form-control}__icon--TransitionDuration: 0s;
+  --#{$form-control}__icon--TransitionProperty: none;
   --#{$form-control}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}--m-success__icon--m-status--Color: var(--pf-t--global--icon--color--status--success--default);
   --#{$form-control}--m-warning__icon--m-status--Color: var(--pf-t--global--icon--color--status--warning--default);
@@ -150,6 +158,10 @@
   --#{$form-control}__toggle-icon--PaddingInlineEnd: 0; // remove in breaking change
   --#{$form-control}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}__toggle-icon--FontSize: var(--pf-t--global--icon--size--font--body--default); 
+  --#{$form-control}__toggle-icon--TransitionDelay: 0s;
+  --#{$form-control}__toggle-icon--TransitionTimingFunction: auto;
+  --#{$form-control}__toggle-icon--TransitionDuration: 0s;
+  --#{$form-control}__toggle-icon--TransitionProperty: none;
   --#{$form-control}--m-disabled__toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 }
 
@@ -167,7 +179,7 @@
   border-radius: var(--#{$form-control}--BorderRadius);
   transition-delay: var(--#{$form-control}--TransitionDelay);
   transition-timing-function: var(--#{$form-control}--TransitionTimingFunction);
-  transition-duration: var(--pf-t--global--motion--duration--fade--default);
+  transition-duration: var(--#{$form-control}--TransitionDuration);
   transition-property: var(--#{$form-control}--TransitionProperty);
 
   &::before,
@@ -204,7 +216,10 @@
     border: none;
     border-radius: var(--#{$form-control}--BorderRadius);
     outline-offset: var(--#{$form-control}--OutlineOffset);
-    transition: inherit;
+    transition-delay: var(--#{$form-control}__control--TransitionDelay);
+    transition-timing-function: var(--#{$form-control}__control--TransitionTimingFunction);
+    transition-duration: var(--#{$form-control}__control--TransitionDuration);
+    transition-property: var(--#{$form-control}__control--TransitionProperty);
   }
 
   > ::placeholder {
@@ -451,7 +466,10 @@
 .#{$form-control}__icon {
   font-size: var(--#{$form-control}__icon--FontSize);
   color: var(--#{$form-control}__icon--Color);
-  transition: inherit;
+  transition-delay: var(--#{$form-control}__icon--TransitionDelay);
+  transition-timing-function: var(--#{$form-control}__icon--TransitionTimingFunction);
+  transition-duration: var(--#{$form-control}__icon--TransitionDuration);
+  transition-property: var(--#{$form-control}__icon--TransitionProperty);
 
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
@@ -467,7 +485,10 @@
   font-size: var(--#{$form-control}__toggle-icon--FontSize);
   color: var(--#{$form-control}__toggle-icon--Color);
   pointer-events: none;
-  transition: inherit;
+  transition-delay: var(--#{$form-control}__toggle-icon--TransitionDelay);
+  transition-timing-function: var(--#{$form-control}__toggle-icon--TransitionTimingFunction);
+  transition-duration: var(--#{$form-control}__toggle-icon--TransitionDuration);
+  transition-property: var(--#{$form-control}__toggle-icon--TransitionProperty);
 }
 
 .#{$form-control}__utilities {
@@ -479,4 +500,5 @@
   padding-block-start: var(--#{$form-control}__utilities--PaddingBlockStart);
   padding-inline-end: var(--#{$form-control}__utilities--PaddingInlineEnd);
   pointer-events: none;
+  transition: inherit;
 }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -79,6 +79,7 @@
   // disabled
   --#{$form-control}--m-disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$form-control}--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$form-control}--m-disabled--before--BorderColor: transparent;
   --#{$form-control}--m-disabled--after--BorderColor: transparent;
 
   // readonly
@@ -311,8 +312,8 @@
     --#{$form-control}--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}--m-placeholder--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}__toggle-icon--Color: var(--#{$form-control}--m-disabled__toggle-icon--Color);
-    --#{$form-control}--before--BorderStyle: none;
-    --#{$form-control}--after--BorderStyle: none;
+    --#{$form-control}--before--BorderColor: var(--#{$form-control}--m-disabled--before--BorderColor);
+    --#{$form-control}--after--BorderColor: var(--#{$form-control}--m-disabled--after--BorderColor);
 
     cursor: not-allowed;
   }

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -176,6 +176,7 @@
     inset: 0;
     pointer-events: none;
     content: "";
+    transition: inherit;
   }
 
   &::before {
@@ -294,10 +295,13 @@
     --#{$form-control}--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}--m-placeholder--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}__toggle-icon--Color: var(--#{$form-control}--m-disabled__toggle-icon--Color);
-    --#{$form-control}--before--BorderStyle: none;
-    --#{$form-control}--after--BorderStyle: none;
 
     cursor: not-allowed;
+
+    &::before,
+    &::after {
+      border-color: transparent;
+    }
   }
 
   &.pf-m-error {

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -22,10 +22,6 @@
   --#{$form-control}--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--accelerate);
   --#{$form-control}--TransitionDuration: var(--pf-t--global--motion--duration--fade--default);
   --#{$form-control}--TransitionProperty: color, background-color, border-color;
-  --#{$form-control}__control--TransitionDelay: 0s;
-  --#{$form-control}__control--TransitionTimingFunction: auto;
-  --#{$form-control}__control--TransitionDuration: 0s;
-  --#{$form-control}__control--TransitionProperty: none;
 
   // padding
   --#{$form-control}--inset--base: var(--pf-t--global--spacer--control--horizontal--default);
@@ -79,7 +75,6 @@
   // disabled
   --#{$form-control}--m-disabled--Color: var(--pf-t--global--text--color--on-disabled);
   --#{$form-control}--m-disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
-  --#{$form-control}--m-disabled--before--BorderColor: transparent;
   --#{$form-control}--m-disabled--after--BorderColor: transparent;
 
   // readonly
@@ -139,10 +134,6 @@
   // Form control icon
   --#{$form-control}__icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}__icon--FontSize: var(--pf-t--global--icon--size--font--body--default);
-  --#{$form-control}__icon--TransitionDelay: 0s;
-  --#{$form-control}__icon--TransitionTimingFunction: auto;
-  --#{$form-control}__icon--TransitionDuration: 0s;
-  --#{$form-control}__icon--TransitionProperty: none;
   --#{$form-control}__icon--m-status--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}--m-success__icon--m-status--Color: var(--pf-t--global--icon--color--status--success--default);
   --#{$form-control}--m-warning__icon--m-status--Color: var(--pf-t--global--icon--color--status--warning--default);
@@ -159,10 +150,6 @@
   --#{$form-control}__toggle-icon--PaddingInlineEnd: 0; // remove in breaking change
   --#{$form-control}__toggle-icon--Color: var(--pf-t--global--icon--color--regular);
   --#{$form-control}__toggle-icon--FontSize: var(--pf-t--global--icon--size--font--body--default); 
-  --#{$form-control}__toggle-icon--TransitionDelay: 0s;
-  --#{$form-control}__toggle-icon--TransitionTimingFunction: auto;
-  --#{$form-control}__toggle-icon--TransitionDuration: 0s;
-  --#{$form-control}__toggle-icon--TransitionProperty: none;
   --#{$form-control}--m-disabled__toggle-icon--Color: var(--pf-t--global--icon--color--disabled);
 }
 
@@ -189,7 +176,6 @@
     inset: 0;
     pointer-events: none;
     content: "";
-    transition: inherit;
   }
 
   &::before {
@@ -217,10 +203,6 @@
     border: none;
     border-radius: var(--#{$form-control}--BorderRadius);
     outline-offset: var(--#{$form-control}--OutlineOffset);
-    transition-delay: var(--#{$form-control}__control--TransitionDelay);
-    transition-timing-function: var(--#{$form-control}__control--TransitionTimingFunction);
-    transition-duration: var(--#{$form-control}__control--TransitionDuration);
-    transition-property: var(--#{$form-control}__control--TransitionProperty);
   }
 
   > ::placeholder {
@@ -312,8 +294,8 @@
     --#{$form-control}--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}--m-placeholder--Color: var(--#{$form-control}--m-disabled--Color);
     --#{$form-control}__toggle-icon--Color: var(--#{$form-control}--m-disabled__toggle-icon--Color);
-    --#{$form-control}--before--BorderColor: var(--#{$form-control}--m-disabled--before--BorderColor);
-    --#{$form-control}--after--BorderColor: var(--#{$form-control}--m-disabled--after--BorderColor);
+    --#{$form-control}--before--BorderStyle: none;
+    --#{$form-control}--after--BorderStyle: none;
 
     cursor: not-allowed;
   }
@@ -467,10 +449,6 @@
 .#{$form-control}__icon {
   font-size: var(--#{$form-control}__icon--FontSize);
   color: var(--#{$form-control}__icon--Color);
-  transition-delay: var(--#{$form-control}__icon--TransitionDelay);
-  transition-timing-function: var(--#{$form-control}__icon--TransitionTimingFunction);
-  transition-duration: var(--#{$form-control}__icon--TransitionDuration);
-  transition-property: var(--#{$form-control}__icon--TransitionProperty);
 
   &.pf-m-status {
     --#{$form-control}__icon--Color: var(--#{$form-control}__icon--m-status--Color);
@@ -486,10 +464,6 @@
   font-size: var(--#{$form-control}__toggle-icon--FontSize);
   color: var(--#{$form-control}__toggle-icon--Color);
   pointer-events: none;
-  transition-delay: var(--#{$form-control}__toggle-icon--TransitionDelay);
-  transition-timing-function: var(--#{$form-control}__toggle-icon--TransitionTimingFunction);
-  transition-duration: var(--#{$form-control}__toggle-icon--TransitionDuration);
-  transition-property: var(--#{$form-control}__toggle-icon--TransitionProperty);
 }
 
 .#{$form-control}__utilities {
@@ -501,5 +475,4 @@
   padding-block-start: var(--#{$form-control}__utilities--PaddingBlockStart);
   padding-inline-end: var(--#{$form-control}__utilities--PaddingInlineEnd);
   pointer-events: none;
-  transition: inherit;
 }


### PR DESCRIPTION
Add transition to form-control so the input background and border changes animate in sync with the increment/decrement buttons when toggling isDisabled.

This resolves the visual delay where the buttons and input updated at different times.



https://github.com/user-attachments/assets/716b9cc0-1fe1-4750-9e49-35d3c41edab0


Fixes #7429



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved form control animations by introducing configurable transition timing, duration, delay, and transition properties.
  * Updated related pseudo-element animations so they follow the same transition settings for smoother visual behavior.
* **Bug Fixes**
  * Refined the disabled form control state styling so it no longer overrides border style during transitions, ensuring consistent appearance while remaining non-interactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->