### PR TITLE
feat(Hero): make glass styles glass-theme only

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -140,15 +140,13 @@
     border-radius: inherit;
   }
 
-  :where(.pf-v6-theme-glass) & {
-    &.pf-m-glass {
-      --#{$card}--BackgroundColor: var(--#{$card}--m-glass--BackgroundColor);
-      --#{$card}--BorderColor: var(--#{$card}--m-glass--BorderColor);
-      --#{$card}--BorderWidth: var(--#{$card}--m-glass--BorderWidth);
-      
-      backdrop-filter: var(--#{$card}--m-glass--BackdropFilter);
-      box-shadow: var(--#{$card}--m-glass--BoxShadow);
-    }
+  :where(.pf-v6-theme-glass) &.pf-m-glass {
+    --#{$card}--BackgroundColor: var(--#{$card}--m-glass--BackgroundColor);
+    --#{$card}--BorderColor: var(--#{$card}--m-glass--BorderColor);
+    --#{$card}--BorderWidth: var(--#{$card}--m-glass--BorderWidth);
+    
+    backdrop-filter: var(--#{$card}--m-glass--BackdropFilter);
+    box-shadow: var(--#{$card}--m-glass--BoxShadow);
   }
 
   // SELECTABLE CARDS

--- a/src/patternfly/components/Hero/examples/Hero.md
+++ b/src/patternfly/components/Hero/examples/Hero.md
@@ -23,4 +23,4 @@ cssPrefix: pf-v6-c-hero
 | -- | -- | -- |
 | `.pf-v6-c-hero` | `<div>` | Initiates the hero. **Required** |
 | `.pf-v6-c-hero__body` | `<div>` | Initiates the hero body. |
-| `.pf-m-no-glass` | `.pf-v6-c-hero` | Modifies the hero to remove glass styling when using glass theme. |
+| `.pf-m-glass` | `.pf-v6-c-hero` | Applies glass styles when glass theme is enabled. |

--- a/src/patternfly/components/Hero/hero.hbs
+++ b/src/patternfly/components/Hero/hero.hbs
@@ -1,4 +1,8 @@
-<div class="{{pfv}}hero{{#if hero--modifier}} {{hero--modifier}}{{/if}}"
+<div class="{{pfv}}hero
+  {{setModifiers
+    hero--IsGlass='pf-m-glass'
+    hero--modifier=hero--modifier
+  }}"
   {{#if hero--attribute}}
     {{{hero--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -12,7 +12,8 @@
   --#{$hero}--gradient--stop-1--dark: transparent;
   --#{$hero}--gradient--stop-2--dark: transparent;
   --#{$hero}--gradient--stop-3--dark: transparent;
-  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--glass--primary--default);
+  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$hero}--BackgroundColor--glass: var(--pf-t--global--background--color--glass--primary--default);
   --#{$hero}--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary);
   --#{$hero}--BackgroundImage--light: none;
   --#{$hero}--BackgroundImage--dark: none;
@@ -41,16 +42,7 @@
   padding-block-end: var(--#{$hero}--PaddingBlockEnd);
   padding-inline-start: var(--#{$hero}--PaddingInlineStart);
   padding-inline-end: var(--#{$hero}--PaddingInlineEnd);
-  background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
-    linear-gradient(
-      var(--#{$hero}--gradient--angle),
-      var(--#{$hero}--gradient--stop-1, var(--#{$hero}--gradient--stop-1--light)) 0%,
-      var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
-      var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
-    );
-  background-repeat: var(--#{$hero}--BackgroundRepeat);
-  background-position: var(--#{$hero}--BackgroundPosition);
-  background-size: var(--#{$hero}--BackgroundSize);
+  background-color: var(--#{$hero}--BackgroundColor);
   border-color: var(--#{$hero}--BorderColor);
   border-style: var(--#{$hero}--BorderStyle);
   border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
@@ -62,23 +54,30 @@
   border-end-start-radius: var(--#{$hero}--BorderEndStartRadius);
   border-end-end-radius: var(--#{$hero}--BorderEndEndRadius);
 
+  :where(:root.#{$pf-prefix}theme-glass) &:not(.pf-m-no-glass) { 
+    --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
+    --#{$hero}--BackgroundColor: var(--#{$hero}--BackgroundColor--glass);
+  
+    background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
+    linear-gradient(
+      var(--#{$hero}--gradient--angle),
+      var(--#{$hero}--gradient--stop-1, var(--#{$hero}--gradient--stop-1--light)) 0%,
+      var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
+      var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
+    );
+    background-repeat: var(--#{$hero}--BackgroundRepeat);
+    background-position: var(--#{$hero}--BackgroundPosition);
+    background-size: var(--#{$hero}--BackgroundSize);
+    backdrop-filter: var(--#{$hero}--BackdropFilter);
+    box-shadow: var(--#{$hero}--m-glass--BoxShadow);
+  }
+
   :root:where(.#{$pf-prefix}theme-dark) & {
     --#{$hero}--BackgroundImage: var(--#{$hero}--BackgroundImage--dark);
     --#{$hero}--gradient--stop-1: var(--#{$hero}--gradient--stop-1--dark);
     --#{$hero}--gradient--stop-2: var(--#{$hero}--gradient--stop-2--dark);
     --#{$hero}--gradient--stop-3: var(--#{$hero}--gradient--stop-3--dark);
-  }
-
-  :root:where(.#{$pf-prefix}theme-glass) & {
-    --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
-  
-    box-shadow: var(--#{$hero}--m-glass--BoxShadow);
-  }
-
-  &:not(.pf-m-no-glass) {
-    background-color: var(--#{$hero}--BackgroundColor);
-    backdrop-filter: var(--#{$hero}--BackdropFilter);
-  }
+  } 
 }
 
 .#{$hero}__body {

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -1,10 +1,10 @@
 @use '../../sass-utilities' as *;
 
 @include pf-root($hero) {
-  --#{$hero}--PaddingBlockStart: var(--pf-t--global--spacer--xl);
-  --#{$hero}--PaddingBlockEnd: var(--pf-t--global--spacer--xl);
+  --#{$hero}--PaddingBlockStart: var(--pf-t--global--spacer--3xl);
+  --#{$hero}--PaddingBlockEnd: var(--pf-t--global--spacer--3xl);
   --#{$hero}--PaddingInlineStart: var(--pf-t--global--spacer--3xl);
-  --#{$hero}--PaddingInlineEnd: var(--pf-t--global--spacer--xl);
+  --#{$hero}--PaddingInlineEnd: var(--pf-t--global--spacer--3xl);
   --#{$hero}--gradient--angle: 109deg;
   --#{$hero}--gradient--stop-1--light: transparent;
   --#{$hero}--gradient--stop-2--light: transparent;
@@ -12,9 +12,7 @@
   --#{$hero}--gradient--stop-1--dark: transparent;
   --#{$hero}--gradient--stop-2--dark: transparent;
   --#{$hero}--gradient--stop-3--dark: transparent;
-  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
-  --#{$hero}--BackgroundColor--glass: var(--pf-t--global--background--color--glass--primary--default);
-  --#{$hero}--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary);
+  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--tertiary--default);
   --#{$hero}--BackgroundImage--light: none;
   --#{$hero}--BackgroundImage--dark: none;
   --#{$hero}--BackgroundRepeat: no-repeat;
@@ -26,14 +24,18 @@
   --#{$hero}--BorderInlineStartWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderInlineEndWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--glass--default);
-  --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
-  --#{$hero}--BorderStartStartRadius: 24px;
-  --#{$hero}--BorderStartEndRadius: 72px;
-  --#{$hero}--BorderEndEndRadius: 24px;
-  --#{$hero}--BorderEndStartRadius: 72px;
+  --#{$hero}--BorderStartStartRadius: var(--pf-t--global--border--radius--medium);
+  --#{$hero}--BorderStartEndRadius: 48px;
+  --#{$hero}--BorderEndEndRadius: var(--pf-t--global--border--radius--medium);
+  --#{$hero}--BorderEndStartRadius: 48px;
   --#{$hero}__body--Width: 800px;
   --#{$hero}__body--MaxWidth: 80%;
+
+  // Glass styles
+  --#{$hero}--m-glass--BackgroundColor: var(--pf-t--global--background--color--glass--primary--default);
+  --#{$hero}--m-glass--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary);
+  --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--glass--default);
+  --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
 }
 
 .#{$hero} {
@@ -53,7 +55,6 @@
   background-repeat: var(--#{$hero}--BackgroundRepeat);
   background-position: var(--#{$hero}--BackgroundPosition);
   background-size: var(--#{$hero}--BackgroundSize);
-  backdrop-filter: var(--#{$hero}--BackdropFilter);
   border-color: var(--#{$hero}--BorderColor);
   border-style: var(--#{$hero}--BorderStyle);
   border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
@@ -65,11 +66,14 @@
   border-end-start-radius: var(--#{$hero}--BorderEndStartRadius);
   border-end-end-radius: var(--#{$hero}--BorderEndEndRadius);
 
-  :where(:root.#{$pf-prefix}theme-glass) &:not(.pf-m-no-glass) { 
-    --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
-    --#{$hero}--BackgroundColor: var(--#{$hero}--BackgroundColor--glass);
-  
-    box-shadow: var(--#{$hero}--m-glass--BoxShadow);
+  :where(.#{$pf-prefix}theme-glass) & {
+    &.pf-m-glass {
+      --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
+      --#{$hero}--BackgroundColor: var(--#{$hero}--m-glass--BackgroundColor);
+
+      backdrop-filter: var(--#{$hero}--m-glass--BackdropFilter);
+      box-shadow: var(--#{$hero}--m-glass--BoxShadow);
+    }
   }
 
   :root:where(.#{$pf-prefix}theme-dark) & {

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -12,7 +12,7 @@
   --#{$hero}--gradient--stop-1--dark: transparent;
   --#{$hero}--gradient--stop-2--dark: transparent;
   --#{$hero}--gradient--stop-3--dark: transparent;
-  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  --#{$hero}--BackgroundColor: var(--pf-t--global--background--color--secondary--default);
   --#{$hero}--BackgroundColor--glass: var(--pf-t--global--background--color--glass--primary--default);
   --#{$hero}--BackdropFilter: var(--pf-t--global--background--filter--glass--blur--primary);
   --#{$hero}--BackgroundImage--light: none;
@@ -43,6 +43,17 @@
   padding-inline-start: var(--#{$hero}--PaddingInlineStart);
   padding-inline-end: var(--#{$hero}--PaddingInlineEnd);
   background-color: var(--#{$hero}--BackgroundColor);
+  background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
+  linear-gradient(
+    var(--#{$hero}--gradient--angle),
+    var(--#{$hero}--gradient--stop-1, var(--#{$hero}--gradient--stop-1--light)) 0%,
+    var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
+    var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
+  );
+  background-repeat: var(--#{$hero}--BackgroundRepeat);
+  background-position: var(--#{$hero}--BackgroundPosition);
+  background-size: var(--#{$hero}--BackgroundSize);
+  backdrop-filter: var(--#{$hero}--BackdropFilter);
   border-color: var(--#{$hero}--BorderColor);
   border-style: var(--#{$hero}--BorderStyle);
   border-block-start-width: var(--#{$hero}--BorderBlockStartWidth);
@@ -58,17 +69,6 @@
     --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
     --#{$hero}--BackgroundColor: var(--#{$hero}--BackgroundColor--glass);
   
-    background-image: var(--#{$hero}--BackgroundImage, var(--#{$hero}--BackgroundImage--light)),
-    linear-gradient(
-      var(--#{$hero}--gradient--angle),
-      var(--#{$hero}--gradient--stop-1, var(--#{$hero}--gradient--stop-1--light)) 0%,
-      var(--#{$hero}--gradient--stop-2, var(--#{$hero}--gradient--stop-2--light)) 50%,
-      var(--#{$hero}--gradient--stop-3, var(--#{$hero}--gradient--stop-3--light)) 100%
-    );
-    background-repeat: var(--#{$hero}--BackgroundRepeat);
-    background-position: var(--#{$hero}--BackgroundPosition);
-    background-size: var(--#{$hero}--BackgroundSize);
-    backdrop-filter: var(--#{$hero}--BackdropFilter);
     box-shadow: var(--#{$hero}--m-glass--BoxShadow);
   }
 

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -26,8 +26,8 @@
   --#{$hero}--BorderInlineStartWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderInlineEndWidth: var(--pf-t--global--border--width--regular);
   --#{$hero}--BorderColor: var(--pf-t--global--border--color--default);
-  --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--alt);
-  --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--md);
+  --#{$hero}--m-glass--BorderColor: var(--pf-t--global--border--color--glass--default);
+  --#{$hero}--m-glass--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
   --#{$hero}--BorderStartStartRadius: 24px;
   --#{$hero}--BorderStartEndRadius: 72px;
   --#{$hero}--BorderEndEndRadius: 24px;

--- a/src/patternfly/components/Hero/hero.scss
+++ b/src/patternfly/components/Hero/hero.scss
@@ -66,14 +66,12 @@
   border-end-start-radius: var(--#{$hero}--BorderEndStartRadius);
   border-end-end-radius: var(--#{$hero}--BorderEndEndRadius);
 
-  :where(.#{$pf-prefix}theme-glass) & {
-    &.pf-m-glass {
-      --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
-      --#{$hero}--BackgroundColor: var(--#{$hero}--m-glass--BackgroundColor);
+  :where(.#{$pf-prefix}theme-glass) &.pf-m-glass {
+    --#{$hero}--BorderColor: var(--#{$hero}--m-glass--BorderColor);
+    --#{$hero}--BackgroundColor: var(--#{$hero}--m-glass--BackgroundColor);
 
-      backdrop-filter: var(--#{$hero}--m-glass--BackdropFilter);
-      box-shadow: var(--#{$hero}--m-glass--BoxShadow);
-    }
+    backdrop-filter: var(--#{$hero}--m-glass--BackdropFilter);
+    box-shadow: var(--#{$hero}--m-glass--BoxShadow);
   }
 
   :root:where(.#{$pf-prefix}theme-dark) & {

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -30,7 +30,7 @@ This demo populates the main Compass section with a dashboard, which is often us
     {{> compass--sidebar--start}}
     {{#> compass-main}}
       {{#> compass-hero}}
-        {{#> hero hero--IsGlass}}
+        {{#> hero hero--IsGlass=true}}
           {{#> hero-body}}
             {{#> content}}
               <h1>Automation that does more</h1>

--- a/src/patternfly/demos/Compass/examples/Compass.md
+++ b/src/patternfly/demos/Compass/examples/Compass.md
@@ -30,7 +30,7 @@ This demo populates the main Compass section with a dashboard, which is often us
     {{> compass--sidebar--start}}
     {{#> compass-main}}
       {{#> compass-hero}}
-        {{#> hero}}
+        {{#> hero hero--IsGlass}}
           {{#> hero-body}}
             {{#> content}}
               <h1>Automation that does more</h1>


### PR DESCRIPTION
Closes #8316.

~~Moves gradient, backdrop filter, and background image styles to glass theme only block (unless `pf-m-no-glass`).
Adds background color to base styles & set to primary background color (glass theme resets color to glass token).~~

~~Do we want to add a plain modifier opt in for non-glass theme? Hero is pretty opinionated in its styling so unsure if it's necessary to proactively add one.~~


Updated:
- Keep background image and gradient in base styles
- Adds `pf-m-glass`, making Hero glass styles opt-in
- Removes `pf-m-no-glass`
- Updates background color to tertiary
- Updates padding to 3xl all around
- Updates border radii to md/48px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined Hero spacing, sizing and background composition; improved and reorganized glass-theme visuals and variables, including dark-theme compatibility.
  * Updated Card glass styling for consistent backdrop, border and shadow behavior.

* **Refactor**
  * Simplified Hero template class construction and added a glass modifier flag for clearer modifier handling.
  * Demo updated to enable the Hero glass flag where applicable.

* **Documentation**
  * Hero docs updated to show the current glass modifier usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->