### PR TITLE
feat(banner): add pill variant

### DIFF
--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -57,6 +57,9 @@
   --#{$banner}--m-blue--Color: var(--pf-t--global--text--color--nonstatus--on-blue--default);
   --#{$banner}--m-purple--BackgroundColor: var(--pf-t--global--color--nonstatus--purple--default);
   --#{$banner}--m-purple--Color: var(--pf-t--global--text--color--nonstatus--on-purple--default);
+  
+  // pill
+  --#{$banner}--m-pill--BorderRadius: var(--pf-t--global--border--radius--pill);
 }
 
 .#{$banner} {
@@ -142,6 +145,10 @@
     inset-block-start: 0;
     z-index: var(--#{$banner}--m-sticky--ZIndex);
     box-shadow: var(--#{$banner}--m-sticky--BoxShadow);
+  }
+
+  &.pf-m-pill {
+    border-radius: var(--#{$banner}--m-pill--BorderRadius);
   }
 
   a {

--- a/src/patternfly/components/Banner/examples/Banner.md
+++ b/src/patternfly/components/Banner/examples/Banner.md
@@ -172,6 +172,79 @@ When a banner is used to convey status, it is advised to add an icon that also c
 {{/banner}}
 ```
 
+### Pill
+To display a banner with rounded corners, use `pf-m-pill`. The pill modifier can be combined with any status modifier.
+
+```hbs
+{{#> banner banner--modifier="pf-m-pill pf-m-success"}}
+  {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+    {{#> l-flex-item}}
+      {{#> screen-reader}}Success banner:{{/screen-reader}}
+      {{pfIcon "rh-ui-check-circle-fill"}}
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Success banner
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/banner}}
+
+<br>
+
+{{#> banner banner--modifier="pf-m-pill pf-m-warning"}}
+  {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+    {{#> l-flex-item}}
+      {{#> screen-reader}}Warning banner:{{/screen-reader}}
+      {{pfIcon "rh-ui-warning-fill"}}
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Warning banner
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/banner}}
+
+<br>
+
+{{#> banner banner--modifier="pf-m-pill pf-m-danger"}}
+  {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+    {{#> l-flex-item}}
+      {{#> screen-reader}}Danger banner:{{/screen-reader}}
+      {{pfIcon "rh-ui-error-fill"}}
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Danger banner
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/banner}}
+
+<br>
+
+{{#> banner banner--modifier="pf-m-pill pf-m-info"}}
+  {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+    {{#> l-flex-item}}
+      {{#> screen-reader}}Custom status banner:{{/screen-reader}}
+      {{pfIcon "rh-ui-information-fill"}}
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Info banner
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/banner}}
+
+<br>
+
+{{#> banner banner--modifier="pf-m-pill pf-m-custom"}}
+  {{#> l-flex l-flex--modifier="pf-m-space-items-sm"}}
+    {{#> l-flex-item}}
+      {{#> screen-reader}}Custom status banner:{{/screen-reader}}
+      {{pfIcon "rh-ui-notification-fill"}}
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Custom banner
+    {{/l-flex-item}}
+  {{/l-flex}}
+{{/banner}}
+```
+
 ## Documentation
 
 ### Usage
@@ -192,3 +265,4 @@ When a banner is used to convey status, it is advised to add an icon that also c
 | `.pf-m-info` | `.pf-v6-c-banner` |  Modifies banner for info status styling. |
 | `.pf-m-custom` | `.pf-v6-c-banner` |  Modifies banner for custom status styling. |
 | `.pf-m-sticky` | `.pf-v6-c-banner` |  Modifies banner to be sticky to the top of its container. |
+| `.pf-m-pill` | `.pf-v6-c-banner` |  Modifies banner for pill styles. |

--- a/src/patternfly/components/Banner/examples/Banner.md
+++ b/src/patternfly/components/Banner/examples/Banner.md
@@ -173,7 +173,7 @@ When a banner is used to convey status, it is advised to add an icon that also c
 ```
 
 ### Pill
-To display a banner with rounded corners, use `pf-m-pill`. The pill modifier can be combined with any status modifier.
+To display a banner with rounded corners, use `pf-m-pill`. The pill modifier can be combined with any Banner modifier.
 
 ```hbs
 {{#> banner banner--modifier="pf-m-pill pf-m-success"}}


### PR DESCRIPTION
Closes #8124

Adds pill-shaped banner variant (`pf-m-pill`) and updates examples and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pill-style modifier for the Banner component that applies rounded corners and can be combined with existing status variants.

* **Documentation**
  * Added Banner examples and usage docs demonstrating the new pill-style Banner with success, warning, danger, info, and custom status combinations, including accessibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->