### PR TITLE
feat(Table): update sticky column background token

### DIFF
--- a/src/patternfly/components/Table/table-scrollable.scss
+++ b/src/patternfly/components/Table/table-scrollable.scss
@@ -7,7 +7,7 @@
   --#{$table}__sticky-cell--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$table}__sticky-cell--InsetInlineEnd: auto;
   --#{$table}__sticky-cell--InsetInlineStart: auto;
-  --#{$table}__sticky-cell--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$table}__sticky-cell--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
   --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndWidth: var(--pf-t--global--border--width--divider--default);
   --#{$table}__sticky-cell--m-border-right--before--BorderInlineEndColor: var(--pf-t--global--border--color--default);
   --#{$table}__sticky-cell--m-border-left--before--BorderInlineStartWidth: var(--pf-t--global--border--width--divider--default);


### PR DESCRIPTION
Closes #8232 

- Updates sticky cell background color to sticky token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CSS variable organization for table sticky cell backgrounds to use a dedicated design token for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->