### PR TITLE
chore(ci): group non @patternfly/patternfly-a11y dependency bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,7 @@
       "enabled": false
     },
     {
-      "groupName": "non-pf-a11y-deps",
+      "groupName": "grouped-pf-deps",
       "datasources": ["npm"],
       "packageNames": [
         "@patternfly/patternfly-a11y",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,7 @@
       "enabled": false
     },
     {
+      "groupName": "non-pf-a11y-deps",
       "datasources": ["npm"],
       "packageNames": [
         "@patternfly/patternfly-a11y",
@@ -31,6 +32,12 @@
         "sass",
         "stylelint*",
         "backstopjs"
+      ]
+    },
+    {
+      "datasources": ["npm"],
+      "packageNames": [
+        "@patternfly/patternfly-a11y"
       ]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,6 @@
       "groupName": "grouped-pf-deps",
       "datasources": ["npm"],
       "packageNames": [
-        "@patternfly/patternfly-a11y",
         "@patternfly/react-core",
         "@patternfly/react-icons",
         "@patternfly/react-code-editor",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized dependency grouping in update configuration to prepare for consolidated updates.
  * Added a dedicated rule to handle the PatternFly accessibility package separately, while keeping the automated updates disabled for now.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->