### PR TITLE
feat(Toolbar): add dynamic sticky styles

### DIFF
--- a/src/patternfly/components/Toolbar/examples/Toolbar.css
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.css
@@ -75,7 +75,7 @@
   background-color: var(--pf-t--global--background--color--secondary--default);
 }
 
-#ws-core-c-toolbar-sticky-toolbar .ws-preview-html {
+#ws-core-c-toolbar-sticky-toolbar, #ws-core-c-toolbar-dynamic-sticky-toolbar .ws-preview-html {
   height: 200px;
   overflow: auto;
 }

--- a/src/patternfly/components/Toolbar/examples/Toolbar.css
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.css
@@ -75,7 +75,7 @@
   background-color: var(--pf-t--global--background--color--secondary--default);
 }
 
-#ws-core-c-toolbar-sticky-toolbar, #ws-core-c-toolbar-dynamic-sticky-toolbar .ws-preview-html {
+#ws-core-c-toolbar-sticky-toolbar .ws-preview-html, #ws-core-c-toolbar-dynamic-sticky-toolbar .ws-preview-html {
   height: 200px;
   overflow: auto;
 }

--- a/src/patternfly/components/Toolbar/examples/Toolbar.md
+++ b/src/patternfly/components/Toolbar/examples/Toolbar.md
@@ -618,6 +618,68 @@ Etiam nulla lacus, porttitor vel volutpat et, malesuada id nunc. Suspendisse por
 Fusce tristique nulla id vestibulum maximus. Morbi sit amet nisi nec orci pulvinar interdum. Duis convallis, nunc vel pharetra blandit, urna neque eleifend nunc, maximus faucibus tellus nisl a velit. Aliquam quis turpis tempor nisi ultricies fermentum at et ipsum. Pellentesque vel tincidunt nisl. Donec elit ante, sodales ac ultrices vitae, egestas ut magna. Nulla sollicitudin ornare mi, a porttitor sem fermentum vitae. Praesent maximus fringilla gravida. Sed ultricies turpis ut lacus sodales, et aliquet risus accumsan. Pellentesque lacus sapien, cursus vitae nulla vel, bibendum tristique risus.
 ```
 
+### Dynamic sticky toolbar
+
+This example shows the use of `.pf-m-sticky-base` and `.pf-m-sticky-stuck`. `.pf-m-sticky-stuck` can be applied dynamically as the page has scrolled to only show sticky styles when the toolbar is "stuck" and floating above the content.
+
+```hbs
+{{#> toolbar toolbar--modifier="pf-m-sticky-base pf-m-sticky-stuck" toolbar--id="toolbar-sticky-stuck-example"}}
+  {{#> toolbar-content}}
+    {{#> toolbar-content-section}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{> divider divider--modifier="pf-m-vertical"}}
+      {{#> toolbar-group}}
+        {{#> toolbar-item}}
+          Item
+        {{/toolbar-item}}
+        {{#> toolbar-item}}
+          Item
+        {{/toolbar-item}}
+        {{#> toolbar-item}}
+          Item
+        {{/toolbar-item}}
+      {{/toolbar-group}}
+      {{> divider divider--modifier="pf-m-vertical"}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+      {{#> toolbar-item}}
+        Item
+      {{/toolbar-item}}
+    {{/toolbar-content-section}}
+  {{/toolbar-content}}
+{{/toolbar}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tempor mattis massa dignissim blandit. Mauris pellentesque nisi a erat ultricies, mollis auctor nulla volutpat. Donec eu nisl magna. Donec nisi nulla, blandit et mauris in, lobortis elementum neque. Nunc pharetra eleifend purus, in commodo nisl accumsan in. Vestibulum feugiat nisl eu venenatis feugiat. Morbi ornare velit vitae tellus sollicitudin, sed ornare neque sagittis. Proin sodales, libero et vestibulum luctus, nunc mi euismod dui, vel accumsan lacus odio vel nibh. Etiam at mattis purus, sit amet vestibulum metus. Maecenas feugiat condimentum ligula eget hendrerit. Nullam eleifend convallis sodales. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nullam rhoncus consectetur enim, at interdum mi tincidunt eget. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+<br><br>
+
+Maecenas vel sollicitudin ipsum, pulvinar pharetra magna. Aenean vel ipsum vel purus malesuada sagittis eget ac odio. Nullam vitae diam mollis, consectetur est vitae, sodales diam. Vivamus eu lectus quis mi maximus porta. Praesent erat sapien, vestibulum nec libero non, tincidunt congue mauris. Pellentesque vitae imperdiet mi. Nulla in ipsum neque. Cras a quam ut sem venenatis euismod non at tortor. Mauris porta purus augue, ut pharetra elit varius at. Vestibulum fringilla ligula ac leo tristique, porta venenatis nibh convallis.
+
+<br><br>
+
+Vestibulum vel orci mattis magna tristique suscipit. In vel tellus tempor, consectetur mi at, pellentesque enim. Cras venenatis tellus eget velit porttitor, sit amet malesuada tortor venenatis. Maecenas vitae augue ac orci volutpat gravida. In fermentum, orci eget tincidunt lobortis, turpis orci porta nibh, cursus dignissim lectus sapien at felis. Nulla facilisi. Aenean lectus justo, pellentesque sed nulla ut, pulvinar pellentesque tortor. Ut tempus euismod dolor gravida rhoncus. Quisque sed lorem sit amet erat tincidunt aliquet quis in nulla. Maecenas arcu erat, hendrerit a dui eget, convallis pharetra sapien. Nunc tellus enim, dictum eu egestas vel, ultrices eget est. Etiam quis vehicula sem. Nulla facilisi. Donec ante ipsum, fringilla iaculis ex a, tincidunt lobortis mi.
+
+<br><br>
+
+Etiam nulla lacus, porttitor vel volutpat et, malesuada id nunc. Suspendisse porttitor sem quis ante consequat, vitae commodo nulla ultricies. Nulla fermentum ipsum ac dolor elementum, eu luctus ex condimentum. Sed sed arcu aliquam, porta metus in, sollicitudin felis. Sed faucibus lacus consectetur orci ultricies laoreet. Morbi sed lectus dictum sem tempor porta. Donec ut diam tempor, venenatis erat vitae, accumsan diam. Etiam sed purus eget lacus vehicula iaculis non euismod dolor. Quisque ultricies eget est in semper.
+
+<br><br>
+
+Fusce tristique nulla id vestibulum maximus. Morbi sit amet nisi nec orci pulvinar interdum. Duis convallis, nunc vel pharetra blandit, urna neque eleifend nunc, maximus faucibus tellus nisl a velit. Aliquam quis turpis tempor nisi ultricies fermentum at et ipsum. Pellentesque vel tincidunt nisl. Donec elit ante, sodales ac ultrices vitae, egestas ut magna. Nulla sollicitudin ornare mi, a porttitor sem fermentum vitae. Praesent maximus fringilla gravida. Sed ultricies turpis ut lacus sodales, et aliquet risus accumsan. Pellentesque lacus sapien, cursus vitae nulla vel, bibendum tristique risus.
+```
+
 ### Vertical
 ```hbs isBeta
 {{#> toolbar toolbar--id="toolbar-vertical-example" toolbar--IsVertical=true}}

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -179,9 +179,15 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     padding-inline-start: var(--#{$toolbar}--m-sticky--PaddingInlineStart);
     padding-inline-end: var(--#{$toolbar}--m-sticky--PaddingInlineEnd);
     border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
-    
-
+  
     &::before {
+      --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
+
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
+      box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
       opacity: 0;
       transition-timing-function: var(--#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor);
       transition-duration: var(--#{$toolbar}--m-sticky--TransitionDuration--BackgroundColor);
@@ -190,11 +196,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   }
 
   &.pf-m-sticky-stuck {
-    --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
-
-    border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
-    box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
-
     &::before {
       opacity: 1;
     }

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -78,12 +78,14 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
   --#{$toolbar}--m-sticky--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
 
-  :where(.pf-v6-theme-glass) & {
-    --#{$toolbar}--m-sticky--BorderBlockEndWidth: 0;
-    --#{$toolbar}--m-sticky--BoxShadow: var(--#{$toolbar}--m-sticky--BoxShadow--glass);
-    --#{$toolbar}--m-sticky--BorderRadius: var(--#{$toolbar}--m-sticky--BorderRadius--glass);
-    --#{$toolbar}--m-sticky--PaddingInlineStart: var(--#{$toolbar}--m-sticky--PaddingInlineStart--glass);
-    --#{$toolbar}--m-sticky--PaddingInlineEnd: var(--#{$toolbar}--m-sticky--PaddingInlineEnd--glass);
+  :where(.pf-v6-theme-glass) {
+    .#{$toolbar} {
+      --#{$toolbar}--m-sticky--BorderBlockEndWidth: 0;
+      --#{$toolbar}--m-sticky--BoxShadow: var(--#{$toolbar}--m-sticky--BoxShadow--glass);
+      --#{$toolbar}--m-sticky--BorderRadius: var(--#{$toolbar}--m-sticky--BorderRadius--glass);
+      --#{$toolbar}--m-sticky--PaddingInlineStart: var(--#{$toolbar}--m-sticky--PaddingInlineStart--glass);
+      --#{$toolbar}--m-sticky--PaddingInlineEnd: var(--#{$toolbar}--m-sticky--PaddingInlineEnd--glass);
+    }
   }
 
   // * Toolbar vertical
@@ -186,6 +188,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
       position: absolute;
       inset: 0;
       z-index: -1;
+      content: '';
       border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
       box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
       opacity: 0;

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -181,7 +181,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     padding-inline-start: var(--#{$toolbar}--m-sticky--PaddingInlineStart);
     padding-inline-end: var(--#{$toolbar}--m-sticky--PaddingInlineEnd);
     background: transparent;
-    border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
+    border-radius: inherit;
   
     &::before {
       position: absolute;
@@ -190,6 +190,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
       content: '';
       background: var(--#{$toolbar}--BackgroundColor);
       border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
+      border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
       box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
       opacity: 0;
       transition-timing-function: var(--#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -171,6 +171,8 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   }
 
   &.pf-m-sticky-base {
+    --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
+
     position: sticky;
     inset-block-start: 0;
     z-index: var(--#{$toolbar}--m-sticky--ZIndex);
@@ -178,15 +180,15 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);
     padding-inline-start: var(--#{$toolbar}--m-sticky--PaddingInlineStart);
     padding-inline-end: var(--#{$toolbar}--m-sticky--PaddingInlineEnd);
+    background: transparent;
     border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
   
     &::before {
-      --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
-
       position: absolute;
       inset: 0;
       z-index: -1;
       content: '';
+      background: var(--#{$toolbar}--BackgroundColor);
       border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
       box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
       opacity: 0;

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -62,7 +62,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // * Toolbar sticky
   --#{$toolbar}--m-sticky--ZIndex: var(--pf-t--global--z-index--xs);
-  --#{$toolbar}--m-sticky--InsetBlockStart: var(--pf-t--global--spacer--sm);
   --#{$toolbar}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingInlineStart: 0;
@@ -175,7 +174,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
 
     position: sticky;
-    inset-block-start: var(--#{$toolbar}--m-sticky--InsetBlockStart);
+    inset-block-start: 0;
     z-index: var(--#{$toolbar}--m-sticky--ZIndex);
     padding-block-start: var(--#{$toolbar}--m-sticky--PaddingBlockStart);
     padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -170,7 +170,6 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
   }
 
-  // maintain same styles in default
   &.pf-m-sticky-base {
     position: sticky;
     inset-block-start: 0;

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -78,14 +78,12 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
   --#{$toolbar}--m-sticky--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
 
-  :where(.pf-v6-theme-glass) {
-    .#{$toolbar} {
-      --#{$toolbar}--m-sticky--BorderBlockEndWidth: 0;
-      --#{$toolbar}--m-sticky--BoxShadow: var(--#{$toolbar}--m-sticky--BoxShadow--glass);
-      --#{$toolbar}--m-sticky--BorderRadius: var(--#{$toolbar}--m-sticky--BorderRadius--glass);
-      --#{$toolbar}--m-sticky--PaddingInlineStart: var(--#{$toolbar}--m-sticky--PaddingInlineStart--glass);
-      --#{$toolbar}--m-sticky--PaddingInlineEnd: var(--#{$toolbar}--m-sticky--PaddingInlineEnd--glass);
-    }
+  :where(.pf-v6-theme-glass) & {
+    --#{$toolbar}--m-sticky--BorderBlockEndWidth: 0;
+    --#{$toolbar}--m-sticky--BoxShadow: var(--#{$toolbar}--m-sticky--BoxShadow--glass);
+    --#{$toolbar}--m-sticky--BorderRadius: var(--#{$toolbar}--m-sticky--BorderRadius--glass);
+    --#{$toolbar}--m-sticky--PaddingInlineStart: var(--#{$toolbar}--m-sticky--PaddingInlineStart--glass);
+    --#{$toolbar}--m-sticky--PaddingInlineEnd: var(--#{$toolbar}--m-sticky--PaddingInlineEnd--glass);
   }
 
   // * Toolbar vertical

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -62,6 +62,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
 
   // * Toolbar sticky
   --#{$toolbar}--m-sticky--ZIndex: var(--pf-t--global--z-index--xs);
+  --#{$toolbar}--m-sticky--InsetBlockStart: var(--pf-t--global--spacer--sm);
   --#{$toolbar}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingInlineStart: 0;
@@ -174,7 +175,7 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
 
     position: sticky;
-    inset-block-start: 0;
+    inset-block-start: var(--#{$toolbar}--m-sticky--InsetBlockStart);
     z-index: var(--#{$toolbar}--m-sticky--ZIndex);
     padding-block-start: var(--#{$toolbar}--m-sticky--PaddingBlockStart);
     padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -64,24 +64,27 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}--m-sticky--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$toolbar}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
+  --#{$toolbar}--m-sticky--PaddingInlineStart: 0;
+  --#{$toolbar}--m-sticky--PaddingInlineEnd: 0;
   --#{$toolbar}--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
   --#{$toolbar}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
   --#{$toolbar}--m-sticky--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toolbar}--m-sticky--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$toolbar}--m-sticky--BorderRadius: 0;
+  --#{$toolbar}--m-sticky--BorderRadius--glass: var(--pf-t--global--border--radius--medium);
+  --#{$toolbar}--m-sticky--BoxShadow--glass: var(--pf-t--global--box-shadow--sm);
+  --#{$toolbar}--m-sticky--PaddingInlineStart--glass: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky--PaddingInlineEnd--glass: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
+  --#{$toolbar}--m-sticky--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
 
-  // * Toolbar sticky stuck
-  --#{$toolbar}--m-sticky-base--InsetBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$toolbar}--m-sticky-base--BorderRadius: var(--pf-t--global--border--radius--medium);
-  --#{$toolbar}--m-sticky-base--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-  --#{$toolbar}--m-sticky-base--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
-  --#{$toolbar}--m-sticky-stuck--PaddingBlockStart: var(--pf-t--global--spacer--sm);
-  --#{$toolbar}--m-sticky-stuck--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
-  --#{$toolbar}--m-sticky-stuck--PaddingInlineStart: var(--pf-t--global--spacer--sm);
-  --#{$toolbar}--m-sticky-stuck--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$toolbar}--m-sticky-stuck--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
-  --#{$toolbar}--m-sticky-stuck--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
-  --#{$toolbar}--m-sticky-stuck--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
-  --#{$toolbar}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
+  :where(.pf-v6-theme-glass) & {
+    --#{$toolbar}--m-sticky--BorderBlockEndWidth: 0;
+    --#{$toolbar}--m-sticky--BoxShadow: var(--#{$toolbar}--m-sticky--BoxShadow--glass);
+    --#{$toolbar}--m-sticky--BorderRadius: var(--#{$toolbar}--m-sticky--BorderRadius--glass);
+    --#{$toolbar}--m-sticky--PaddingInlineStart: var(--#{$toolbar}--m-sticky--PaddingInlineStart--glass);
+    --#{$toolbar}--m-sticky--PaddingInlineEnd: var(--#{$toolbar}--m-sticky--PaddingInlineEnd--glass);
+  }
 
   // * Toolbar vertical
   --#{$toolbar}--m-vertical--Width: fit-content;
@@ -167,25 +170,35 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
   }
 
+  // maintain same styles in default
   &.pf-m-sticky-base {
     position: sticky;
-    inset-block-start: var(--#{$toolbar}--m-sticky-base--InsetBlockStart);
+    inset-block-start: 0;
     z-index: var(--#{$toolbar}--m-sticky--ZIndex);
-    border-radius: var(--#{$toolbar}--m-sticky-base--BorderRadius);
-    transition-timing-function: var(--#{$toolbar}--m-sticky-base--TransitionTimingFunction);
-    transition-duration: var(--#{$toolbar}--m-sticky-base--TransitionDuration);
-    transition-property: background-color, box-shadow;
+    padding-block-start: var(--#{$toolbar}--m-sticky--PaddingBlockStart);
+    padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);
+    padding-inline-start: var(--#{$toolbar}--m-sticky--PaddingInlineStart);
+    padding-inline-end: var(--#{$toolbar}--m-sticky--PaddingInlineEnd);
+    border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
+    
+
+    &::before {
+      opacity: 0;
+      transition-timing-function: var(--#{$toolbar}--m-sticky--TransitionTimingFunction--BackgroundColor);
+      transition-duration: var(--#{$toolbar}--m-sticky--TransitionDuration--BackgroundColor);
+      transition-property: opacity;
+    }
   }
 
   &.pf-m-sticky-stuck {
-    --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky-stuck--BackgroundColor);
+    --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky--BackgroundColor);
 
-    padding-block-start: var(--#{$toolbar}--m-sticky-stuck--PaddingBlockStart);
-    padding-block-end: var(--#{$toolbar}--m-sticky-stuck--PaddingBlockEnd);
-    padding-inline-start: var(--#{$toolbar}--m-sticky-stuck--PaddingInlineStart);
-    padding-inline-end: var(--#{$toolbar}--m-sticky-stuck--PaddingInlineEnd);
-    border-block-end: var(--#{$toolbar}--m-sticky-stuck--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky-stuck--BorderBlockEndColor);
-    box-shadow: var(--#{$toolbar}--m-sticky-stuck--BoxShadow);
+    border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
+    box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
+
+    &::before {
+      opacity: 1;
+    }
   }
 
   //  - Toolbar static

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -65,9 +65,23 @@ $pf-v6--include-toolbar-breakpoints: true !default;
   --#{$toolbar}--m-sticky--PaddingBlockStart: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--PaddingBlockEnd: var(--pf-t--global--spacer--md);
   --#{$toolbar}--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
-  --#{$toolbar}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$toolbar}--m-sticky--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
   --#{$toolbar}--m-sticky--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$toolbar}--m-sticky--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
+
+  // * Toolbar sticky stuck
+  --#{$toolbar}--m-sticky-base--InsetBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky-base--BorderRadius: var(--pf-t--global--border--radius--medium);
+  --#{$toolbar}--m-sticky-base--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+  --#{$toolbar}--m-sticky-base--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$toolbar}--m-sticky-stuck--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky-stuck--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky-stuck--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky-stuck--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$toolbar}--m-sticky-stuck--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
+  --#{$toolbar}--m-sticky-stuck--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$toolbar}--m-sticky-stuck--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
+  --#{$toolbar}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--md--bottom);
 
   // * Toolbar vertical
   --#{$toolbar}--m-vertical--Width: fit-content;
@@ -151,6 +165,27 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);
     border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
     box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
+  }
+
+  &.pf-m-sticky-base {
+    position: sticky;
+    inset-block-start: var(--#{$toolbar}--m-sticky-base--InsetBlockStart);
+    z-index: var(--#{$toolbar}--m-sticky--ZIndex);
+    border-radius: var(--#{$toolbar}--m-sticky-base--BorderRadius);
+    transition-timing-function: var(--#{$toolbar}--m-sticky-base--TransitionTimingFunction);
+    transition-duration: var(--#{$toolbar}--m-sticky-base--TransitionDuration);
+    transition-property: background-color, box-shadow;
+  }
+
+  &.pf-m-sticky-stuck {
+    --#{$toolbar}--BackgroundColor: var(--#{$toolbar}--m-sticky-stuck--BackgroundColor);
+
+    padding-block-start: var(--#{$toolbar}--m-sticky-stuck--PaddingBlockStart);
+    padding-block-end: var(--#{$toolbar}--m-sticky-stuck--PaddingBlockEnd);
+    padding-inline-start: var(--#{$toolbar}--m-sticky-stuck--PaddingInlineStart);
+    padding-inline-end: var(--#{$toolbar}--m-sticky-stuck--PaddingInlineEnd);
+    border-block-end: var(--#{$toolbar}--m-sticky-stuck--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky-stuck--BorderBlockEndColor);
+    box-shadow: var(--#{$toolbar}--m-sticky-stuck--BoxShadow);
   }
 
   //  - Toolbar static


### PR DESCRIPTION
Adds `pf-m-sticky-base` and `pf-m-sticky-stuck` for Toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dynamic sticky toolbar example demonstrating a stuck-state toolbar.

* **Style**
  * Introduced distinct sticky base and stuck visual states with transitions and glass-theme variants.
  * Adjusted preview container sizing to enable scrolling for toolbar examples.

* **Documentation**
  * Added a comprehensive example showing sticky toolbar behavior with scrollable content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->