### PR TITLE
fix(clipboard-copy): update icons and verify tokens

### DIFF
--- a/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
@@ -1,6 +1,4 @@
-<div class="{{pfv}}clipboard-copy__expandable-content
-{{#if clipboard-copy-expandable-content--IsReadonlyExpandable}} pf-m-expandable-readonly{{/if}}
-{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
+<div class="{{pfv}}clipboard-copy__expandable-content {{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
   {{#unless clipboard-copy--IsExpanded}}hidden{{/unless}}
   {{#if clipboard-copy-expandable-content--attribute}}
     {{{clipboard-copy-expandable-content--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
@@ -1,4 +1,6 @@
-<div class="{{pfv}}clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
+<div class="{{pfv}}clipboard-copy__expandable-content
+{{#if clipboard-copy-expandable-content--IsReadonlyExpandable}} pf-m-expandable-readonly{{/if}}
+{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
   {{#unless clipboard-copy--IsExpanded}}hidden{{/unless}}
   {{#if clipboard-copy-expandable-content--attribute}}
     {{{clipboard-copy-expandable-content--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
@@ -1,4 +1,4 @@
-<div class="{{pfv}}clipboard-copy__expandable-content {{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
+<div class="{{pfv}}clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
   {{#unless clipboard-copy--IsExpanded}}hidden{{/unless}}
   {{#if clipboard-copy-expandable-content--attribute}}
     {{{clipboard-copy-expandable-content--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.hbs
@@ -3,6 +3,7 @@
   {{~#if clipboard-copy--IsInline}} pf-m-inline{{/if}}
   {{~#if clipboard-copy--IsBlock}} pf-m-block{{/if}}
   {{~#if clipboard-copy--IsTruncate}} pf-m-truncate{{/if}}
+  {{~#if clipboard-copy--IsReadonly}} pf-m-readonly{{/if}}
   {{~#if clipboard-copy--modifier}} {{clipboard-copy--modifier}}{{/if}}"
   {{#if clipboard-copy--attribute}}
     {{{clipboard-copy--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -22,6 +22,10 @@
   --#{$clipboard-copy}__expandable-content--BorderRadius: var(--pf-t--global--border--radius--control--form-element);
   --#{$clipboard-copy}__expandable-content--OutlineOffset: var(--pf-t--global--spacer--xs);
 
+  // Readonly
+  --#{$clipboard-copy}--m-readonly__expandable-content--BackgroundColor: var(--pf-t--global--background--color--control--read-only);
+  --#{$clipboard-copy}--m-readonly__expandable-content--BorderColor: var(--pf-t--global--border--color--control--read-only);
+
   // Group
   --#{$clipboard-copy}__group--Gap: var(--pf-t--global--spacer--gap--control-to-control--default);
 
@@ -62,6 +66,11 @@
       display: inline-flex;
     }
   }
+
+  &.pf-m-readonly {
+    --#{$clipboard-copy}__expandable-content--BackgroundColor: var(--#{$clipboard-copy}--m-readonly__expandable-content--BackgroundColor);
+    --#{$clipboard-copy}__expandable-content--BorderColor: var(--#{$clipboard-copy}--m-readonly__expandable-content--BorderColor);
+  }
 }
 
 
@@ -95,11 +104,6 @@
 
   pre {
     white-space: pre-wrap;
-  }
-
-  &.pf-m-expandable-readonly {
-    background-color: var(--pf-t--global--background--color--control--read-only);
-    border-color: var(--pf-t--global--border--color--control--read-only);
   }
 }
 

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -96,6 +96,11 @@
   pre {
     white-space: pre-wrap;
   }
+
+  &.pf-m-expandable-readonly {
+    background-color: var(--pf-t--global--background--color--control--read-only);
+    border-color: var(--pf-t--global--border--color--control--read-only);
+  }
 }
 
 .#{$clipboard-copy}__text {

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -13,7 +13,7 @@
   --#{$clipboard-copy}__expandable-content--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$clipboard-copy}__expandable-content--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$clipboard-copy}__expandable-content--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$clipboard-copy}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$clipboard-copy}__expandable-content--BackgroundColor: var(--pf-t--global--background--color--control--default);
   --#{$clipboard-copy}__expandable-content--BorderBlockStartWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderInlineEndWidth: var(--pf-t--global--border--width--control--default);
   --#{$clipboard-copy}__expandable-content--BorderBlockEndWidth: var(--pf-t--global--border--width--control--default);

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -267,5 +267,5 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
 | `.pf-m-truncate` | `.pf-v6-c-clipboard-copy.pf-m-truncate` | Modifies the inline copy clipboard component for use with text used in trucate component. |
 | `.pf-m-expanded` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for the expanded state. |
 | `.pf-m-expanded` | `.pf-v6-c-button.pf-m-control` | Modifies the control toggle button for the expanded state. |
-| `.pf-m-expandable-readonly` | `.pf-v6-c-clipboard-copy__expandable-content` | Modifies expandable content to match readonly form control background and boarder. |
+| `.pf-m-expandable-readonly` | `.pf-v6-c-clipboard-copy__expandable-content` | Modifies expandable content to match readonly form control background and border. |
 | `.pf-m-code` | `code.pf-v6-c-clipboard-copy__text` | Modifies the inline copy clipboard text styles for use with the `<code>` element. |

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -20,7 +20,7 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-group}}
 {{/clipboard-copy}}
 <br />
-{{#> clipboard-copy clipboard-copy--id="basic-readonly"}}
+{{#> clipboard-copy clipboard-copy--id="basic-readonly" clipboard-copy--IsReadonly="true"}}
   {{#> clipboard-copy-group}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is read-only" id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -14,7 +14,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button
       button--IsControl=true
       button--IsIcon=true
-      button--icon="copy"
+      button--icon="rh-ui-copy-fill"
       button--aria-label="Copy to clipboard basic editable example"
       button--id=(concat clipboard-copy--id '-copy-button')}}
   {{/clipboard-copy-group}}
@@ -27,7 +27,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button
       button--IsControl=true
       button--IsIcon=true
-      button--icon="copy"
+      button--icon="rh-ui-copy-fill"
       button--aria-label="Copy to clipboard basic read-only example"
       button--id=(concat clipboard-copy--id '-copy-button')}}
   {{/clipboard-copy-group}}
@@ -42,7 +42,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--AriaExpanded=false button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle unexpanded editable example" aria-controls="' clipboard-copy--id '-content"' )}}
     {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard unexpanded editable example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard unexpanded editable example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
@@ -54,7 +54,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--AriaExpanded=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle expanded editable example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard expanded editable example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard expanded editable example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'contenteditable="true" id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
@@ -67,7 +67,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--AriaExpanded=false button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only unexpanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard read-only collapsed example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only collapsed example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
@@ -79,7 +79,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--AriaExpanded=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only expanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard read-only expanded example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only expanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
@@ -92,7 +92,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--AriaExpanded=false button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle code unexpanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'dir="ltr" type="text" value="{ &quot;menu&quot;: {     &quot;id&quot;: &quot;file&quot;,     &quot;value&quot;: &quot;File&quot;,     &quot;popup&quot;: {       &quot;menuitem&quot;: [         {&quot;value&quot;: &quot;New&quot;, &quot;onclick&quot;: &quot;CreateNewDoc()&quot;},         {&quot;value&quot;: &quot;Open&quot;, &quot;onclick&quot;: &quot;OpenDoc()&quot;},         {&quot;value&quot;: &quot;Close&quot;, &quot;onclick&quot;: &quot;CloseDoc()&quot;}       ]     }   }} " id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard code unexpanded example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard code unexpanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
 { "menu": {
@@ -114,7 +114,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{> button button--IsControl=true button--AriaExpanded=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle code expanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'dir="ltr" type="text" value="{ &quot;menu&quot;: {     &quot;id&quot;: &quot;file&quot;,     &quot;value&quot;: &quot;File&quot;,     &quot;popup&quot;: {       &quot;menuitem&quot;: [         {&quot;value&quot;: &quot;New&quot;, &quot;onclick&quot;: &quot;CreateNewDoc()&quot;},         {&quot;value&quot;: &quot;Open&quot;, &quot;onclick&quot;: &quot;OpenDoc()&quot;},         {&quot;value&quot;: &quot;Close&quot;, &quot;onclick&quot;: &quot;CloseDoc()&quot;}       ]     }   }} " id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
-    {{> button button--IsControl=true button--IsIcon=true button--icon="copy" button--attribute=(concat 'aria-label="Copy to clipboard code expanded example" id="' clipboard-copy--id '-copy-button"')}}
+    {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard code expanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'contenteditable="true" id="' clipboard-copy--id '-content"')}}
 { "menu": {
@@ -140,7 +140,7 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -154,7 +154,7 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact code example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact code example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -168,10 +168,10 @@ cssPrefix: pf-v6-c-clipboard-copy
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact with additional action example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact with additional action example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Run in web terminal"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Run in web terminal"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -187,7 +187,7 @@ Lorem ipsum&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard basic inline compact example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard basic inline compact example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -203,7 +203,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard long inline compact example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard long inline compact example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -218,7 +218,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard long block compact example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard long block compact example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}
@@ -235,7 +235,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
   {{/clipboard-copy-text}}
   {{#> clipboard-copy-actions}}
     {{#> clipboard-copy-actions-item}}
-      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact with truncation example"' button--IsIcon=true button--icon="copy"}}
+      {{> button button--IsPlain=true button--HasNoPadding=true button--attribute='aria-label="Copy to clipboard inline compact with truncation example"' button--IsIcon=true button--icon="rh-ui-copy-fill"}}
     {{/clipboard-copy-actions-item}}
   {{/clipboard-copy-actions}}
 {{/clipboard-copy}}

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -266,6 +266,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
 | `.pf-m-block` | `.pf-v6-c-clipboard-copy.pf-m-inline` | Modifies the inline copy clipboard component to have block formatting. |
 | `.pf-m-truncate` | `.pf-v6-c-clipboard-copy.pf-m-truncate` | Modifies the inline copy clipboard component for use with text used in trucate component. |
 | `.pf-m-expanded` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for the expanded state. |
-| `.pf-m-readonly` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for read-only styles |
+| `.pf-m-readonly` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for read-only styles. |
 | `.pf-m-expanded` | `.pf-v6-c-button.pf-m-control` | Modifies the control toggle button for the expanded state. |
 | `.pf-m-code` | `code.pf-v6-c-clipboard-copy__text` | Modifies the inline copy clipboard text styles for use with the `<code>` element. |

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -69,19 +69,19 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only collapsed example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
-  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--IsReadonlyExpandable=true clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br>
-{{#> clipboard-copy clipboard-copy--id="expandable-expanded-readonly" clipboard-copy--IsExpanded="true"}}
+{{#> clipboard-copy clipboard-copy--id="expandable-expanded-readonly" clipboard-copy--IsExpanded="true" clipboard-copy--IsReadonly="true"}}
   {{#> clipboard-copy-group}}
     {{> button button--IsControl=true button--AriaExpanded=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only expanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only expanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
-  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--IsReadonlyExpandable=true clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
@@ -267,5 +267,5 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
 | `.pf-m-truncate` | `.pf-v6-c-clipboard-copy.pf-m-truncate` | Modifies the inline copy clipboard component for use with text used in trucate component. |
 | `.pf-m-expanded` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for the expanded state. |
 | `.pf-m-expanded` | `.pf-v6-c-button.pf-m-control` | Modifies the control toggle button for the expanded state. |
-| `.pf-m-expandable-readonly` | `.pf-v6-c-clipboard-copy__expandable-content` | Modifies expandable content to match readonly form control background and border. |
+| `.pf-m-readonly` | `.pf-v6-c-clipboard-copy` | Designates the clipboard copy component as read-only and modifies expandable content to match read-only background and border styles. |
 | `.pf-m-code` | `code.pf-v6-c-clipboard-copy__text` | Modifies the inline copy clipboard text styles for use with the `<code>` element. |

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -65,7 +65,7 @@ cssPrefix: pf-v6-c-clipboard-copy
 {{#> clipboard-copy clipboard-copy--id="expandable-not-expanded-readonly" clipboard-copy--IsReadonly="true"}}
   {{#> clipboard-copy-group}}
     {{> button button--IsControl=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--AriaExpanded=false button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only unexpanded example" aria-controls="' clipboard-copy--id '-content"')}}
-    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is a read-only version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only collapsed example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
@@ -77,12 +77,12 @@ cssPrefix: pf-v6-c-clipboard-copy
 {{#> clipboard-copy clipboard-copy--id="expandable-expanded-readonly" clipboard-copy--IsExpanded="true" clipboard-copy--IsReadonly="true"}}
   {{#> clipboard-copy-group}}
     {{> button button--IsControl=true button--AriaExpanded=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only expanded example" aria-controls="' clipboard-copy--id '-content"')}}
-    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is a read-only version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only expanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
-    This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is a read-only version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br>

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -62,7 +62,7 @@ cssPrefix: pf-v6-c-clipboard-copy
 {{/clipboard-copy}}
 <br />
 <h4>Read-only</h4>
-{{#> clipboard-copy clipboard-copy--id="expandable-not-expanded-readonly"}}
+{{#> clipboard-copy clipboard-copy--id="expandable-not-expanded-readonly" clipboard-copy--IsReadonly="true"}}
   {{#> clipboard-copy-group}}
     {{> button button--IsControl=true button--IsIcon=true button--icon-template="clipboard-copy-toggle-icon" button--AriaExpanded=false button--attribute=(concat 'id="' clipboard-copy--id '-toggle" aria-label="Toggle read-only unexpanded example" aria-controls="' clipboard-copy--id '-content"')}}
     {{#> form-control controlType="input" input="true" form-control--IsReadonly="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="' clipboard-copy--id '-text-input" aria-label="Copyable input"')}}
@@ -266,6 +266,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
 | `.pf-m-block` | `.pf-v6-c-clipboard-copy.pf-m-inline` | Modifies the inline copy clipboard component to have block formatting. |
 | `.pf-m-truncate` | `.pf-v6-c-clipboard-copy.pf-m-truncate` | Modifies the inline copy clipboard component for use with text used in trucate component. |
 | `.pf-m-expanded` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for the expanded state. |
+| `.pf-m-readonly` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for read-only styles |
 | `.pf-m-expanded` | `.pf-v6-c-button.pf-m-control` | Modifies the control toggle button for the expanded state. |
-| `.pf-m-readonly` | `.pf-v6-c-clipboard-copy` | Designates the clipboard copy component as read-only and modifies expandable content to match read-only background and border styles. |
 | `.pf-m-code` | `code.pf-v6-c-clipboard-copy__text` | Modifies the inline copy clipboard text styles for use with the `<code>` element. |

--- a/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -69,7 +69,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only collapsed example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
-  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--IsReadonlyExpandable=true clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
@@ -81,7 +81,7 @@ cssPrefix: pf-v6-c-clipboard-copy
     {{/form-control}}
     {{> button button--IsControl=true button--IsIcon=true button--icon="rh-ui-copy-fill" button--attribute=(concat 'aria-label="Copy to clipboard read-only expanded example" id="' clipboard-copy--id '-copy-button"')}}
   {{/clipboard-copy-group}}
-  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--IsReadonlyExpandable=true clipboard-copy-expandable-content--attribute=(concat 'id="' clipboard-copy--id '-content"')}}
     This is an editable version of the copy to clipboard component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
@@ -267,4 +267,5 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;
 | `.pf-m-truncate` | `.pf-v6-c-clipboard-copy.pf-m-truncate` | Modifies the inline copy clipboard component for use with text used in trucate component. |
 | `.pf-m-expanded` | `.pf-v6-c-clipboard-copy` | Modifies the clipboard copy component for the expanded state. |
 | `.pf-m-expanded` | `.pf-v6-c-button.pf-m-control` | Modifies the control toggle button for the expanded state. |
+| `.pf-m-expandable-readonly` | `.pf-v6-c-clipboard-copy__expandable-content` | Modifies expandable content to match readonly form control background and boarder. |
 | `.pf-m-code` | `code.pf-v6-c-clipboard-copy__text` | Modifies the inline copy clipboard text styles for use with the `<code>` element. |


### PR DESCRIPTION
## Summary
Update the Clipboard Copy component to use the correct copy icon and confirm token usage.

## What changed
- **Clipboard Copy icon:** Replaced the copy-button icon from `copy` to `rh-ui-copy-fill` across all Clipboard Copy examples so the component uses the intended design-system icon.
- **File updated:** `src/patternfly/components/ClipboardCopy/examples/ClipboardCopy.md` — all `button--icon="copy"` references are now `button--icon="rh-ui-copy-fill"` (basic, expandable, inline compact, and all variants).

Fixes #8186

## Verification
- Token usage for the Clipboard Copy component has been verified and is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only state styling support for the ClipboardCopy component with updated visual styling for read-only expandable content.

* **Documentation**
  * Updated ClipboardCopy component examples with new icon names and documented the read-only state modifier and styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->