### PR TITLE
feat(Wizard): added plain styling

### DIFF
--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -490,8 +490,8 @@ import './Wizard.css'
 
 ### Plain header
 ```hbs isFullscreen
-{{#> wizard wizard--id="wizard-plain-header"}}
-  {{#> wizard-header wizard-header--modifier="pf-m-plain"}}
+{{#> wizard wizard--id="wizard-plain-header" wizard--modifier="pf-m-plain"}}
+  {{#> wizard-header}}
     {{> wizard-close}}
     {{> wizard-title wizard-title-text--value="Wizard title"}}
     {{#> wizard-description}}
@@ -612,8 +612,8 @@ import './Wizard.css'
 | `.pf-v6-c-wizard__footer-cancel` | `<div>` | Initiates the cancel button. **Required** |
 | `.pf-m-expanded` | `.pf-v6-c-wizard__toggle`, `.pf-v6-c-wizard__nav` | Modifies the mobile steps toggle and steps menu for the expanded state. |
 | `.pf-m-finished` | `.pf-v6-c-wizard` | Modifies the wizard for the finished state. |
-| `.pf-m-plain` | `.pf-v6-c-wizard__header` | Modifies the header to have a transparent background and no bottom border. |
-| `.pf-m-no-plain` | `.pf-v6-c-wizard__header` | Prevents the header from automatically applying plain styling when glass theme is enabled. |
+| `.pf-m-plain` | `.pf-v6-c-wizard` | Modifies the wizard to have a transparent background. |
+| `.pf-m-no-plain` | `.pf-v6-c-wizard` | Prevents the wizard from automatically applying plain styling when glass theme is enabled. |
 | `.pf-m-expandable` | `.pf-v6-c-wizard__nav-item` | Modifies a nav item for the expandable state. |
 | `.pf-m-expanded` | `.pf-v6-c-wizard__nav-item` | Modifies a nav item for the expanded state. |
 | `.pf-m-current` | `.pf-v6-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -488,6 +488,81 @@ import './Wizard.css'
 {{> wizard--status wizard--status--IsExpanded=true  wizard--status--id="warning-on-step-nav-expanded" wizard--status--IsWarning=true}}
 ```
 
+### Plain header
+```hbs isFullscreen
+{{#> wizard wizard--id="wizard-plain-header"}}
+  {{#> wizard-header wizard-header--modifier="pf-m-plain"}}
+    {{> wizard-close}}
+    {{> wizard-title wizard-title-text--value="Wizard title"}}
+    {{#> wizard-description}}
+      Here is where the description goes
+    {{/wizard-description}}
+  {{/wizard-header}}
+  {{#> wizard-toggle}}
+    {{#> wizard-toggle-list}}
+        {{#> wizard-toggle-list-item}}
+          {{#> wizard-toggle-num}}2{{/wizard-toggle-num}}
+          Configuration
+          {{> wizard-toggle-separator}}
+        {{/wizard-toggle-list-item}}
+        {{#> wizard-toggle-list-item}}
+          Substep B
+        {{/wizard-toggle-list-item}}
+      {{/wizard-toggle-list}}
+      {{> wizard-toggle-icon}}
+    {{/wizard-toggle}}
+    {{#> wizard-outer-wrap}}
+      {{#> wizard-inner-wrap}}
+        {{#> wizard-nav}}
+          {{#> wizard-nav-list}}
+            {{#> wizard-nav-item}}
+              {{#> wizard-nav-link}}
+                Information
+              {{/wizard-nav-link}}
+            {{/wizard-nav-item}}
+            {{#> wizard-nav-item wizard-nav-item--IsExpandable="true" wizard-nav-item--IsExpanded="true"}}
+              {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current"}}
+                Configuration
+              {{/wizard-nav-link}}
+              {{#> wizard-nav-list}}
+                {{#> wizard-nav-item newcontext}}
+                  {{#> wizard-nav-link}}
+                    Substep A
+                  {{/wizard-nav-link}}
+                {{/wizard-nav-item}}
+                {{#> wizard-nav-item newcontext}}
+                  {{#> wizard-nav-link wizard-nav-link--modifier="pf-m-current" wizard-nav-link--IsCurrentPage="true"}}
+                    Substep B
+                  {{/wizard-nav-link}}
+                {{/wizard-nav-item}}
+                {{#> wizard-nav-item newcontext}}
+                  {{#> wizard-nav-link}}
+                    Substep C
+                  {{/wizard-nav-link}}
+                {{/wizard-nav-item}}
+              {{/wizard-nav-list}}
+            {{/wizard-nav-item}}
+            {{#> wizard-nav-item}}
+              {{#> wizard-nav-link}}
+                Additional
+              {{/wizard-nav-link}}
+            {{/wizard-nav-item}}
+            {{#> wizard-nav-item}}
+              {{#> wizard-nav-link wizard-nav-link--IsDisabled="true"}}
+                Review
+              {{/wizard-nav-link}}
+            {{/wizard-nav-item}}
+          {{/wizard-nav-list}}
+        {{/wizard-nav}}
+      {{#> wizard-main}}
+        {{> __wizard-form}}
+      {{/wizard-main}}
+    {{/wizard-inner-wrap}}
+    {{> wizard-footer}}
+  {{/wizard-outer-wrap}}
+{{/wizard}}
+```
+
 ## Documentation
 ### Accessibility
 | Attribute | Applied to | Outcome |
@@ -537,6 +612,8 @@ import './Wizard.css'
 | `.pf-v6-c-wizard__footer-cancel` | `<div>` | Initiates the cancel button. **Required** |
 | `.pf-m-expanded` | `.pf-v6-c-wizard__toggle`, `.pf-v6-c-wizard__nav` | Modifies the mobile steps toggle and steps menu for the expanded state. |
 | `.pf-m-finished` | `.pf-v6-c-wizard` | Modifies the wizard for the finished state. |
+| `.pf-m-plain` | `.pf-v6-c-wizard__header` | Modifies the header to have a transparent background and no bottom border. |
+| `.pf-m-no-plain` | `.pf-v6-c-wizard__header` | Prevents the header from automatically applying plain styling when glass theme is enabled. |
 | `.pf-m-expandable` | `.pf-v6-c-wizard__nav-item` | Modifies a nav item for the expandable state. |
 | `.pf-m-expanded` | `.pf-v6-c-wizard__nav-item` | Modifies a nav item for the expanded state. |
 | `.pf-m-current` | `.pf-v6-c-wizard__nav-link` | Modifies a step link for the current state. **Required** |

--- a/src/patternfly/components/Wizard/examples/Wizard.md
+++ b/src/patternfly/components/Wizard/examples/Wizard.md
@@ -488,7 +488,7 @@ import './Wizard.css'
 {{> wizard--status wizard--status--IsExpanded=true  wizard--status--id="warning-on-step-nav-expanded" wizard--status--IsWarning=true}}
 ```
 
-### Plain header
+### Plain
 ```hbs isFullscreen
 {{#> wizard wizard--id="wizard-plain-header" wizard--modifier="pf-m-plain"}}
   {{#> wizard-header}}

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -15,6 +15,10 @@
   --#{$wizard}__header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$wizard}__header--BorderBlockEndColor: var(--pf-t--global--border--color--default);
 
+  // Header plain
+  --#{$wizard}__header--m-plain--BackgroundColor: transparent;
+  --#{$wizard}__header--m-plain--BorderBlockEndColor: transparent;
+
   // Close
   --#{$wizard}__close--InsetBlockStart: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--spacer--control--vertical--plain));
   --#{$wizard}__close--InsetInlineEnd: var(--pf-t--global--spacer--sm);
@@ -186,6 +190,7 @@
   --#{$wizard}__footer--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--BorderBlockStartWidth: var(--pf-t--global--border--width--divider--default);
   --#{$wizard}__footer--BorderBlockStartColor: var(--pf-t--global--border--color--default);
+
 }
 
 .#{$wizard} {
@@ -236,6 +241,12 @@
     button {
       font-size: var(--#{$wizard}__close--FontSize);
     }
+  }
+
+  @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
+  &.pf-m-plain {
+    --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
+    --#{$wizard}__header--BorderBlockEndColor: var(--#{$wizard}__header--m-plain--BorderBlockEndColor);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -17,7 +17,6 @@
 
   // Header plain
   --#{$wizard}__header--m-plain--BackgroundColor: transparent;
-  --#{$wizard}__header--m-plain--BorderBlockEndColor: transparent;
 
   // Close
   --#{$wizard}__close--InsetBlockStart: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--spacer--control--vertical--plain));
@@ -246,7 +245,6 @@
   @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
   &.pf-m-plain {
     --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
-    --#{$wizard}__header--BorderBlockEndColor: var(--#{$wizard}__header--m-plain--BorderBlockEndColor);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -225,7 +225,7 @@
   @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
   &.pf-m-plain {
     --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
-    --#{$wizard}__toggle--BackgroundColor: var(--#{$wizard}__toggle--m-plina--BackgroundColor);
+    --#{$wizard}__toggle--BackgroundColor: var(--#{$wizard}__toggle--m-plain--BackgroundColor);
     --#{$wizard}__nav--BackgroundColor: var(--#{$wizard}__nav--m-plain--BackgroundColor);
     --#{$wizard}__outer-wrap--BackgroundColor: var(--#{$wizard}__outer-wrap--m-plain--BackgroundColor);
     --#{$wizard}__footer--BackgroundColor: var(--#{$wizard}__footer--m-plain--BackgroundColor);

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -7,6 +7,7 @@
 
   // Header
   --#{$wizard}__header--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$wizard}__header--m-plain--BackgroundColor: transparent;
   --#{$wizard}__header--ZIndex: auto;
   --#{$wizard}__header--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -14,9 +15,6 @@
   --#{$wizard}__header--PaddingInlineStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__header--BorderBlockEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$wizard}__header--BorderBlockEndColor: var(--pf-t--global--border--color--default);
-
-  // Header plain
-  --#{$wizard}__header--m-plain--BackgroundColor: transparent;
 
   // Close
   --#{$wizard}__close--InsetBlockStart: calc(var(--pf-t--global--spacer--lg) - var(--pf-t--global--spacer--control--vertical--plain));
@@ -102,6 +100,7 @@
 
   // Toggle
   --#{$wizard}__toggle--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$wizard}__toggle--m-plain--BackgroundColor: transparent;
   --#{$wizard}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$wizard}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
@@ -141,6 +140,7 @@
   // Nav
   --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$wizard}__nav--m-plain--BackgroundColor: transparent;
   --#{$wizard}__nav--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$wizard}__nav--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
   --#{$wizard}__nav--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
@@ -168,6 +168,7 @@
 
   // Outer wrap
   --#{$wizard}__outer-wrap--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$wizard}__outer-wrap--m-plain--BackgroundColor: transparent;
   --#{$wizard}__outer-wrap--lg--PaddingInlineStart: var(--#{$wizard}__nav--Width);
   --#{$wizard}__outer-wrap--MinHeight: #{pf-size-prem(250px)};
 
@@ -182,6 +183,7 @@
 
   // Footer
   --#{$wizard}__footer--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$wizard}__footer--m-plain--BackgroundColor: transparent;
   --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$wizard}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -219,6 +221,15 @@
       display: none;
     }
   }
+
+  @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
+  &.pf-m-plain {
+    --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
+    --#{$wizard}__toggle--BackgroundColor: var(--#{$wizard}__toggle--m-plina--BackgroundColor);
+    --#{$wizard}__nav--BackgroundColor: var(--#{$wizard}__nav--m-plain--BackgroundColor);
+    --#{$wizard}__outer-wrap--BackgroundColor: var(--#{$wizard}__outer-wrap--m-plain--BackgroundColor);
+    --#{$wizard}__footer--BackgroundColor: var(--#{$wizard}__footer--m-plain--BackgroundColor);
+  }
 }
 
 .#{$wizard}__header {
@@ -240,11 +251,6 @@
     button {
       font-size: var(--#{$wizard}__close--FontSize);
     }
-  }
-
-  @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
-  &.pf-m-plain {
-    --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -60,7 +60,7 @@
   --#{$wizard}__nav-link-main--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-main--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$wizard}__nav-link-main--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$wizard}__nav-link-main--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$wizard}__nav-link-main--BorderRadius: var(--pf-t--global--border--radius--action--plain--default);
   --#{$wizard}__nav-link-main--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$wizard}__nav-link-main--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$wizard}__nav-link--hover__nav-link-main--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -7,7 +7,7 @@
 
   // Header
   --#{$wizard}__header--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$wizard}__header--m-plain--BackgroundColor: transparent;
+  --#{$wizard}--m-plain__header--BackgroundColor: transparent;
   --#{$wizard}__header--ZIndex: auto;
   --#{$wizard}__header--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__header--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -100,7 +100,7 @@
 
   // Toggle
   --#{$wizard}__toggle--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__toggle--m-plain--BackgroundColor: transparent;
+  --#{$wizard}--m-plain__toggle--BackgroundColor: transparent;
   --#{$wizard}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$wizard}__toggle--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
@@ -139,17 +139,19 @@
 
   // Nav
   --#{$wizard}__nav--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__nav--m-plain--BackgroundColor: transparent;
+  --#{$wizard}__nav--BackgroundColor: var(--pf-t--global--background--color--floating--default);
+  --#{$wizard}--m-plain__nav--BackgroundColor: transparent;
   --#{$wizard}__nav--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$wizard}__nav--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
   --#{$wizard}__nav--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
   --#{$wizard}__nav--Width: 100%;
+  --#{$wizard}__nav--lg--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$wizard}__nav--lg--Width: #{pf-size-prem(250px)};
   --#{$wizard}__nav--lg--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$wizard}__nav--lg--BorderInlineEndColor: var(--pf-t--global--border--color--default);
 
   @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
+    --#{$wizard}__nav--BackgroundColor: var(--#{$wizard}__nav--lg--BackgroundColor);
     --#{$wizard}__nav--Width: var(--#{$wizard}__nav--lg--Width);
     --#{$wizard}__nav--BoxShadow: none;
     --#{$wizard}__nav--BorderBlockEndWidth: 0;
@@ -168,7 +170,7 @@
 
   // Outer wrap
   --#{$wizard}__outer-wrap--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__outer-wrap--m-plain--BackgroundColor: transparent;
+  --#{$wizard}--m-plain__outer-wrap--BackgroundColor: transparent;
   --#{$wizard}__outer-wrap--lg--PaddingInlineStart: var(--#{$wizard}__nav--Width);
   --#{$wizard}__outer-wrap--MinHeight: #{pf-size-prem(250px)};
 
@@ -183,7 +185,7 @@
 
   // Footer
   --#{$wizard}__footer--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$wizard}__footer--m-plain--BackgroundColor: transparent;
+  --#{$wizard}--m-plain__footer--BackgroundColor: transparent;
   --#{$wizard}__footer--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$wizard}__footer--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$wizard}__footer--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
@@ -224,11 +226,14 @@
 
   @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-no-plain),
   &.pf-m-plain {
-    --#{$wizard}__header--BackgroundColor: var(--#{$wizard}__header--m-plain--BackgroundColor);
-    --#{$wizard}__toggle--BackgroundColor: var(--#{$wizard}__toggle--m-plain--BackgroundColor);
-    --#{$wizard}__nav--BackgroundColor: var(--#{$wizard}__nav--m-plain--BackgroundColor);
-    --#{$wizard}__outer-wrap--BackgroundColor: var(--#{$wizard}__outer-wrap--m-plain--BackgroundColor);
-    --#{$wizard}__footer--BackgroundColor: var(--#{$wizard}__footer--m-plain--BackgroundColor);
+    --#{$wizard}__header--BackgroundColor: var(--#{$wizard}--m-plain__header--BackgroundColor);
+    --#{$wizard}__toggle--BackgroundColor: var(--#{$wizard}--m-plain__toggle--BackgroundColor);
+    --#{$wizard}__outer-wrap--BackgroundColor: var(--#{$wizard}--m-plain__outer-wrap--BackgroundColor);
+    --#{$wizard}__footer--BackgroundColor: var(--#{$wizard}--m-plain__footer--BackgroundColor);
+    
+    @media screen and (min-width: $pf-v6-global--breakpoint--lg) {
+      --#{$wizard}__nav--BackgroundColor: var(--#{$wizard}--m-plain__nav--BackgroundColor);   
+    }
   }
 }
 


### PR DESCRIPTION
Closes #8106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "plain header" example showing a wizard with a transparent/plain header, toggle, nav, main and footer.
  * Extended accessibility/usage guidance with notes for applying the plain header and opting out when theme-specific plain styling is enabled.

* **Style**
  * Introduced plain-mode styling across header, toggle, nav, outer wrap and footer with theme-aware overrides to preserve transparency.
  * Adjusted corner styling for main navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->