### PR TITLE
fix(docked): add min width on icon elements

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -989,6 +989,10 @@
     justify-content: flex-start;
     width: 100%;
 
+    .#{$button}__icon {
+      min-width: 1lh;
+    }
+
     @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
       justify-content: center;
 
@@ -1005,12 +1009,6 @@
 
     .#{$button}__text {
       display: revert;
-    }
-  }
-
-  &:where(.pf-m-docked, .pf-m-text-expanded) {
-    .#{$button}__icon {
-      min-width: 1lh;
     }
   }
 }

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1007,6 +1007,12 @@
       display: revert;
     }
   }
+
+  &:where(.pf-m-docked, .pf-m-text-expanded) {
+    .#{$button}__icon {
+      min-width: 1lh;
+    }
+  }
 }
 
 .#{$button}__icon {

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -458,8 +458,14 @@
     .#{$menu-toggle}__controls {
       display: revert;
     }
+    
+    .#{$menu-toggle}__icon {
+      min-width: 1lh;
+    }
   }
 
+  // &:where(.pf-m-docked, .pf-m-text-expanded) {
+  // }
 }
 
 // Register the property type for the custom property to be animatable

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -438,6 +438,10 @@
     justify-content: flex-start;
     width: 100%;
 
+    .#{$menu-toggle}__icon {
+      min-width: 1lh;
+    }
+
     @media (min-width: $pf-v6-global--breakpoint--dock--desktop) {
       justify-content: center;
       width: auto;
@@ -457,12 +461,6 @@
     .#{$menu-toggle}__text,
     .#{$menu-toggle}__controls {
       display: revert;
-    }
-  }
-
-  &:where(.pf-m-docked, .pf-m-text-expanded) {
-    .#{$menu-toggle}__icon {
-      min-width: 1lh;
     }
   }
 }

--- a/src/patternfly/components/MenuToggle/menu-toggle.scss
+++ b/src/patternfly/components/MenuToggle/menu-toggle.scss
@@ -458,14 +458,13 @@
     .#{$menu-toggle}__controls {
       display: revert;
     }
-    
+  }
+
+  &:where(.pf-m-docked, .pf-m-text-expanded) {
     .#{$menu-toggle}__icon {
       min-width: 1lh;
     }
   }
-
-  // &:where(.pf-m-docked, .pf-m-text-expanded) {
-  // }
 }
 
 // Register the property type for the custom property to be animatable


### PR DESCRIPTION
Closes: #8333

Sets min-width: 1lh on icon elements. This mimics the nav component's icon spacing pattern for docked navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enforced a minimum icon width in docked/text-expanded button layouts to keep icons aligned and prevent layout shifts when text visibility changes.
  * Applied the same minimum-width constraint to menu toggle icons in docked/text-expanded layouts for more consistent spacing and visual balance across controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->