### PR TITLE
fix: adjusted button and menu toggle icon size

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,11 +1,12 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($button) {
+  asdf
   --#{$button}--Display: inline-flex;
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;
   --#{$button}--Gap: var(--pf-t--global--spacer--gap--text-to-element--default);
-  --#{$button}--MinWidth: initial;
+  --#{$button}--MinWidth: calc(1lh + var(--#{$button}--PaddingBlockStart) + var(--#{$button}--PaddingBlockEnd));
   --#{$button}--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--default);
   --#{$button}--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--default);
   --#{$button}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
@@ -868,6 +869,8 @@
 
   &.pf-m-circle {
     --#{$button}--BorderRadius: var(--#{$button}--m-circle--BorderRadius);
+
+    padding-inline: 0;
   }
 
   &:hover,
@@ -997,7 +1000,6 @@
 }
 
 .#{$button}__icon {
-  min-width: 1lh;
   margin-inline-start: var(--#{$button}__icon--MarginInlineStart);
   margin-inline-end: var(--#{$button}__icon--MarginInlineEnd);
   color: var(--#{$button}__icon--Color);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,7 +1,6 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($button) {
-  asdf
   --#{$button}--Display: inline-flex;
   --#{$button}--AlignItems: baseline;
   --#{$button}--JustifyContent: center;

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -6,7 +6,7 @@
   --#{$menu-toggle}--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$menu-toggle}--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--default);
   --#{$menu-toggle}--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
-  --#{$menu-toggle}--MinWidth: initial;
+  --#{$menu-toggle}--MinWidth: calc(1lh + var(--#{$menu-toggle}--PaddingBlockStart) + var(--#{$menu-toggle}--PaddingBlockEnd));
   --#{$menu-toggle}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$menu-toggle}--Color: var(--pf-t--global--text--color--regular);
   --#{$menu-toggle}--LineHeight: var(--pf-t--global--font--line-height--body);

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -642,7 +642,6 @@
 
 .#{$menu-toggle}__icon {
   flex-shrink: 0;
-  min-width: 1lh;
   transition-delay: var(--#{$menu-toggle}__icon--TransitionDelay);
   transition-duration: var(--#{$menu-toggle}__icon--TransitionDuration);
   transition-property: var(--#{$menu-toggle}__icon--TransitionProperty);


### PR DESCRIPTION
fixes #8220

Adjusted button/menu-toggle icon width and moved min-width back to the parent. Also addressed circle buttons to be a circle.

[Backstop PDF](https://drive.google.com/file/d/1maU8E0qlzon4ON0h8jsjWNImZDj5SA2s/view?usp=sharing)

[Full backstop report](https://drive.google.com/file/d/14ehxzH0rX6acM7xLVLxdsstwJUFyhMZK/view?usp=sharing)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Button: Adjusted default minimum width to improve consistent sizing across layouts.
  * Circle button: Removed horizontal padding for a more compact circular appearance.
  * Button icon: Removed enforced minimum icon width to allow more flexible icon layout.
  * Menu toggle: Refined default minimum width for better alignment with other controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->