### PR TITLE
fix(sidebar): remove background in glass

### DIFF
--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -356,7 +356,7 @@ import './Drawer.css'
 | `.pf-m-no-border` | `.pf-v6-c-drawer__panel` | Modifies the drawer panel border treatment to disable all border treatment. |
 | `.pf-m-padding` | `.pf-v6-c-drawer__body` | Modifies the element to add padding. |
 | `.pf-m-no-padding` | `.pf-v6-c-drawer__body` | Modifies the element to remove padding. |
-| `.pf-m-no-background` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__panel` | Modifies the drawer element background color to transparent. |
+| `.pf-m-no-background` | `.pf-v6-c-drawer__section`, `.pf-v6-c-drawer__panel` | Modifies the drawer element background color to transparent. **Note:** `.pf-m-no-background` is deprecated, use `.pf-m-plain` instead. |
 | `.pf-m-plain` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static`, `.pf-v6-c-drawer__section` | Applies plain styling. |
 | `.pf-m-no-plain-on-glass` | `.pf-v6-c-drawer__panel.pf-m-inline`, `.pf-v6-c-drawer__panel.pf-m-static`, `.pf-v6-c-drawer__section` | Prevents the elements from automatically applying plain styling when glass theme is enabled. |
 | `.pf-m-primary` | `.pf-v6-c-drawer__content` | Modifies the drawer content to use the primary background color. |

--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -234,6 +234,7 @@ import './Sidebar.css'
 | `.pf-m-sticky` | `.pf-v6-c-sidebar__panel` | Modifies the panel to be sticky to the top of the layout. |
 | `.pf-m-static` | `.pf-v6-c-sidebar__panel` | Modifies the panel to be positioned statically. |
 | `.pf-m-width-{default, 25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-v6-c-sidebar__panel` | Modifies the panel width at optional [breakpoint](/foundations-and-styles/design-tokens/all-design-tokens). **Note:** does not apply when the panel is stacked on top of the content. |
-| `.pf-m-no-background` | `.pf-v6-c-sidebar`, `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Modifies the element to have a transparent background. |
+| `.pf-m-no-background` | `.pf-v6-c-sidebar__panel`, `.pf-v6-c-sidebar__content` | Modifies the element to have a transparent background. **Note:** `.pf-m-no-background` is deprecated, use `.pf-m-plain` instead. |
+| `.pf-m-plain` | `.pf-v6-c-sidebar__panel`, `.pf-v6-c-sidebar__content` | Modifies the element to have a transparent background. |
 | `.pf-m-secondary` | `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Modifies the element to have secondary styling. |
 | `.pf-m-no-plain-on-glass` | `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Prevents the elements from automatically applying plain styling when glass theme is enabled. |

--- a/src/patternfly/components/Sidebar/examples/Sidebar.md
+++ b/src/patternfly/components/Sidebar/examples/Sidebar.md
@@ -236,3 +236,4 @@ import './Sidebar.css'
 | `.pf-m-width-{default, 25, 33, 50, 66, 75, 100}{-on-[breakpoint]}` | `.pf-v6-c-sidebar__panel` | Modifies the panel width at optional [breakpoint](/foundations-and-styles/design-tokens/all-design-tokens). **Note:** does not apply when the panel is stacked on top of the content. |
 | `.pf-m-no-background` | `.pf-v6-c-sidebar`, `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Modifies the element to have a transparent background. |
 | `.pf-m-secondary` | `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Modifies the element to have secondary styling. |
+| `.pf-m-no-plain-on-glass` | `.pf-v6-c-sidebar__panel, .pf-v6-c-sidebar__content` | Prevents the elements from automatically applying plain styling when glass theme is enabled. |

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -206,6 +206,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   }
 
   &.pf-m-no-background,
+  :where(:root:not(.pf-v6-theme-glass)) &.pf-m-plain,
   :where(:root.pf-v6-theme-glass) &:not(.pf-m-no-plain-on-glass) {
     --#{$sidebar}__panel--BackgroundColor: transparent;
   }
@@ -232,6 +233,7 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
   }
 
   &.pf-m-no-background,
+  :where(:root:not(.pf-v6-theme-glass)) &.pf-m-plain,
   :where(:root.pf-v6-theme-glass) &:not(.pf-m-no-plain-on-glass) {
     --#{$sidebar}__content--BackgroundColor: transparent;
   }

--- a/src/patternfly/components/Sidebar/sidebar.scss
+++ b/src/patternfly/components/Sidebar/sidebar.scss
@@ -205,6 +205,11 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__panel--InsetBlockStart: auto;
   }
 
+  &.pf-m-no-background,
+  :where(:root.pf-v6-theme-glass) &:not(.pf-m-no-plain-on-glass) {
+    --#{$sidebar}__panel--BackgroundColor: transparent;
+  }
+
   &.pf-m-secondary {
     --#{$sidebar}__panel--BackgroundColor: var(--#{$sidebar}__panel--m-secondary--BackgroundColor);
   }
@@ -226,7 +231,8 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
     --#{$sidebar}__content--PaddingInlineStart: var(--#{$sidebar}__content--m-padding--PaddingBlockStart);
   }
 
-  &.pf-m-no-background {
+  &.pf-m-no-background,
+  :where(:root.pf-v6-theme-glass) &:not(.pf-m-no-plain-on-glass) {
     --#{$sidebar}__content--BackgroundColor: transparent;
   }
 
@@ -240,14 +246,6 @@ $pf-v6-c-sidebar__panel--list--width: ("default", 25, 33, 50, 66, 75, 100);
 
   :where(&:first-child) {
     --#{$sidebar}__content--Order: -1;
-  }
-}
-
-.#{$sidebar},
-.#{$sidebar}__panel,
-.#{$sidebar}__content {
-  &.pf-m-no-background {
-    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `.pf-m-no-plain-on-glass` docs for Sidebar panel/content and updated `.pf-m-no-background` usage to note deprecation and scope; updated `.pf-m-secondary` usage details; also added deprecation note for Drawer `.pf-m-no-background`.
* **Bug Fixes**
  * Improved Sidebar background handling across themes so panel/content backgrounds render correctly and avoid unintended "plain" styling under glass themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->