### PR TITLE
feat(Accordion): unified theme updates

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -17,12 +17,14 @@
   --#{$accordion}__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$accordion}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
+  --#{$accordion}__toggle--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$accordion}__toggle--BorderWidth: var(--pf-t--global--border--width--action--plain--default);
   --#{$accordion}__toggle--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$accordion}__toggle--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
+  --#{$accordion}__toggle--m-expanded--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
 
   // Accordion toggle toggle-start modifier
   // This decreases the gap between icon and text, alternative is calc it to * 2 the token or create a new token
@@ -43,9 +45,10 @@
 
   // accordion expandable content
   --#{$accordion}__expandable-content--MarginInlineEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}__expandable-content--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$accordion}__expandable-content--MarginBlockEnd: 0;
-  --#{$accordion}__expandable-content--MarginInlineStart: var(--pf-t--global--spacer--md);
-  --#{$accordion}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$accordion}__expandable-content--MarginInlineStart: var(--pf-t--global--spacer--lg);
+  --#{$accordion}__expandable-content--BackgroundColor: var(--#{$accordion}--BackgroundColor);
   --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
   --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--default);
@@ -55,7 +58,7 @@
   --#{$accordion}__expandable-content--Visibility: hidden;
   --#{$accordion}__item--m-expanded__expandable-content--Visibility: visible;
   --#{$accordion}__item--m-expanded__expandable-content--MaxHeight: 99999px;
-  --#{$accordion}__item--m-expanded__expandable-content--MarginBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$accordion}__item--m-expanded__expandable-content--MarginBlockEnd: var(--pf-t--global--spacer--lg);
 
   // expand animation
   --#{$accordion}__item--before--TransitionDuration--expand--fade: var(--pf-t--global--motion--duration--fade--default);
@@ -97,7 +100,7 @@
   --#{$accordion}--m-display-lg__toggle--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--PaddingBlockEnd: var(--pf-t--global--spacer--md);
-  --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$accordion}--m-display-lg__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}--m-display-lg__toggle--FontFamily: var(--pf-t--global--font--family--heading);
   --#{$accordion}--m-display-lg__toggle--FontSize: var(--pf-t--global--font--size--heading--sm);
@@ -165,7 +168,6 @@
     inset: 0;
     pointer-events: none;
     content: "";
-    background-color: var(--#{$accordion}__item--m-expanded--BackgroundColor);
     border: var(--#{$accordion}__item--BorderWidth) solid var(--#{$accordion}__item--BorderColor);
     border-radius: var(--#{$accordion}__item--BorderRadius);
     opacity: var(--#{$accordion}__item--before--Opacity);
@@ -175,7 +177,9 @@
   }
 
   &.pf-m-expanded {
+    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--m-expanded--BackgroundColor);
     --#{$accordion}__toggle--PaddingBlockEnd: var(--#{$accordion}__toggle--m-expanded--PaddingBlockEnd);
+    --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--m-expanded--BorderWidth);
     --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
     --#{$accordion}__toggle-icon--Rotate: var(--#{$accordion}__toggle--m-expanded__toggle-icon--Rotate);
     --#{$accordion}__item--before--TransitionDuration--slide: var(--#{$accordion}__item--before--TransitionDuration--expand--slide);
@@ -223,7 +227,7 @@
     border-radius: inherit;
   }
 
-  &:is(:hover, :focus) {
+  :where(.#{$accordion}__item:not(.pf-m-expanded)) &:is(:hover, :focus) {
     --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--hover--BackgroundColor);
     --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--hover--BorderWidth);
   }
@@ -245,11 +249,17 @@
 }
 
 .#{$accordion}__expandable-content:where([hidden]) {
+  --#{$accordion}__expandable-content--MarginBlockStart: 0;
+  --#{$accordion}__expandable-content--MarginBlockEnd: 0;
+  --#{$accordion}__expandable-content--MarginInlineStart: 0;
+  --#{$accordion}__expandable-content--MarginInlineEnd: 0;
+
   display: revert;
 }
 
 .#{$accordion}__expandable-content {
   max-height:  var(--#{$accordion}__expandable-content--MaxHeight);
+  margin-block-start: var(--#{$accordion}__expandable-content--MarginBlockStart);
   margin-block-end: var(--#{$accordion}__expandable-content--MarginBlockEnd);
   margin-inline-start: var(--#{$accordion}__expandable-content--MarginInlineStart);
   margin-inline-end: var(--#{$accordion}__expandable-content--MarginInlineEnd);
@@ -257,8 +267,6 @@
   color: var(--#{$accordion}__expandable-content--Color);
   visibility:  var(--#{$accordion}__expandable-content--Visibility);
   background-color: var(--#{$accordion}__expandable-content--BackgroundColor);
-  border: var(--#{$accordion}__expandable-content--BorderWidth) solid var(--#{$accordion}__expandable-content--BorderColor);
-  border-radius: var(--#{$accordion}__expandable-content--BorderRadius);
   opacity: var(--#{$accordion}__expandable-content--Opacity);
   transition-delay: 0s, 0s, var(--#{$accordion}__expandable-content--TransitionDuration--fade), var(--#{$accordion}__expandable-content--TransitionDuration--fade), var(--#{$accordion}__expandable-content--TransitionDuration--fade);
   transition-timing-function: var(--#{$accordion}__expandable-content--TransitionTimingFunction);
@@ -273,11 +281,6 @@
 }
 
 .#{$accordion}__expandable-content-body {
-  padding-block-start: var(--#{$accordion}__expandable-content-body--PaddingBlockStart);
-  padding-block-end: var(--#{$accordion}__expandable-content-body--PaddingBlockEnd);
-  padding-inline-start: var(--#{$accordion}__expandable-content-body--PaddingInlineStart);
-  padding-inline-end: var(--#{$accordion}__expandable-content-body--PaddingInlineEnd);
-
   & + & {
     --#{$accordion}__expandable-content-body--PaddingBlockStart: var(--#{$accordion}__expandable-content-body--expandable-content-body--PaddingBlockStart);
   }

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -2,10 +2,11 @@
 
 @include pf-root($accordion) {
   // accordion
-  --#{$accordion}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$accordion}--BackgroundColor: transparent;
   --#{$accordion}--RowGap: var(--pf-t--global--spacer--xs); // No applicable spacer
 
   // accordion item
+  --#{$accordion}__item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}__item--BorderRadius: var(--pf-t--global--border--radius--200);
   --#{$accordion}__item--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked); // TODO - remove "m-expanded" in breaking change
 
@@ -17,7 +18,7 @@
   --#{$accordion}__toggle--m-expanded--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$accordion}__toggle--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$accordion}__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$accordion}__toggle--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
+  --#{$accordion}__item--m-expanded__toggle--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$accordion}__toggle--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$accordion}__toggle--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__toggle--ZIndex: var(--pf-t--global--z-index--xs);
@@ -45,10 +46,10 @@
 
   // accordion expandable content
   --#{$accordion}__expandable-content--MarginInlineEnd: var(--pf-t--global--spacer--md);
-  --#{$accordion}__expandable-content--MarginBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$accordion}__expandable-content--MarginBlockStart: 0;
   --#{$accordion}__expandable-content--MarginBlockEnd: 0;
   --#{$accordion}__expandable-content--MarginInlineStart: var(--pf-t--global--spacer--lg);
-  --#{$accordion}__expandable-content--BackgroundColor: var(--#{$accordion}--BackgroundColor);
+  --#{$accordion}__expandable-content--BackgroundColor: transparent;
   --#{$accordion}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$accordion}__expandable-content--Color: var(--pf-t--global--text--color--regular);
   --#{$accordion}__expandable-content--FontSize: var(--pf-t--global--font--size--body--default);
@@ -58,6 +59,7 @@
   --#{$accordion}__expandable-content--Visibility: hidden;
   --#{$accordion}__item--m-expanded__expandable-content--Visibility: visible;
   --#{$accordion}__item--m-expanded__expandable-content--MaxHeight: 99999px;
+  --#{$accordion}__item--m-expanded__expandable-content--MarginBlockStart: var(--pf-t--global--spacer--sm);
   --#{$accordion}__item--m-expanded__expandable-content--MarginBlockEnd: var(--pf-t--global--spacer--lg);
 
   // expand animation
@@ -168,16 +170,13 @@
     inset: 0;
     pointer-events: none;
     content: "";
+    background: var(--#{$accordion}__item--BackgroundColor);
     border: var(--#{$accordion}__item--BorderWidth) solid var(--#{$accordion}__item--BorderColor);
     border-radius: var(--#{$accordion}__item--BorderRadius);
-    opacity: var(--#{$accordion}__item--before--Opacity);
-    transition-timing-function: var(--#{$accordion}__item--before--TransitionTimingFunction);
-    transition-duration: var(--#{$accordion}__item--before--TransitionDuration--fade);
-    transition-property: opacity;
   }
 
   &.pf-m-expanded {
-    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--m-expanded--BackgroundColor);
+    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__item--m-expanded__toggle--BackgroundColor);
     --#{$accordion}__toggle--PaddingBlockEnd: var(--#{$accordion}__toggle--m-expanded--PaddingBlockEnd);
     --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--m-expanded--BorderWidth);
     --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
@@ -187,6 +186,7 @@
     --#{$accordion}__item--before--Opacity: var(--#{$accordion}__item--m-expanded--before--Opacity);
     --#{$accordion}__item--before--TranslateY: var(--#{$accordion}__item--m-expanded--before--TranslateY);
     --#{$accordion}__item--BorderWidth: var(--#{$accordion}__item--m-expanded--BorderWidth);
+    --#{$accordion}__expandable-content--MarginBlockStart: var(--#{$accordion}__item--m-expanded__expandable-content--MarginBlockStart);
     --#{$accordion}__expandable-content--TransitionDuration--slide: var(--#{$accordion}__expandable-content--TransitionDuration--expand--slide);
     --#{$accordion}__expandable-content--TransitionDuration--fade: var(--#{$accordion}__expandable-content--TransitionDuration--expand--fade);
     --#{$accordion}__expandable-content--Opacity: var(--#{$accordion}__item--m-expanded__expandable-content--Opacity);
@@ -249,11 +249,6 @@
 }
 
 .#{$accordion}__expandable-content:where([hidden]) {
-  --#{$accordion}__expandable-content--MarginBlockStart: 0;
-  --#{$accordion}__expandable-content--MarginBlockEnd: 0;
-  --#{$accordion}__expandable-content--MarginInlineStart: 0;
-  --#{$accordion}__expandable-content--MarginInlineEnd: 0;
-
   display: revert;
 }
 
@@ -271,7 +266,7 @@
   transition-delay: 0s, 0s, var(--#{$accordion}__expandable-content--TransitionDuration--fade), var(--#{$accordion}__expandable-content--TransitionDuration--fade), var(--#{$accordion}__expandable-content--TransitionDuration--fade);
   transition-timing-function: var(--#{$accordion}__expandable-content--TransitionTimingFunction);
   transition-duration: var(--#{$accordion}__expandable-content--TransitionDuration--fade), var(--#{$accordion}__expandable-content--TransitionDuration--slide), 0s, 0s, 0s;
-  transition-property: opacity, translate, visibility, max-height, margin-block-end;
+  transition-property: opacity, translate, visibility, max-height, margin;
   translate: 0 var(--#{$accordion}__expandable-content--TranslateY);
 
   &.pf-m-fixed {

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -176,9 +176,7 @@
   }
 
   &.pf-m-expanded {
-    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__item--m-expanded__toggle--BackgroundColor);
     --#{$accordion}__toggle--PaddingBlockEnd: var(--#{$accordion}__toggle--m-expanded--PaddingBlockEnd);
-    --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--m-expanded--BorderWidth);
     --#{$accordion}__toggle-text--FontWeight: var(--#{$accordion}__toggle--m-expanded__toggle-text--FontWeight);
     --#{$accordion}__toggle-icon--Rotate: var(--#{$accordion}__toggle--m-expanded__toggle-icon--Rotate);
     --#{$accordion}__item--before--TransitionDuration--slide: var(--#{$accordion}__item--before--TransitionDuration--expand--slide);
@@ -227,9 +225,14 @@
     border-radius: inherit;
   }
 
-  :where(.#{$accordion}__item:not(.pf-m-expanded)) &:is(:hover, :focus) {
+  &:is(:hover, :focus) {
     --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__toggle--hover--BackgroundColor);
     --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--hover--BorderWidth);
+  }
+
+  .#{$accordion}__item.pf-m-expanded & {
+    --#{$accordion}__toggle--BackgroundColor: var(--#{$accordion}__item--m-expanded__toggle--BackgroundColor);
+    --#{$accordion}__toggle--BorderWidth: var(--#{$accordion}__toggle--m-expanded--BorderWidth);
   }
 }
 

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -2,11 +2,10 @@
 
 @include pf-root($accordion) {
   // accordion
-  --#{$accordion}--BackgroundColor: transparent;
+  --#{$accordion}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}--RowGap: var(--pf-t--global--spacer--xs); // No applicable spacer
 
   // accordion item
-  --#{$accordion}__item--BackgroundColor: var(--pf-t--global--background--color--primary--default);
   --#{$accordion}__item--BorderRadius: var(--pf-t--global--border--radius--200);
   --#{$accordion}__item--m-expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked); // TODO - remove "m-expanded" in breaking change
 
@@ -170,7 +169,6 @@
     inset: 0;
     pointer-events: none;
     content: "";
-    background: var(--#{$accordion}__item--BackgroundColor);
     border: var(--#{$accordion}__item--BorderWidth) solid var(--#{$accordion}__item--BorderColor);
     border-radius: var(--#{$accordion}__item--BorderRadius);
   }


### PR DESCRIPTION
Closes #8079

Summary:
- Separated the toggle background color from the expandable content/before background color
- Updated expandable content background color to match overall accordion background color (see comment)
- Updated expandable content margin to match Figma & removed expandable content body padding (was previously split due to differing background colors)
- Updated expanded toggle padding to be uniform for large variant
- Updated hover toggle styling to not apply when item is expanded (clicked styling should take precedence)
- Removed visible margin on expandable content when hidden
- Added toggle border width for expanded items (HC)
- Removed expandable content border (HC)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Accordion root now uses a transparent background and clearer expanded-item visuals.
  * Improved expanded-state toggle visuals (background, border and spacing) for consistent appearance.
  * Harmonized spacing and responsive margins for expandable content; adjusted large-display toggle padding.
  * Hover/focus effects limited to non-expanded items for clearer interactions.
  * Smoother expand/collapse timing and transitions; removed extra body padding for cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->