### PR TITLE
fix(pagination): glass inset bug

### DIFF
--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -47,6 +47,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-sticky-base--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
   --#{$pagination}--m-sticky-stuck--BoxShadow: var(--#{$pagination}--m-sticky--BoxShadow);
   --#{$pagination}--m-sticky-stuck--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
+  --#{$pagination}--m-sticky--BorderRadius--glass: var(--pf-t--global--border--radius--medium);
 
   // bottom
   --#{$pagination}--m-bottom--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -68,6 +69,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   :where(:root.pf-v6-theme-glass) & {
     --#{$pagination}--m-sticky-stuck--BorderRadius: var(--pf-t--global--border--radius--glass--default);
     --#{$pagination}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
+    --#{$pagination}--m-sticky--BorderRadius: var(--#{$pagination}--m-sticky--BorderRadius--glass);
   }
 
   // page menu
@@ -197,6 +199,7 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
     inset-block-start: var(--#{$pagination}--m-sticky--InsetBlockStart);
     background-color: var(--#{$pagination}--m-sticky--BackgroundColor);
+    border-radius: var(--#{$pagination}--m-sticky--BorderRadius);
     box-shadow: var(--#{$pagination}--m-sticky--BoxShadow);
   }
 

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -66,10 +66,8 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
   --#{$pagination}--m-bottom--m-sticky-base--InsetBlockEnd: 0;
 
   :where(:root.pf-v6-theme-glass) & {
-    --#{$pagination}--m-sticky-base--InsetBlockStart: var(--pf-t--global--spacer--sm);
     --#{$pagination}--m-sticky-stuck--BorderRadius: var(--pf-t--global--border--radius--glass--default);
     --#{$pagination}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
-    --#{$pagination}--m-bottom--m-sticky-base--InsetBlockEnd: var(--pf-t--global--spacer--sm);
   }
 
   // page menu

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -68,8 +68,9 @@ $pf-v6-c-pagination--variable-map: build-spacer-map("none", "sm", "md", "lg", "x
 
   :where(:root.pf-v6-theme-glass) & {
     --#{$pagination}--m-sticky-stuck--BorderRadius: var(--pf-t--global--border--radius--glass--default);
-    --#{$pagination}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--glass--default);
+    --#{$pagination}--m-sticky-stuck--BoxShadow: var(--pf-t--global--box-shadow--sm);
     --#{$pagination}--m-sticky--BorderRadius: var(--#{$pagination}--m-sticky--BorderRadius--glass);
+    --#{$pagination}--m-sticky--BoxShadow: var(--pf-t--global--box-shadow--sm);
   }
 
   // page menu


### PR DESCRIPTION
Closes #8361

Fixes pagination inset applying in glass theme by removing glass-specific InsetBlockStart and InsetBlockEnd overrides. Now Pagination uses the default inset values across all themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated glass-theme pagination styling to centralize sticky state visuals: added glass-specific border-radius tokens, switched sticky corner radius and shadow to glass defaults, removed legacy inset overrides, and explicitly applied rounded corners to sticky pagination containers for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->