### PR TITLE
feat(toggle-group): full width toggle group option

### DIFF
--- a/src/patternfly/components/ToggleGroup/examples/toggle-group.md
+++ b/src/patternfly/components/ToggleGroup/examples/toggle-group.md
@@ -314,6 +314,85 @@ cssPrefix: pf-v6-c-toggle-group
 {{/toggle-group}}
 ```
 
+### Filled
+```hbs
+{{#> toggle-group toggle-group--modifier="pf-m-fill"}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 1
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 2
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 3
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+{{/toggle-group}}
+
+<br/>
+
+{{#> toggle-group toggle-group--modifier="pf-m-fill"}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button toggle-group-button--modifier="pf-m-selected"}}
+      {{#> toggle-group-text}}
+        Option 1
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button toggle-group-button--modifier="pf-m-selected"}}
+      {{#> toggle-group-text}}
+        Option 2
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 3
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+{{/toggle-group}}
+
+<br/>
+
+{{#> toggle-group toggle-group--modifier="pf-m-fill"}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 1
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button}}
+      {{#> toggle-group-text}}
+        Option 2
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+  {{#> toggle-group-item}}
+    {{#> toggle-group-button toggle-group-button--attribute="disabled"}}
+      {{#> toggle-group-text}}
+        Option 3
+      {{/toggle-group-text}}
+    {{/toggle-group-button}}
+  {{/toggle-group-item}}
+{{/toggle-group}}
+```
+
 ## Documentation
 
 ### Accessibility
@@ -331,4 +410,5 @@ cssPrefix: pf-v6-c-toggle-group
 | `.pf-v6-c-toggle-group__text` | `<span>` | Initiates the toggle button text element. |
 | `.pf-v6-c-toggle-group__icon` | `<span>` | Initiates the toggle button icon element. |
 | `.pf-m-compact` | `.pf-v6-c-toggle-group` | Modifies the toggle group for compact styles. |
+| `.pf-m-fill` | `.pf-v6-c-toggle-group` | Modifies the group items to fill the available space. |
 | `.pf-m-selected` | `.pf-v6-c-toggle-group__button` | Modifies the toggle button group button for the selected state. |

--- a/src/patternfly/components/ToggleGroup/examples/toggle-group.md
+++ b/src/patternfly/components/ToggleGroup/examples/toggle-group.md
@@ -314,7 +314,8 @@ cssPrefix: pf-v6-c-toggle-group
 {{/toggle-group}}
 ```
 
-### Filled
+### Full width toggle
+To make toggle group items fill the available space, use `.pf-m-fill`. In the following example, the toggle group items fill the width of the parent as the window size changes.
 ```hbs
 {{#> toggle-group toggle-group--modifier="pf-m-fill"}}
   {{#> toggle-group-item}}

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -51,9 +51,9 @@
   --#{$toggle-group}__button--disabled--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Compact
-  --#{$toggle-group}--m-compact__button--PaddingBlockStart: 0;
+  --#{$toggle-group}--m-compact__button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$toggle-group}--m-compact__button--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$toggle-group}--m-compact__button--PaddingBlockEnd: 0;
+  --#{$toggle-group}--m-compact__button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$toggle-group}--m-compact__button--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$toggle-group}--m-compact__button--FontSize: var(--pf-t--global--font--size--body--default);
 }
@@ -67,6 +67,23 @@
     --#{$toggle-group}__button--PaddingBlockEnd: var(--#{$toggle-group}--m-compact__button--PaddingBlockEnd);
     --#{$toggle-group}__button--PaddingInlineStart: var(--#{$toggle-group}--m-compact__button--PaddingInlineStart);
     --#{$toggle-group}__button--FontSize: var(--#{$toggle-group}--m-compact__button--FontSize);
+  }
+
+  // Filled style
+  &.pf-m-fill {
+    .#{$toggle-group} {
+      flex-basis: 100%;
+    }
+
+    .#{$toggle-group}__item {
+      display: flex;
+      flex-grow: 1;
+    }
+
+    .#{$toggle-group}__button {
+      flex-basis: 100%;
+      justify-content: center;
+    }
   }
 }
 

--- a/src/patternfly/components/ToggleGroup/toggle-group.scss
+++ b/src/patternfly/components/ToggleGroup/toggle-group.scss
@@ -71,10 +71,6 @@
 
   // Filled style
   &.pf-m-fill {
-    .#{$toggle-group} {
-      flex-basis: 100%;
-    }
-
     .#{$toggle-group}__item {
       display: flex;
       flex-grow: 1;


### PR DESCRIPTION
Closes #8325

Addresses a RHOAI request for the toggle group component: support a layout where options use the full width of the row and restore vertical padding on the compact variant using design tokens.

## Changes
- Fill width layout: Documents and shows the use of the .pf-m-fill modifier on .pf-v6-c-toggle-group, so items grow to share available space and toggle buttons expand within each segment.
- Compact padding: Defines compact-specific button padding tokens so block padding uses --pf-t--global--spacer--xs (4px).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `.pf-m-fill` modifier for toggle groups to enable filled, equal-width button layout.

* **Documentation**
  * Added a "Full width toggle" / "Filled" example demonstrating unselected, selected, and disabled button states and updated the usage table to document the `.pf-m-fill` modifier.

* **Style**
  * Adjusted compact toggle-group button vertical padding to use global spacing tokens for consistent spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->