### PR TITLE
fix(drag and drop): ghost row border radius

### DIFF
--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -2,10 +2,10 @@
 
 @include pf-root($draggable) {
   --#{$draggable}--Cursor: auto;
-  --#{$draggable}--m-dragging--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$draggable}--m-dragging--Cursor: grabbing;
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$draggable}--m-dragging--BackgroundColor: transparent;
+  --#{$draggable}--m-dragging--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$draggable}--m-dragging--after--BorderWidth: var(--pf-t--global--border--width--regular);
   --#{$draggable}--m-dragging--after--BorderColor: var(--pf-t--global--border--color--brand--default);
   --#{$draggable}--m-dragging--after--BorderRadius: var(--pf-t--global--border--radius--small);

--- a/src/patternfly/components/DragDrop/drag-drop.scss
+++ b/src/patternfly/components/DragDrop/drag-drop.scss
@@ -2,6 +2,7 @@
 
 @include pf-root($draggable) {
   --#{$draggable}--Cursor: auto;
+  --#{$draggable}--m-dragging--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$draggable}--m-dragging--Cursor: grabbing;
   --#{$draggable}--m-dragging--BoxShadow: var(--pf-t--global--box-shadow--md);
   --#{$draggable}--m-dragging--BackgroundColor: transparent;
@@ -20,6 +21,7 @@
 
     position: relative;
     background-color: var(--#{$draggable}--m-dragging--BackgroundColor);
+    border-radius: var(--#{$draggable}--m-dragging--BorderRadius);
     box-shadow: var(--#{$draggable}--m-dragging--BoxShadow);
 
     &::after {
@@ -42,6 +44,7 @@
 
 @include pf-root($droppable) {
   --#{$droppable}--before--BackgroundColor: transparent;
+  --#{$droppable}--before--BorderRadius: var(--pf-t--global--border--radius--small);
   --#{$droppable}--before--Opacity: 0;
   --#{$droppable}--after--BorderWidth: 0;
   --#{$droppable}--after--BorderColor: transparent;
@@ -67,6 +70,7 @@
 
   &::before {
     background-color: var(--#{$droppable}--before--BackgroundColor);
+    border-radius: var(--#{$droppable}--before--BorderRadius);
     opacity: var(--#{$droppable}--before--Opacity);
   }
 


### PR DESCRIPTION
Fixes #8115

Adds border-radius to the background color of both the draggable ghost row (.pf-m-dragging) and the droppable overlay (::before) so they match the rounded corners already applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling for drag-and-drop interactions with enhanced border-radius properties for dragging and droppable element states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly/pull/8435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->