### PR TITLE
feat(compass): support for responsive docked nav

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -992,7 +992,7 @@
     }
   }
 
-  @at-root .#{$page}__dock.pf-m-text-expanded &,
+  @at-root :is(.#{$page}__dock, .#{$compass}__dock).pf-m-text-expanded &,
   &.pf-m-text-expanded {
     justify-content: flex-start;
     width: 100%;

--- a/src/patternfly/components/Compass/compass-dock-main.hbs
+++ b/src/patternfly/components/Compass/compass-dock-main.hbs
@@ -1,0 +1,9 @@
+<div class="{{pfv}}compass__dock-main
+  {{setModifiers
+    compass-dock-main--modifier=compass-dock-main--modifier
+  }}"
+  {{#if compass-dock-main--attribute}}
+    {{{compass-dock-main--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Compass/compass-dock.hbs
+++ b/src/patternfly/components/Compass/compass-dock.hbs
@@ -1,5 +1,7 @@
 <div class="{{pfv}}compass__dock
   {{setModifiers
+    compass-dock--IsExpanded='pf-m-expanded'
+    compass-dock--IsTextExpanded='pf-m-text-expanded'
     compass-dock--modifier=compass-dock--modifier
   }}"
   {{#if compass-dock--attribute}}

--- a/src/patternfly/components/Compass/compass-dock.hbs
+++ b/src/patternfly/components/Compass/compass-dock.hbs
@@ -5,5 +5,7 @@
   {{#if compass-dock--attribute}}
     {{{compass-dock--attribute}}}
   {{/if}}>
-  {{> @partial-block}}
+  {{#> compass-dock-main}}
+    {{> @partial-block}}
+  {{/compass-dock-main}}
 </div>

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -113,7 +113,7 @@
     }
 
     > .#{$masthead} {
-      --pf-v6-c-masthead--BackgroundColor: var(--#{$compass}--m-docked__masthead--BackgroundColor);
+      --#{$masthead}--BackgroundColor: var(--#{$compass}--m-docked__masthead--BackgroundColor);
   
       grid-area: header;
     }

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -25,6 +25,9 @@
   --#{$compass}__message-bar--MinWidth: 300px;
   --#{$compass}__message-bar--MaxWidth: 600px;
 
+  // Docked
+  --#{$compass}--m-docked__masthead--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+
   // Section animation
   --#{$compass}--section--slide--length--header: 100%;
   --#{$compass}--section--slide--length--sidebar: 100%;
@@ -108,14 +111,16 @@
     .#{$compass}__main {
       padding: var(--#{$compass}--Padding);
     }
+
+    > .#{$masthead} {
+      --pf-v6-c-masthead--BackgroundColor: var(--#{$compass}--m-docked__masthead--BackgroundColor);
+  
+      grid-area: header;
+    }
   }
 
   :root:where(.#{$pf-prefix}theme-dark) & {
     --#{$compass}--BackgroundImage: var(--#{$compass}--BackgroundImage--dark);
-  }
-
-  > .#{$masthead} {
-    grid-area: header;
   }
 
   @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
@@ -130,6 +135,39 @@
       > .#{$masthead} {
         display: none;
       }
+    }
+  }
+
+  // Masthead hamburger
+  > .#{$masthead} .#{$masthead}__toggle .#{$button}.pf-m-hamburger:is(:hover, :focus-visible) {
+    @include pf-v6-hamburger;
+  }
+
+  // mobile - show collapse when sidebar expanded
+  &:where(:has(> .#{$compass}__dock.pf-m-expanded)) > .#{$masthead} .#{$masthead}__toggle :is(.#{$button}.pf-m-hamburger, .#{$button}.pf-m-hamburger:hover, .#{$button}.pf-m-hamburger:focus-visible) {
+    @include pf-v6-hamburger($collapse: true);
+  }
+
+  // Docked masthead hamburger
+  .#{$compass}__dock.pf-m-expanded .#{$masthead}__toggle .#{$button}.pf-m-hamburger {
+    @include pf-v6-hamburger($collapse: true);
+  }
+
+  @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
+    // desktop - reset dock internal toggle to bars
+    .#{$compass}__dock .#{$masthead}__toggle .#{$button}.pf-m-hamburger,
+    .#{$compass}__dock.pf-m-expanded .#{$masthead}__toggle .#{$button}.pf-m-hamburger {
+      @include pf-v6-hamburger($reset: true);
+    }
+
+    // desktop - show expand arrow on hover
+    .#{$compass}__dock .#{$masthead}__toggle .#{$button}.pf-m-hamburger:is(:hover, :focus-visible) {
+      @include pf-v6-hamburger;
+    }
+
+    // desktop - show collapse arrow on hover when text expanded
+    .#{$compass}__dock.pf-m-text-expanded .#{$masthead}__toggle .#{$button}.pf-m-hamburger:is(:hover, :focus-visible) {
+      @include pf-v6-hamburger($collapse: true);
     }
   }
 }

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -97,9 +97,11 @@
   background-size: cover;
 
   &.pf-m-docked {
-    grid-template-areas: "dock main";
-    grid-template-rows: auto;
-    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "header"
+      "main";
+    grid-template-rows: max-content 1fr;
+    grid-template-columns: 1fr;
     align-items: stretch;
     padding: 0;
 
@@ -110,6 +112,25 @@
 
   :root:where(.#{$pf-prefix}theme-dark) & {
     --#{$compass}--BackgroundImage: var(--#{$compass}--BackgroundImage--dark);
+  }
+
+  > .#{$masthead} {
+    grid-area: header;
+  }
+
+  @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
+    &.pf-m-docked {
+      grid-template-areas: "dock main";
+      grid-template-rows: auto;
+      grid-template-columns: auto 1fr;
+      row-gap: var(--#{$compass}__main--RowGap);
+      align-items: stretch;
+      padding: 0;
+
+      > .#{$masthead} {
+        display: none;
+      }
+    }
   }
 }
 

--- a/src/patternfly/components/Compass/compass.scss
+++ b/src/patternfly/components/Compass/compass.scss
@@ -39,6 +39,27 @@
   --#{$compass}--section--m-expanded--TransitionDuration: var(--#{$compass}--section--m-expanded--duration), 0s, 0s, 0s, 0s, 0s;
   --#{$compass}--section--m-expanded--TransitionDelay: 0s;
 
+  // Dock
+  --#{$compass}__dock--Width: #{pf-size-prem(250px)};
+  --#{$compass}__dock--desktop--Width: auto;
+  --#{$compass}__dock--ZIndex: var(--pf-t--global--z-index--md);
+  --#{$compass}__dock--TransitionDuration--slide: 0s;
+  --#{$compass}__dock--m-expanded--TransitionDuration--slide: 0s;
+  --#{$compass}__dock--TransitionTimingFunction--slide: var(--pf-t--global--motion--timing-function--decelerate);
+
+  // Dock main
+  --#{$compass}__dock-main--BackgroundColor: var(--pf-t--global--background--color--floating--default);
+  --#{$compass}__dock-main--desktop--BackgroundColor: var(--pf-t--global--background--color--glass--primary--default, var(--pf-t--global--background--color--primary--default));
+  --#{$compass}__dock-main--BoxShadow: none;
+  --#{$compass}__dock--m-expanded__dock-main--BoxShadow: var(--pf-t--global--box-shadow--sm--right);
+  --#{$compass}__dock-main--desktop--BoxShadow: var(--pf-t--global--box-shadow--glass--default, none);
+  --#{$compass}__dock-main--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary, revert);
+  --#{$compass}__dock-main--BorderInlineEndWidth: var(--pf-t--global--border--width--glass--default, 0);
+  --#{$compass}__dock-main--BorderInlineEndColor: transparent;
+  --#{$compass}__dock-main--desktop--BorderInlineEndColor: var(--pf-t--global--border--color--glass--default, transparent);
+  --#{$compass}__dock--m-expanded__dock-main--BorderInlineEndWidth: var(--pf-t--global--border--width--glass--default, var(--pf-t--global--border--width--regular));
+  --#{$compass}__dock--m-expanded__dock-main--BorderInlineEndColor: var(--pf-t--global--border--color--glass--default, var(--pf-t--global--border--color--subtle));  
+
   @media screen and (prefers-reduced-motion: no-preference) {
     --#{$compass}--section--TransitionDuration: var(--#{$compass}--section--duration), 0s, var(--#{$compass}--section--duration), 0s, 0s, 0s;
     --#{$compass}--section--TransitionDelay: 0s, var(--#{$compass}--section--duration), 0s, var(--#{$compass}--section--duration), var(--#{$compass}--section--duration), var(--#{$compass}--section--duration);
@@ -211,6 +232,65 @@
     &.pf-m-expanded {
       margin-inline-start: var(--#{$compass}--Gap);
     }
+  }
+}
+
+// Dock
+.#{$compass}__dock {
+  position: fixed;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  z-index: var(--#{$compass}__dock--ZIndex);
+  display: flex;
+  flex-direction: column;
+  grid-area: dock;
+  width: var(--#{$compass}__dock--Width);
+  transition: translate var(--#{$compass}__dock--TransitionDuration--slide) var(--#{$compass}__dock--TransitionTimingFunction--slide);
+  translate: -100% 0;
+
+  &.pf-m-expanded {
+    --#{$compass}__dock--TransitionDuration--slide: var(--#{$compass}__dock--m-expanded--TransitionDuration--slide);
+
+    translate: 0;
+  }
+
+  @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
+    --#{$compass}__dock-main--BackgroundColor: var(--#{$compass}__dock-main--desktop--BackgroundColor);
+    --#{$compass}__dock-main--BorderInlineEndColor: var(--#{$compass}__dock-main--desktop--BorderInlineEndColor);
+
+    position: revert;
+    inset: revert;
+    width: auto;
+    translate: 0;
+  }
+
+  .#{$toolbar}.pf-m-vertical :is(.#{$toolbar}__content-section, .#{$toolbar}__group, .#{$toolbar}__item) {
+    align-items: stretch;
+  }
+
+  &.pf-m-text-expanded {
+    width: var(--#{$compass}__dock--Width);
+  }
+}
+
+.#{$compass}__dock-main {
+  flex-grow: 1;
+  background-color: var(--#{$compass}__dock-main--BackgroundColor);
+  backdrop-filter: var(--#{$compass}__dock-main--BackdropFilter);
+  border-inline-end: var(--#{$compass}__dock-main--BorderInlineEndWidth) solid var(--#{$compass}__dock-main--BorderInlineEndColor);
+  box-shadow: var(--#{$compass}__dock-main--BoxShadow);
+
+  .#{$compass}__dock.pf-m-expanded & {
+    border-inline-end: var(--#{$compass}__dock--m-expanded__dock-main--BorderInlineEndWidth) solid var(--#{$compass}__dock--m-expanded__dock-main--BorderInlineEndColor);
+    box-shadow: var(--#{$compass}__dock--m-expanded__dock-main--BoxShadow);
+  }
+
+  @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
+    --#{$compass}__dock-main--BoxShadow: var(--#{$compass}__dock-main--desktop--BoxShadow);
+    --#{$compass}__dock--m-expanded__dock-main--BoxShadow: var(--#{$compass}__dock-main--desktop--BoxShadow);
+    --#{$compass}__dock--m-expanded__dock-main--BorderInlineEndWidth: var(--#{$compass}__dock-main--BorderInlineEndWidth);
+    --#{$compass}__dock--m-expanded__dock-main--BorderInlineEndColor: var(--#{$compass}__dock-main--desktop--BorderInlineEndColor);
   }
 }
 

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -80,6 +80,7 @@ In a basic Compass layout, the page structure is defined by the order of element
 | `.pf-v6-c-compass__header` | `<div>` | Initiates the Compass header. **Required** |
 | `.pf-v6-c-compass__logo` | `<div>` | Initiates the Compass logo header. |
 | `.pf-v6-c-compass__dock` | `<div>` | Initiates the Compass dock. |
+| `.pf-v6-c-compass__dock-main` | `<div>` | Initiates the Compass dock main wrapper. |
 | `.pf-v6-c-compass__profile` | `<div>` | Initiates the Compass profile. |
 | `.pf-v6-c-compass__sidebar` | `<div>` | Initiates a Compass sidebar. **Required** |
 | `.pf-v6-c-compass__main` | `<div>` | Initiates the Compass main wrapper. **Required** |

--- a/src/patternfly/components/Masthead/masthead.scss
+++ b/src/patternfly/components/Masthead/masthead.scss
@@ -210,7 +210,7 @@ $pf-v6-c-masthead--inset-map: build-spacer-map("none", "sm", "md", "lg", "xl", "
       }
     }
 
-    @at-root .#{$page}__dock.pf-m-text-expanded & {
+    @at-root :is(.#{$page}__dock, .#{$compass}__dock).pf-m-text-expanded & {
       .#{$masthead}__logo {
         display: revert;
 

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -449,7 +449,7 @@
     }
   }
 
-  @at-root .#{$page}__dock.pf-m-text-expanded &,
+  @at-root :is(.#{$page}__dock, .#{$compass}__dock).pf-m-text-expanded &,
   &.pf-m-text-expanded {
     justify-content: flex-start;
     width: 100%;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -208,7 +208,7 @@
       }
     }
 
-    @at-root .#{$page}__dock.pf-m-text-expanded &,
+    @at-root :is(.#{$page}__dock, .#{$compass}__dock).pf-m-text-expanded &,
     &.pf-m-text-expanded {
       width: 100%;
 

--- a/src/patternfly/demos/Compass/compass--docked.hbs
+++ b/src/patternfly/demos/Compass/compass--docked.hbs
@@ -1,0 +1,68 @@
+{{#> compass--demo-context compass--id=compass--docked--id}}
+  {{#> compass compass--HasDock=true}}
+    {{#> masthead masthead--IsDisplayInline=true}}
+      {{#> masthead-main}}
+        {{> masthead-toggle}}
+        {{#> masthead-brand}}
+          {{> masthead-logo}}
+        {{/masthead-brand}}
+      {{/masthead-main}}
+      {{#> masthead-content}}
+        {{#> toolbar toolbar--IsStatic=true}}
+          {{#> toolbar-content}}
+            {{#> toolbar-content-section}}
+              {{#> toolbar-item toolbar-item--modifier="pf-m-align-end"}}
+                {{> button button--IsPlain=true button--IsIcon=true button--icon="search" button--aria-label="Search"}}
+              {{/toolbar-item}}
+            {{/toolbar-content-section}}
+          {{/toolbar-content}}
+        {{/toolbar}}
+      {{/masthead-content}}
+    {{/masthead}}
+    {{#> compass-dock}}
+      {{> masthead-template masthead-template--HasDockedNav=true masthead-template--id=(concat compass--id '-masthead')}}
+    {{/compass-dock}}
+    {{#> compass-main}}
+      {{#> compass-main-header}}
+        {{#> panel panel--IsGlass=true}}
+          {{#> panel-main}}
+            {{#> panel-main-body}}
+              {{#> compass-main-header-content}}
+                {{#> compass-main-header-title}}
+                  {{#> title titleType="h2" title--modifier="pf-m-h1"}}
+                    Header
+                  {{/title}}
+                {{/compass-main-header-title}}
+                {{#> compass-main-header-toolbar}}
+                  {{#> action-list}}
+                    {{#> action-list-group}}
+                      {{#> action-list-item}}
+                        {{#> button button--IsPrimary=true}}
+                          action
+                        {{/button}}
+                      {{/action-list-item}}
+                      {{#> action-list-item}}
+                        {{#> button button--IsSecondary=true}}
+                          action
+                        {{/button}}
+                      {{/action-list-item}}
+                    {{/action-list-group}}
+                  {{/action-list}}
+                {{/compass-main-header-toolbar}}
+              {{/compass-main-header-content}}
+            {{/panel-main-body}}
+          {{/panel-main}}
+        {{/panel}}
+      {{/compass-main-header}}
+      {{#> compass-content}}
+        {{#> panel panel--IsGlass=true}}
+          {{#> panel-main}}
+            {{#> panel-main-body}}
+              [so much room for activities]
+            {{/panel-main-body}}
+          {{/panel-main}}
+        {{/panel}}
+      {{/compass-content}}
+    {{/compass-main}}
+  {{/compass}}
+{{/compass--demo-context}}

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -203,74 +203,22 @@ This demo showcases how you can position a side-panel drawer on top of the other
 {{/drawer}}
 ```
 
-### Docked
+### Docked nav
 ```hbs isFullscreen isBeta
-{{#> compass--demo-context compass--id="compass-docked-demo"}}
-  {{#> compass compass--HasDock=true}}
-    {{#> masthead masthead--IsDisplayInline=true}}
-      {{#> masthead-main}}
-        {{> masthead-toggle}}
-        {{#> masthead-brand}}
-          {{> masthead-logo}}
-        {{/masthead-brand}}
-      {{/masthead-main}}
-      {{#> masthead-content}}
-        {{#> toolbar toolbar--IsStatic=true}}
-          {{#> toolbar-content}}
-            {{#> toolbar-content-section}}
-              {{#> toolbar-item toolbar-item--modifier="pf-m-align-end"}}
-                {{> button button--IsPlain=true button--IsIcon=true button--icon="search" button--aria-label="Search"}}
-              {{/toolbar-item}}
-            {{/toolbar-content-section}}
-          {{/toolbar-content}}
-        {{/toolbar}}
-      {{/masthead-content}}
-    {{/masthead}}
-    {{#> compass-dock}}
-      {{> masthead-template masthead-template--HasDockedNav=true masthead-template--id=(concat compass--id '-masthead')}}
-    {{/compass-dock}}
-    {{#> compass-main}}
-      {{#> compass-main-header}}
-        {{#> panel panel--IsGlass=true}}
-          {{#> panel-main}}
-            {{#> panel-main-body}}
-              {{#> compass-main-header-content}}
-                {{#> compass-main-header-title}}
-                  {{#> title titleType="h2" title--modifier="pf-m-h1"}}
-                    Header
-                  {{/title}}
-                {{/compass-main-header-title}}
-                {{#> compass-main-header-toolbar}}
-                  {{#> action-list}}
-                    {{#> action-list-group}}
-                      {{#> action-list-item}}
-                        {{#> button button--IsPrimary=true}}
-                          action
-                        {{/button}}
-                      {{/action-list-item}}
-                      {{#> action-list-item}}
-                        {{#> button button--IsSecondary=true}}
-                          action
-                        {{/button}}
-                      {{/action-list-item}}
-                    {{/action-list-group}}
-                  {{/action-list}}
-                {{/compass-main-header-toolbar}}
-              {{/compass-main-header-content}}
-            {{/panel-main-body}}
-          {{/panel-main}}
-        {{/panel}}
-      {{/compass-main-header}}
-      {{#> compass-content}}
-        {{#> panel panel--IsGlass=true}}
-          {{#> panel-main}}
-            {{#> panel-main-body}}
-              [so much room for activities]
-            {{/panel-main-body}}
-          {{/panel-main}}
-        {{/panel}}
-      {{/compass-content}}
-    {{/compass-main}}
-  {{/compass}}
-{{/compass--demo-context}}
+{{> compass--docked compass--docked--id="compass-docked-example"}}
+```
+
+### Docked nav - expanded on mobile
+```hbs isFullscreen isBeta
+{{> compass--docked compass--docked--id="compass-docked-mobile-expanded-example" compass-dock--IsExpanded=true}}
+```
+
+### Docked nav text expanded
+```hbs isFullscreen isBeta
+{{> compass--docked compass--docked--id="compass-docked-text-expanded-example" compass-dock--IsTextExpanded=true}}
+```
+
+### Docked nav text expanded - expanded on mobile
+```hbs isFullscreen isBeta
+{{> compass--docked compass--docked--id="compass-docked-text-expanded-mobile-expanded-example" compass-dock--IsExpanded=true compass-dock--IsTextExpanded=true}}
 ```

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -205,10 +205,29 @@ This demo showcases how you can position a side-panel drawer on top of the other
 
 ### Docked
 ```hbs isFullscreen isBeta
-{{#> compass--demo-context}}
+{{#> compass--demo-context compass--id="compass-docked-demo"}}
   {{#> compass compass--HasDock=true}}
+    {{#> masthead masthead--IsDisplayInline=true}}
+      {{#> masthead-main}}
+        {{> masthead-toggle}}
+        {{#> masthead-brand}}
+          {{> masthead-logo}}
+        {{/masthead-brand}}
+      {{/masthead-main}}
+      {{#> masthead-content}}
+        {{#> toolbar toolbar--IsStatic=true}}
+          {{#> toolbar-content}}
+            {{#> toolbar-content-section}}
+              {{#> toolbar-item toolbar-item--modifier="pf-m-align-end"}}
+                {{> button button--IsPlain=true button--IsIcon=true button--icon="search" button--aria-label="Search"}}
+              {{/toolbar-item}}
+            {{/toolbar-content-section}}
+          {{/toolbar-content}}
+        {{/toolbar}}
+      {{/masthead-content}}
+    {{/masthead}}
     {{#> compass-dock}}
-      {{> masthead-template masthead-template--HasDockedNav=true}}
+      {{> masthead-template masthead-template--HasDockedNav=true masthead-template--id=(concat compass--id '-masthead')}}
     {{/compass-dock}}
     {{#> compass-main}}
       {{#> compass-main-header}}

--- a/src/patternfly/demos/Page/page-template.hbs
+++ b/src/patternfly/demos/Page/page-template.hbs
@@ -6,27 +6,25 @@
     page--HasDock=masthead-template--HasDockedNav}}
   {{#unless page-template--HasNoMasthead}}
     {{#if masthead-template--HasDockedNav}}
-      {{#if masthead-template--HasDockedNav}}
-        {{#> masthead masthead--IsDisplayInline=true}}
-          {{#> masthead-main}}
-            {{> masthead-toggle}}
-            {{#> masthead-brand}}
-              {{> masthead-logo}}
-            {{/masthead-brand}}
-          {{/masthead-main}}
-          {{#> masthead-content}}
-            {{#> toolbar toolbar--IsStatic=true}}
-              {{#> toolbar-content}}
-                {{#> toolbar-content-section}}
-                  {{#> toolbar-item toolbar-item--modifier="pf-m-align-end"}}
-                    {{> button button--IsPlain=true button--IsIcon=true button--icon="search" button--aria-label="Search"}}
-                  {{/toolbar-item}}
-                {{/toolbar-content-section}}
-              {{/toolbar-content}}
-            {{/toolbar}}
-          {{/masthead-content}}
-        {{/masthead}}
-      {{/if}}
+      {{#> masthead masthead--IsDisplayInline=true}}
+        {{#> masthead-main}}
+          {{> masthead-toggle}}
+          {{#> masthead-brand}}
+            {{> masthead-logo}}
+          {{/masthead-brand}}
+        {{/masthead-main}}
+        {{#> masthead-content}}
+          {{#> toolbar toolbar--IsStatic=true}}
+            {{#> toolbar-content}}
+              {{#> toolbar-content-section}}
+                {{#> toolbar-item toolbar-item--modifier="pf-m-align-end"}}
+                  {{> button button--IsPlain=true button--IsIcon=true button--icon="search" button--aria-label="Search"}}
+                {{/toolbar-item}}
+              {{/toolbar-content-section}}
+            {{/toolbar-content}}
+          {{/toolbar}}
+        {{/masthead-content}}
+      {{/masthead}}
       {{#> page-dock}}
         {{> masthead-template masthead-template--id=(concat page--id '-masthead')}}
       {{/page-dock}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8042

Link - https://pf-pr-8330.surge.sh/ai/generative-uis/compass/html-demos/docked/

Adds `.pf-v6-c-compass__dock-main` to mimic the page component dock. Otherwise it's identical to the docked page responsive. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compass dock gains a dedicated dock-main wrapper and responsive mobile slide-in behavior.

* **Improvements**
  * New visual tokens for dock backgrounds, borders, and shadows; refined masthead and toggle behavior across breakpoints.
  * Buttons, menu toggle, nav and masthead visuals updated to better respect dock expanded/text-expanded states.

* **Documentation**
  * Updated Compass usage docs and demos showcasing docked variants and new classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->