### PR TITLE
fix(drawer): prevent pill inline drawer from extending beyond viewport

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -6,8 +6,9 @@ $pf-v6-c-drawer--breakpoint-map--width: build-breakpoint-map("base", "lg", "xl",
 $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 @include pf-root($drawer) {
-  // Main
-  --#{$drawer}--m-pill--m-inline__main--Gap: var(--pf-t--global--spacer--inset--page-chrome);
+  // Pill inline main
+  --#{$drawer}--m-pill--m-inline__main--Gap: 0;
+  --#{$drawer}--m-pill--m-inline__main--PaddingBlock: 0;
 
   // Section
   --#{$drawer}__section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -294,6 +295,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // Expanded
   // stylelint-disable selector-max-class
   &.pf-m-expanded {
+    --#{$drawer}--m-pill--m-inline__main--Gap: var(--pf-t--global--spacer--inset--page-chrome);
+    --#{$drawer}--m-pill--m-inline__main--PaddingBlock: var(--pf-t--global--spacer--inset--page-chrome);
     --#{$drawer}__panel--TransitionDelay--focus: var(--#{$drawer}__panel--TransitionDelay--expand--focus);
 
     > .#{$drawer}__main > .#{$drawer}__panel {
@@ -355,6 +358,15 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
         border-inline-start-width: var(--#{$drawer}--m-pill__panel--BorderInlineStartWidth);
         border-inline-end-width: var(--#{$drawer}--m-pill__panel--BorderInlineEndWidth);
         box-shadow: var(--#{$drawer}--m-pill--m-expanded__panel--BoxShadow);
+      }
+    }
+
+    &.pf-m-inline,
+    &.pf-m-static {
+      @media screen and (min-width: $pf-v6-global--breakpoint--md) {
+        > .#{$drawer}__main {
+          padding-block-end: var(--#{$drawer}--m-pill--m-inline__main--PaddingBlock);
+        }
       }
     }
 

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -8,7 +8,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 @include pf-root($drawer) {
   // Pill inline main
   --#{$drawer}--m-pill--m-inline__main--Gap: 0;
-  --#{$drawer}--m-pill--m-inline__main--PaddingBlock: 0;
+  --#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd: 0;
 
   // Section
   --#{$drawer}__section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -296,7 +296,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // stylelint-disable selector-max-class
   &.pf-m-expanded {
     --#{$drawer}--m-pill--m-inline__main--Gap: var(--pf-t--global--spacer--inset--page-chrome);
-    --#{$drawer}--m-pill--m-inline__main--PaddingBlock: var(--pf-t--global--spacer--inset--page-chrome);
+    --#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd: var(--pf-t--global--spacer--inset--page-chrome);
     --#{$drawer}__panel--TransitionDelay--focus: var(--#{$drawer}__panel--TransitionDelay--expand--focus);
 
     > .#{$drawer}__main > .#{$drawer}__panel {
@@ -365,7 +365,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     &.pf-m-static {
       @media screen and (min-width: $pf-v6-global--breakpoint--md) {
         > .#{$drawer}__main {
-          padding-block-end: var(--#{$drawer}--m-pill--m-inline__main--PaddingBlock);
+          padding-block-end: var(--#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd);
         }
       }
     }

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -8,7 +8,6 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 @include pf-root($drawer) {
   // Pill inline main
   --#{$drawer}--m-pill--m-inline__main--Gap: 0;
-  --#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd: 0;
 
   // Section
   --#{$drawer}__section--BackgroundColor: var(--pf-t--global--background--color--primary--default);
@@ -296,7 +295,6 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   // stylelint-disable selector-max-class
   &.pf-m-expanded {
     --#{$drawer}--m-pill--m-inline__main--Gap: var(--pf-t--global--spacer--inset--page-chrome);
-    --#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd: var(--pf-t--global--spacer--inset--page-chrome);
     --#{$drawer}__panel--TransitionDelay--focus: var(--#{$drawer}__panel--TransitionDelay--expand--focus);
 
     > .#{$drawer}__main > .#{$drawer}__panel {
@@ -358,15 +356,6 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
         border-inline-start-width: var(--#{$drawer}--m-pill__panel--BorderInlineStartWidth);
         border-inline-end-width: var(--#{$drawer}--m-pill__panel--BorderInlineEndWidth);
         box-shadow: var(--#{$drawer}--m-pill--m-expanded__panel--BoxShadow);
-      }
-    }
-
-    &.pf-m-inline,
-    &.pf-m-static {
-      @media screen and (min-width: $pf-v6-global--breakpoint--md) {
-        > .#{$drawer}__main {
-          padding-block-end: var(--#{$drawer}--m-pill--m-inline__main--PaddingBlockEnd);
-        }
       }
     }
 


### PR DESCRIPTION
Fixes #8351

The pill inline drawer was extending below the browser window due to gap spacing on __main being added to the 100% container height. Defaulted gap to 0 and managed it in expanded. Use padding-block-end to allow for pill shadows instead of gap for pill + inline variants, keeping the inset spacing internal to the container height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted inline pill spacing for the Drawer root to remove default inline gap.
  * Restored intended inline spacing for the expanded Drawer so pill items align with the page chrome inset.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8386)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->