### PR TITLE
feat(card): update card to use unified theme tokens

### DIFF
--- a/src/patternfly/components/Card/card-header-toggle-icon.hbs
+++ b/src/patternfly/components/Card/card-header-toggle-icon.hbs
@@ -2,5 +2,5 @@
   {{#if card-header-toggle-icon--attribute}}
     {{{card-header-toggle-icon--attribute}}}
   {{/if}}>
-  {{pfIcon "rh-ui-caret-right"}}
+  {{pfIcon "rh-microns-caret-down"}}
 </span>

--- a/src/patternfly/components/Card/card-header-toggle-icon.hbs
+++ b/src/patternfly/components/Card/card-header-toggle-icon.hbs
@@ -2,5 +2,5 @@
   {{#if card-header-toggle-icon--attribute}}
     {{{card-header-toggle-icon--attribute}}}
   {{/if}}>
-  <i class="fas fa-angle-right" aria-hidden="true"></i>
+  {{pfIcon "rh-ui-caret-right"}}
 </span>

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -249,8 +249,8 @@
     --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
 
-    &.pf-m-selectable:not(.pf-m-current):not(.pf-m-selected),
-    &.pf-m-clickable:not(.pf-m-current):not(.pf-m-selected) {
+    &.pf-m-selectable:not(.pf-m-current, .pf-m-selected),
+    &.pf-m-clickable:not(.pf-m-current, .pf-m-selected) {
       --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
       --#{$card}--BorderWidth: var(--#{$card}--m-selectable--BorderWidth);
     }

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -148,8 +148,9 @@
   // SELECTABLE or CLICKABLE CARDS
   &.pf-m-selectable,
   &.pf-m-clickable {
-    isolation: isolate;
     --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
+
+    isolation: isolate;
 
     &::before {
       border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -99,8 +99,6 @@
 
   // Secondary
   --#{$card}--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$card}--m-secondary--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$card}--m-secondary--BorderWidth: var(--pf-t--global--border--width--high-contrast--regular);
 
   // Full height
   --#{$card}--m-full-height--Height: 100%;
@@ -245,8 +243,6 @@
   }
 
   &.pf-m-secondary {
-    --#{$card}--BorderColor: var(--#{$card}--m-secondary--BorderColor);
-    --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
 
     &.pf-m-selectable:not(.pf-m-current, .pf-m-selected),

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -2,10 +2,11 @@
 
 @include pf-root($card) {
   --#{$card}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$card}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$card}--BorderColor: var(--pf-t--global--border--color--subtle);
   --#{$card}--BorderStyle: solid;
   --#{$card}--BorderWidth: var(--pf-t--global--border--width--box--default);
   --#{$card}--BorderRadius: var(--pf-t--global--border--radius--medium);
+  --#{$card}--BoxShadow: var(--pf-t--global--box-shadow--sm);
   --#{$card}--first-child--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$card}--child--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$card}--child--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
@@ -39,7 +40,8 @@
   --#{$card}--m-expanded__header-toggle-icon--Rotate: -180deg;
 
   // Selectable/Clickable
-  --#{$card}--m-selectable--BorderWidth: var(--#{$card}--BorderWidth);
+  --#{$card}--m-selectable--BorderWidth: var(--pf-t--global--border--width--box--default);
+  --#{$card}--m-selectable--BorderColor: var(--pf-t--global--border--color--control--default);
 
   // Clickable clicked
   --#{$card}--m-clickable--m-current--BorderColor: var(--pf-t--global--border--color--clicked);
@@ -110,6 +112,10 @@
   // Toggle right
   --#{$card}__header--m-toggle-right--toggle--MarginInlineEnd: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header--m-toggle-right--toggle--MarginInlineStart: var(--pf-t--global--spacer--gap--text-to-element--default);
+
+  // As tile
+  --#{$card}--m-as-tile--BackgroundColor: var(--pf-t--global--background--color--control--default);
+  --#{$card}--m-as-tile--BorderColor: var(--pf-t--global--border--color--control--default);
 }
 
 .#{$card} {
@@ -120,6 +126,7 @@
   background-color: var(--#{$card}--BackgroundColor);
   border: 0;
   border-radius: var(--#{$card}--BorderRadius);
+  box-shadow: var(--#{$card}--BoxShadow);
 
   &::before {
     position: absolute;
@@ -142,6 +149,7 @@
   &.pf-m-selectable,
   &.pf-m-clickable {
     isolation: isolate;
+    --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
 
     &::before {
       border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border
@@ -198,6 +206,11 @@
 
   // when the whole card is clickable and the card actions are invisible, remove the padding/margin so it doesn't take up space
   @at-root .#{$card}__actions:has(> .#{$card}__selectable-actions input.#{$pf-prefix}screen-reader), // targets "card as tile", which are selectable cards with inputs
+  &.pf-m-selectable {
+    --#{$card}--BackgroundColor: var(--#{$card}--m-as-tile--BackgroundColor);
+    --#{$card}--BorderColor: var(--#{$card}--m-as-tile--BorderColor);
+  }
+  
   &.pf-m-clickable:not(.pf-m-selectable) {
     --#{$card}__actions--PaddingInlineStart: 0;
     --#{$card}__actions--MarginBlockStart: 0;
@@ -232,6 +245,11 @@
     --#{$card}--BorderColor: var(--#{$card}--m-secondary--BorderColor);
     --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
+
+    &.pf-m-selectable, &.pf-m-clickable {
+      --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
+      --#{$card}--BorderWidth: var(--#{$card}--m-selectable--BorderWidth);
+    }
   }
 
   &.pf-m-plain {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -2,10 +2,11 @@
 
 @include pf-root($card) {
   --#{$card}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$card}--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$card}--BorderColor: var(--pf-t--global--border--color--subtle);
   --#{$card}--BorderStyle: solid;
   --#{$card}--BorderWidth: var(--pf-t--global--border--width--box--default);
   --#{$card}--BorderRadius: var(--pf-t--global--border--radius--medium);
+  --#{$card}--BoxShadow: var(--pf-t--global--box-shadow--sm);
   --#{$card}--first-child--PaddingBlockStart: var(--pf-t--global--spacer--lg);
   --#{$card}--child--PaddingInlineEnd: var(--pf-t--global--spacer--lg);
   --#{$card}--child--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
@@ -39,7 +40,8 @@
   --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
 
   // Selectable/Clickable
-  --#{$card}--m-selectable--BorderWidth: var(--#{$card}--BorderWidth);
+  --#{$card}--m-selectable--BorderWidth: var(--pf-t--global--border--width--box--default);
+  --#{$card}--m-selectable--BorderColor: var(--pf-t--global--border--color--control--default);
 
   // Clickable clicked
   --#{$card}--m-clickable--m-current--BorderColor: var(--pf-t--global--border--color--clicked);
@@ -110,6 +112,10 @@
   // Toggle right
   --#{$card}__header--m-toggle-right--toggle--MarginInlineEnd: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header--m-toggle-right--toggle--MarginInlineStart: var(--pf-t--global--spacer--gap--text-to-element--default);
+
+  // As tile
+  --#{$card}--m-as-tile--BackgroundColor: var(--pf-t--global--background--color--control--default);
+  --#{$card}--m-as-tile--BorderColor: var(--pf-t--global--border--color--control--default);
 }
 
 .#{$card} {
@@ -120,6 +126,7 @@
   background-color: var(--#{$card}--BackgroundColor);
   border: 0;
   border-radius: var(--#{$card}--BorderRadius);
+  box-shadow: var(--#{$card}--BoxShadow);
 
   &::before {
     position: absolute;
@@ -142,6 +149,7 @@
   &.pf-m-selectable,
   &.pf-m-clickable {
     isolation: isolate;
+    --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
 
     &::before {
       border: none; // border will come from the input's ::before instead of the card so remove this so there's isn't a double border
@@ -198,6 +206,11 @@
 
   // when the whole card is clickable and the card actions are invisible, remove the padding/margin so it doesn't take up space
   @at-root .#{$card}__actions:has(> .#{$card}__selectable-actions input.#{$pf-prefix}screen-reader), // targets "card as tile", which are selectable cards with inputs
+  &.pf-m-selectable {
+    --#{$card}--BackgroundColor: var(--#{$card}--m-as-tile--BackgroundColor);
+    --#{$card}--BorderColor: var(--#{$card}--m-as-tile--BorderColor);
+  }
+  
   &.pf-m-clickable:not(.pf-m-selectable) {
     --#{$card}__actions--PaddingInlineStart: 0;
     --#{$card}__actions--MarginBlockStart: 0;
@@ -232,6 +245,11 @@
     --#{$card}--BorderColor: var(--#{$card}--m-secondary--BorderColor);
     --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
+
+    &.pf-m-selectable, &.pf-m-clickable {
+      --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
+      --#{$card}--BorderWidth: var(--#{$card}--m-selectable--BorderWidth);
+    }
   }
 
   &.pf-m-plain {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -37,7 +37,7 @@
   --#{$card}__header-toggle--MarginInlineStart: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
   --#{$card}__header-toggle-icon--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$card}__header-toggle-icon--TransitionDuration: var(--pf-t--global--motion--duration--icon--default);
-  --#{$card}--m-expanded__header-toggle-icon--Rotate: 90deg;
+  --#{$card}--m-expanded__header-toggle-icon--Rotate: -180deg;
 
   // Selectable/Clickable
   --#{$card}--m-selectable--BorderWidth: var(--pf-t--global--border--width--box--default);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -206,13 +206,14 @@
   }
   // stylelint-enable selector-max-class
 
-  // when the whole card is clickable and the card actions are invisible, remove the padding/margin so it doesn't take up space
+  
   @at-root .#{$card}__actions:has(> .#{$card}__selectable-actions input.#{$pf-prefix}screen-reader), // targets "card as tile", which are selectable cards with inputs
   &:has(.#{$card}__selectable-actions input.#{$pf-prefix}screen-reader) {
     --#{$card}--BackgroundColor: var(--#{$card}--m-as-tile--BackgroundColor);
     --#{$card}--BorderColor: var(--#{$card}--m-as-tile--BorderColor);
   }
   
+  // when the whole card is clickable and the card actions are invisible, remove the padding/margin so it doesn't take up space
   &.pf-m-clickable:not(.pf-m-selectable) {
     --#{$card}__actions--PaddingInlineStart: 0;
     --#{$card}__actions--MarginBlockStart: 0;

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -108,6 +108,7 @@
   // Plain - no border or background color
   --#{$card}--m-plain--BorderColor: transparent;
   --#{$card}--m-plain--BackgroundColor: transparent;
+  --#{$card}--m-plain--BoxShadow: none;
 
   // Toggle right
   --#{$card}__header--m-toggle-right--toggle--MarginInlineEnd: calc(var(--pf-t--global--spacer--action--horizontal--plain--default) * -1);
@@ -207,7 +208,7 @@
 
   // when the whole card is clickable and the card actions are invisible, remove the padding/margin so it doesn't take up space
   @at-root .#{$card}__actions:has(> .#{$card}__selectable-actions input.#{$pf-prefix}screen-reader), // targets "card as tile", which are selectable cards with inputs
-  &.pf-m-selectable {
+  &:has(.#{$card}__selectable-actions input.#{$pf-prefix}screen-reader) {
     --#{$card}--BackgroundColor: var(--#{$card}--m-as-tile--BackgroundColor);
     --#{$card}--BorderColor: var(--#{$card}--m-as-tile--BorderColor);
   }
@@ -256,6 +257,7 @@
   &.pf-m-plain {
     --#{$card}--BorderColor: var(--#{$card}--m-plain--BorderColor);
     --#{$card}--BackgroundColor: var(--#{$card}--m-plain--BackgroundColor);
+    --#{$card}--BoxShadow: var(--#{$card}--m-plain--BoxShadow);
   }
 
   &.pf-m-expanded {

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -248,7 +248,8 @@
     --#{$card}--BorderWidth: var(--#{$card}--m-secondary--BorderWidth);
     --#{$card}--BackgroundColor: var(--#{$card}--m-secondary--BackgroundColor);
 
-    &.pf-m-selectable, &.pf-m-clickable {
+    &.pf-m-selectable:not(.pf-m-current):not(.pf-m-selected),
+    &.pf-m-clickable:not(.pf-m-current):not(.pf-m-selected) {
       --#{$card}--BorderColor: var(--#{$card}--m-selectable--BorderColor);
       --#{$card}--BorderWidth: var(--#{$card}--m-selectable--BorderWidth);
     }

--- a/src/patternfly/demos/Card/card-template-gallery.hbs
+++ b/src/patternfly/demos/Card/card-template-gallery.hbs
@@ -2,11 +2,9 @@
   {{#> card card--id=(concat card-template-gallery--id '-card-empty-state') card--modifier="pf-m-selectable-raised pf-m-compact"}}
     {{#> bullseye}}
       {{#> empty-state empty-state--modifier="pf-m-xs"}}
-        {{#> icon }}
-          {{#> icon-content icon-content--modifier="{{pfv}}empty-state__icon"}}
-            {{pfIcon "rh-ui-add-circle-fill"}}
-          {{/icon-content}}
-        {{/icon}}
+        <div class="{{concat (pfv) "empty-state__icon"}}">
+          {{pfIcon "rh-ui-add-circle-fill"}}
+        </div>
         {{> card-title card-title-text--value="Add a new card to your page" card-title-text--modifier="pf-m-md"}}
         {{#> empty-state-secondary}}
           {{#> button button--IsLink=true}}

--- a/src/patternfly/demos/Card/card-template-gallery.hbs
+++ b/src/patternfly/demos/Card/card-template-gallery.hbs
@@ -2,7 +2,11 @@
   {{#> card card--id=(concat card-template-gallery--id '-card-empty-state') card--modifier="pf-m-selectable-raised pf-m-compact"}}
     {{#> bullseye}}
       {{#> empty-state empty-state--modifier="pf-m-xs"}}
-        <i class="fas fa-plus-circle {{pfv}}empty-state__icon"></i>
+        {{#> icon }}
+          {{#> icon-content icon-content--modifier="{{pfv}}empty-state__icon"}}
+            {{pfIcon "rh-ui-add-circle-fill"}}
+          {{/icon-content}}
+        {{/icon}}
         {{> card-title card-title-text--value="Add a new card to your page" card-title-text--modifier="pf-m-md"}}
         {{#> empty-state-secondary}}
           {{#> button button--IsLink=true}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -131,7 +131,7 @@ import './Card.css'
                 <a href="#">See what's possible with the Explore page</a>
               </li>
               <li>
-                <a href="#">OpenShift 4.5: Top Tasks <i class="fas fa-external-link-alt" aria-hidden="true"></i></a>
+                <a href="#">OpenShift 4.5: Top Tasks {{pfIcon "rh-ui-external-link"}}</a>
               </li>
               <li>
                 <a href="#">Try a demo app</a>
@@ -293,7 +293,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-success"}}
-              <i class="fas fa-check-circle" aria-hidden="true"></i>
+              {{pfIcon "rh-ui-check-circle"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -303,7 +303,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-warning"}}
-              <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+              {{pfIcon "rh-ui-warning"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -313,7 +313,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-danger"}}
-              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+              {{pfIcon "rh-ui-error"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -330,7 +330,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-check-circle"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -343,7 +343,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -362,7 +362,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-check-circle"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -375,7 +375,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -394,7 +394,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -407,7 +407,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -430,7 +430,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -443,7 +443,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -463,7 +463,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-check-circle"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -476,7 +476,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -496,7 +496,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-warning"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -509,7 +509,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -580,7 +580,7 @@ import './Card.css'
                 {{#> l-flex-item}}
                   {{#> icon icon--modifier="pf-m-inline"}}
                     {{#> icon-content icon-content--modifier="pf-m-success"}}
-                      <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                     {{/icon-content}}
                   {{/icon}}
                 {{/l-flex-item}}
@@ -632,7 +632,7 @@ import './Card.css'
                 {{#> l-flex-item}}
                   {{#> icon icon--modifier="pf-m-inline"}}
                     {{#> icon-content icon-content--modifier="pf-m-success"}}
-                      <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                     {{/icon-content}}
                   {{/icon}}
                 {{/l-flex-item}}
@@ -776,7 +776,7 @@ import './Card.css'
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-danger"}}
-              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
             {{/icon-content}}
           {{/icon}}
           <a hfer="#">25 incidents detected</a>
@@ -1127,7 +1127,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-error"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -1153,7 +1153,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-check-circle"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -1201,7 +1201,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                    {{pfIcon "rh-ui-check-circle"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}

--- a/src/patternfly/demos/Card/examples/Card.md
+++ b/src/patternfly/demos/Card/examples/Card.md
@@ -293,7 +293,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-success"}}
-              {{pfIcon "rh-ui-check-circle"}}
+              {{pfIcon "rh-ui-check-circle-fill"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -303,7 +303,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-warning"}}
-              {{pfIcon "rh-ui-warning"}}
+              {{pfIcon "rh-ui-warning-fill"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -313,7 +313,7 @@ import './Card.css'
         {{#> card-body}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-danger"}}
-              {{pfIcon "rh-ui-error"}}
+              {{pfIcon "rh-ui-error-fill"}}
             {{/icon-content}}
           {{/icon}}
         {{/card-body}}
@@ -330,7 +330,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-check-circle"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -343,7 +343,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -362,7 +362,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-check-circle"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -375,7 +375,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -394,7 +394,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -407,7 +407,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -430,7 +430,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -443,7 +443,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -463,7 +463,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-check-circle"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -476,7 +476,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -496,7 +496,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-warning"}}
-                    {{pfIcon "rh-ui-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -509,7 +509,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -580,7 +580,7 @@ import './Card.css'
                 {{#> l-flex-item}}
                   {{#> icon icon--modifier="pf-m-inline"}}
                     {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                     {{/icon-content}}
                   {{/icon}}
                 {{/l-flex-item}}
@@ -632,7 +632,7 @@ import './Card.css'
                 {{#> l-flex-item}}
                   {{#> icon icon--modifier="pf-m-inline"}}
                     {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                     {{/icon-content}}
                   {{/icon}}
                 {{/l-flex-item}}
@@ -776,7 +776,7 @@ import './Card.css'
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> icon icon--modifier="pf-m-inline"}}
             {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
             {{/icon-content}}
           {{/icon}}
           <a hfer="#">25 incidents detected</a>
@@ -1127,7 +1127,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                    {{pfIcon "rh-ui-error"}}
+                    {{pfIcon "rh-ui-error-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -1153,7 +1153,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-check-circle"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}
@@ -1201,7 +1201,7 @@ import './Card.css'
               {{#> l-flex-item}}
                 {{#> icon icon--modifier="pf-m-inline"}}
                   {{#> icon-content icon-content--modifier="pf-m-success"}}
-                    {{pfIcon "rh-ui-check-circle"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
                   {{/icon-content}}
                 {{/icon}}
               {{/l-flex-item}}

--- a/src/patternfly/demos/Card/templates/card-demo--popover-table.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--popover-table.hbs
@@ -21,7 +21,12 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
         {{#> table-text}}
-          20%&nbsp;<i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-200" aria-hidden="true"></i>
+          20%&nbsp;
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                {{pfIcon "rh-ui-error-fill"}}
+              {{/icon-content}}
+            {{/icon}}
         {{/table-text}}
       {{/table-td}}
     {{/table-tr}}
@@ -53,7 +58,12 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
         {{#> table-text}}
-          100%&nbsp;<i class="fas fa-check-circle {{pfv 'u'}}success-color-200" aria-hidden="true"></i>
+          100%&nbsp;
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
         {{/table-text}}
       {{/table-td}}
     {{/table-tr}}
@@ -78,7 +88,12 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
         {{#> table-text}}
-          100%&nbsp;<i class="fas fa-check-circle {{pfv 'u'}}success-color-200" aria-hidden="true"></i>
+          100%&nbsp;
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
         {{/table-text}}
       {{/table-td}}
     {{/table-tr}}
@@ -103,7 +118,12 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
         {{#> table-text}}
-          91%&nbsp;<i class="fas fa-check-circle {{pfv 'u'}}success-color-200" aria-hidden="true"></i>
+          91%&nbsp;
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
         {{/table-text}}
       {{/table-td}}
     {{/table-tr}}

--- a/src/patternfly/demos/Card/templates/card-demo--status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--status-card.hbs
@@ -9,7 +9,11 @@
       {{#> grid-item}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex-item}}
             <span>Cluster</span>
@@ -19,7 +23,11 @@
       {{#> grid-item}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> l-flex-item}}
-            <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                {{pfIcon "rh-ui-error-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex-item}}
             <span class="popover-parent">
@@ -32,7 +40,11 @@
       {{#> grid-item}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> l-flex-item}}
-            <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                {{pfIcon "rh-ui-error-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}
@@ -47,7 +59,11 @@
       {{#> grid-item}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}

--- a/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
@@ -2,7 +2,11 @@
     {{#> card card--id="card-empty-state" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> bullseye}}
         {{#> empty-state empty-state--modifier="pf-m-xs"}}
-          <i class="fas fa-plus-circle {{pfv}}empty-state__icon"></i>
+          {{#> icon }}
+            {{#> icon-content icon-content--modifier="{{pfv}}empty-state__icon"}}
+              {{pfIcon "rh-ui-add-circle-fill"}}
+            {{/icon-content}}
+          {{/icon}}
           {{#> title titleType="h2" title--modifier="pf-m-md"}}
             Add a new card to your page
           {{/title}}

--- a/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
@@ -2,11 +2,9 @@
     {{#> card card--id="card-empty-state" card--modifier="pf-m-selectable-raised pf-m-compact"}}
       {{#> bullseye}}
         {{#> empty-state empty-state--modifier="pf-m-xs"}}
-          {{#> icon }}
-            {{#> icon-content icon-content--modifier=(concat pfv "empty-state__icon")}}
-              {{pfIcon "rh-ui-add-circle-fill"}}
-            {{/icon-content}}
-          {{/icon}}
+          <div class="{{concat (pfv) "empty-state__icon"}}">
+            {{pfIcon "rh-ui-add-circle-fill"}}
+          </div>
           {{#> title titleType="h2" title--modifier="pf-m-md"}}
             Add a new card to your page
           {{/title}}

--- a/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
+++ b/src/patternfly/demos/Card/templates/card-demo--template-gallery.hbs
@@ -3,7 +3,7 @@
       {{#> bullseye}}
         {{#> empty-state empty-state--modifier="pf-m-xs"}}
           {{#> icon }}
-            {{#> icon-content icon-content--modifier="{{pfv}}empty-state__icon"}}
+            {{#> icon-content icon-content--modifier=(concat pfv "empty-state__icon"}}
               {{pfIcon "rh-ui-add-circle-fill"}}
             {{/icon-content}}
           {{/icon}}

--- a/src/patternfly/demos/Card/templates/card-template-data-list.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-data-list.hbs
@@ -18,7 +18,11 @@
               <a href="#">
                 {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
                   <span>3</span>
-                  <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                  {{#> icon }}
+                    {{#> icon-content icon-content--modifier="pf-m-success"}}
+                      {{pfIcon "rh-ui-check-circle-fill"}}
+                    {{/icon-content}}
+                  {{/icon}}
                 {{/l-flex}}
               </a>
             {{/data-list-cell}}
@@ -35,7 +39,11 @@
               <a href="#">
                 {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
                   <span>8</span>
-                  <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                  {{#> icon }}
+                    {{#> icon-content icon-content--modifier="pf-m-success"}}
+                      {{pfIcon "rh-ui-check-circle-fill"}}
+                    {{/icon-content}}
+                  {{/icon}}
                 {{/l-flex}}
               </a>
             {{/data-list-cell}}
@@ -52,7 +60,11 @@
               <a href="#">
                 {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
                   <span>20</span>
-                  <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                  {{#> icon }}
+                    {{#> icon-content icon-content--modifier="pf-m-success"}}
+                      {{pfIcon "rh-ui-check-circle-fill"}}
+                    {{/icon-content}}
+                  {{/icon}}
                 {{/l-flex}}
               </a>
             {{/data-list-cell}}
@@ -69,7 +81,11 @@
               <a href="#">
                 {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
                   <span>12</span>
-                  <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                  {{#> icon }}
+                    {{#> icon-content icon-content--modifier="pf-m-success"}}
+                      {{pfIcon "rh-ui-check-circle-fill"}}
+                    {{/icon-content}}
+                  {{/icon}}
                 {{/l-flex}}
               </a>
             {{/data-list-cell}}
@@ -86,7 +102,11 @@
               <a href="#">
                 {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
                   <span>18</span>
-                  <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                  {{#> icon }}
+                    {{#> icon-content icon-content--modifier="pf-m-success"}}
+                      {{pfIcon "rh-ui-check-circle-fill"}}
+                    {{/icon-content}}
+                  {{/icon}}
                 {{/l-flex}}
               </a>
             {{/data-list-cell}}

--- a/src/patternfly/demos/Card/templates/card-template-events.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-events.hbs
@@ -16,7 +16,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                    {{pfIcon "rh-ui-error-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Readiness probe failed
@@ -34,7 +38,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-success"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Successful assignment
@@ -70,7 +78,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-success"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Created container
@@ -89,7 +101,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-exclamation-triangle {{pfv 'u'}}warning-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-warning"}}
+                    {{pfIcon "rh-ui-warning-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 CPU utilitization over 50%
@@ -108,7 +124,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                    {{pfIcon "rh-ui-error-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Rook-osd-10-328949
@@ -127,7 +147,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-success"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Created container
@@ -146,7 +170,11 @@
           {{#> description-list-term}}
             {{#> l-flex l-flex--modifier="pf-m-nowrap"}}
               {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
-                <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+                {{#> icon }}
+                  {{#> icon-content icon-content--modifier="pf-m-success"}}
+                    {{pfIcon "rh-ui-check-circle-fill"}}
+                  {{/icon-content}}
+                {{/icon}}
               {{/l-flex-item}}
               {{#> l-flex-item}}
                 Created container

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -12,7 +12,7 @@
                       {{#if card-template-expandable-status-card--label-icon}}
                         {{{card-template-expandable-status-card--label-icon}}}
                       {{else}}
-                        <i class="pf-v6-pficon pf-v6-pficon-port" aria-hidden="true"></i>
+                        {{pfIcon "rh-ui-port"}}
                       {{/if}}
                     {{/label-icon}}
                     {{> label-text label-text--value=(ternary card-template-expandable-status-card--label-text card-template-expandable-status-card--label-text 'Performance')}}
@@ -51,10 +51,18 @@
           {{/if}}
           {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
             {{#if card-template-expandable-status-card--RequiresReboot}}
-              <i class="pf-v6-pficon pf-v6-pficon-on {{pfv 'u'}}danger-color-100" style="line-height: 1" aria-hidden="true"></i>
+              {{#> icon}}
+                {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                  {{pfIcon "rh-ui-connected"}}
+                {{/icon-content}}
+              {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is</b> required</p>
             {{else}}
-              <i class="pf-v6-pficon pf-v6-pficon-on {{pfv 'u'}}color-400" style="line-height: 1" aria-hidden="true"></i>
+              {{#> icon}}
+                {{#> icon-content icon-content--modifier="pf-m-success"}}
+                  {{pfIcon "rh-ui-connected"}}
+                {{/icon-content}}
+              {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is not</b> required</p>
             {{/if}}
           {{/l-flex}}

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -10,7 +10,7 @@
                   {{#> label label--color="blue" label--IsOutlined=true}}
                     {{#> label-icon}}
                       {{#if card-template-expandable-status-card--label-icon}}
-                        {{{card-template-expandable-status-card--label-icon}}}
+                        {{pfIcon card-template-expandable-status-card--label-icon}}
                       {{else}}
                         {{pfIcon "rh-ui-port"}}
                       {{/if}}

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
@@ -16,7 +16,7 @@
         {{> card-template-expandable-status-card card-template-expandable-status-card--HasIncident=true}}
         {{> divider divider--modifier="pf-m-vertical-on-md pf-m-inset-3xl"}}
         {{> card-template-expandable-status-card
-            card-template-expandable-status-card--label-icon='<i class="fas fa-cube" aria-hidden="true"></i>'
+            card-template-expandable-status-card--label-icon='{{pfIcon "rh-ui-container"}}'
             card-template-expandable-status-card--label-text="Stablility"
             card-template-expandable-status-card--label--HasOverflowLabel=true
             card-template-expandable-status-card--header-link--text="211 systems"
@@ -25,7 +25,7 @@
           }}
         {{> divider divider--modifier="pf-m-vertical-on-md pf-m-inset-3xl"}}
         {{> card-template-expandable-status-card
-            card-template-expandable-status-card--label-icon='<i class="pf-v6-pficon pf-v6-pficon-automation" aria-hidden="true"></i>'
+            card-template-expandable-status-card--label-icon='{{pfIcon "rh-ui-automation"}}'
             card-template-expandable-status-card--label-text="Availability"
             card-template-expandable-status-card--header-link--text="166 systems"
             card-template-expandable-status-card--body--text="Fine tune your Oracle DB configuration to improve database performance and avoid process failure"

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
@@ -25,7 +25,7 @@
           }}
         {{> divider divider--modifier="pf-m-vertical-on-md pf-m-inset-3xl"}}
         {{> card-template-expandable-status-card
-            card-template-expandable-status-card--label-icon='{{pfIcon "rh-ui-automation"}}'
+            card-template-expandable-status-card--label-icon="rh-ui-automation"
             card-template-expandable-status-card--label-text="Availability"
             card-template-expandable-status-card--header-link--text="166 systems"
             card-template-expandable-status-card--body--text="Fine tune your Oracle DB configuration to improve database performance and avoid process failure"

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
@@ -16,7 +16,7 @@
         {{> card-template-expandable-status-card card-template-expandable-status-card--HasIncident=true}}
         {{> divider divider--modifier="pf-m-vertical-on-md pf-m-inset-3xl"}}
         {{> card-template-expandable-status-card
-            card-template-expandable-status-card--label-icon='{{pfIcon "rh-ui-container"}}'
+            card-template-expandable-status-card--label-icon="rh-ui-container"
             card-template-expandable-status-card--label-text="Stablility"
             card-template-expandable-status-card--label--HasOverflowLabel=true
             card-template-expandable-status-card--header-link--text="211 systems"

--- a/src/patternfly/demos/Card/templates/card-template-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-status.hbs
@@ -9,7 +9,11 @@
       {{#> gallery gallery--modifier="pf-m-gutter" gallery--attribute='style="--pf-v6-l-gallery--GridTemplateColumns--min: 100%; --pf-v6-l-gallery--GridTemplateColumns--min-on-sm: 180px; --pf-v6-l-gallery--GridTemplateColumns--min-on-lg: 150px; --pf-v6-l-gallery--GridTemplateColumns--max-on-sm: 1fr;"'}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex-item}}
             <span>Cluster</span>
@@ -17,7 +21,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                {{pfIcon "rh-ui-error-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex-item l-flex-item--modifier="pf-v6-u-text-nowrap"}}
             <span class="popover-parent">
@@ -28,7 +36,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item l-flex-item--modifier="pf-v6-u-text-nowrap"}}
-            <i class="fas fa-exclamation-circle {{pfv 'u'}}danger-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                {{pfIcon "rh-ui-error-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}
@@ -41,7 +53,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}
@@ -54,7 +70,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}
@@ -67,7 +87,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}
@@ -77,7 +101,11 @@
         {{/l-flex}}
         {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-nowrap"}}
           {{#> l-flex-item}}
-            <i class="fas fa-check-circle {{pfv 'u'}}success-color-100" aria-hidden="true"></i>
+            {{#> icon }}
+              {{#> icon-content icon-content--modifier="pf-m-success"}}
+                {{pfIcon "rh-ui-check-circle-fill"}}
+              {{/icon-content}}
+            {{/icon}}
           {{/l-flex-item}}
           {{#> l-flex l-flex--modifier="pf-m-column pf-m-space-items-none"}}
             {{#> l-flex-item}}


### PR DESCRIPTION
Closes #8086 

Figma: https://www.figma.com/design/qRn3S225WwGHIdgGZX0LTC/Unified-Theme--Design-Tokens--Styles---Specs?node-id=9552-14258&p=f&t=AmaPrRnVNe38gCx6-0

Convenience link: https://pf-pr-8180.surge.sh/components/card

Redo of https://github.com/patternfly/patternfly/pull/8180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card component styling for improved border colors, box shadows, and interactive states (selectable, clickable, tile variants).
  * Modernized icon rendering across card templates and examples with PatternFly icon components for consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->