### PR TITLE
fix(CodeEditor): make plain header background transparent

### DIFF
--- a/src/patternfly/components/CodeEditor/code-editor.scss
+++ b/src/patternfly/components/CodeEditor/code-editor.scss
@@ -15,7 +15,7 @@
 
   // header content
   --#{$code-editor}__header-content--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$code-editor}__header-content--m-plain--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$code-editor}__header-content--m-plain--BackgroundColor: transparent;
   --#{$code-editor}__header-content--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$code-editor}__header-content--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$code-editor}__header-content--PaddingInlineStart: var(--pf-t--global--spacer--sm);


### PR DESCRIPTION
Closes #8107 

Fixes CodeEditorHeader's plain modifier to make the background transparent (specifically, for our docs in glass theme where every example uses a plain CodeEditorHeader).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Code Editor component's plain-mode header to display with a transparent background instead of the default primary color background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->