### PR TITLE
feat(page): add glass mode support for sticky page sections

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -284,7 +284,7 @@ import './Page.css'
         Breadcrumb
       {{/page-main-breadcrumb}}
       {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic section title"'}}
-        This <code>.pf-v6-c-page__main-group</code> uses <code>.pf-m-sticky-top</code> and <code>.pf-m-sticky-top-stuck</code> for dynamic sticky positioning with a fade-in background and shadow.
+        This <code>.pf-v6-c-page__main-group</code> uses <code>.pf-m-sticky-top</code> and <code>.pf-m-sticky-top-stuck</code>. In glass mode, the background and shadow fade in when the section becomes stuck.
       {{/page-main-section}}
     {{/page-main-group}}
     {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic content section"'}}
@@ -338,10 +338,8 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-align-center` | `.pf-v6-c-page__main-section.pf-m-limit-width` | Modifies a page section body to align center. |
 | `.pf-m-sticky-top{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the top of its container at an optional height breakpoint. |
 | `.pf-m-sticky-bottom{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the bottom of its container at an optional height breakpoint. |
-| `.pf-m-sticky-top-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky top positioning with a transparent background and a `::before` pseudo-element for the fade-in background/shadow. Used with `.pf-m-sticky-top-stuck`. |
-| `.pf-m-sticky-top-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky top visual state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
-| `.pf-m-sticky-bottom-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky bottom positioning with a transparent background and a `::before` pseudo-element for the fade-in background/shadow. Used with `.pf-m-sticky-bottom-stuck`. |
-| `.pf-m-sticky-bottom-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky bottom visual state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
+| `.pf-m-sticky-top-stuck` | `.pf-v6-c-page__main-*` | Modifies a sticky top section to have stuck styles in glass mode, fades in the background and shadow. |
+| `.pf-m-sticky-bottom-stuck` | `.pf-v6-c-page__main-*` | Modifies a sticky bottom section to have stuck styles in glass mode, fades in the background and shadow. |
 | `.pf-m-shadow-bottom` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a bottom shadow. |
 | `.pf-m-shadow-top` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a top shadow. |
 | `.pf-m-overflow-scroll` | `.pf-v6-c-page__main-*` | Modifies a section/group to show a scrollbar if it has overflow content. |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -264,6 +264,36 @@ import './Page.css'
 {{/page}}
 ```
 
+### Sticky section dynamic
+```hbs
+{{#> page page--nav-direction="vertical"}}
+  {{#> masthead}}
+    {{#> masthead-main}}
+      {{> masthead-toggle}}
+      {{#> masthead-brand}}
+        {{#> masthead-logo}}
+          Logo
+        {{/masthead-logo}}
+      {{/masthead-brand}}
+    {{/masthead-main}}
+    {{> masthead-content}}
+  {{/masthead}}
+  {{#> page-main}}
+    {{#> page-main-group page-main-group--modifier="pf-m-sticky-top pf-m-sticky-top-stuck"}}
+      {{#> page-main-breadcrumb}}
+        Breadcrumb
+      {{/page-main-breadcrumb}}
+      {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic section title"'}}
+        This <code>.pf-v6-c-page__main-group</code> uses <code>.pf-m-sticky-top</code> and <code>.pf-m-sticky-top-stuck</code> for dynamic sticky positioning with a fade-in background and shadow.
+      {{/page-main-section}}
+    {{/page-main-group}}
+    {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic content section"'}}
+      Content below the sticky section.
+    {{/page-main-section}}
+  {{/page-main}}
+{{/page}}
+```
+
 ## Documentation
 ### Overview
 This component provides the basic chrome for a page, including sidebar and main areas.
@@ -308,6 +338,10 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-align-center` | `.pf-v6-c-page__main-section.pf-m-limit-width` | Modifies a page section body to align center. |
 | `.pf-m-sticky-top{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the top of its container at an optional height breakpoint. |
 | `.pf-m-sticky-bottom{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the bottom of its container at an optional height breakpoint. |
+| `.pf-m-sticky-top-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky top positioning with a transparent background and a `::before` pseudo-element for the fade-in background/shadow. Used with `.pf-m-sticky-top-stuck`. |
+| `.pf-m-sticky-top-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky top visual state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
+| `.pf-m-sticky-bottom-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky bottom positioning with a transparent background and a `::before` pseudo-element for the fade-in background/shadow. Used with `.pf-m-sticky-bottom-stuck`. |
+| `.pf-m-sticky-bottom-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky bottom visual state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
 | `.pf-m-shadow-bottom` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a bottom shadow. |
 | `.pf-m-shadow-top` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a top shadow. |
 | `.pf-m-overflow-scroll` | `.pf-v6-c-page__main-*` | Modifies a section/group to show a scrollbar if it has overflow content. |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -279,12 +279,12 @@ import './Page.css'
     {{> masthead-content}}
   {{/masthead}}
   {{#> page-main}}
-    {{#> page-main-group page-main-group--modifier="pf-m-sticky-top pf-m-sticky-top-stuck"}}
+    {{#> page-main-group page-main-group--modifier="pf-m-sticky-top-base pf-m-sticky-top-stuck"}}
       {{#> page-main-breadcrumb}}
         Breadcrumb
       {{/page-main-breadcrumb}}
       {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic section title"'}}
-        This <code>.pf-v6-c-page__main-group</code> uses <code>.pf-m-sticky-top</code> and <code>.pf-m-sticky-top-stuck</code>. In glass mode, the background and shadow fade in when the section becomes stuck.
+        This <code>.pf-v6-c-page__main-group</code> uses <code>.pf-m-sticky-top-base</code> and <code>.pf-m-sticky-top-stuck</code> for dynamic sticky positioning with a fade-in background and shadow.
       {{/page-main-section}}
     {{/page-main-group}}
     {{#> page-main-section page-main-section--attribute='aria-label="Sticky dynamic content section"'}}
@@ -338,8 +338,10 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-m-align-center` | `.pf-v6-c-page__main-section.pf-m-limit-width` | Modifies a page section body to align center. |
 | `.pf-m-sticky-top{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the top of its container at an optional height breakpoint. |
 | `.pf-m-sticky-bottom{-on-[breakpoint]-height}` | `.pf-v6-c-page__main-*` | Modifies a section/group to be sticky to the bottom of its container at an optional height breakpoint. |
-| `.pf-m-sticky-top-stuck` | `.pf-v6-c-page__main-*` | Modifies a sticky top section to have stuck styles in glass mode, fades in the background and shadow. |
-| `.pf-m-sticky-bottom-stuck` | `.pf-v6-c-page__main-*` | Modifies a sticky bottom section to have stuck styles in glass mode, fades in the background and shadow. |
+| `.pf-m-sticky-top-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky top positioning with no background or shadow. Used with `.pf-m-sticky-top-stuck`. |
+| `.pf-m-sticky-top-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky top stuck state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
+| `.pf-m-sticky-bottom-base` | `.pf-v6-c-page__main-*` | Sets up dynamic sticky bottom positioning with no background or shadow. Used with `.pf-m-sticky-bottom-stuck`. |
+| `.pf-m-sticky-bottom-stuck` | `.pf-v6-c-page__main-*` | Triggers the sticky bottom stuck state, fading in the background and shadow. Apply via JS when the section becomes stuck. |
 | `.pf-m-shadow-bottom` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a bottom shadow. |
 | `.pf-m-shadow-top` | `.pf-v6-c-page__main-*` | Modifies a section/group to have a top shadow. |
 | `.pf-m-overflow-scroll` | `.pf-v6-c-page__main-*` | Modifies a section/group to show a scrollbar if it has overflow content. |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -663,6 +663,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         position: sticky;
         inset-block-start: 0;
         z-index: var(--#{$page}--section--m-sticky-top--ZIndex);
+        background-color: var(--pf-t--global--background--color--sticky--default);
         border-block-end: var(--#{$page}--section--m-sticky-top--BorderBlockEndWidth) solid var(--#{$page}--section--m-sticky-top--BorderBlockEndColor);
         box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
       }
@@ -671,6 +672,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         position: sticky;
         inset-block-end: 0;
         z-index: var(--#{$page}--section--m-sticky-bottom--ZIndex);
+        background-color: var(--pf-t--global--background--color--sticky--default);
         border-block-start: var(--#{$page}--section--m-sticky-bottom--BorderBlockStartWidth) solid var(--#{$page}--section--m-sticky-bottom--BorderBlockStartColor);
         box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       }
@@ -684,13 +686,24 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     inset-block-start: 0;
     z-index: var(--#{$page}--section--m-sticky-top--ZIndex);
     box-shadow: none;
-    transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
-    transition-property: background-color, box-shadow;
+
+    &::before {
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      content: "";
+      background-color: var(--pf-t--global--background--color--sticky--default);
+      box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
+      opacity: 0;
+      transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
+      transition-property: opacity;
+    }
   }
 
   &.pf-m-sticky-top-stuck {
-    background-color: var(--pf-t--global--background--color--sticky--default);
-    box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
+    &::before {
+      opacity: 1;
+    }
   }
 
   &.pf-m-sticky-bottom-base {
@@ -698,13 +711,24 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     inset-block-end: 0;
     z-index: var(--#{$page}--section--m-sticky-bottom--ZIndex);
     box-shadow: none;
-    transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
-    transition-property: background-color, box-shadow;
+
+    &::before {
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      content: "";
+      background-color: var(--pf-t--global--background--color--sticky--default);
+      box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
+      opacity: 0;
+      transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
+      transition-property: opacity;
+    }
   }
 
   &.pf-m-sticky-bottom-stuck {
-    background-color: var(--pf-t--global--background--color--sticky--default);
-    box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
+    &::before {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -184,7 +184,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--section--m-sticky-bottom--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}--section--m-sticky-bottom--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
 
-  // Sticky - glass
+  // Sticky - dynamic
   --#{$page}--section--m-sticky-top--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
   --#{$page}--section--m-sticky-bottom--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
 
@@ -675,34 +675,36 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       }
 
-      // Glass sticky overrides: no shadow + fade transition when stuck
-      :where(.pf-v6-theme-glass) & {
-        &.pf-m-sticky-top#{$breakpoint-name} {
-          box-shadow: none;
-          transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
-          transition-property: background-color, box-shadow;
-        }
-
-        &.pf-m-sticky-bottom#{$breakpoint-name} {
-          box-shadow: none;
-          transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
-          transition-property: background-color, box-shadow;
-        }
-      }
     }
   }
 
-  // Glass sticky stuck state (not breakpoint-dependent)
-  :where(.pf-v6-theme-glass) & {
-    &.pf-m-sticky-top-stuck {
-      background-color: var(--pf-t--global--background--color--sticky--default);
-      box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
-    }
+  // Dynamic sticky modifiers: no shadow + fade transition when stuck
+  &.pf-m-sticky-top-base {
+    position: sticky;
+    inset-block-start: 0;
+    z-index: var(--#{$page}--section--m-sticky-top--ZIndex);
+    box-shadow: none;
+    transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
+    transition-property: background-color, box-shadow;
+  }
 
-    &.pf-m-sticky-bottom-stuck {
-      background-color: var(--pf-t--global--background--color--sticky--default);
-      box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
-    }
+  &.pf-m-sticky-top-stuck {
+    background-color: var(--pf-t--global--background--color--sticky--default);
+    box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
+  }
+
+  &.pf-m-sticky-bottom-base {
+    position: sticky;
+    inset-block-end: 0;
+    z-index: var(--#{$page}--section--m-sticky-bottom--ZIndex);
+    box-shadow: none;
+    transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
+    transition-property: background-color, box-shadow;
+  }
+
+  &.pf-m-sticky-bottom-stuck {
+    background-color: var(--pf-t--global--background--color--sticky--default);
+    box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -184,6 +184,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--section--m-sticky-bottom--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}--section--m-sticky-bottom--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
 
+  // Sticky - glass
+  --#{$page}--section--m-sticky-top--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$page}--section--m-sticky-bottom--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+
   // Shadows
   --#{$page}--section--m-shadow-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
   --#{$page}--section--m-shadow-bottom--ZIndex: var(--pf-t--global--z-index--xs);
@@ -670,6 +674,34 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         border-block-start: var(--#{$page}--section--m-sticky-bottom--BorderBlockStartWidth) solid var(--#{$page}--section--m-sticky-bottom--BorderBlockStartColor);
         box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       }
+
+      // Glass sticky overrides: no shadow + fade transition when stuck
+      :where(:root.pf-v6-theme-glass) & {
+        &.pf-m-sticky-top#{$breakpoint-name} {
+          box-shadow: none;
+          transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
+          transition-property: background-color, box-shadow;
+        }
+
+        &.pf-m-sticky-bottom#{$breakpoint-name} {
+          box-shadow: none;
+          transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
+          transition-property: background-color, box-shadow;
+        }
+      }
+    }
+  }
+
+  // Glass sticky stuck state (not breakpoint-dependent)
+  :where(:root.pf-v6-theme-glass) & {
+    &.pf-m-sticky-top-stuck {
+      background-color: var(--pf-t--global--background--color--sticky--default);
+      box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
+    }
+
+    &.pf-m-sticky-bottom-stuck {
+      background-color: var(--pf-t--global--background--color--sticky--default);
+      box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
     }
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -676,7 +676,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       }
 
       // Glass sticky overrides: no shadow + fade transition when stuck
-      :where(:root.pf-v6-theme-glass) & {
+      :where(.pf-v6-theme-glass) & {
         &.pf-m-sticky-top#{$breakpoint-name} {
           box-shadow: none;
           transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
@@ -693,7 +693,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   }
 
   // Glass sticky stuck state (not breakpoint-dependent)
-  :where(:root.pf-v6-theme-glass) & {
+  :where(.pf-v6-theme-glass) & {
     &.pf-m-sticky-top-stuck {
       background-color: var(--pf-t--global--background--color--sticky--default);
       box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -179,10 +179,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--section--m-sticky-top--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
   --#{$page}--section--m-sticky-top--BorderBlockEndWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}--section--m-sticky-top--BorderBlockEndColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$page}--section--m-sticky-top--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
   --#{$page}--section--m-sticky-bottom--ZIndex: var(--pf-t--global--z-index--md);
   --#{$page}--section--m-sticky-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--top);
   --#{$page}--section--m-sticky-bottom--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}--section--m-sticky-bottom--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
+  --#{$page}--section--m-sticky-bottom--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
 
   // Sticky - dynamic
   --#{$page}--section--m-sticky-top--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
@@ -663,7 +665,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         position: sticky;
         inset-block-start: 0;
         z-index: var(--#{$page}--section--m-sticky-top--ZIndex);
-        background-color: var(--pf-t--global--background--color--sticky--default);
+        background-color: var(--#{$page}--section--m-sticky-top--BackgroundColor);
         border-block-end: var(--#{$page}--section--m-sticky-top--BorderBlockEndWidth) solid var(--#{$page}--section--m-sticky-top--BorderBlockEndColor);
         box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
       }
@@ -672,7 +674,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         position: sticky;
         inset-block-end: 0;
         z-index: var(--#{$page}--section--m-sticky-bottom--ZIndex);
-        background-color: var(--pf-t--global--background--color--sticky--default);
+        background-color: var(--#{$page}--section--m-sticky-bottom--BackgroundColor);
         border-block-start: var(--#{$page}--section--m-sticky-bottom--BorderBlockStartWidth) solid var(--#{$page}--section--m-sticky-bottom--BorderBlockStartColor);
         box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       }
@@ -692,12 +694,17 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       inset: 0;
       z-index: -1;
       content: "";
-      background-color: var(--pf-t--global--background--color--sticky--default);
+      background-color: var(--#{$page}--section--m-sticky-top--BackgroundColor);
       box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
       opacity: 0;
       transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
       transition-property: opacity;
     }
+  }
+
+  &.pf-m-sticky-top-base,
+  .#{$page}__main-group.pf-m-sticky-top-base &:last-child {
+    --#{$page}__main-breadcrumb--PaddingBlockEnd: var(--#{$page}__main-breadcrumb--m-sticky-top--PaddingBlockEnd);
   }
 
   &.pf-m-sticky-top-stuck {
@@ -717,7 +724,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       inset: 0;
       z-index: -1;
       content: "";
-      background-color: var(--pf-t--global--background--color--sticky--default);
+      background-color: var(--#{$page}--section--m-sticky-bottom--BackgroundColor);
       box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       opacity: 0;
       transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
@@ -824,7 +831,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   padding-inline-end: var(--#{$page}__main-subnav--PaddingInlineEnd);
   background-color: var(--#{$page}__main-subnav--BackgroundColor);
 
-  &.pf-m-sticky-top {
+  &.pf-m-sticky-top,
+  &.pf-m-sticky-top-base {
     padding-block-end: var(--#{$page}__main-subnav--m-sticky-top--PaddingBlockEnd);
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -188,7 +188,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
   // Sticky - dynamic
   --#{$page}--section--m-sticky-top--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$page}--section--m-sticky-top--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$page}--section--m-sticky-bottom--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
+  --#{$page}--section--m-sticky-bottom--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
+
 
   // Shadows
   --#{$page}--section--m-shadow-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
@@ -698,6 +701,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       box-shadow: var(--#{$page}--section--m-sticky-top--BoxShadow);
       opacity: 0;
       transition-duration: var(--#{$page}--section--m-sticky-top--TransitionDuration);
+      transition-timing-function: var(--#{$page}--section--m-sticky-top--TransitionTimingFunction);
       transition-property: opacity;
     }
   }
@@ -728,6 +732,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       box-shadow: var(--#{$page}--section--m-sticky-bottom--BoxShadow);
       opacity: 0;
       transition-duration: var(--#{$page}--section--m-sticky-bottom--TransitionDuration);
+      transition-timing-function: var(--#{$page}--section--m-sticky-bottom--TransitionTimingFunction);
       transition-property: opacity;
     }
   }


### PR DESCRIPTION
Closes #8224

Convenience link: https://pf-pr-8345.surge.sh/components/page#sticky-section-dynamic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved glass-theme sticky visuals: added transition-duration variables and fade-style transitions for dynamic sticky top/bottom sections, with refined "base" vs "stuck" behavior that reveals background/shadow via a fade-in overlay.
* **Documentation**
  * New example demonstrating a vertical-nav page with dynamic sticky sections and updated modifier docs describing base vs stuck sticky states and their visual effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->