### PR TITLE
feat(tabs): update to unified design icons and tokens

### DIFF
--- a/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
@@ -23,20 +23,20 @@ __tabs-item--NoText: bool
 {{#> tabs-list}}
   {{> __tabs-item
     __tabs-item--id="sub-1"
-    __tabs-item--icon-name="address-card"
+    __tabs-item--icon-name="rh-ui-template-fill"
     __tabs-item--aria-label="Item 1"
     __tabs-item--text="Item 1"
     }}
   {{> __tabs-item
     __tabs-item--id="sub-2"
-    __tabs-item--icon-name="anchor"
+    __tabs-item--icon-name="rh-ui-link"
     __tabs-item--aria-label="Item 2"
     __tabs-item--text="Item 2"
     }}
   {{> __tabs-item
     __tabs-item--current="true"
     __tabs-item--id="sub-3"
-    __tabs-item--icon-name="arrow-alt-circle-right"
+    __tabs-item--icon-name="rh-ui-arrow-circle-right-fill"
     __tabs-item--aria-label="Item 3"
     __tabs-item--text="Item 3"
     }}
@@ -45,14 +45,14 @@ __tabs-item--NoText: bool
     {{#if __tabs-list--IsDisabled}}
       {{> __tabs-item
         __tabs-item--id="sub-disabled"
-        __tabs-item--icon-name="balance-scale"
+        __tabs-item--icon-name="rh-ui-balance-scale-fill"
         __tabs-item--aria-label="Disabled"
         __tabs-item--text="Disabled"
         tabs-link--IsDisabled="true"
         }}
       {{> __tabs-item
         __tabs-item--id="sub-aria-disabled"
-        __tabs-item--icon-name="bell"
+        __tabs-item--icon-name="rh-ui-notification-fill"
         __tabs-item--aria-label="ARIA disabled"
         __tabs-item--text="ARIA disabled"
         tabs-link--IsAriaDisabled="true"
@@ -60,20 +60,20 @@ __tabs-item--NoText: bool
     {{else}}
       {{> __tabs-item
         __tabs-item--id="sub-4"
-        __tabs-item--icon-name="balance-scale"
+        __tabs-item--icon-name="rh-ui-balance-scale-fill"
         __tabs-item--aria-label="Item 4"
         __tabs-item--text="Item 4"
         }}
       {{> __tabs-item
         __tabs-item--id="sub-5"
-        __tabs-item--icon-name="bell"
+        __tabs-item--icon-name="rh-ui-notification-fill"
         __tabs-item--aria-label="Item 5"
         __tabs-item--text="Item 5"
         }}
     {{/if}}
     {{> __tabs-item
       __tabs-item--id="sub-6"
-      __tabs-item--icon-name="book"
+      __tabs-item--icon-name="rh-ui-catalogue-alt-fill"
       __tabs-item--aria-label="Item 6"
       __tabs-item--text="Item 6"
       }}
@@ -81,19 +81,19 @@ __tabs-item--NoText: bool
     {{#if __tabs-list-secondary--IsLong}}
       {{> __tabs-item
         __tabs-item--id="sub-7"
-        __tabs-item--icon-name="chart-pie"
+        __tabs-item--icon-name="rh-ui-pie-chart-fill"
         __tabs-item--aria-label="Item 7"
         __tabs-item--text="Item 7"
         }}
       {{> __tabs-item
         __tabs-item--id="sub-8"
-        __tabs-item--icon-name="coffee"
+        __tabs-item--icon-name="rh-ui-truck-fill"
         __tabs-item--aria-label="Item 8"
         __tabs-item--text="Item 8"
         }}
       {{> __tabs-item
         __tabs-item--id="sub-9"
-        __tabs-item--icon-name="dot-circle"
+        __tabs-item--icon-name="rh-ui-resources-full"
         __tabs-item--aria-label="Item 9"
         __tabs-item--text="Item 9"
         }}

--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -29,20 +29,20 @@ __tabs-list--IsCloseDisabled: bool
 {{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
   {{> __tabs-item
     __tabs-item--id="users"
-    __tabs-item--icon-name="fas fa-users"
+    __tabs-item--icon-name="rh-ui-users-fill"
     __tabs-item--aria-label="Users"
     __tabs-item--text="Users"
     }}
   {{> __tabs-item
     __tabs-item--current=(inverse __tabs-list--IsOverflowSelected)
     __tabs-item--id="containers"
-    __tabs-item--icon-name="fas fa-box"
+    __tabs-item--icon-name="rh-ui-container-fill"
     __tabs-item--aria-label="Containers"
     __tabs-item--text=(ternary __tabs-list--HasMultiLine "Containers <br> and more" "Containers")
     }}
   {{> __tabs-item
     __tabs-item--id="database"
-    __tabs-item--icon-name="database"
+    __tabs-item--icon-name="rh-ui-storage-fill"
     __tabs-item--aria-label="Database"
     __tabs-item--text="Database"
     }}
@@ -51,7 +51,7 @@ __tabs-list--IsCloseDisabled: bool
     {{#if __tabs-list--IsDisabled}}
       {{> __tabs-item
         __tabs-item--id="disabled"
-        __tabs-item--icon-name="server"
+        __tabs-item--icon-name="rh-ui-server-fill"
         __tabs-item--aria-label="Disabled"
         __tabs-item--text="Disabled"
         tabs-link--IsDisabled="true"
@@ -60,7 +60,7 @@ __tabs-list--IsCloseDisabled: bool
         }}
       {{> __tabs-item
         __tabs-item--id="aria-disabled"
-        __tabs-item--icon-name="laptop"
+        __tabs-item--icon-name="rh-ui-laptop-fill"
         __tabs-item--aria-label="ARIA disabled"
         __tabs-item--text="ARIA disabled"
         tabs-link--IsAriaDisabled="true"
@@ -70,7 +70,7 @@ __tabs-list--IsCloseDisabled: bool
         {{#if __tabs-list--IsHelpDisabled}}
           {{> __tabs-item
             __tabs-item--id="help-disabled"
-            __tabs-item--icon-name="download"
+            __tabs-item--icon-name="rh-ui-download"
             __tabs-item--aria-label="Help disabled"
             __tabs-item--text="Help disabled"
             tabs-link--IsDisabled="true"
@@ -80,7 +80,7 @@ __tabs-list--IsCloseDisabled: bool
         {{#if __tabs-list--IsCloseDisabled}}
           {{> __tabs-item
             __tabs-item--id="close-disabled"
-            __tabs-item--icon-name="code"
+            __tabs-item--icon-name="rh-ui-code"
             __tabs-item--aria-label="Close disabled"
             __tabs-item--text="Close disabled"
             tabs-link--IsDisabled="true"
@@ -90,7 +90,7 @@ __tabs-list--IsCloseDisabled: bool
         {{#if __tabs-list--IsHelpCloseDisabled}}
           {{> __tabs-item
             __tabs-item--id="help-close-disabled"
-            __tabs-item--icon-name="folder"
+            __tabs-item--icon-name="rh-ui-folder-fill"
             __tabs-item--aria-label="Help and disabled"
             __tabs-item--text="Help and close disabled"
             tabs-link--IsDisabled="true"
@@ -101,39 +101,39 @@ __tabs-list--IsCloseDisabled: bool
     {{else}}
       {{> __tabs-item
         __tabs-item--id="server"
-        __tabs-item--icon-name="server"
+        __tabs-item--icon-name="rh-ui-server-fill"
         __tabs-item--aria-label="Server"
         __tabs-item--text="Server"
         }}
       {{> __tabs-item
         __tabs-item--id="system"
-        __tabs-item--icon-name="laptop"
+        __tabs-item--icon-name="rh-ui-laptop-fill"
         __tabs-item--aria-label="System"
         __tabs-item--text="System"
         }}
     {{/if}}
     {{> __tabs-item
       __tabs-item--id="network-wired"
-      __tabs-item--icon-name="project-diagram"
+      __tabs-item--icon-name="rh-ui-network-fill"
       __tabs-item--aria-label="Network"
       __tabs-item--text="Network"
       }}
     {{#if __tabs-list--IsLong}}
       {{> __tabs-item
         __tabs-item--id="cloud"
-        __tabs-item--icon-name="cloud"
+        __tabs-item--icon-name="rh-ui-cloud-fill"
         __tabs-item--aria-label="Hybrid Cloud"
         __tabs-item--text="Hybrid Cloud"
         }}
       {{> __tabs-item
         __tabs-item--id="automation"
-        __tabs-item--icon-name="magic"
+        __tabs-item--icon-name="rh-ui-automation-fill"
         __tabs-item--aria-label="Automation"
         __tabs-item--text="Automation"
         }}
       {{> __tabs-item
         __tabs-item--id="files"
-        __tabs-item--icon-name="file"
+        __tabs-item--icon-name="rh-ui-document-fill"
         __tabs-item--aria-label="files"
         __tabs-item--text="Files"
         }}
@@ -142,7 +142,7 @@ __tabs-list--IsCloseDisabled: bool
       {{#> wrapper
         __tabs-item--current=__tabs-list--IsOverflowSelected
         __tabs-item--id="more"
-        __tabs-item--icon-name="more"
+        __tabs-item--icon-name="rh-ui-enhancement-fill"
         __tabs-item--aria-label="Show more tabs"
         __tabs-item--text="More"
         __tabs-item--IsOverflow="true"

--- a/src/patternfly/components/Tabs/tabs-item-action.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-action.hbs
@@ -5,7 +5,7 @@
   {{/if}}>
   {{#if tabs-item-action--IsHelp}}
     {{#> tabs-item-action-button tabs-item-action-button--aria-label=(concat "More info for " __tabs-item--text " label") tabs-item-action-button--IsDisabled=tabs-item-action--IsHelpDisabled tabs-item-action-button--IsAriaDisabled=tabs-item-action--IsHelpAriaDisabled}}
-      <i class="pf-v6-pficon pf-v6-pficon-help" aria-hidden="true"></i>
+      {{pfIcon "rh-ui-question-mark-circle"}}
     {{/tabs-item-action-button}}
   {{/if}}
   {{#if tabs-item-action--IsClose}}

--- a/src/patternfly/components/Tabs/tabs-item-icon.hbs
+++ b/src/patternfly/components/Tabs/tabs-item-icon.hbs
@@ -2,5 +2,5 @@
   {{#if tabs-item-icon--attribute}}
     {{{tabs-item-icon--attribute}}}
   {{/if}}>
-  <i class="fas fa-{{tabs-item-icon--name}}" aria-hidden="true"></i>
+  {{pfIcon tabs-item-icon--name}}
 </span>

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -56,8 +56,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical__item--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$tabs}__item--m-current--BackgroundColor: transparent;
   --#{$tabs}--m-box__item--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$tabs}--m-box__item--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$tabs}--m-box--m-secondary__item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$tabs}--m-box__item--m-current--BackgroundColor: transparent;
+  --#{$tabs}--m-box--m-secondary__item--BackgroundColor: transparent;
   --#{$tabs}--m-box--m-secondary__item--m-current--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
   --#{$tabs}__item--m-action--before--ZIndex: var(--pf-t--global--z-index--sm);
 
@@ -65,7 +65,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--Color: var(--pf-t--global--text--color--subtle);
   --#{$tabs}__link--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}__link--BorderRadius: var(--pf-t--global--border--radius--small);
+  --#{$tabs}__link--BorderRadius: var(--pf-t--global--border--radius--control--default);
   --#{$tabs}__link--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$tabs}__link--BorderColor: transparent;
   --#{$tabs}__link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
@@ -75,21 +75,21 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$tabs}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--ColumnGap: var(--pf-t--global--spacer--sm);
-  --#{$tabs}__link--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$tabs}__link--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$tabs}__link--disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$tabs}__link--disabled--BackgroundColor: transparent;
   --#{$tabs}__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}__item--m-current__link--Color: var(--pf-t--global--text--color--regular);
   --#{$tabs}__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-vertical__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}--m-vertical__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tabs}--m-box__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}--m-box__link--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$tabs}--m-box__link--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$tabs}--m-box__link--disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$tabs}--m-box__link--disabled--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}--m-box__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box--m-secondary__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}--m-box--m-secondary__link--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --#{$tabs}--m-box--m-secondary__link--disabled--BackgroundColor: var(--pf-t--global--background--color--disabled--default);
+  --#{$tabs}--m-box--m-secondary__link--disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$tabs}--m-box--m-secondary__link--disabled--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box--m-secondary__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}--m-box--m-secondary__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
@@ -125,7 +125,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--after--BorderBlockStartWidth: 0;
   --#{$tabs}__link--after--BorderInlineEndWidth: 0;
   --#{$tabs}__link--after--BorderInlineStartWidth: 0;
-  --#{$tabs}__item--m-current__link--after--BorderColor: var(--pf-t--global--border--color--clicked);
+  --#{$tabs}__link--after--BorderRadius: var(--pf-t--global--border--radius--pill);
+  --#{$tabs}--m-box__link--after--BorderRadius: var(--pf-t--global--border--radius--sharp);
+  --#{$tabs}__item--m-current__link--after--BorderColor: var(--pf-t--global--color--brand--accent--default);
   --#{$tabs}__item--m-current__link--after--BorderWidth: var(--pf-t--global--border--width--extra-strong);
 
   // Link accent
@@ -307,6 +309,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__link--before--BorderBlockEndWidth: var(--#{$tabs}__link--before--border-width--base);
     --#{$tabs}__link--after--InsetBlockStart: 0;
     --#{$tabs}__link--after--InsetBlockEnd: auto;
+    --#{$tabs}__link--after--BorderRadius: var(--#{$tabs}--m-box__link--after--BorderRadius);
 
     .#{$tabs}__link {
       --#{$tabs}__link--after--BorderBlockStartWidth: var(--#{$tabs}__link--after--BorderWidth);
@@ -690,6 +693,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
       border-block-end-width: var(--#{$tabs}__link--after--BorderBlockEndWidth);
       border-inline-start-width: var(--#{$tabs}__link--after--BorderInlineStartWidth);
       border-inline-end-width: var(--#{$tabs}__link--after--BorderInlineEndWidth);
+      border-radius: var(--#{$tabs}__link--after--BorderRadius);
     }
   }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -89,7 +89,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-box__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box--m-secondary__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box--m-secondary__link--disabled--Color: var(--pf-t--global--text--color--disabled);
-  --#{$tabs}--m-box--m-secondary__link--disabled--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$tabs}--m-box--m-secondary__link--disabled--BackgroundColor: transparent;
   --#{$tabs}--m-box--m-secondary__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}--m-box--m-secondary__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -551,7 +551,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
 .#{$tabs}__toggle-button {
   .#{$button} {
-    justify-content: start;
     white-space: normal;
   }
 }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -84,7 +84,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-vertical__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tabs}--m-box__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box__link--disabled--Color: var(--pf-t--global--text--color--disabled);
-  --#{$tabs}--m-box__link--disabled--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$tabs}--m-box__link--disabled--BackgroundColor: transparent;
   --#{$tabs}--m-box__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}--m-box__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
   --#{$tabs}--m-box--m-secondary__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -65,7 +65,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--Color: var(--pf-t--global--text--color--subtle);
   --#{$tabs}__link--FontSize: var(--pf-t--global--font--size--sm);
   --#{$tabs}__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}__link--BorderRadius: var(--pf-t--global--border--radius--control--default);
+  --#{$tabs}__link--BorderRadius: var(--pf-t--global--border--radius--action--plain--default);
   --#{$tabs}__link--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$tabs}__link--BorderColor: transparent;
   --#{$tabs}__link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -549,12 +549,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   align-items: center;
 }
 
-.#{$tabs}__toggle-button {
-  .#{$button} {
-    white-space: normal;
-  }
-}
-
 .#{$tabs}__toggle-icon {
   @include pf-v6-mirror-inline-on-rtl;
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -111,6 +111,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-box__link--m-current--before--BorderInlineStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$tabs}--m-box__link--m-current--before--BorderInlineEndColor: var(--pf-t--global--border--color--high-contrast);
   --#{$tabs}--m-box__link--m-current--before--BorderInlineEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$tabs}--m-box__link--m-current--before--BorderBlockEndColor: var(--pf-t--global--border--color--alt);
   --#{$tabs}__link--disabled--before--BorderInlineEndWidth: 0;
   --#{$tabs}__link--disabled--before--BorderBlockEndWidth: var(--#{$tabs}--before--border-width--base);
   --#{$tabs}__link--disabled--before--BorderInlineStartWidth: 0;
@@ -322,7 +323,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
     .#{$tabs}__item.pf-m-current {
       --#{$tabs}__link--BackgroundColor: var(--#{$tabs}__item--m-current__link--BackgroundColor);
-      --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}__link--BackgroundColor);
+      --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}--m-box__link--m-current--before--BorderBlockEndColor);
       --#{$tabs}__link--before--BorderInlineStartColor: var(--#{$tabs}--m-box__link--m-current--before--BorderInlineStartColor);
       --#{$tabs}__link--before--BorderInlineStartWidth: var(--#{$tabs}--m-box__link--m-current--before--BorderInlineStartWidth);
       --#{$tabs}__link--before--BorderInlineEndColor: var(--#{$tabs}--m-box__link--m-current--before--BorderInlineEndColor);
@@ -479,13 +480,15 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     .#{$tabs}__item:last-child {
       --#{$tabs}__link--before--BorderInlineEndWidth: var(--#{$tabs}__link--before--border-width--base);
     }
+
     .#{$tabs}__item:first-child {
       --#{$tabs}__link--before--BorderBlockStartWidth: var(--#{$tabs}__link--before--border-width--base);
     }
 
     // Add border right color and weight
     .#{$tabs}__item.pf-m-current {
-      --#{$tabs}__link--before--BorderInlineEndColor: var(--#{$tabs}__item--m-current__link--BackgroundColor);
+      --#{$tabs}__link--before--BorderInlineEndColor: var(--#{$tabs}--m-box__link--m-current--before--BorderBlockEndColor);
+      --#{$tabs}__link--before--BorderInlineEndWidth: var(--#{$tabs}__link--before--border-width--base);
       --#{$tabs}__link--before--BorderBlockEndColor: var(--#{$tabs}__link--before--border-color--base);
     }
 


### PR DESCRIPTION
Fixes #8015 

I picked a lot of tokens to replace ones that weren't exactly mapped into the UI tokens.
I did not change the overflow buttons - they are regular plain buttons per design.

[Figma](https://www.figma.com/design/qRn3S225WwGHIdgGZX0LTC/Unified-Theme--Design-Tokens--Styles---Specs?node-id=10861-5678&m=dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated tab icons to the new rh-ui design-system icons everywhere, including help/action icons.
  * Refined tab backgrounds, current-item visuals, after-border rendering, and box current-item border behavior for a more consistent appearance.
  * Adjusted disabled tab colors, link border-radius, and vertical box border handling for clearer, more accessible states.
  * Removed legacy expandable-toggle layout tweaks for cleaner tab layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->