### PR TITLE
fix(accordion): prevent triggering unnecessary overflow

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -55,7 +55,9 @@
   --#{$accordion}__expandable-content--m-fixed--MaxHeight: #{pf-size-prem(150px)};
   --#{$accordion}__expandable-content--MaxHeight: 0;
   --#{$accordion}__expandable-content--Visibility: hidden;
+  --#{$accordion}__expandable-content--Overflow: hidden;
   --#{$accordion}__item--m-expanded__expandable-content--Visibility: visible;
+  --#{$accordion}__item--m-expanded__expandable-content--Overflow: visible;
   --#{$accordion}__item--m-expanded__expandable-content--MaxHeight: 99999px;
   --#{$accordion}__item--m-expanded__expandable-content--MarginBlockEnd: var(--pf-t--global--spacer--md);
 
@@ -204,6 +206,7 @@
     --#{$accordion}__expandable-content--TransitionDuration--fade: 0s;
     --#{$accordion}__expandable-content--m-fixed--MaxHeight--base: var(--#{$accordion}__expandable-content--m-fixed--MaxHeight);
     --#{$accordion}__expandable-content--BorderWidth: var(--#{$accordion}__item--m-expanded__expandable-content--BorderWidth);
+    --#{$accordion}__expandable-content--Overflow: var(--#{$accordion}__item--m-expanded__expandable-content--Overflow);
   }
 }
 
@@ -264,7 +267,7 @@
   margin-block-end: var(--#{$accordion}__expandable-content--MarginBlockEnd);
   margin-inline-start: var(--#{$accordion}__expandable-content--MarginInlineStart);
   margin-inline-end: var(--#{$accordion}__expandable-content--MarginInlineEnd);
-  overflow-y: auto;
+  overflow-y: var(--#{$accordion}__expandable-content--Overflow);
   font-size: var(--#{$accordion}__expandable-content--FontSize);
   color: var(--#{$accordion}__expandable-content--Color);
   visibility:  var(--#{$accordion}__expandable-content--Visibility);
@@ -279,6 +282,8 @@
   translate: 0 var(--#{$accordion}__expandable-content--TranslateY);
 
   &.pf-m-fixed {
+    --#{$accordion}__expandable-content--Overflow: auto;
+
     max-height: var(--#{$accordion}__expandable-content--m-fixed--MaxHeight--base);
   }
 }

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -264,6 +264,7 @@
   margin-block-end: var(--#{$accordion}__expandable-content--MarginBlockEnd);
   margin-inline-start: var(--#{$accordion}__expandable-content--MarginInlineStart);
   margin-inline-end: var(--#{$accordion}__expandable-content--MarginInlineEnd);
+  overflow-y: auto;
   font-size: var(--#{$accordion}__expandable-content--FontSize);
   color: var(--#{$accordion}__expandable-content--Color);
   visibility:  var(--#{$accordion}__expandable-content--Visibility);
@@ -279,7 +280,6 @@
 
   &.pf-m-fixed {
     max-height: var(--#{$accordion}__expandable-content--m-fixed--MaxHeight--base);
-    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8268

One thing to double check is that this overflow isn't interfering with the animation between collapsed/expanded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved accordion expandable-content scrolling so collapsed items hide overflow while expanded items reveal it, ensuring predictable scroll behavior across states.
  * Adjusted fixed-mode behavior so long content scrolls appropriately when needed, preventing unexpected clipping or double-scroll scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8404)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->