### PR TITLE
chore(ci): prevent cross-workflow cache poisoning in pr-preview (CVE-2026-45321 mitigation)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -42,9 +42,9 @@ jobs:
             ~/.cache/Cypress
             ~/.cache/yarn
             .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-pr-yarn-cache-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-cache-
+            ${{ runner.os }}-pr-yarn-cache-
       
       - name: Install dependencies
         shell: bash
@@ -62,7 +62,7 @@ jobs:
         name: Load webpack cache
         with:
           path: '.cache'
-          key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-pr-v4-${{ hashFiles('yarn.lock') }}
       - run: yarn build:docs
         name: Build docs
       - run: node .github/upload-preview.js public


### PR DESCRIPTION
## Summary

- Namespaces `pr-preview.yml` cache keys to prevent cross-workflow cache poisoning with `release.yml`
- Mitigates the same GitHub Actions cache poisoning vector exploited in the [TanStack supply-chain compromise (May 2026)](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)

## Background

On May 11, 2026, the **Mini Shai-Hulud** worm ([CVE-2026-45321](https://snyk.io/blog/tanstack-npm-packages-compromised/), CVSS 9.6) compromised 84 npm package artifacts across 42 `@tanstack/*` packages by chaining:

1. **Pwn Request** — `pull_request_target` trigger that runs fork code with base repo privileges
2. **Cache poisoning** — shared `actions/cache` keys across PR and release workflows, allowing malicious cache entries from PR builds to be restored in release builds
3. **OIDC token extraction** — runner memory scraping to publish packages with valid SLSA Build Level 3 attestations

This repo's `pr-preview.yml` is susceptible to vectors 1 and 2. This PR addresses vector 2.

## What changed

`pr-preview.yml` and `release.yml` shared identical cache keys:

```yaml
# Both workflows used:
key: ${{ runner.os }}-yarn-cache-${{ hashFiles('yarn.lock') }}
key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
```

A malicious PR could poison the yarn or webpack cache, which would then be restored by `release.yml` during the next production build — injecting attacker-controlled code into published packages.

**Fix:** Added `pr-` prefix to all cache keys in `pr-preview.yml`:

```yaml
key: ${{ runner.os }}-pr-yarn-cache-${{ hashFiles('yarn.lock') }}
key: ${{ runner.os }}-pr-v4-${{ hashFiles('yarn.lock') }}
```

## Remaining risk (follow-up needed)

`pr-preview.yml` still uses `pull_request_target` and checks out fork PR code (lines 15-16), exposing `SURGE_TOKEN`, `SURGE_LOGIN`, and `GH_PR_TOKEN` to attacker-controlled code. Fixing this requires splitting into two workflows (`pull_request` build + `workflow_run` deploy)
## References

- [TanStack Postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
- [TanStack Hardening Follow-up](https://tanstack.com/blog/incident-followup)
- [Snyk Analysis](https://snyk.io/blog/tanstack-npm-packages-compromised/)
- [Orca Security Writeup](https://orca.security/resources/blog/tanstack-npm-supply-chain-worm/)

## Test plan

- [ ] Verify `pr-preview.yml` and `release.yml` have no overlapping cache key prefixes
- [ ] Confirm PR preview builds still work (cache miss on first run, then caches populate with new keys)
- [ ] Confirm release builds are unaffected (their cache keys are unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pull request preview build caching to enhance performance and reduce build times for development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->