### PR TITLE
feat(Toolbar,OverflowMenu): add support for responsive height

### DIFF
--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.css
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.css
@@ -1,11 +1,14 @@
 #ws-core-c-overflow-menu-simple .pf-v6-c-overflow-menu__item,
 #ws-core-c-overflow-menu-simple .pf-v6-c-overflow-menu__group,
-#ws-core-c-overflow-menu-group-types .pf-v6-c-overflow-menu__group:not([class*="pf-m-"]) {
+#ws-core-c-overflow-menu-group-types .pf-v6-c-overflow-menu__group:not([class*="pf-m-"]),
+#ws-core-c-overflow-menu-vertical .pf-v6-c-overflow-menu__item,
+#ws-core-c-overflow-menu-vertical .pf-v6-c-overflow-menu__group {
   padding: .5rem;
   border: 2px dashed #393f44;
 }
 
-#ws-core-c-overflow-menu-simple .pf-v6-c-overflow-menu__group .pf-v6-c-overflow-menu__item {
+#ws-core-c-overflow-menu-simple .pf-v6-c-overflow-menu__group .pf-v6-c-overflow-menu__item,
+#ws-core-c-overflow-menu-vertical .pf-v6-c-overflow-menu__group .pf-v6-c-overflow-menu__item {
   padding: 0;
   border: none;
 }

--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
@@ -250,6 +250,6 @@ The action group consists of a primary and secondary action. Any additional acti
 | `.pf-v6-c-overflow-menu__control` | `<div>` | Initiates the overflow menu control. **Required** |
 | `.pf-v6-c-overflow-menu__group` | `<div>` | Initiates an overflow menu group. |
 | `.pf-v6-c-overflow-menu__item` | `<div>` | Initiates an overflow menu item. **Required** |
-| `.pf-m-vertical` | `.pf-v6-c-overflow-menu` | Modifies the flex direction of `.pf-v6-c-overflow-menu`, `.pf-v6-c-overflow-menu__content`, and `.pf-v6-c-overflow-menu__group` to "column", for vertically aligned overflow menus. |
+| `.pf-m-vertical` | `.pf-v6-c-overflow-menu` | Modifies the flex direction to "column", for vertically aligned overflow menus. |
 | `.pf-m-button-group` | `.pf-v6-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-button-group--spacer)`. Child spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-button-group--space-items)`. |
 | `.pf-m-icon-button-group` | `.pf-v6-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-icon-button-group--spacer)`. Child spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-icon-button-group--space-items)`. |

--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
@@ -250,5 +250,6 @@ The action group consists of a primary and secondary action. Any additional acti
 | `.pf-v6-c-overflow-menu__control` | `<div>` | Initiates the overflow menu control. **Required** |
 | `.pf-v6-c-overflow-menu__group` | `<div>` | Initiates an overflow menu group. |
 | `.pf-v6-c-overflow-menu__item` | `<div>` | Initiates an overflow menu item. **Required** |
+| `.pf-m-vertical` | `.pf-v6-c-overflow-menu` | Modifies the flex direction of `.pf-v6-c-overflow-menu`, `.pf-v6-c-overflow-menu__content`, and `.pf-v6-c-overflow-menu__group` to "column", for vertically aligned overflow menus. |
 | `.pf-m-button-group` | `.pf-v6-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-button-group--spacer)`. Child spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-button-group--space-items)`. |
 | `.pf-m-icon-button-group` | `.pf-v6-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-icon-button-group--spacer)`. Child spacer value is set to `var(--pf-v6-c-overflow-menu__group--m-icon-button-group--space-items)`. |

--- a/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
+++ b/src/patternfly/components/OverflowMenu/examples/overflow-menu.md
@@ -45,6 +45,31 @@ The overflow menu relies on groups (`.pf-v6-c-overflow-menu__group`) and items (
 {{/overflow-menu}}
 ```
 
+### Vertical
+```hbs isBeta
+{{#> overflow-menu overflow-menu--modifier="pf-m-vertical" overflow-menu--id="overflow-menu-vertical-expanded"}}
+  {{#> overflow-menu-content}}
+    {{#> overflow-menu-item}}
+      Item 1
+    {{/overflow-menu-item}}
+    {{#> overflow-menu-item}}
+      Item 2
+    {{/overflow-menu-item}}
+    {{#> overflow-menu-group}}
+      {{#> overflow-menu-item}}
+        Item 3
+      {{/overflow-menu-item}}
+      {{#> overflow-menu-item}}
+        Item 4
+      {{/overflow-menu-item}}
+      {{#> overflow-menu-item}}
+        Item 5
+      {{/overflow-menu-item}}
+    {{/overflow-menu-group}}
+  {{/overflow-menu-content}}
+{{/overflow-menu}}
+```
+
 ### Default spacing for items and groups:
 
 | Class | CSS Variable | Computed Value |

--- a/src/patternfly/components/OverflowMenu/overflow-menu.scss
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.scss
@@ -2,21 +2,35 @@
 
 @include pf-root($overflow-menu) {
   --#{$overflow-menu}--ColumnGap: var(--pf-t--global--spacer--md);
+  --#{$overflow-menu}--RowGap: var(--pf-t--global--spacer--md);
 
   // * Overflow menu group
   --#{$overflow-menu}__group--ColumnGap: var(--pf-t--global--spacer--md);
+  --#{$overflow-menu}__group--RowGap: var(--pf-t--global--spacer--md);
 
   // * Overflow menu button group
   --#{$overflow-menu}__group--m-button-group--ColumnGap: var(--pf-t--global--spacer--sm);
+  --#{$overflow-menu}__group--m-button-group--RowGap: var(--pf-t--global--spacer--sm);
 
   // * Overflow menu icon button group
   --#{$overflow-menu}__group--m-icon-button-group--ColumnGap: var(--pf-t--global--spacer--xs);
+  --#{$overflow-menu}__group--m-icon-button-group--RowGap: var(--pf-t--global--spacer--xs);
 }
 
 // - Overflow menu
 .#{$overflow-menu} {
   display: inline-flex;
+  row-gap: var(--#{$overflow-menu}--RowGap);
   column-gap: var(--#{$overflow-menu}--ColumnGap);
+}
+
+// - Overflow menu - vertical
+.#{$overflow-menu}.pf-m-vertical {
+  &,
+  .#{$overflow-menu}__content,
+  .#{$overflow-menu}__group {
+    flex-direction: column;
+  }
 }
 
 // - Overflow menu content - Overflow menu group
@@ -28,26 +42,31 @@
 
 // - Overflow menu group
 .#{$overflow-menu}__group {
+  row-gap: var(--#{$overflow-menu}__group--RowGap);
   column-gap: var(--#{$overflow-menu}__group--ColumnGap);
-
+  
   // - Overflow menu button group
   &.pf-m-button-group {
+    row-gap: var(--#{$overflow-menu}__group--m-button-group--RowGap);
     column-gap: var(--#{$overflow-menu}__group--m-button-group--ColumnGap);
   }
 
   // - Overflow menu icon button group
   &.pf-m-icon-button-group {
+    row-gap: var(--#{$overflow-menu}__group--m-icon-button-group--RowGap);
     column-gap: var(--#{$overflow-menu}__group--m-icon-button-group--ColumnGap);
   }
 }
 
 // - Oveflow menu item
 .#{$overflow-menu}__item {
+  row-gap: var(--#{$overflow-menu}__item--RowGap, var(--#{$overflow-menu}--RowGap));
   column-gap: var(--#{$overflow-menu}__item--ColumnGap, var(--#{$overflow-menu}--ColumnGap));
 }
 
 // - Overflow menu content - Overflow menu control
 .#{$overflow-menu}__content,
 .#{$overflow-menu}__control  {
+  row-gap: var(--#{$overflow-menu}--RowGap);
   column-gap: var(--#{$overflow-menu}--ColumnGap);
 }

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -657,6 +657,52 @@ Fusce tristique nulla id vestibulum maximus. Morbi sit amet nisi nec orci pulvin
 {{/toolbar}}
 ```
 
+### Vertical with height visibility breakpoints
+
+Visibility can be set per breakpoint to show or hide items and groups based on viewport height.
+
+```hbs isBeta
+{{#> toolbar toolbar--id="toolbar-vertical-height-toggle-example" toolbar--IsVertical=true}}
+  {{#> toolbar-content}}
+    {{#> toolbar-content-section}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{> divider}}
+      {{#> toolbar-group}}
+        {{#> toolbar-item}}
+          Item
+        {{/toolbar-item}}
+        {{#> toolbar-item}}
+          Item
+        {{/toolbar-item}}
+        {{#> toolbar-item toolbar-item--modifier="pf-m-hidden pf-m-visible-on-md-height"}}
+          Item (hidden below md)
+        {{/toolbar-item}}
+      {{/toolbar-group}}
+      {{> divider}}
+      {{#> toolbar-group toolbar-group--modifier="pf-m-hidden pf-m-visible-on-lg-height"}}
+        {{#> toolbar-item}}
+          Item (hidden below lg)
+        {{/toolbar-item}}
+        {{#> toolbar-item}}
+          Item (hidden below lg)
+        {{/toolbar-item}}
+        {{#> toolbar-item}}
+          Item (hidden below lg)
+        {{/toolbar-item}}
+      {{/toolbar-group}}
+    {{/toolbar-content-section}}
+  {{/toolbar-content}}
+{{/toolbar}}
+```
+
 ## Documentation
 
 ### Overview
@@ -715,6 +761,7 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | -- | -- | -- |
 | `.pf-m-toggle-group` | `.pf-v6-c-toolbar__group` | Modifies toolbar group to control when, and at which breakpoint, filters will be hidden/shown. By default, all filters are hidden until the specified breakpoint is reached. |
 | `.pf-m-[show/hide]` | `.pf-v6-c-toolbar__group.pf-m-toggle-group`, `.pf-v6-c-toolbar__expandable-content` | Modifies toolbar element to hidden. |
+| `.pf-m-[show/hide]-on-{breakpoint}-height` | `.pf-v6-c-toolbar__group.pf-m-toggle-group` within `.pf-v6-c-toolbar.pf-m-vertical` | Same as width-based toggle group modifiers, but keyed to global **height** breakpoints (viewport `min-height`). Use for vertical toolbars such as docked navigation. |
 
 ### Spacer system
 

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -30,6 +30,8 @@ Toolbar relies on groups (`.pf-v6-c-toolbar__group`) and items (`.pf-v6-c-toolba
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-[hidden/visible]` | `.pf-v6-c-toolbar > *` | Modifies toolbar element to be hidden/visible. |
+| `.pf-m-[hidden/visible]{-on-[breakpoint]}` | `.pf-v6-c-toolbar__content-section`, `.pf-v6-c-toolbar__group`, `.pf-v6-c-toolbar__item` | Modifies toolbar elements to be hidden/visible on an option breakpoint. |
+| `.pf-m-[hidden/visible]{-on-[breakpoint]}-height` | `.pf-v6-c-toolbar__content-section`, `.pf-v6-c-toolbar__group`, `.pf-v6-c-toolbar__item` | Modifies toolbar elements to be hidden/visible on an option height breakpoint. Primarily for use with vertical toolbars. |
 | `.pf-m-flex-grow` | `.pf-v6-c-toolbar__group`, `.pf-v6-c-toolbar__item` | Modifies toolbar element to `flex-grow: 1`, allowing it to consume available main-axis space. |
 | `.pf-m-align-[start/end]` | `.pf-v6-c-toolbar__group`, `.pf-v6-c-toolbar__item` | Modifies toolbar [main axis](https://developer.mozilla.org/en-US/docs/Glossary/Main_Axis) element alignment. |
 | `.pf-m-align-items-[stretch/baseline/start/center/end]` | `.pf-v6-c-toolbar__content-section`, `.pf-v6-c-toolbar__group`, `.pf-v6-c-toolbar__item` | Modifies toolbar element [cross axis](https://developer.mozilla.org/en-US/docs/Glossary/Cross_Axis) child alignment. |
@@ -761,7 +763,6 @@ As the toolbar component is a hybrid layout and component, some of its elements 
 | -- | -- | -- |
 | `.pf-m-toggle-group` | `.pf-v6-c-toolbar__group` | Modifies toolbar group to control when, and at which breakpoint, filters will be hidden/shown. By default, all filters are hidden until the specified breakpoint is reached. |
 | `.pf-m-[show/hide]` | `.pf-v6-c-toolbar__group.pf-m-toggle-group`, `.pf-v6-c-toolbar__expandable-content` | Modifies toolbar element to hidden. |
-| `.pf-m-[show/hide]-on-{breakpoint}-height` | `.pf-v6-c-toolbar__group.pf-m-toggle-group` within `.pf-v6-c-toolbar.pf-m-vertical` | Same as width-based toggle group modifiers, but keyed to global **height** breakpoints (viewport `min-height`). Use for vertical toolbars such as docked navigation. |
 
 ### Spacer system
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -101,7 +101,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 .#{$toolbar}__content-section,
 .#{$toolbar}__group,
 .#{$toolbar}__item {
-  @include pf-v6-hidden-visible(flex);
+  @include pf-v6-hidden-visible(flex, $ifIncludeHeight: true);
 }
 
 // - Toolbar - Toolbar content

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -112,7 +112,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
 // - Toolbar content - Toolbar content section - Toolbar expandable content
 .#{$toolbar}__content {
-  @include pf-v6-hidden-visible(grid);
+  @include pf-v6-hidden-visible(grid, $ifIncludeHeight: true);
 
   row-gap: var(--#{$toolbar}__content--RowGap);
   padding-inline-start: var(--#{$toolbar}__content--PaddingInlineStart);

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -196,7 +196,7 @@
   -ms-overflow-style: -ms-autohiding-scrollbar; // auto hides scrollbars in Edge
 }
 
-@mixin pf-v6-hidden-visible($val: "block") {
+@mixin pf-v6-hidden-visible($val: "block", $ifIncludeHeight: false) {
   // stylelint-disable-next-line
   --#{$pf-prefix}hidden-visible--visible--Display: #{$val};
 
@@ -216,6 +216,21 @@
   // toggle values based on state
   &.pf-m-hidden {
     --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
+  }
+
+  // only apply height breakpoints if $ifIncludeHeight is true
+  @if $ifIncludeHeight {
+    @each $size, $bp in $pf-v6-global--height-breakpoint-name-map {
+      @media screen and (min-height: $bp) {
+        &.pf-m-hidden-on-#{$size}-height {
+          --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--hidden--Display);
+        }
+
+        &.pf-m-visible-on-#{$size}-height {
+          --#{$pf-prefix}hidden-visible--Display: var(--#{$pf-prefix}hidden-visible--visible--Display);
+        }
+      }
+    }
   }
 
   @each $size, $bp in $pf-v6-global--breakpoint-name-map {


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly/issues/8031

- Updates the `hidden-visible` mixin to optionally create height breakpoints
- Opts `Toolbar` into the height breakpoints
- Adds vertical variant to OverflowMenu
- Adds `row-gap` to OverflowMenu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertical layout support for overflow menus with a vertical modifier, improved vertical spacing, and vertical-specific spacing variables.
  * Height-based visibility breakpoints for toolbar items/groups to enable responsive hide/show by viewport height.

* **Documentation**
  * Added a vertical overflow menu example.
  * Added a vertical toolbar example demonstrating height-based visibility controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->