### PR TITLE
feat(button): add plain variant

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -673,51 +673,6 @@
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-control--m-small--PaddingInlineStart);
   }
 
-  // Stateful
-  &.pf-m-stateful {
-    --#{$button}--BorderRadius: var(--#{$button}--m-stateful--BorderRadius);
-    --#{$button}--PaddingInlineStart: var(--#{$button}--m-stateful--PaddingInlineStart);
-    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-stateful--PaddingInlineEnd);
-    --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-stateful--m-small--PaddingInlineEnd);
-    --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-stateful--m-small--PaddingInlineStart);
-  }
-  
-  // Read
-  &.pf-m-read {
-    --#{$button}--BackgroundColor: var(--#{$button}--m-read--BackgroundColor);
-    --#{$button}--BorderColor: var(--#{$button}--m-read--BorderColor);
-    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-read--hover--BackgroundColor);
-    --#{$button}--hover--BorderColor: var(--#{$button}--m-read--hover--BorderColor);
-    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-read--m-clicked--BackgroundColor);
-    --#{$button}--m-clicked--BorderColor: var(--#{$button}--m-read--m-clicked--BorderColor);
-  }
-
-  // Unread
-  &.pf-m-unread {
-    --#{$button}--Color: var(--#{$button}--m-unread--Color);
-    --#{$button}--BackgroundColor: var(--#{$button}--m-unread--BackgroundColor);
-    --#{$button}__icon--Color: var(--#{$button}--m-unread__icon--Color);
-    --#{$button}--hover--Color: var(--#{$button}--m-unread--hover--Color);
-    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-unread--hover--BackgroundColor);
-    --#{$button}--hover__icon--Color: var(--#{$button}--m-unread--hover__icon--Color);
-    --#{$button}--m-clicked--Color: var(--#{$button}--m-unread--m-clicked--Color);
-    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-unread--m-clicked--BackgroundColor);
-    --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-unread--m-clicked__icon--Color);
-  }
-
-  // Attention
-  &.pf-m-attention {
-    --#{$button}--Color: var(--#{$button}--m-attention--Color);
-    --#{$button}--BackgroundColor: var(--#{$button}--m-attention--BackgroundColor);
-    --#{$button}__icon--Color: var(--#{$button}--m-attention__icon--Color);
-    --#{$button}--hover--Color: var(--#{$button}--m-attention--hover--Color);
-    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-attention--hover--BackgroundColor);
-    --#{$button}--hover__icon--Color: var(--#{$button}--m-attention--hover__icon--Color);
-    --#{$button}--m-clicked--Color: var(--#{$button}--m-attention--m-clicked--Color);
-    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-attention--m-clicked--BackgroundColor);
-    --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-attention--m-clicked__icon--Color);
-  }
-
   // Icon buttons
   &.pf-m-plain {
     --#{$button}--BorderWidth: var(--#{$button}--m-plain--BorderWidth);
@@ -755,10 +710,57 @@
       --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-no-padding--m-small--PaddingInlineEnd);
       --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-no-padding--m-small--PaddingInlineStart);
       --#{$button}--border--offset: var(--#{$button}--m-plain--m-no-padding--border--offset);
+      --#{$button}--m-stateful--PaddingInlineEnd: var(--#{$button}--m-plain--PaddingInlineEnd);
+      --#{$button}--m-stateful--PaddingInlineStart: var(--#{$button}--m-plain--PaddingInlineStart);
+      --#{$button}--m-read--hover--BackgroundColor: var(--#{$button}--m-plain--hover--BackgroundColor);
+      --#{$button}--m-read--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
+      --#{$button}--m-read--BackgroundColor: var(--#{$button}--m-plain--BackgroundColor);
 
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
       background: var(--#{$button}--BackgroundColor); // override the ripple background
     }
+  }
+
+  // Stateful
+  &.pf-m-stateful {
+    --#{$button}--BorderRadius: var(--#{$button}--m-stateful--BorderRadius);
+    --#{$button}--PaddingInlineStart: var(--#{$button}--m-stateful--PaddingInlineStart);
+    --#{$button}--PaddingInlineEnd: var(--#{$button}--m-stateful--PaddingInlineEnd);
+    --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-stateful--m-small--PaddingInlineEnd);
+    --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-stateful--m-small--PaddingInlineStart);
+  }
+  
+  // Read
+  &.pf-m-read {
+    --#{$button}--BorderColor: var(--#{$button}--m-read--BorderColor);
+    --#{$button}--hover--BorderColor: var(--#{$button}--m-read--hover--BorderColor);
+    --#{$button}--m-clicked--BorderColor: var(--#{$button}--m-read--m-clicked--BorderColor);
+  }
+
+  // Unread
+  &.pf-m-unread {
+    --#{$button}--Color: var(--#{$button}--m-unread--Color);
+    --#{$button}--BackgroundColor: var(--#{$button}--m-unread--BackgroundColor);
+    --#{$button}__icon--Color: var(--#{$button}--m-unread__icon--Color);
+    --#{$button}--hover--Color: var(--#{$button}--m-unread--hover--Color);
+    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-unread--hover--BackgroundColor);
+    --#{$button}--hover__icon--Color: var(--#{$button}--m-unread--hover__icon--Color);
+    --#{$button}--m-clicked--Color: var(--#{$button}--m-unread--m-clicked--Color);
+    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-unread--m-clicked--BackgroundColor);
+    --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-unread--m-clicked__icon--Color);
+  }
+
+  // Attention
+  &.pf-m-attention {
+    --#{$button}--Color: var(--#{$button}--m-attention--Color);
+    --#{$button}--BackgroundColor: var(--#{$button}--m-attention--BackgroundColor);
+    --#{$button}__icon--Color: var(--#{$button}--m-attention__icon--Color);
+    --#{$button}--hover--Color: var(--#{$button}--m-attention--hover--Color);
+    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-attention--hover--BackgroundColor);
+    --#{$button}--hover__icon--Color: var(--#{$button}--m-attention--hover__icon--Color);
+    --#{$button}--m-clicked--Color: var(--#{$button}--m-attention--m-clicked--Color);
+    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-attention--m-clicked--BackgroundColor);
+    --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-attention--m-clicked__icon--Color);
   }
 
   &.pf-m-block {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -221,8 +221,8 @@
 
   // Stateful
   --#{$button}--m-stateful--BorderRadius: var(--pf-t--global--border--radius--action--plain--default);
-  --#{$button}--m-stateful--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
-  --#{$button}--m-stateful--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
+  --#{$button}--m-stateful--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$button}--m-stateful--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
   --#{$button}--m-stateful--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
   --#{$button}--m-stateful--m-small--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--compact);
 
@@ -697,6 +697,11 @@
     --#{$button}--disabled--BackgroundColor: var(--#{$button}--m-plain--disabled--BackgroundColor);
     --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-small--PaddingInlineEnd);
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-small--PaddingInlineStart);
+    --#{$button}--m-stateful--PaddingInlineEnd: var(--#{$button}--m-plain--PaddingInlineEnd);
+    --#{$button}--m-stateful--PaddingInlineStart: var(--#{$button}--m-plain--PaddingInlineStart);
+    --#{$button}--m-read--hover--BackgroundColor: var(--#{$button}--m-plain--hover--BackgroundColor);
+    --#{$button}--m-read--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
+    --#{$button}--m-read--BackgroundColor: var(--#{$button}--m-plain--BackgroundColor);
 
     &.pf-m-no-padding {
       --#{$button}__icon--Color: var(--#{$button}--m-plain--m-no-padding__icon--Color);
@@ -710,11 +715,6 @@
       --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-plain--m-no-padding--m-small--PaddingInlineEnd);
       --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-plain--m-no-padding--m-small--PaddingInlineStart);
       --#{$button}--border--offset: var(--#{$button}--m-plain--m-no-padding--border--offset);
-      --#{$button}--m-stateful--PaddingInlineEnd: var(--#{$button}--m-plain--PaddingInlineEnd);
-      --#{$button}--m-stateful--PaddingInlineStart: var(--#{$button}--m-plain--PaddingInlineStart);
-      --#{$button}--m-read--hover--BackgroundColor: var(--#{$button}--m-plain--hover--BackgroundColor);
-      --#{$button}--m-read--m-clicked--BackgroundColor: var(--#{$button}--m-plain--m-clicked--BackgroundColor);
-      --#{$button}--m-read--BackgroundColor: var(--#{$button}--m-plain--BackgroundColor);
 
       min-width: var(--#{$button}--m-plain--m-no-padding--MinWidth);
       background: var(--#{$button}--BackgroundColor); // override the ripple background

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -732,8 +732,11 @@
   
   // Read
   &.pf-m-read {
+    --#{$button}--BackgroundColor: var(--#{$button}--m-read--BackgroundColor);
     --#{$button}--BorderColor: var(--#{$button}--m-read--BorderColor);
+    --#{$button}--hover--BackgroundColor: var(--#{$button}--m-read--hover--BackgroundColor);
     --#{$button}--hover--BorderColor: var(--#{$button}--m-read--hover--BorderColor);
+    --#{$button}--m-clicked--BackgroundColor: var(--#{$button}--m-read--m-clicked--BackgroundColor);
     --#{$button}--m-clicked--BorderColor: var(--#{$button}--m-read--m-clicked--BorderColor);
   }
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -221,8 +221,8 @@
 
   // Stateful
   --#{$button}--m-stateful--BorderRadius: var(--pf-t--global--border--radius--action--plain--default);
-  --#{$button}--m-stateful--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--default);
-  --#{$button}--m-stateful--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--default);
+  --#{$button}--m-stateful--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
+  --#{$button}--m-stateful--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$button}--m-stateful--m-small--PaddingInlineEnd: var(--pf-t--global--spacer--control--horizontal--compact);
   --#{$button}--m-stateful--m-small--PaddingInlineStart: var(--pf-t--global--spacer--control--horizontal--compact);
 

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -228,6 +228,18 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 <br><br>
 
+<strong>Read Plain</strong>
+<br>
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+<br><br>
+
 <strong>Unread</strong>
 <br>
 {{#> button button--IsStateful=true button--IsUnread=true button--icon="rh-ui-notification-fill"}}
@@ -305,7 +317,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | `.pf-m-danger` | `.pf-v6-c-button` | Modifies for danger styles. |
 | `.pf-m-warning` | `.pf-v6-c-button` | Modifies for warning styles. |
 | `.pf-m-link` | `.pf-v6-c-button` | Modifies for link styles. This button has no background or border and is styled as a link. This button would commonly appear in a form and may include an icon. |
-| `.pf-m-plain` | `.pf-v6-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, etc. |
+| `.pf-m-plain` | `.pf-v6-c-button` | Modifies for icon styles. This button has no background or border, uses a standard text color, and is used for `.pf-m-plain` icon buttons such as close, expand, kebab, stateful, etc. |
 | `.pf-m-no-padding` | `.pf-v6-c-button.pf-m-plain` | Modifies a plain button to remove padding. This modifier should only be used when the button is inline within a sentence or block of text. Adjacent plain buttons without padding should always have spacing between them. |
 | `.pf-m-inline` | `.pf-v6-c-button.pf-m-link` | Modifies for inline styles. This button is presented similar to a normal link and has no padding and is displayed inline with other inline content. When used as a `<span>`, the text will flow inline with text around it. |
 | `.pf-m-block` | `.pf-v6-c-button` | Creates a block level button. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -228,18 +228,6 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 <br><br>
 
-<strong>Read Plain</strong>
-<br>
-{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
-{{/button}}
-
-{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
-{{/button}}
-
-<br><br>
-
 <strong>Unread</strong>
 <br>
 {{#> button button--IsStateful=true button--IsUnread=true button--icon="rh-ui-notification-fill"}}
@@ -260,6 +248,64 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 {{#> button button--IsStateful=true button--IsAttention=true button--IsClicked=true button--icon="rh-ui-attention-bell-fill"}}
   10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
+{{/button}}
+
+<br><br>
+
+<strong>Plain</strong>
+<br>
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill"}}
+{{/button}}
+
+<br>
+
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill"}}
+{{/button}}
+
+<br>
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--icon="rh-ui-attention-bell-fill"}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-attention-bell-fill"}}
+{{/button}}
+
+<br><br>
+
+<strong>Plain with count</strong>
+<br>
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+<br>
+
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+<br>
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--icon="rh-ui-attention-bell-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-attention-bell-fill"}}
+  10 {{#> screen-reader}}items{{/screen-reader}}
 {{/button}}
 ```
 

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -254,26 +254,26 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 
 <strong>Plain</strong>
 <br>
-{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--icon="rh-ui-notification-fill" button--aria-label="all items read"}}
 {{/button}}
 
-{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill"}}
-{{/button}}
-
-<br>
-
-{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
-{{/button}}
-
-{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill"}}
+{{#> button button--IsStateful=true button--IsRead=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill" button--aria-label="all items read"}}
 {{/button}}
 
 <br>
 
-{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--icon="rh-ui-attention-bell-fill"}}
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--icon="rh-ui-notification-fill" button--aria-label="unread items"}}
 {{/button}}
 
-{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-attention-bell-fill"}}
+{{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-notification-fill" button--aria-label="unread items"}}
+{{/button}}
+
+<br>
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--icon="rh-ui-attention-bell-fill" button--aria-label="unread items, needs attention"}}
+{{/button}}
+
+{{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--IsClicked=true  button--icon="rh-ui-attention-bell-fill" button--aria-label="unread items, needs attention"}}
 {{/button}}
 
 <br><br>
@@ -291,21 +291,21 @@ For when a plain/icon button is placed inline with text {{> button button--IsPla
 <br>
 
 {{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--icon="rh-ui-notification-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
+  10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
 {{#> button button--IsStateful=true button--IsUnread=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-notification-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
+  10 {{#> screen-reader}}unread items{{/screen-reader}}
 {{/button}}
 
 <br>
 
 {{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--icon="rh-ui-attention-bell-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
+  10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 
 {{#> button button--IsStateful=true button--IsAttention=true button--IsPlain=true button--IsClicked=true button--icon="rh-ui-attention-bell-fill"}}
-  10 {{#> screen-reader}}items{{/screen-reader}}
+  10 {{#> screen-reader}}unread items, needs attention{{/screen-reader}}
 {{/button}}
 ```
 


### PR DESCRIPTION
Closes #8212

Adds plain variant to stateful buttons.

Changes
**button.scss:** For stateful buttons, PaddingInlineStart / PaddingInlineEnd now use --pf-t--global--spacer--action--horizontal--plain--default instead of the control horizontal default, so plain stateful controls match plain action padding in figma.

**Button.md:** Adds a Read Plain demo (read + clicked) next to the existing stateful examples, and extends the .pf-m-plain table description to include stateful use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted plain icon/button modifier order to change override precedence and refine spacing and hover/click visuals for plain and no‑padding stateful/read variants.

* **Documentation**
  * Added stateful "Plain" examples (Read, Unread, Attention — clicked/non-clicked) including variants with visible counts and screen‑reader labels; expanded plain-button usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->