### PR TITLE
fix(drawer): glass drawer placement and tokens update

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -31,7 +31,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}__panel--BorderInlineEndWidth: 0;
   --#{$drawer}__panel--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   --#{$drawer}__panel--m-inline--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  --#{$drawer}__panel--m-secondary--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
+  --#{$drawer}__panel--m-secondary--BackgroundColor: var(--pf-t--global--background--color--floating--secondary--default);
   --#{$drawer}__panel--RowGap: var(--pf-t--global--spacer--sm);
   --#{$drawer}__panel--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --#{$drawer}__panel--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
@@ -64,9 +64,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}--m-pill__panel--BorderBlockEndWidth: var(--pf-t--global--border--width--regular);
   --#{$drawer}--m-pill__panel--BorderInlineStartWidth: var(--pf-t--global--border--width--regular);
   --#{$drawer}--m-pill__panel--BorderInlineEndWidth: var(--pf-t--global--border--width--regular);
-  --#{$drawer}--m-pill__panel--BorderColor: var(--pf-t--global--border--color--default);
+  --#{$drawer}--m-pill__panel--BorderColor: var(--pf-t--global--border--color--subtle);
   --#{$drawer}--m-pill__panel--BorderRadius: var(--pf-t--global--border--radius--large);
   --#{$drawer}--m-pill--m-expanded__panel--inset: var(--pf-t--global--spacer--inset--page-chrome);
+  --#{$drawer}--m-pill--m-expanded__panel--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$drawer}__panel--m-glass--BackgroundColor: var(--pf-t--global--background--color--glass--primary--default);
   --#{$drawer}__panel--m-glass--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary);
   --#{$drawer}__panel--m-glass--BorderColor: var(--pf-t--global--border--color--glass--default);
@@ -355,6 +356,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
         border-block-end-width: var(--#{$drawer}--m-pill__panel--BorderBlockEndWidth);
         border-inline-start-width: var(--#{$drawer}--m-pill__panel--BorderInlineStartWidth);
         border-inline-end-width: var(--#{$drawer}--m-pill__panel--BorderInlineEndWidth);
+        box-shadow: var(--#{$drawer}--m-pill--m-expanded__panel--BoxShadow);
       }
     }
 

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -283,6 +283,18 @@ import './Drawer.css'
 
 ### Pill
 ```hbs isBeta
+{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}
+ {{#> drawer-main}}
+    {{#> drawer-content}}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+    {{/drawer-content}}
+    {{> drawer-example-panel}}
+  {{/drawer-main}}
+{{/drawer}}
+```
+
+### Resizable Pill
+```hbs isBeta
 {{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
@@ -295,7 +307,7 @@ import './Drawer.css'
 
 ### Pill inline
 ```hbs isBeta
-{{#> drawer drawer--id="pill--inline" drawer--IsInline=true drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
+{{#> drawer drawer--id="pill--inline" drawer--IsInline=true drawer--IsPill=true drawer-panel--IsOpen=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -283,7 +283,7 @@ import './Drawer.css'
 
 ### Pill
 ```hbs isBeta
-{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true}}
+{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
@@ -295,7 +295,7 @@ import './Drawer.css'
 
 ### Pill inline
 ```hbs isBeta
-{{#> drawer drawer--id="pill--inline" drawer--IsInline=true drawer--IsPill=true drawer-panel--IsOpen=true}}
+{{#> drawer drawer--id="pill--inline" drawer--IsInline=true drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -295,7 +295,7 @@ import './Drawer.css'
 
 ### Resizable Pill
 ```hbs isBeta
-{{#> drawer drawer--id="pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
+{{#> drawer drawer--id="resizable-pill" drawer--IsPill=true drawer-panel--IsOpen=true drawer-panel--IsResizable=true}}
  {{#> drawer-main}}
     {{#> drawer-content}}
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat, nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -259,7 +259,6 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
 
   // placeholder for banded
   @at-root :where(.pf-v6-theme-glass) &:not(.pf-m-docked) {
-    margin-block-end: var(--pf-t--global--spacer--inset--page-chrome);
     background-color: var(--pf-t--global--background--color--glass--primary--default);
     backdrop-filter: var(--pf-t--global--background--filter--glass--blur--primary);
     border-block-end: var(--pf-t--global--border--width--glass--default) solid var(--pf-t--global--border--color--glass--default);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -234,6 +234,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   // Glass theme
   --#{$page}--BackgroundColor--glass: transparent;
   --#{$page}__sidebar--Width--base--glass: calc(#{pf-size-prem(290px)} + var(--pf-t--global--spacer--inset--page-chrome) * 2);
+  --#{$page}__sidebar--MarginBlockStart--glass: var(--pf-t--global--spacer--inset--page-chrome);
   --#{$page}__sidebar-body--PaddingInlineStart--glass: var(--pf-t--global--spacer--lg);
   --#{$page}__sidebar-body--PaddingInlineEnd--glass: var(--pf-t--global--spacer--lg);
   --#{$page}__sidebar-main--PaddingBlockEnd--glass: var(--#{$page}__sidebar--PaddingBlockEnd);
@@ -253,10 +254,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__sidebar-main--xl--MarginBlockEnd--glass: var(--pf-t--global--spacer--inset--page-chrome);
   --#{$page}__sidebar-main--xl--MarginInlineStart--glass: var(--pf-t--global--spacer--inset--page-chrome);
   --#{$page}__sidebar-main--xl--MarginInlineEnd--glass: var(--pf-t--global--spacer--inset--page-chrome);
+  --#{$page}__main-container--MarginBlockStart--glass: var(--pf-t--global--spacer--inset--page-chrome);
 
   :where(.pf-v6-theme-glass) & {
     --#{$page}--BackgroundColor: var(--#{$page}--BackgroundColor--glass);
     --#{$page}__sidebar--Width--base: var(--#{$page}__sidebar--Width--base--glass);
+    --#{$page}__sidebar--MarginBlockStart: var(--#{$page}__sidebar--MarginBlockStart--glass);
     --#{$page}__sidebar-body--PaddingInlineStart: var(--#{$page}__sidebar-body--PaddingInlineStart--glass);
     --#{$page}__sidebar-body--PaddingInlineEnd: var(--#{$page}__sidebar-body--PaddingInlineEnd--glass);
     --#{$page}__sidebar-main--PaddingBlockEnd: var(--#{$page}__sidebar-main--PaddingBlockEnd--glass);
@@ -272,6 +275,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     --#{$page}__sidebar-main--BorderColor: var(--#{$page}__sidebar-main--BorderColor--glass);
     --#{$page}__sidebar-main--BorderRadius: var(--#{$page}__sidebar-main--BorderRadius--glass);
     --#{$page}__sidebar-main--BoxShadow: var(--#{$page}__sidebar-main--BoxShadow--glass);
+    --#{$page}__main-container--MarginBlockStart: var(--#{$page}__main-container--MarginBlockStart--glass);
   }
 
   @media (min-width: $pf-v6-global--breakpoint--xl) {


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/8234

**Drawer**
Secondary panel: background uses background--color--floating--secondary--default instead of secondary--default.
Pill variant: border color uses border--color--subtle. Expanded pill panel gets box-shadow--md for clearer separation.

**Page / masthead (glass)**
Removes masthead margin-block-end in the glass theme so the band no longer owns that gap.
Adds matching top margin on the sidebar and main container via new glass tokens (MarginBlockStart = page chrome inset), so spacing stays consistent while living on the page chrome instead of the masthead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Drawer secondary panel theming and pill styling with subtler borders and an enhanced shadow for expanded pill panels.
  * Removed a bottom margin in the glass-themed, non-docked Masthead variant.
  * Added glass-theme margin overrides for Page sidebar and main container spacing.

* **Documentation**
  * Added a "Resizable Pill" Drawer example demonstrating a resizable pill panel variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->