### PR TITLE
chore: update react-icons deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@patternfly/patternfly-a11y": "5.1.0",
     "@patternfly/react-code-editor": "6.4.3",
     "@patternfly/react-core": "6.4.3",
-    "@patternfly/react-icons": "6.5.0-prerelease.13",
+    "@patternfly/react-icons": "6.5.0-prerelease.38",
     "@patternfly/react-table": "6.4.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3475,7 +3475,7 @@ __metadata:
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-code-editor": "npm:6.4.3"
     "@patternfly/react-core": "npm:6.4.3"
-    "@patternfly/react-icons": "npm:6.5.0-prerelease.13"
+    "@patternfly/react-icons": "npm:6.5.0-prerelease.38"
     "@patternfly/react-table": "npm:6.4.3"
     "@rspack/cli": "npm:^1.6.0"
     "@rspack/core": "npm:^1.6.0"
@@ -3562,13 +3562,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:6.5.0-prerelease.13":
-  version: 6.5.0-prerelease.13
-  resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.13"
+"@patternfly/react-icons@npm:6.5.0-prerelease.38":
+  version: 6.5.0-prerelease.38
+  resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.38"
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/518809f6d0deedb8079fbbaa3e503ccdfdfdd076bab6f3ad94575eb09d10b283ddbe921de0a58079580431d0a638e68878648873fc02a9be517b4fec4c06290b
+  checksum: 10c0/ca8329ad991011b612fc317c5325248a433809e2c4c3e5dbdb651cd6fe90b63743f95639d94e6b3aa4f9dbb2dfcb0b6d640ea7306ab115273932a2d8cb3961c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstop report - 
[update-react-icons-5.18.26.pdf](https://github.com/user-attachments/files/27964300/update-react-icons-5.18.26.pdf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI icon library dependency to the latest available version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8405)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->