### PR TITLE
fix(button): fix circle buttons

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -424,9 +424,11 @@
   --#{$button}--m-circle--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$button}--m-circle--Padding--base: var(--pf-t--global--spacer--control--vertical--default);
   --#{$button}--m-circle--PaddingBlockStart: var(--#{$button}--m-circle--Padding--base);
-  --#{$button}--m-circle--PaddingInlineEnd: 0;
+  --#{$button}--m-circle--PaddingInlineEnd: var(--#{$button}--m-circle--Padding--base);
   --#{$button}--m-circle--PaddingBlockEnd: var(--#{$button}--m-circle--Padding--base);
-  --#{$button}--m-circle--PaddingInlineStart: 0;
+  --#{$button}--m-circle--PaddingInlineStart: var(--#{$button}--m-circle--Padding--base);
+  --#{$button}--m-circle--BlockSize--padding-multiplier: 2.75;
+  --#{$button}--m-circle--BlockSize: calc(var(--#{$button}--m-circle--BlockSize--padding-multiplier) * var(--#{$button}--m-circle--Padding--base) + 1em);
 }
 
 .#{$button} {
@@ -879,6 +881,8 @@
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-circle--PaddingInlineEnd);
     --#{$button}--PaddingBlockEnd: var(--#{$button}--m-circle--PaddingBlockEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-circle--PaddingInlineStart);
+    aspect-ratio: 1;
+    block-size: var(--#{$button}--m-circle--BlockSize);
 
     & .pf-v6-c-button__icon {
       scale: var(--#{$button}--m-circle--ScaleX) var(--#{$button}--m-circle--ScaleY);
@@ -1012,7 +1016,6 @@
 }
 
 .#{$button}__icon {
-  min-width: 1lh;
   margin-inline-start: var(--#{$button}__icon--MarginInlineStart);
   margin-inline-end: var(--#{$button}__icon--MarginInlineEnd);
   color: var(--#{$button}__icon--Color);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -881,6 +881,7 @@
     --#{$button}--PaddingInlineEnd: var(--#{$button}--m-circle--PaddingInlineEnd);
     --#{$button}--PaddingBlockEnd: var(--#{$button}--m-circle--PaddingBlockEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-circle--PaddingInlineStart);
+
     aspect-ratio: 1;
     block-size: var(--#{$button}--m-circle--BlockSize);
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -882,8 +882,8 @@
     --#{$button}--PaddingBlockEnd: var(--#{$button}--m-circle--PaddingBlockEnd);
     --#{$button}--PaddingInlineStart: var(--#{$button}--m-circle--PaddingInlineStart);
 
-    aspect-ratio: 1;
     block-size: var(--#{$button}--m-circle--BlockSize);
+    aspect-ratio: 1;
 
     & .pf-v6-c-button__icon {
       scale: var(--#{$button}--m-circle--ScaleX) var(--#{$button}--m-circle--ScaleY);


### PR DESCRIPTION
Summary
Fixes .pf-m-circle so icon-only circle buttons render as a true circle, and aligns circle padding with the design intent.

Changes
Symmetric circle padding: PaddingInlineStart / PaddingInlineEnd for .pf-m-circle now use --#{$button}--m-circle--Padding--base (same as block padding) instead of 0.

Definite block size + square aspect: Added --#{$button}--m-circle--BlockSize (from a padding multiplier 2.75 × padding base + 1em) and applied block-size plus aspect-ratio: 1 on .pf-m-circle so the box is square and aspect-ratio can take effect.

Tunable multiplier: Introduced --#{$button}--m-circle--BlockSize--padding-multiplier (default 2.75) so the padding contribution to the circle size is documented and overridable without editing the full calc().

Icon wrapper: Removed min-width: 1lh from .pf-v6-c-button__icon so it doesn’t fight other icon sizings in buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enforced consistent square dimensions for circular buttons to improve alignment and layout across interfaces.
  * Improved padding and size calculations for circular button variants to provide more consistent spacing and visual balance.
  * Relaxed icon minimum width so icons can size more flexibly within buttons, reducing overflow and improving compact layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->