### PR TITLE
feat(icon): add rh-standard icon styling

### DIFF
--- a/src/patternfly/base/patternfly-svg-icons.scss
+++ b/src/patternfly/base/patternfly-svg-icons.scss
@@ -22,9 +22,7 @@
 }
 
 .#{$pf-prefix}icon-rh-standard {
-  width: 3em;
-  height: 3em;
-
-  // color: var(--pf-t--global--icon--color--brand--default);
-  color: var(--pf-t--global--color--brand--accent--default);
+  width: 3rem;
+  height: 3rem;
+  color: var(--pf-t--global--icon--color--brand--accent--default);
 }

--- a/src/patternfly/base/patternfly-svg-icons.scss
+++ b/src/patternfly/base/patternfly-svg-icons.scss
@@ -20,3 +20,11 @@
     display: revert;
   }
 }
+
+.#{$pf-prefix}icon-rh-standard {
+  width: 3em;
+  height: 3em;
+
+  // color: var(--pf-t--global--icon--color--brand--default);
+  color: var(--pf-t--global--color--brand--accent--default);
+}


### PR DESCRIPTION
Closes #8071.

Add `.pf-v6-icon-rh-standard` to any icon to test the styling, as I don't believe core uses any RH standard set icons atm.


`--pf-t--global--icon--color--brand--default` feels like the more correct token to use here, but it currently does not change in the redhat theme so I'm currently using the accent color token instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a new standard icon style with fixed dimensions (3rem) to ensure consistent sizing across the UI.
  * The icon now uses the brand accent color token for consistent theming and visual alignment with brand styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->