### PR TITLE
chore(gulp): remove dev server rimraf

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -97,9 +97,6 @@ export async function buildWebpack() {
 
 async function startWebpackDevServer() {
   await start(themeCLIOptions);
-
-  // temporary auto deletion of public dir due to docs-framework bug
-  rimraf(path.join(process.cwd(), 'public'))
 }
 
 const buildSrc = parallel(compileSrcSASS, series(compileSrcHBS, compileSrcMD));


### PR DESCRIPTION
Removes a rimraf that was added previously to address a docs framework bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic cleanup step that deleted the public directory when starting the development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->