### PR TITLE
fix(jump-links): adjust accent line for unified theme

### DIFF
--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -35,14 +35,19 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   --#{$jump-links}__link--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--sm));
 
   // before
+  --#{$jump-links}__link--before--Height: var(--#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth);
+  --#{$jump-links}__link--before--Width: auto;
   --#{$jump-links}__link--before--BorderBlockStartWidth: 0;
   --#{$jump-links}__link--before--BorderInlineEndWidth: 0;
   --#{$jump-links}__link--before--BorderBlockEndWidth: 0;
   --#{$jump-links}__link--before--BorderInlineStartWidth: 0;
   --#{$jump-links}__link--before--BorderColor: transparent;
+  --#{$jump-links}__link--before--BorderRadius: var(--pf-t--global--border--radius--pill);
   --#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth: var(--pf-t--global--border--width--extra-strong);
   --#{$jump-links}__item--m-current__link--before--BorderInlineStartWidth: 0;
-  --#{$jump-links}__item--m-current__link--before--BorderColor: var(--pf-t--global--border--color--clicked);
+  --#{$jump-links}__item--m-current__link--before--BorderColor: var(--pf-t--global--color--brand--accent--default);
+  --#{$jump-links}--m-vertical__link--before--Height: auto;
+  --#{$jump-links}--m-vertical__link--before--Width: var(--#{$jump-links}__item--m-current__link--before--BorderInlineStartWidth);
   --#{$jump-links}--m-vertical__item--m-current__link--before--BorderBlockStartWidth: 0;
   --#{$jump-links}--m-vertical__item--m-current__link--before--BorderInlineStartWidth: var(--pf-t--global--border--width--extra-strong);
 
@@ -85,6 +90,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
     --#{$jump-links}__list--PaddingInlineEnd: var(--#{$jump-links}--m-vertical__list--PaddingInlineEnd);
     --#{$jump-links}__list--PaddingBlockEnd: var(--#{$jump-links}--m-vertical__list--PaddingBlockEnd);
     --#{$jump-links}__list--PaddingInlineStart: var(--#{$jump-links}--m-vertical__list--PaddingInlineStart);
+    --#{$jump-links}__link--before--Width: var(--#{$jump-links}--m-vertical__link--before--Width);
+    --#{$jump-links}__link--before--Height: var(--#{$jump-links}--m-vertical__link--before--Height);
     --#{$jump-links}__list--before--BorderBlockStartWidth: var(--#{$jump-links}--m-vertical__list--before--BorderBlockStartWidth);
     --#{$jump-links}__list--before--BorderInlineStartWidth: var(--#{$jump-links}--m-vertical__list--before--BorderInlineStartWidth);
     --#{$jump-links}__item--m-current__link--before--BorderBlockStartWidth: var(--#{$jump-links}--m-vertical__item--m-current__link--before--BorderBlockStartWidth);
@@ -174,6 +181,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   &::before {
     position: absolute;
     inset: 0;
+    height: var(--#{$jump-links}__link--before--Height);
+    width: var(--#{$jump-links}__link--before--Width);
     pointer-events: none;
     content: "";
     border-color: var(--#{$jump-links}__link--before--BorderColor);
@@ -182,6 +191,7 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
     border-block-end-width: var(--#{$jump-links}__link--before--BorderBlockEndWidth);
     border-inline-start-width: var(--#{$jump-links}__link--before--BorderInlineStartWidth);
     border-inline-end-width: var(--#{$jump-links}__link--before--BorderInlineEndWidth);
+    border-radius: var(--#{$jump-links}__link--before--BorderRadius);
   }
 }
 

--- a/src/patternfly/components/JumpLinks/jump-links.scss
+++ b/src/patternfly/components/JumpLinks/jump-links.scss
@@ -181,8 +181,8 @@ $pf-v6-c-jump-links--m-expandable--breakpoint-map: build-breakpoint-map("base", 
   &::before {
     position: absolute;
     inset: 0;
-    height: var(--#{$jump-links}__link--before--Height);
     width: var(--#{$jump-links}__link--before--Width);
+    height: var(--#{$jump-links}__link--before--Height);
     pointer-events: none;
     content: "";
     border-color: var(--#{$jump-links}__link--before--BorderColor);


### PR DESCRIPTION
Adjusts the accent line color and rounds the ends of it.
Other changes were done with button changes and global caret icon replacement.

Fixes #8187 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved JumpLinks styling by introducing CSS custom properties to control the decorative pseudo-element’s size and shape for better visual consistency.
  * Enhanced vertical/expandable layout support and adjusted the current-item accent to improve visibility and alignment across layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->