### PR TITLE
feat(drawer): add plain variant to section

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -387,7 +387,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     --#{$drawer}__section--BackgroundColor: var(--#{$drawer}__section--m-secondary--BackgroundColor);
   }
 
-  &.pf-m-no-background {
+  &.pf-m-no-background,
+  &.pf-m-plain {
     --#{$drawer}__section--BackgroundColor: transparent;
   }
 }

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -387,8 +387,9 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     --#{$drawer}__section--BackgroundColor: var(--#{$drawer}__section--m-secondary--BackgroundColor);
   }
 
-  &.pf-m-no-background,
-  &.pf-m-plain {
+  @at-root :where(:root:not(.pf-v6-theme-glass)) &.pf-m-plain,
+  :where(:root.pf-v6-theme-glass) &:not(.pf-m-no-plain-on-glass),
+  &.pf-m-no-background {
     --#{$drawer}__section--BackgroundColor: transparent;
   }
 }

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -345,7 +345,7 @@ import './Drawer.css'
 | `.pf-m-padding` | `.pf-v6-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-v6-c-drawer__body` | Modifies the element to remove padding. |
 | `.pf-m-no-background` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__panel` | Modifies the drawer element background color to transparent. |
-| `.pf-m-plain` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static` | Applies plain styling to the drawer panel. |
+| `.pf-m-plain` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static`, `.pf-v6-c-drawer__section` | Applies plain styling. |
 | `.pf-m-no-plain-on-glass` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static` | Prevents the drawer panel from automatically applying plain styling when glass theme is enabled. |
 | `.pf-m-primary` | `.pf-v6-c-drawer__content` | Modifies the drawer content to use the primary background color. |
 | `.pf-m-secondary` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__content`, `.pf-v6-c-drawer__panel` | Modifies the drawer element to use the secondary background color. |

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -346,7 +346,7 @@ import './Drawer.css'
 | `.pf-m-no-padding` | `.pf-v6-c-drawer__body` | Modifies the element to remove padding. |
 | `.pf-m-no-background` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__panel` | Modifies the drawer element background color to transparent. |
 | `.pf-m-plain` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static`, `.pf-v6-c-drawer__section` | Applies plain styling. |
-| `.pf-m-no-plain-on-glass` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static` | Prevents the drawer panel from automatically applying plain styling when glass theme is enabled. |
+| `.pf-m-no-plain-on-glass` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static`, `.pf-v6-c-drawer__section` | Prevents the elements from automatically applying plain styling when glass theme is enabled. |
 | `.pf-m-primary` | `.pf-v6-c-drawer__content` | Modifies the drawer content to use the primary background color. |
 | `.pf-m-secondary` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__content`, `.pf-v6-c-drawer__panel` | Modifies the drawer element to use the secondary background color. |
 | `.pf-m-width-{25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-v6-c-drawer__panel` | Modifies the drawer panel width at optional [breakpoint](/foundations-and-styles/design-tokens/all-design-tokens). |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Drawer section header plain styling now renders a transparent background consistently with other background modifiers.

* **Documentation**
  * Updated Drawer docs to reflect that the plain modifier applies to section elements and how the no-plain-on-glass exception behaves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->