### PR TITLE
fix(banner): link colors

### DIFF
--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -23,7 +23,7 @@
   --#{$banner}--link--TextDecoration: underline;
   --#{$banner}--link--hover--Color: var(--#{$banner}--Color);
   --#{$banner}--link--disabled--Color: var(--pf-t--global--text--color--disabled);
-  --#{$banner}--a--TextDecorationColor: currentColor;
+  --#{$banner}--a--TextDecorationColor: currentcolor;
   --#{$banner}--m-link--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
   --#{$banner}--m-link--hover--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
 

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -154,9 +154,6 @@
     border-radius: var(--#{$banner}--m-pill--BorderRadius);
   }
     
-    a {
-      color: var(--#{$banner}--link--Color);
-      text-decoration-line: var(--#{$banner}--link--TextDecoration);
   a {
     color: var(--#{$banner}--link--Color);
     text-decoration-line: var(--#{$banner}--link--TextDecoration);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -157,7 +157,10 @@
     a {
       color: var(--#{$banner}--link--Color);
       text-decoration-line: var(--#{$banner}--link--TextDecoration);
-      text-decoration-color: var(--#{$banner}--a--TextDecorationColor);
+  a {
+    color: var(--#{$banner}--link--Color);
+    text-decoration-line: var(--#{$banner}--link--TextDecoration);
+    text-decoration-color: var(--#{$banner}--a--TextDecorationColor);
 
     &:hover:not(.pf-m-disabled) {
       --#{$banner}--link--Color: var(--#{$banner}--link--hover--Color);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -23,7 +23,7 @@
   --#{$banner}--link--TextDecoration: underline;
   --#{$banner}--link--hover--Color: var(--#{$banner}--Color);
   --#{$banner}--link--disabled--Color: var(--pf-t--global--text--color--disabled);
-  --#{$banner}--a--TextDecorationColor: currentcolor;
+  --#{$banner}--link--TextDecorationColor: currentcolor;
   --#{$banner}--m-link--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
   --#{$banner}--m-link--hover--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
 

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -78,10 +78,6 @@
   border-block-start: var(--#{$banner}--BorderWidth) solid var(--#{$banner}--BorderColor);
   border-block-end: var(--#{$banner}--BorderWidth) solid var(--#{$banner}--BorderColor);
 
-  a {
-    text-decoration-color: var(--#{$banner}--a--TextDecorationColor);
-  }
-
   &.pf-m-danger {
     --#{$banner}--BackgroundColor: var(--#{$banner}--m-danger--BackgroundColor);
     --#{$banner}--Color: var(--#{$banner}--m-danger--Color);
@@ -157,10 +153,11 @@
   &.pf-m-pill {
     border-radius: var(--#{$banner}--m-pill--BorderRadius);
   }
-
-  a {
-    color: var(--#{$banner}--link--Color);
-    text-decoration-line: var(--#{$banner}--link--TextDecoration);
+    
+    a {
+      color: var(--#{$banner}--link--Color);
+      text-decoration-line: var(--#{$banner}--link--TextDecoration);
+      text-decoration-color: var(--#{$banner}--a--TextDecorationColor);
 
     &:hover:not(.pf-m-disabled) {
       --#{$banner}--link--Color: var(--#{$banner}--link--hover--Color);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -179,13 +179,10 @@
     --#{$button}--m-link--m-inline--Color: var(--#{$banner}--link--Color);
     --#{$button}--m-link--m-inline--hover--Color: var(--#{$banner}--link--hover--Color);
     --#{$button}--disabled--Color: var(--#{$banner}--link--disabled--Color);
-
-    text-decoration-line: var(--#{$banner}--link--TextDecoration);
+    --#{$button}--m-link--m-inline--TextDecorationColor: var(--#{$banner}--link--TextDecorationColor);
+    --#{$button}--m-link--m-inline--hover--TextDecorationColor: var(--#{$banner}--link--TextDecorationColor);
     
-    &.pf-m-link {
-      --#{$button}--TextDecorationColor: var(--#{$banner}--m-link--TextDecorationColor);
-      --#{$button}--hover--TextDecorationColor: var(--#{$banner}--m-link--hover--TextDecorationColor);
-    }
+    text-decoration-line: var(--#{$banner}--link--TextDecoration);
 
     &:disabled,
     &.pf-m-disabled {

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -24,8 +24,6 @@
   --#{$banner}--link--hover--Color: var(--#{$banner}--Color);
   --#{$banner}--link--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$banner}--link--TextDecorationColor: currentcolor;
-  --#{$banner}--m-link--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
-  --#{$banner}--m-link--hover--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
 
   // modifier variables
   --#{$banner}--m-sticky--ZIndex: var(--pf-t--global--z-index--md);
@@ -153,7 +151,7 @@
   &.pf-m-pill {
     border-radius: var(--#{$banner}--m-pill--BorderRadius);
   }
-    
+
   a {
     color: var(--#{$banner}--link--Color);
     text-decoration-line: var(--#{$banner}--link--TextDecoration);

--- a/src/patternfly/components/Banner/banner.scss
+++ b/src/patternfly/components/Banner/banner.scss
@@ -23,6 +23,9 @@
   --#{$banner}--link--TextDecoration: underline;
   --#{$banner}--link--hover--Color: var(--#{$banner}--Color);
   --#{$banner}--link--disabled--Color: var(--pf-t--global--text--color--disabled);
+  --#{$banner}--a--TextDecorationColor: currentColor;
+  --#{$banner}--m-link--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
+  --#{$banner}--m-link--hover--TextDecorationColor: var(--#{$banner}--a--TextDecorationColor);
 
   // modifier variables
   --#{$banner}--m-sticky--ZIndex: var(--pf-t--global--z-index--md);
@@ -74,6 +77,10 @@
   background-color: var(--#{$banner}--BackgroundColor);
   border-block-start: var(--#{$banner}--BorderWidth) solid var(--#{$banner}--BorderColor);
   border-block-end: var(--#{$banner}--BorderWidth) solid var(--#{$banner}--BorderColor);
+
+  a {
+    text-decoration-color: var(--#{$banner}--a--TextDecorationColor);
+  }
 
   &.pf-m-danger {
     --#{$banner}--BackgroundColor: var(--#{$banner}--m-danger--BackgroundColor);
@@ -174,6 +181,11 @@
     --#{$button}--disabled--Color: var(--#{$banner}--link--disabled--Color);
 
     text-decoration-line: var(--#{$banner}--link--TextDecoration);
+    
+    &.pf-m-link {
+      --#{$button}--TextDecorationColor: var(--#{$banner}--m-link--TextDecorationColor);
+      --#{$button}--hover--TextDecorationColor: var(--#{$banner}--m-link--hover--TextDecorationColor);
+    }
 
     &:disabled,
     &.pf-m-disabled {


### PR DESCRIPTION
Fixes #8403

Fixes link text decoration colors. Links and their underlines now inherit the banner's text color tokens (on-danger, on-success, etc.) instead of using default link colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved banner link styling so `text-decoration-color` is now consistently applied, including correct behavior for hover states.
  * Added dedicated theming variables for banner-level and link-level text-decoration color, ensuring inline link-styled buttons match banner link appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->