### PR TITLE
fix(breadcrumbs): update tokens and icons

### DIFF
--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -22,6 +22,7 @@
   --#{$breadcrumb}__link--hover--TextDecorationStyle: var(--pf-t--global--text-decoration--link--style--hover);
   --#{$breadcrumb}__link--m-current--Color: var(--pf-t--global--text--color--regular);
   --#{$breadcrumb}__link--BackgroundColor: transparent;
+  --#{$breadcrumb}__link--FontSize: var(--pf-t--global--font--size--body--default);
 
   // Heading
   --#{$breadcrumb}__heading--FontSize: var( --pf-t--global--font--size--body--sm);
@@ -77,7 +78,7 @@
 .#{$breadcrumb}__link {
   padding-inline-start: var(--#{$breadcrumb}__link--PaddingInlineStart); // use a mutable value for alignment control
   padding-inline-end: var(--#{$breadcrumb}__link--PaddingInlineEnd); // use a mutable value for alignment control
-  font-size: inherit;
+  font-size: var(--#{$breadcrumb}__link--FontSize);
   font-weight: var(--#{$breadcrumb}__link--FontWeight);
   line-height: inherit;
   color: var(--#{$breadcrumb}__link--Color);

--- a/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
+++ b/src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
@@ -140,7 +140,7 @@ cssPrefix: pf-v6-c-breadcrumb
       {{#> breadcrumb-dropdown}}
         {{#> menu-toggle menu-toggle--IsText=true menu-toggle--IsPlain=true menu-toggle--IsSmall=true}}
           {{#> menu-toggle-count}}
-            {{#> badge badge--modifier="pf-m-unread"}}
+            {{#> badge badge--modifier="pf-m-read"}}
               4
               <span class="pf-v6-screen-reader">additional items</span>
             {{/badge}}

--- a/src/patternfly/components/MenuToggle/menu-toggle-toggle-icon.hbs
+++ b/src/patternfly/components/MenuToggle/menu-toggle-toggle-icon.hbs
@@ -5,6 +5,6 @@
   {{#if @partial-block}}
     {{> @partial-block}}
   {{else}}
-    <i class="fas fa-caret-down fa-fw" aria-hidden="true"></i>
+    {{pfIcon "rh-microns-caret-down-fill"}}
   {{/if}}
 </span>

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -143,7 +143,7 @@
   --#{$menu-toggle}--m-plain--hover--BorderWidth: var(--pf-t--global--border--width--action--plain--hover);
   --#{$menu-toggle}--m-plain--expanded--BorderWidth: var(--pf-t--global--border--width--action--plain--clicked);
   --#{$menu-toggle}--m-plain--BorderRadius: var(--pf-t--global--border--radius--small);
-  --#{$menu-toggle}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
+  --#{$menu-toggle}--m-plain--hover--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$menu-toggle}--m-plain--expanded--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$menu-toggle}--m-plain--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$menu-toggle}--m-plain--disabled__icon--Color: var(--pf-t--global--icon--color--disabled);
@@ -157,10 +157,11 @@
   --#{$menu-toggle}--m-typeahead__button--AlignSelf: stretch;
 
   // * Menu toggle small
-  --#{$menu-toggle}--m-small--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
-  --#{$menu-toggle}--m-small--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--compact);
-  --#{$menu-toggle}--m-small--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--compact);
-  --#{$menu-toggle}--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
+  --#{$menu-toggle}--toggle--m--small--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}--toggle--m--small--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$menu-toggle}--toggle--m--small--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--toggle--m--small--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$menu-toggle}--m-small--BorderRadius: var(--pf-t--global--border--radius--action--default);
 
   // Status icon
   --#{$menu-toggle}__status-icon--Color: var(--pf-t--global--icon--color--regular);
@@ -349,10 +350,11 @@
 
   // - Menu item small
   &.pf-m-small {
-    --#{$menu-toggle}--PaddingBlockStart: var(--#{$menu-toggle}--m-small--PaddingBlockStart);
-    --#{$menu-toggle}--PaddingBlockEnd: var(--#{$menu-toggle}--m-small--PaddingBlockEnd);
-    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--m-small--PaddingInlineStart);
-    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--m-small--PaddingInlineEnd);
+    --#{$menu-toggle}--BorderRadius: var(--#{$menu-toggle}--m-small--BorderRadius);
+    --#{$menu-toggle}--PaddingBlockStart: var(--#{$menu-toggle}--toggle--m--small--PaddingBlockStart);
+    --#{$menu-toggle}--PaddingBlockEnd: var(--#{$menu-toggle}--toggle--m--small--PaddingBlockEnd);
+    --#{$menu-toggle}--PaddingInlineStart: var(--#{$menu-toggle}--toggle--m--small--PaddingInlineStart);
+    --#{$menu-toggle}--PaddingInlineEnd: var(--#{$menu-toggle}--toggle--m--small--PaddingInlineEnd);
     --#{$menu-toggle}__button--toggle-icon--PaddingInlineStart: var(--#{$menu-toggle}--m-small__button--toggle-icon--PaddingInlineStart);
     --#{$menu-toggle}__button--toggle-icon--PaddingInlineEnd: var(--#{$menu-toggle}--m-small__button--toggle-icon--PaddingInlineEnd);
     --#{$menu-toggle}--m-split-button--pill--child--PaddingInlineStart--offset: var(--#{$menu-toggle}--m-split-button--m-small--pill--child--PaddingInlineStart--offset);


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/8185

**Summary**
Aligns breadcrumb and menu-toggle styling with design tokens and the React Icons set, and adjusts a breadcrumb dropdown example for consistency.

**Breadcrumb**
Link typography: Adds --#{$breadcrumb}__link--FontSize set to var(--pf-t--global--font--size--body--default) and uses it on .pf-v6-c-breadcrumb__link instead of font-size: inherit, so link size is token-driven and overridable.
Example: In the breadcrumb dropdown example, the count badge modifier changes from pf-m-unread to pf-m-read.

**Menu toggle**
Toggle icon: Replaces the Font Awesome caret (<i class="fas fa-caret-down …">) with {{pfIcon "rh-microns-caret-down-fill"}} in menu-toggle-toggle-icon.hbs.
Plain hover: --#{$menu-toggle}--m-plain--hover--BackgroundColor now uses var(--pf-t--global--background--color--secondary--default) instead of the plain action hover background token.
Small variant: Introduces --#{$menu-toggle}--toggle--m--small--* padding tokens (spacer--xs block, spacer--sm inline), adds --#{$menu-toggle}--m-small--BorderRadius → border--radius--action--default, and in .pf-m-small wires --#{$menu-toggle}--BorderRadius and padding to those variables.

**Files touched**
src/patternfly/components/Breadcrumb/breadcrumb.scss
src/patternfly/components/Breadcrumb/examples/Breadcrumb.md
src/patternfly/components/MenuToggle/menu-toggle-toggle-icon.hbs
src/patternfly/components/MenuToggle/menu-toggle.scss