### PR TITLE
fix(empty-state): align alert title with centered empty state content

### DIFF
--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -57,6 +57,11 @@
   // Actions
   --#{$empty-state}__actions--RowGap: var(--pf-t--global--spacer--gap--group--vertical);
   --#{$empty-state}__actions--ColumnGap: var(--pf-t--global--spacer--gap--action-to-action--default);
+
+  // Alert alignment
+  --#{$empty-state}__alert-title--Offset: var(--pf-t--global--spacer--lg);
+  --#{$empty-state}__alert-title--PaddingInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$empty-state}__alert-title--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
 }
 
 .#{$empty-state} {
@@ -121,6 +126,12 @@
 
   &.pf-m-custom {
     --#{$empty-state}__icon--Color: var(--#{$empty-state}--m-custom__icon--Color);
+  }
+
+  .#{$alert}__title {
+    padding-inline-start: var(--#{$empty-state}__alert-title--PaddingInlineStart);
+    padding-inline-end: var(--#{$empty-state}__alert-title--PaddingInlineEnd);
+    margin-inline-start: calc(-1 * var(--#{$empty-state}__alert-title--Offset));
   }
 }
 


### PR DESCRIPTION
Fixes #7310 

<img width="902" height="493" alt="Screenshot 2026-03-08 at 10 56 19 PM" src="https://github.com/user-attachments/assets/bdafc1a8-5383-49cc-b984-f7cd724f9f7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and alignment of alert titles within empty states to improve visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->