### PR TITLE
chore(Compass): move docs to 'components'

### DIFF
--- a/patternfly-docs/patternfly-docs.config.js
+++ b/patternfly-docs/patternfly-docs.config.js
@@ -9,8 +9,7 @@ module.exports = {
   sideNavItems: [
     { section: 'components' },
     { section: 'patterns' },
-    { section: 'foundations-and-styles' },
-    { section: 'AI' }
+    { section: 'foundations-and-styles' }
   ],
   topNavItems: [
     {

--- a/src/patternfly/components/Compass/examples/Compass.css
+++ b/src/patternfly/components/Compass/examples/Compass.css
@@ -1,8 +1,8 @@
-#ws-page-main .ws-core-a-compass .pf-v6-c-compass {
+#ws-page-main .ws-core-c-compass .pf-v6-c-compass {
   height: 600px;
 }
 
-#ws-core-a-compass-basic [class*="pf-v6-c-compass"],
-#ws-core-a-compass-docked [class*="pf-v6-c-compass"] {
+#ws-core-c-compass-basic [class*="pf-v6-c-compass"],
+#ws-core-c-compass-docked [class*="pf-v6-c-compass"] {
   outline: var(--pf-t--global--border--width--regular) dashed var(--pf-t--global--border--color--default);
 }

--- a/src/patternfly/components/Compass/examples/Compass.md
+++ b/src/patternfly/components/Compass/examples/Compass.md
@@ -1,8 +1,7 @@
 ---
 id: 'Compass'
 beta: true
-section: AI
-subsection: Generative UIs
+section: components
 cssPrefix: pf-v6-c-compass
 ---
 

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -1,7 +1,6 @@
 ---
 id: Compass
-section: AI
-subsection: Generative UIs
+section: components
 wrapperTag: div
 ---
 


### PR DESCRIPTION
Closes: https://github.com/patternfly/patternfly/issues/8355

Moves the Compass component docs and demos to the Components section (out of the Generative AI section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified primary site navigation by removing the AI section, leaving components, patterns, and foundations-and-styles as the main categories.
  * Reclassified Compass examples from the AI section into the components section for clearer documentation organization.
* **Style**
  * Updated Compass component styling selectors/namespacing (no layout or content changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->