### PR TITLE
feat: added dynamic sticky header styles

### DIFF
--- a/src/patternfly/components/Table/examples/Table.css
+++ b/src/patternfly/components/Table/examples/Table.css
@@ -11,7 +11,8 @@
 
 #ws-core-c-table-sticky-columns-and-header .ws-preview-html,
 #ws-core-c-table-nested-column-headers-sticky-header .ws-preview-html,
-#ws-core-c-table-sticky-header .ws-preview-html {
+#ws-core-c-table-sticky-header .ws-preview-html,
+#ws-core-c-table-sticky-header-with-base-and-stuck .ws-preview-html {
   height: 400px;
 }
 

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3855,6 +3855,132 @@ There are a few ways this can be handled:
           2 days ago
         {{/table-td}}
       {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 6
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 7
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 8
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 9
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
+
+      {{#> table-tr}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          Repository 11
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          10
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          25
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          5
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          2 days ago
+        {{/table-td}}
+      {{/table-tr}}
     {{/table-tbody}}
   {{/table}}
 </div>
@@ -3915,6 +4041,8 @@ For sticky columns to function correctly, the parent table's width must be contr
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-sticky-header` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll. |
+| `.pf-m-sticky-header-unstuck` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-header-stuck` should be used to apply sticky styling. |
+| `.pf-m-sticky-header-stuck` | `.pf-v6-c-table` | Applies sticky header styling to a table with `.pf-m-sticky-header-unstuck`. |
 | `.pf-v6-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-v6-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
 | `.pf-v6-c-table__sticky-cell` | `<th>`, `<td>` | Initiates a sticky table cell. |

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3762,227 +3762,24 @@ There are a few ways this can be handled:
 ### Sticky header
 ```hbs
 <div class="pf-v6-c-scroll-inner-wrapper">
-  {{#> table table--id="table-sticky-header" table--IsGrid=true table--modifier="pf-m-grid-md pf-m-sticky-header" table--attribute='aria-label="This is a table with sticky header cells"'}}
-    {{#> table-thead}}
-      {{#> table-tr}}
-        {{#> table-th table-th--attribute='scope="col"'}}
-          Repositories
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"'}}
-          Branches
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"'}}
-          Pull requests
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"'}}
-          Workspaces
-        {{/table-th}}
-        {{#> table-th table-th--attribute='scope="col"'}}
-          Last commit
-        {{/table-th}}
-      {{/table-tr}}
-    {{/table-thead}}
+  {{> 
+    table--default
+    table--aria-label="This is a table with sticky header cells"
+    table--HasStickyHeader=true}}
+</div>
+```
 
-    {{#> table-tbody}}
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 1
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
+### Sticky header with base and stuck
 
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 2
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
+This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-header-stuck`. `.pf-m-sticky-header-stuck` can be applied dynamically as a table has scrolled to only show sticky styles when the header is "stuck" and floating above the table content.
 
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 3
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 4
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 6
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 7
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 8
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 9
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-
-      {{#> table-tr}}
-        {{#> table-td table-td--data-label="Repository name"}}
-          Repository 11
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Branches"}}
-          10
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Pull requests"}}
-          25
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Workspaces"}}
-          5
-        {{/table-td}}
-        {{#> table-td table-td--data-label="Last commit"}}
-          2 days ago
-        {{/table-td}}
-      {{/table-tr}}
-    {{/table-tbody}}
-  {{/table}}
+```hbs
+<div class="pf-v6-c-scroll-inner-wrapper">
+  {{> 
+    table--default
+    table--aria-label="This is a table with sticky header cells"
+    table--HasStickyHeaderBase=true
+    table--HasStickyHeaderStuck=true}}
 </div>
 ```
 
@@ -3992,8 +3789,7 @@ There are a few ways this can be handled:
   {{> table--scrollable
       table--scrollable--id="sticky-column-example"
       table--scrollable--Column1IsStickyColumn=true
-      table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate pf-m-border-right"
-      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate"}}
+      table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"}}
 </div>
 ```
 
@@ -4004,8 +3800,7 @@ There are a few ways this can be handled:
       table--scrollable--id="sticky-multi-column-example"
       table--scrollable--Column1IsStickyColumn=true
       table--scrollable--Column2IsStickyColumn=true
-      table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate"
-      table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"}}
+      table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"}}
 </div>
 ```
 
@@ -4017,8 +3812,7 @@ There are a few ways this can be handled:
         table--scrollable--modifier="pf-m-sticky-header"
         table--scrollable--Column1IsStickyColumn=true
         table--scrollable--Column2IsStickyColumn=true
-        table--scrollable--th--modifier--cell-1-modifier="pf-m-truncate"
-        table--scrollable--th--modifier--cell-2-modifier="pf-m-truncate pf-m-border-right"}}
+        table--scrollable--th--modifier--cell-2-modifier="pf-m-border-right"}}
   </div>
 </div>
 ```
@@ -4030,7 +3824,17 @@ There are a few ways this can be handled:
   {{> table--scrollable
       table--scrollable--id="sticky-right-column-example"
       table--scrollable--ColumnLastIsStickyColumn=true
-      table--scrollable--th--modifier--cell-9-modifier="pf-m-truncate pf-m-border-left"}}
+      table--scrollable--th--modifier--cell-13-modifier="pf-m-border-left"}}
+</div>
+```
+
+### Sticky column
+```hbs
+<div class="pf-v6-c-scroll-inner-wrapper">
+  {{> table--scrollable
+      table--scrollable--id="sticky-column-example"
+      table--scrollable--Column1IsStickyColumn=true
+      table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"}}
 </div>
 ```
 

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3828,16 +3828,6 @@ This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-heade
 </div>
 ```
 
-### Sticky column
-```hbs
-<div class="pf-v6-c-scroll-inner-wrapper">
-  {{> table--scrollable
-      table--scrollable--id="sticky-column-example"
-      table--scrollable--Column1IsStickyColumn=true
-      table--scrollable--th--modifier--cell-1-modifier="pf-m-border-right"}}
-</div>
-```
-
 ### Sticky table usage
 
 For sticky columns to function correctly, the parent table's width must be controlled with `.pf-v6-c-scroll-inner-wrapper`. For sticky columns and sticky headers to function correctly, the parent table needs an inner and outer wrapper (`.pf-v6-c-scroll-outer-wrapper` and `.pf-v6-c-scroll-inner-wrapper`)

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -4041,8 +4041,8 @@ For sticky columns to function correctly, the parent table's width must be contr
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-sticky-header` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll. |
-| `.pf-m-sticky-header-unstuck` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-header-stuck` should be used to apply sticky styling. |
-| `.pf-m-sticky-header-stuck` | `.pf-v6-c-table` | Applies sticky header styling to a table with `.pf-m-sticky-header-unstuck`. |
+| `.pf-m-sticky-header-base` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-header-stuck` should be used to apply sticky styling. |
+| `.pf-m-sticky-header-stuck` | `.pf-v6-c-table` | Applies sticky header styling to a table with `.pf-m-sticky-header-base`. |
 | `.pf-v6-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-v6-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
 | `.pf-v6-c-table__sticky-cell` | `<th>`, `<td>` | Initiates a sticky table cell. |

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -11,6 +11,7 @@
   {{#if table-th--IsAction}} {{pfv}}table__action{{/if}}
   {{#if table-th--IsIcon}} {{pfv}}table__icon{{/if}}
   {{#if table-th--IsWrap}} pf-m-wrap{{/if}}
+  {{#if table-th--IsNoWrap}} pf-m-nowrap{{/if}}
   {{#if table-th--IsSelected}} pf-m-selected{{/if}}
   {{#if table-th--IsSubhead}} {{pfPrefix 'table__subhead'}}{{/if}}
   {{#if table-th--IsColumnHelp}} pf-m-help{{/if}}

--- a/src/patternfly/components/Table/table.hbs
+++ b/src/patternfly/components/Table/table.hbs
@@ -6,6 +6,10 @@
     table--HasNoPosinset='pf-m-no-inset'
     table--IsCompact='pf-m-compact'
     table--IsAnimateExpand='pf-m-animate-expand'
+    table--HasStickyHeader='pf-m-sticky-header'
+    table--HasStickyHeaderBase='pf-m-sticky-header-base'
+    table--HasStickyHeaderStuck='pf-m-sticky-header-stuck'
+    table--HasMdGridBreakpoint='pf-m-grid-md'
     table--modifier=table--modifier
   }}"
   {{#if table--IsGrid}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -337,10 +337,9 @@
     }
   }
 
-  &.pf-m-sticky-header > .#{$table}__thead,
-  &.pf-m-sticky-header-base > .#{$table}__thead,
-  .#{$table}__thead.pf-m-nested-column-header {
-    &::after {
+  &.pf-m-sticky-header,
+  &.pf-m-sticky-header-base {
+    > .#{$table}__thead::after {
       position: absolute;
       inset: 0;
       z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
@@ -1250,6 +1249,8 @@
   // - Table nested column header button
   &.pf-m-nested-column-header {
     position: relative;
+    background-color: var(--#{$table}--BackgroundColor);
+    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
 
     .#{$table}__button {
       --#{$table}__button--PaddingInlineStart: var(--#{$table}__nested-column-header__button--PaddingInlineStart);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -254,9 +254,25 @@
   --#{$table}--m-striped__tr--BackgroundColor: var(--pf-t--global--background--color--striped--row--default);
 
   // * Table sticky header
+  --#{$table}--m-sticky-header--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
   --#{$table}--m-sticky-header--cell--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$table}--m-sticky-header--ZIndex: calc(var(--pf-t--global--z-index--xs) + 1);
   --#{$table}--m-sticky-header--border--ZIndex: calc(var(--pf-t--global--z-index--xs) + 2);
+  --#{$table}--m-sticky-header--BorderRadius: 0;
+  --#{$table}--m-sticky-header--BoxShadow: 0;
+  --#{$table}--m-sticky-header--BorderBlockEndWidth: var(--#{$table}--border-width--base);
+  --#{$table}--m-sticky-header--BorderBlockEndColor: var(--#{$table}--BorderColor);
+  --#{$table}--m-sticky-header--BorderRadius--glass: var(--pf-t--global--border--radius--medium);
+  --#{$table}--m-sticky-header--BoxShadow--glass: var(--pf-t--global--box-shadow--sm);
+  --#{$table}--m-sticky-header--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}--m-sticky-header--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
+
+  :where(.pf-v6-theme-glass) & {
+    --#{$table}--m-sticky-header--border--ZIndex: -1;
+    --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
+    --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
+    --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
+  }
 }
 
 // TODO: update grouping comments to // Table {element}
@@ -279,41 +295,61 @@
     table-layout: fixed;
   }
 
-  // - Table sticky header
-  &.pf-m-sticky-header > .#{$table}__thead,
-  .#{$table}__thead.pf-m-nested-column-header {
-    position: sticky;
-    inset-block-start: 0;
-    z-index: var(--#{$table}--m-sticky-header--ZIndex);
-    background: var(--#{$table}--BackgroundColor);
-
-    &::before {
-      position: absolute;
-      inset-block-start: 0;
-      inset-block-end: 0;
-      inset-inline-start: 0;
-      inset-inline-end: 0;
-      z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
-      pointer-events: none;
-      content: '';
-      border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
+  &.pf-m-sticky-header-unstuck > .#{$table}__thead {
+    &::before,
+    &::after {
+      opacity: 0;
+      transition-timing-function: var(--#{$table}--m-sticky-header--TransitionTimingFunction--BackgroundColor);
+      transition-duration: var(--#{$table}--m-sticky-header--TransitionDuration--BackgroundColor);
+      transition-property: opacity;
     }
   }
 
-  &.pf-m-sticky-header {
+  &.pf-m-sticky-header-stuck > .#{$table}__thead {
+    &::before,
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &.pf-m-sticky-header,
+  &.pf-m-sticky-header-unstuck {
     position: relative;
 
-    thead:where(.#{$table}__thead) tr:where(.#{$table}__tr) {
+    > .#{$table}__thead {
+      position: sticky;
+      inset-block-start: 0;
+      z-index: var(--#{$table}--m-sticky-header--ZIndex);
+
+      &::before {
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        pointer-events: none;
+        content: '';
+        background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
+        border-radius: var(--#{$table}--m-sticky-header--BorderRadius);
+        box-shadow: var(--#{$table}--m-sticky-header--BoxShadow);
+      }
+
       > :where(th, td) {
         z-index: var(--#{$table}--m-sticky-header--cell--ZIndex); // set z-index here to allow sticky column to override
       }
     }
+  }
 
-    // - Table nested column header
-    > .pf-m-nested-column-header {
-      position: sticky;
-      inset-block-start: 0;
-      background: var(--#{$table}--BackgroundColor);
+  &.pf-m-sticky-header,
+  &.pf-m-sticky-header-stuck,
+  &.pf-m-nested-column-header {
+    > .#{$table}__thead {
+      &::after {
+        position: absolute;
+        inset: 0;
+        z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
+        pointer-events: none;
+        content: '';
+        border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
+      }
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -268,7 +268,6 @@
   --#{$table}--m-sticky-header--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
 
   :where(.pf-v6-theme-glass) & {
-    --#{$table}--m-sticky-header--border--ZIndex: -1;
     --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
@@ -339,7 +338,7 @@
   }
 
   &.pf-m-sticky-header,
-  &.pf-m-sticky-header-stuck,
+  &.pf-m-sticky-header-unstuck,
   &.pf-m-nested-column-header {
     > .#{$table}__thead {
       &::after {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -241,6 +241,7 @@
   // * Table nested column header
   --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: var(--#{$table}--border-width--base);
   --#{$table}__thead--m-nested-column-header--BorderBlockEndColor: var(--#{$table}--BorderColor);
+  --#{$table}__thead--m-nested-column-header--after--ZIndex: calc(var(--pf-t--global--z-index--xs) + 2);
   --#{$table}__thead--m-nested-column-header--button--OutlineOffset: #{pf-size-prem(-3px)};
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd: var(--pf-t--global--spacer--md);
@@ -1256,7 +1257,15 @@
   // - Table nested column header button
   &.pf-m-nested-column-header {
     position: relative;
-    border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
+
+    &::after {
+      position: absolute;
+      inset: 0;
+      z-index: var(--#{$table}__thead--m-nested-column-header--after--ZIndex);
+      pointer-events: none;
+      content: '';
+      border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
+    }
 
     .#{$table}__button {
       --#{$table}__button--PaddingInlineStart: var(--#{$table}__nested-column-header__button--PaddingInlineStart);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -239,6 +239,8 @@
   --#{$table}__tbody--m-selected--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
   // * Table nested column header
+  --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: var(--#{$table}--border-width--base);
+  --#{$table}__thead--m-nested-column-header--BorderBlockEndColor: var(--#{$table}--BorderColor);
   --#{$table}__thead--m-nested-column-header--button--OutlineOffset: #{pf-size-prem(-3px)};
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd: var(--pf-t--global--spacer--md);
@@ -302,6 +304,11 @@
       transition-duration: var(--#{$table}--m-sticky-header--TransitionDuration--BackgroundColor);
       transition-property: opacity;
     }
+  }
+
+  &.pf-m-sticky-header,
+  &.pf-m-sticky-header-stuck {
+    --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: 0;
   }
 
   &.pf-m-sticky-header-stuck > .#{$table}__thead {
@@ -1249,8 +1256,7 @@
   // - Table nested column header button
   &.pf-m-nested-column-header {
     position: relative;
-    background-color: var(--#{$table}--BackgroundColor);
-    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
+    border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
 
     .#{$table}__button {
       --#{$table}__button--PaddingInlineStart: var(--#{$table}__nested-column-header__button--PaddingInlineStart);

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -294,7 +294,7 @@
     table-layout: fixed;
   }
 
-  &.pf-m-sticky-header-unstuck > .#{$table}__thead {
+  &.pf-m-sticky-header-base > .#{$table}__thead {
     &::before,
     &::after {
       opacity: 0;
@@ -312,7 +312,7 @@
   }
 
   &.pf-m-sticky-header,
-  &.pf-m-sticky-header-unstuck {
+  &.pf-m-sticky-header-base {
     position: relative;
 
     > .#{$table}__thead {
@@ -338,7 +338,7 @@
   }
 
   &.pf-m-sticky-header,
-  &.pf-m-sticky-header-unstuck,
+  &.pf-m-sticky-header-base,
   &.pf-m-nested-column-header {
     > .#{$table}__thead {
       &::after {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -337,18 +337,16 @@
     }
   }
 
-  &.pf-m-sticky-header,
-  &.pf-m-sticky-header-base,
-  &.pf-m-nested-column-header {
-    > .#{$table}__thead {
-      &::after {
-        position: absolute;
-        inset: 0;
-        z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
-        pointer-events: none;
-        content: '';
-        border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
-      }
+  &.pf-m-sticky-header > .#{$table}__thead,
+  &.pf-m-sticky-header-base > .#{$table}__thead,
+  .#{$table}__thead.pf-m-nested-column-header {
+    &::after {
+      position: absolute;
+      inset: 0;
+      z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
+      pointer-events: none;
+      content: '';
+      border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
     }
   }
 
@@ -1251,6 +1249,8 @@
 
   // - Table nested column header button
   &.pf-m-nested-column-header {
+    position: relative;
+
     .#{$table}__button {
       --#{$table}__button--PaddingInlineStart: var(--#{$table}__nested-column-header__button--PaddingInlineStart);
       --#{$table}__button--PaddingInlineEnd: var(--#{$table}__nested-column-header__button--PaddingInlineEnd);

--- a/src/patternfly/components/Table/templates/table--default.hbs
+++ b/src/patternfly/components/Table/templates/table--default.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id=table--id table--IsGrid=true table--HasMdGridBreakpoint=true}}
+{{#> table table--IsGrid=true table--HasMdGridBreakpoint=true}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-th table-th--attribute='scope="col"'}}

--- a/src/patternfly/components/Table/templates/table--default.hbs
+++ b/src/patternfly/components/Table/templates/table--default.hbs
@@ -1,0 +1,221 @@
+{{#> table table--id=table--id table--IsGrid=true table--HasMdGridBreakpoint=true}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Workspaces
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Last commit
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 4
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 6
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 7
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 8
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 9
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 11
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}

--- a/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--tbody--tr.hbs
@@ -4,6 +4,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-1-modifier
         table--scrollable--th--content=cell-1--content
         table-th--IsStickyLeft=true
+        table-th--IsNoWrap=true
         table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-1--content}}
@@ -13,6 +14,7 @@
         table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier
         table--scrollable--th--content=cell-2--content
         table-th--IsStickyLeft=true
+        table-th--IsNoWrap=true
         table-th--attribute='style="--pf-v6-c-table__sticky-cell--MinWidth: 80px; --pf-v6-c-table__sticky-cell--InsetInlineStart: 100px;"'}}
   {{else}}
     {{> table--scrollable--td table--scrollable--td--content=cell-2--content}}
@@ -23,14 +25,18 @@
   {{> table--scrollable--td table--scrollable--td--content=cell-6--content}}
   {{> table--scrollable--td table--scrollable--td--content=cell-7--content}}
   {{> table--scrollable--td table--scrollable--td--content=cell-8--content}}
+  {{> table--scrollable--td table--scrollable--td--content=cell-9--content}}
+  {{> table--scrollable--td table--scrollable--td--content=cell-10--content}}
+  {{> table--scrollable--td table--scrollable--td--content=cell-11--content}}
+  {{> table--scrollable--td table--scrollable--td--content=cell-12--content}}
 
   {{#if table--scrollable--ColumnLastIsStickyColumn}}
     {{> table--scrollable--th
-        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
-        table--scrollable--th--content=cell-9--content
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-13-modifier
+        table--scrollable--th--content=cell-13--content
         table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 150px;"'
         table-th--IsStickyRight=true}}
   {{else}}
-    {{> table--scrollable--td table--scrollable--td--content=cell-9--content table--scrollable--td--icon=cell-9--icon}}
+    {{> table--scrollable--td table--scrollable--td--content=cell-13--content table--scrollable--td--icon=cell-13--icon}}
   {{/if}}
 {{/table-tr}}

--- a/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable--thead--tr.hbs
@@ -5,14 +5,15 @@
         table--scrollable--th--content=cell-1--content
         table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 100px;"'
         table-th--IsSortable=true
+        table-th--IsNoWrap=true
         table-th--IsStickyLeft=true}}
   {{else}}
     {{> table--scrollable--th table--scrollable--th--content=cell-1--content table-th--IsSortable=true}}
   {{/if}}
   {{#if table--scrollable--Column2IsStickyColumn}}
-    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--InsetInlineStart: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true}}
+    {{> table--scrollable--th table--scrollable--th--modifier=table--scrollable--th--modifier--cell-2-modifier table--scrollable--th--content=cell-2--content table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 120px; --pf-v6-c-table__sticky-cell--InsetInlineStart: 100px;"' table-th--IsSortable=true table-th--IsStickyLeft=true table-th--IsNoWrap=true}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--IsSortable=true}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-2--content table-th--IsSortable=true table-th--IsNoWrap=true}}
   {{/if}}
   {{> table--scrollable--th table--scrollable--th--content=cell-3--content table--scrollable--th--icon=cell-3--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-4--content table--scrollable--th--icon=cell-4--icon}}
@@ -20,14 +21,18 @@
   {{> table--scrollable--th table--scrollable--th--content=cell-6--content table--scrollable--th--icon=cell-6--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-7--content table--scrollable--th--icon=cell-7--icon}}
   {{> table--scrollable--th table--scrollable--th--content=cell-8--content table--scrollable--th--icon=cell-8--icon}}
+  {{> table--scrollable--th table--scrollable--th--content=cell-9--content table--scrollable--th--icon=cell-9--icon}}
+  {{> table--scrollable--th table--scrollable--th--content=cell-10--content table--scrollable--th--icon=cell-10--icon}}
+  {{> table--scrollable--th table--scrollable--th--content=cell-11--content table--scrollable--th--icon=cell-11--icon}}
+  {{> table--scrollable--th table--scrollable--th--content=cell-12--content table--scrollable--th--icon=cell-12--icon}}
 
   {{#if table--scrollable--ColumnLastIsStickyColumn}}
     {{> table--scrollable--th
-        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-9-modifier
-        table--scrollable--th--content=cell-9--content
+        table--scrollable--th--modifier=table--scrollable--th--modifier--cell-13-modifier
+        table--scrollable--th--content=cell-13--content
         table-th--attribute='scope="col" style="--pf-v6-c-table__sticky-cell--MinWidth: 150px;"'
         table-th--IsStickyRight=true}}
   {{else}}
-    {{> table--scrollable--th table--scrollable--th--content=cell-9--content table--scrollable--th--icon=cell-9--icon}}
+    {{> table--scrollable--th table--scrollable--th--content=cell-13--content table--scrollable--th--icon=cell-13--icon}}
   {{/if}}
 {{/table-tr}}

--- a/src/patternfly/components/Table/templates/table--scrollable.hbs
+++ b/src/patternfly/components/Table/templates/table--scrollable.hbs
@@ -1,17 +1,31 @@
-{{#> table table--id=table--scrollable--id table--IsGrid=true table--modifier=table--scrollable--modifier table--attribute='aria-label="This is a scrollable table"'}}
+{{#> table table--id=table--scrollable--id table--IsGrid=true table--modifier=table--scrollable--modifier table--aria-label='This is a scrollable table'}}
   {{#> table-thead}}
-    {{> table--scrollable--thead--tr table--tr--modifier="pf-m-nowrap" cell-1--content="Fact" cell-2--content="State" cell-3--content="Header 3" cell-4--content="Header 4" cell-5--content="Header 5" cell-6--content="Header 6" cell-7--content="Header 7" cell-8--content="Header 8" cell-9--content="Header 9"}}
+    {{> table--scrollable--thead--tr
+      table--tr--modifier="pf-m-nowrap"
+      cell-1--content="Fact"
+      cell-2--content="State"
+      cell-3--content="Header 3"
+      cell-4--content="Header 4"
+      cell-5--content="Header 5"
+      cell-6--content="Header 6"
+      cell-7--content="Header 7"
+      cell-8--content="Header 8"
+      cell-9--content="Header 9"
+      cell-10--content="Header 10"
+      cell-11--content="Header 11"
+      cell-12--content="Header 12"
+      cell-13--content="Header 13"}}
   {{/table-thead}}
 
   {{#> table-tbody table-td--modifier="pf-m-nowrap"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 1" cell-2--content="State 1" cell-3--content="Test cell 1-3" cell-4--content="Test cell 1-4" cell-5--content="Test cell 1-5" cell-6--content="Test cell 1-6" cell-7--content="Test cell 1-7" cell-8--content="Test cell 1-8" cell-9--content="Test cell 1-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 2" cell-2--content="State 2" cell-3--content="Test cell 2-3" cell-4--content="Test cell 2-4" cell-5--content="Test cell 2-5" cell-6--content="Test cell 2-6" cell-7--content="Test cell 2-7" cell-8--content="Test cell 2-8" cell-9--content="Test cell 2-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 3" cell-2--content="State 3" cell-3--content="Test cell 3-3" cell-4--content="Test cell 3-4" cell-5--content="Test cell 3-5" cell-6--content="Test cell 3-6" cell-7--content="Test cell 3-7" cell-8--content="Test cell 3-8" cell-9--content="Test cell 3-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 4" cell-2--content="State 4" cell-3--content="Test cell 4-3" cell-4--content="Test cell 4-4" cell-5--content="Test cell 4-5" cell-6--content="Test cell 4-6" cell-7--content="Test cell 4-7" cell-8--content="Test cell 4-8" cell-9--content="Test cell 4-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 5" cell-2--content="State 5" cell-3--content="Test cell 5-3" cell-4--content="Test cell 5-4" cell-5--content="Test cell 5-5" cell-6--content="Test cell 5-6" cell-7--content="Test cell 5-7" cell-8--content="Test cell 5-8" cell-9--content="Test cell 5-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 6" cell-2--content="State 6" cell-3--content="Test cell 6-3" cell-4--content="Test cell 6-4" cell-5--content="Test cell 6-5" cell-6--content="Test cell 6-6" cell-7--content="Test cell 6-7" cell-8--content="Test cell 6-8" cell-9--content="Test cell 6-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 7" cell-2--content="State 7" cell-3--content="Test cell 7-3" cell-4--content="Test cell 7-4" cell-5--content="Test cell 7-5" cell-6--content="Test cell 7-6" cell-7--content="Test cell 7-7" cell-8--content="Test cell 7-8" cell-9--content="Test cell 7-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 8" cell-2--content="State 8" cell-3--content="Test cell 8-3" cell-4--content="Test cell 8-4" cell-5--content="Test cell 8-5" cell-6--content="Test cell 8-6" cell-7--content="Test cell 8-7" cell-8--content="Test cell 8-8" cell-9--content="Test cell 8-9"}}
-    {{> table--scrollable--tbody--tr cell-1--content="Fact 9" cell-2--content="State 9" cell-3--content="Test cell 9-3" cell-4--content="Test cell 9-4" cell-5--content="Test cell 9-5" cell-6--content="Test cell 9-6" cell-7--content="Test cell 9-7" cell-8--content="Test cell 9-8" cell-9--content="Test cell 9-9"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 1" cell-2--content="State 1" cell-3--content="Test cell 1-3" cell-4--content="Test cell 1-4" cell-5--content="Test cell 1-5" cell-6--content="Test cell 1-6" cell-7--content="Test cell 1-7" cell-8--content="Test cell 1-8" cell-9--content="Test cell 1-9" cell-10--content="Test cell 1-10" cell-11--content="Test cell 1-11" cell-12--content="Test cell 1-12" cell-13--content="Test cell 1-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 2" cell-2--content="State 2" cell-3--content="Test cell 2-3" cell-4--content="Test cell 2-4" cell-5--content="Test cell 2-5" cell-6--content="Test cell 2-6" cell-7--content="Test cell 2-7" cell-8--content="Test cell 2-8" cell-9--content="Test cell 2-9" cell-10--content="Test cell 2-10" cell-11--content="Test cell 2-11" cell-12--content="Test cell 2-12" cell-13--content="Test cell 2-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 3" cell-2--content="State 3" cell-3--content="Test cell 3-3" cell-4--content="Test cell 3-4" cell-5--content="Test cell 3-5" cell-6--content="Test cell 3-6" cell-7--content="Test cell 3-7" cell-8--content="Test cell 3-8" cell-9--content="Test cell 3-9" cell-10--content="Test cell 3-10" cell-11--content="Test cell 3-11" cell-12--content="Test cell 3-12" cell-13--content="Test cell 3-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 4" cell-2--content="State 4" cell-3--content="Test cell 4-3" cell-4--content="Test cell 4-4" cell-5--content="Test cell 4-5" cell-6--content="Test cell 4-6" cell-7--content="Test cell 4-7" cell-8--content="Test cell 4-8" cell-9--content="Test cell 4-9" cell-10--content="Test cell 4-10" cell-11--content="Test cell 4-11" cell-12--content="Test cell 4-12" cell-13--content="Test cell 4-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 5" cell-2--content="State 5" cell-3--content="Test cell 5-3" cell-4--content="Test cell 5-4" cell-5--content="Test cell 5-5" cell-6--content="Test cell 5-6" cell-7--content="Test cell 5-7" cell-8--content="Test cell 5-8" cell-9--content="Test cell 5-9" cell-10--content="Test cell 5-10" cell-11--content="Test cell 5-11" cell-12--content="Test cell 5-12" cell-13--content="Test cell 5-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 6" cell-2--content="State 6" cell-3--content="Test cell 6-3" cell-4--content="Test cell 6-4" cell-5--content="Test cell 6-5" cell-6--content="Test cell 6-6" cell-7--content="Test cell 6-7" cell-8--content="Test cell 6-8" cell-9--content="Test cell 6-9" cell-10--content="Test cell 6-10" cell-11--content="Test cell 6-11" cell-12--content="Test cell 6-12" cell-13--content="Test cell 6-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 7" cell-2--content="State 7" cell-3--content="Test cell 7-3" cell-4--content="Test cell 7-4" cell-5--content="Test cell 7-5" cell-6--content="Test cell 7-6" cell-7--content="Test cell 7-7" cell-8--content="Test cell 7-8" cell-9--content="Test cell 7-9" cell-10--content="Test cell 7-10" cell-11--content="Test cell 7-11" cell-12--content="Test cell 7-12" cell-13--content="Test cell 7-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 8" cell-2--content="State 8" cell-3--content="Test cell 8-3" cell-4--content="Test cell 8-4" cell-5--content="Test cell 8-5" cell-6--content="Test cell 8-6" cell-7--content="Test cell 8-7" cell-8--content="Test cell 8-8" cell-9--content="Test cell 8-9" cell-10--content="Test cell 8-10" cell-11--content="Test cell 8-11" cell-12--content="Test cell 8-12" cell-13--content="Test cell 8-13"}}
+    {{> table--scrollable--tbody--tr cell-1--content="Fact 9" cell-2--content="State 9" cell-3--content="Test cell 9-3" cell-4--content="Test cell 9-4" cell-5--content="Test cell 9-5" cell-6--content="Test cell 9-6" cell-7--content="Test cell 9-7" cell-8--content="Test cell 9-8" cell-9--content="Test cell 9-9" cell-10--content="Test cell 9-10" cell-11--content="Test cell 9-11" cell-12--content="Test cell 9-12" cell-13--content="Test cell 9-13"}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -324,7 +324,7 @@ import './Table.css'
       <div class="pf-v6-c-scroll-inner-wrapper">
         {{> table--scrollable
             table--scrollable--id="sticky-right-column-example"
-            table--scrollable--th--modifier--cell-9-modifier="pf-m-truncate pf-m-border-left"
+            table--scrollable--th--modifier--cell-13-modifier="pf-m-border-left"
             table--scrollable--ColumnLastIsStickyColumn=true}}
       </div>
       {{> table-pagination-footer}}

--- a/src/patternfly/demos/Table/examples/Table.md
+++ b/src/patternfly/demos/Table/examples/Table.md
@@ -215,7 +215,7 @@ import './Table.css'
         toolbar-template--HasFilterGroup=true
         toolbar-template--HasSortButton=true
       }}
-    {{> table-simple-table table-simple-table--modifier="pf-m-sticky-header"}}
+    {{> table-simple-table table-simple-table--modifier="pf-m-sticky-header" table-simple-table--IsLong=true}}
     {{> table-pagination-footer}}
   {{/page-main-section}}
 {{/inline}}

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id=(concat page--id '-table') table--IsGrid=true table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--attribute='aria-label="This is a table with checkboxes"'}}
+{{#> table table--id=(concat page--id '-table') table--IsGrid=true table--modifier=(concat 'pf-m-grid-md ' table-simple-table--modifier) table--aria-label="This is a table with checkboxes"}}
   {{#> table-thead}}
     {{#> table-tr table-tr--index='1'}}
       {{> table-cell-empty table-cell--text='Row select'}}

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -32,13 +32,13 @@
         </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 10</span>
+        <span>{{pfIcon "code-branch"}} 10</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 25</span>
+        <span>{{pfIcon "code"}} 25</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 5</span>
+        <span>{{pfIcon "desktop"}} 5</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
@@ -58,13 +58,13 @@
         </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 8</span>
+        <span>{{pfIcon "code-branch"}} 8</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 30</span>
+        <span>{{pfIcon "code"}} 30</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 2</span>
+        <span>{{pfIcon "desktop"}} 2</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
@@ -84,13 +84,13 @@
         </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 12</span>
+        <span>{{pfIcon "code-branch"}} 12</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 48</span>
+        <span>{{pfIcon "code"}} 48</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 13</span>
+        <span>{{pfIcon "desktop"}} 13</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         30 days ago
@@ -110,13 +110,13 @@
         </div>
       {{/table-th}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 3</span>
+        <span>{{pfIcon "code-branch"}} 3</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 8</span>
+        <span>{{pfIcon "code"}} 8</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 20</span>
+        <span>{{pfIcon "desktop"}} 20</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         8 days ago
@@ -136,13 +136,13 @@
         </div>
       {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
-        <span><i class="fas fa-code-branch"></i> 34</span>
+        <span>{{pfIcon "code-branch"}} 34</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Pull requests"}}
-        <span><i class="fas fa-code"></i> 21</span>
+        <span>{{pfIcon "code"}} 21</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
-        <span><i class="fas fa-cube"></i> 26</span>
+        <span>{{pfIcon "desktop"}} 26</span>
       {{/table-td}}
       {{#> table-td table-td--data-label="Last commit"}}
         2 days ago
@@ -152,5 +152,137 @@
       {{/table-td}}
       {{> table-cell-action}}
     {{/table-tr}}
+
+    {{#if table-simple-table--IsLong}}
+      {{#> table-tr table-tr--index='7'}}
+        {{> table-cell-check}}
+        {{#> table-th table-th--data-label="Repository name"}}
+          <div>
+            <div id="{{table--id}}-node7">Node 7</div>
+            <a href="#">siemur/test-space</a>
+          </div>
+        {{/table-th}}
+        {{#> table-td table-td--data-label="Branches"}}
+          <span>{{pfIcon "code-branch"}} 15</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          <span>{{pfIcon "code"}} 18</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          <span>{{pfIcon "desktop"}} 7</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          5 days ago
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Action"}}
+          <a href="#">Action link</a>
+        {{/table-td}}
+        {{> table-cell-action}}
+      {{/table-tr}}
+
+      {{#> table-tr table-tr--index='8'}}
+        {{> table-cell-check}}
+        {{#> table-th table-th--data-label="Repository name"}}
+          <div>
+            <div id="{{table--id}}-node8">Node 8</div>
+            <a href="#">siemur/test-space</a>
+          </div>
+        {{/table-th}}
+        {{#> table-td table-td--data-label="Branches"}}
+          <span>{{pfIcon "code-branch"}} 6</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          <span>{{pfIcon "code"}} 22</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          <span>{{pfIcon "desktop"}} 4</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          1 day ago
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Action"}}
+          <a href="#">Action link</a>
+        {{/table-td}}
+        {{> table-cell-action}}
+      {{/table-tr}}
+
+      {{#> table-tr table-tr--index='9'}}
+        {{> table-cell-check}}
+        {{#> table-th table-th--data-label="Repository name"}}
+          <div>
+            <div id="{{table--id}}-node9">Node 9</div>
+            <a href="#">siemur/test-space</a>
+          </div>
+        {{/table-th}}
+        {{#> table-td table-td--data-label="Branches"}}
+          <span>{{pfIcon "code-branch"}} 9</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          <span>{{pfIcon "code"}} 15</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          <span>{{pfIcon "desktop"}} 11</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          14 days ago
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Action"}}
+          <a href="#">Action link</a>
+        {{/table-td}}
+        {{> table-cell-action}}
+      {{/table-tr}}
+
+      {{#> table-tr table-tr--index='10'}}
+        {{> table-cell-check}}
+        {{#> table-th table-th--data-label="Repository name"}}
+          <div>
+            <div id="{{table--id}}-node10">Node 10</div>
+            <a href="#">siemur/test-space</a>
+          </div>
+        {{/table-th}}
+        {{#> table-td table-td--data-label="Branches"}}
+          <span>{{pfIcon "code-branch"}} 11</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          <span>{{pfIcon "code"}} 6</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          <span>{{pfIcon "desktop"}} 17</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          3 days ago
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Action"}}
+          <a href="#">Action link</a>
+        {{/table-td}}
+        {{> table-cell-action}}
+      {{/table-tr}}
+
+      {{#> table-tr table-tr--index='11'}}
+        {{> table-cell-check}}
+        {{#> table-td table-td--data-label="Repository name"}}
+          <div>
+            <div id="{{table--id}}-node11">Node 11</div>
+            <a href="#">siemur/test-space</a>
+          </div>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Branches"}}
+          <span>{{pfIcon "code-branch"}} 19</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Pull requests"}}
+          <span>{{pfIcon "code"}} 14</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Workspaces"}}
+          <span>{{pfIcon "desktop"}} 9</span>
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Last commit"}}
+          6 days ago
+        {{/table-td}}
+        {{#> table-td table-td--data-label="Action"}}
+          <a href="#">Action link</a>
+        {{/table-td}}
+        {{> table-cell-action}}
+      {{/table-tr}}
+    {{/if}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/demos/Table/table-simple-table.hbs
+++ b/src/patternfly/demos/Table/table-simple-table.hbs
@@ -25,12 +25,12 @@
   {{#> table-tbody}}
     {{#> table-tr table-tr--index='2'}}
       {{> table-cell-check}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-td table-td--data-label="Repository name"}}
         <div>
           <div id="{{table--id}}-node1">Node 1</div>
           <a href="#">siemur/test-space</a>
         </div>
-      {{/table-th}}
+      {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         <span>{{pfIcon "code-branch"}} 10</span>
       {{/table-td}}
@@ -51,12 +51,12 @@
 
     {{#> table-tr table-tr--index='3'}}
       {{> table-cell-check}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-td table-td--data-label="Repository name"}}
         <div>
           <div id="{{table--id}}-node2">Node 2</div>
           <a href="#">siemur/test-space</a>
         </div>
-      {{/table-th}}
+      {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         <span>{{pfIcon "code-branch"}} 8</span>
       {{/table-td}}
@@ -77,12 +77,12 @@
 
     {{#> table-tr table-tr--index='4'}}
       {{> table-cell-check}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-td table-td--data-label="Repository name"}}
         <div>
           <div id="{{table--id}}-node3">Node 3</div>
           <a href="#">siemur/test-space</a>
         </div>
-      {{/table-th}}
+      {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         <span>{{pfIcon "code-branch"}} 12</span>
       {{/table-td}}
@@ -103,12 +103,12 @@
 
     {{#> table-tr table-tr--index='5'}}
       {{> table-cell-check}}
-      {{#> table-th table-th--data-label="Repository name"}}
+      {{#> table-td table-td--data-label="Repository name"}}
         <div>
           <div id="{{table--id}}-node4">Node 4</div>
           <a href="#">siemur/test-space</a>
         </div>
-      {{/table-th}}
+      {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         <span>{{pfIcon "code-branch"}} 3</span>
       {{/table-td}}
@@ -156,12 +156,12 @@
     {{#if table-simple-table--IsLong}}
       {{#> table-tr table-tr--index='7'}}
         {{> table-cell-check}}
-        {{#> table-th table-th--data-label="Repository name"}}
+        {{#> table-td table-td--data-label="Repository name"}}
           <div>
             <div id="{{table--id}}-node7">Node 7</div>
             <a href="#">siemur/test-space</a>
           </div>
-        {{/table-th}}
+        {{/table-td}}
         {{#> table-td table-td--data-label="Branches"}}
           <span>{{pfIcon "code-branch"}} 15</span>
         {{/table-td}}
@@ -182,12 +182,12 @@
 
       {{#> table-tr table-tr--index='8'}}
         {{> table-cell-check}}
-        {{#> table-th table-th--data-label="Repository name"}}
+        {{#> table-td table-td--data-label="Repository name"}}
           <div>
             <div id="{{table--id}}-node8">Node 8</div>
             <a href="#">siemur/test-space</a>
           </div>
-        {{/table-th}}
+        {{/table-td}}
         {{#> table-td table-td--data-label="Branches"}}
           <span>{{pfIcon "code-branch"}} 6</span>
         {{/table-td}}
@@ -208,12 +208,12 @@
 
       {{#> table-tr table-tr--index='9'}}
         {{> table-cell-check}}
-        {{#> table-th table-th--data-label="Repository name"}}
+        {{#> table-td table-td--data-label="Repository name"}}
           <div>
             <div id="{{table--id}}-node9">Node 9</div>
             <a href="#">siemur/test-space</a>
           </div>
-        {{/table-th}}
+        {{/table-td}}
         {{#> table-td table-td--data-label="Branches"}}
           <span>{{pfIcon "code-branch"}} 9</span>
         {{/table-td}}
@@ -234,12 +234,12 @@
 
       {{#> table-tr table-tr--index='10'}}
         {{> table-cell-check}}
-        {{#> table-th table-th--data-label="Repository name"}}
+        {{#> table-td table-td--data-label="Repository name"}}
           <div>
             <div id="{{table--id}}-node10">Node 10</div>
             <a href="#">siemur/test-space</a>
           </div>
-        {{/table-th}}
+        {{/table-td}}
         {{#> table-td table-td--data-label="Branches"}}
           <span>{{pfIcon "code-branch"}} 11</span>
         {{/table-td}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8223

[Default backstop report](https://drive.google.com/file/d/1yPVSSv3lgQXNvoEo94OErZYygGbiSc-C/view?usp=sharing)
[Glass backstop report](https://drive.google.com/file/d/1xeE2jm2l9s04Z68UBAlIRzc6giKRUlLi/view?usp=sharing)

https://pf-pr-8290.surge.sh/components/table#sticky-header
https://pf-pr-8290.surge.sh/components/table#sticky-header-with-base-and-stuck

Handlebars/examples updates
* Adds extra rows to some sticky header examples so they scroll and the header can actually be sticky
* Adds extra columns un-truncates some `<th>`s in sticky column examples scroll horizontally.
* Adds a new "Sticky header with base and stuck" example
* Updates icons in a table demo include that's used for sticky table demo

CSS
* Keeps `.pf-m-sticky-header` (the default/existing sticky behavior)
* Creates `.pf-m-sticky-header-base` and `.pf-m-sticky-header-stuck` for the new feature
  * `-base` applies the position/z-index stuff, basically everything but the stylized parts of a sticky header
  * `-stuck` applies all the stylized stuff like background, border, box shadow, etc. This is what should be shown once the user scrolls a little and the sticky header is floating above the table content
* Separates sticky visual styles out into `::before` and `::after`
  * `::before` - the background, border-radius, and box-shadow. Need to put at least the border-radius on a pseudo element since it won't work on a `<thead>` element. All of that sits behind the thead with a negative z-index.
  * `::after` - the border, which needs a positive z-index to sit on top of the thead.
* Updates all sticky headers to use new sticky background
* Adds glass styles to sticky header to make it rounded/shadow
* Adds style transition for "stuck" styles so those fade in (uses fade--default duration)
  *  Fading in the entire pseudo element using `opacity` instead of transitioning background-color, border, box-shadow for performance reasons 
* `.pf-m-nested-column-header` used to share vars/styles with sticky header - separated those from sticky header styles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sticky-header states (base & stuck), a no-wrap header option, and new table modifier mappings.

* **New Templates / Layout**
  * Added a default grid-style table template, a long-table variant, and expanded scrollable tables from 9 to 13 columns.

* **Style**
  * Improved sticky header visuals, transitions and CSS variables; glass-theme overrides; moved sticky styling to modifier-driven overlays.

* **Documentation**
  * Updated demos/examples, aria-label handling, usage notes, and example rows.

* **UX**
  * Switched icons to the platform icon helper and adjusted sticky column target index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->