### PR TITLE
chore: update yarn.lock to fix build

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,23 +3555,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^6.4.1":
-  version: 6.4.1
-  resolution: "@patternfly/react-core@npm:6.4.1"
-  dependencies:
-    "@patternfly/react-icons": "npm:^6.4.0"
-    "@patternfly/react-styles": "npm:^6.4.0"
-    "@patternfly/react-tokens": "npm:^6.4.0"
-    focus-trap: "npm:7.6.4"
-    react-dropzone: "npm:^14.3.5"
-    tslib: "npm:^2.8.1"
-  peerDependencies:
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/204b2b9f2990b0f0f5d907ba9d63f4f78f8691c8a4c7c292318978c5d4ea2dea89dab962be20e97bc3f2fd5172f2ee44abc17683c2c96f8f7eeb8ad357ba9326
-  languageName: node
-  linkType: hard
-
 "@patternfly/react-icons@npm:6.5.0-prerelease.13":
   version: 6.5.0-prerelease.13
   resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.13"


### PR DESCRIPTION
I'm guessing something happened with the deps update PRs. You can see the build failing the "install dependencies" step in a couple of PRs that were rebased recently

https://github.com/patternfly/patternfly/pull/8330
https://github.com/patternfly/patternfly/pull/8181