### PR TITLE
fix(toolbar): sticky header should be pill in glass

### DIFF
--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -166,7 +166,10 @@ $pf-v6--include-toolbar-breakpoints: true !default;
     z-index: var(--#{$toolbar}--m-sticky--ZIndex);
     padding-block-start: var(--#{$toolbar}--m-sticky--PaddingBlockStart);
     padding-block-end: var(--#{$toolbar}--m-sticky--PaddingBlockEnd);
+    padding-inline-start: var(--#{$toolbar}--m-sticky--PaddingInlineStart);
+    padding-inline-end: var(--#{$toolbar}--m-sticky--PaddingInlineEnd);
     border-block-end: var(--#{$toolbar}--m-sticky--BorderBlockEndWidth) solid var(--#{$toolbar}--m-sticky--BorderBlockEndColor);
+    border-radius: var(--#{$toolbar}--m-sticky--BorderRadius);
     box-shadow: var(--#{$toolbar}--m-sticky--BoxShadow);
   }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8369

This PR makes the regular "sticky toolbar" example (non-dynamic) pill shaped in glass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the sticky toolbar's visual appearance with improved horizontal padding and rounded corners for better design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->