### PR TITLE
chore: validator updates to renovate.config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,17 +3,7 @@
   "enabledManagers": ["npm"],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "!@patternfly/patternfly-a11y",
-        "!@patternfly/react-core",
-        "!@patternfly/react-icons",
-        "!@patternfly/react-code-editor",
-        "!@patternfly/react-table",
-        "!@patternfly/documentation-framework",
-        "!sass",
-        "!stylelint*",
-        "!backstopjs"
-      ],
+      "matchDatasources": ["npm"],
       "enabled": false
     },
     {
@@ -26,13 +16,17 @@
         "@patternfly/react-table",
         "@patternfly/documentation-framework",
         "sass",
-        "stylelint*",
         "backstopjs"
-      ]
+      ],
+      "matchPackagePatterns": [
+        "^stylelint"
+      ],
+      "enabled": true
     },
     {
       "matchDatasources": ["npm"],
-      "matchPackageNames": ["@patternfly/patternfly-a11y"]
+      "matchPackageNames": ["@patternfly/patternfly-a11y"],
+      "enabled": true
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,19 +7,16 @@
       "enabled": false
     },
     {
-      "groupName": "grouped-pf-deps",
+      "groupName": "PatternFly dependencies",
       "matchDatasources": ["npm"],
       "matchPackageNames": [
-        "@patternfly/react-core",
-        "@patternfly/react-icons",
-        "@patternfly/react-code-editor",
-        "@patternfly/react-table",
         "@patternfly/documentation-framework",
         "sass",
         "backstopjs"
       ],
       "matchPackagePatterns": [
-        "^stylelint"
+        "^stylelint",
+        "^@patternfly/react"
       ],
       "enabled": true
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,28 +1,25 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:recommended"],
   "enabledManagers": ["npm"],
   "packageRules": [
     {
-      "packagePatterns": ["*"],
-      "excludePackagePatterns": [
-        "@patternfly/patternfly-a11y",
-        "@patternfly/react-core",
-        "@patternfly/react-icons",
-        "@patternfly/react-code-editor",
-        "@patternfly/react-table",
-        "@patternfly/documentation-framework",
-        "sass",
-        "stylelint*",
-        "backstopjs"
+      "matchPackagePatterns": [
+        "!@patternfly/patternfly-a11y",
+        "!@patternfly/react-core",
+        "!@patternfly/react-icons",
+        "!@patternfly/react-code-editor",
+        "!@patternfly/react-table",
+        "!@patternfly/documentation-framework",
+        "!sass",
+        "!stylelint*",
+        "!backstopjs"
       ],
       "enabled": false
     },
     {
       "groupName": "grouped-pf-deps",
-      "datasources": ["npm"],
-      "packageNames": [
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
         "@patternfly/react-core",
         "@patternfly/react-icons",
         "@patternfly/react-code-editor",
@@ -34,10 +31,8 @@
       ]
     },
     {
-      "datasources": ["npm"],
-      "packageNames": [
-        "@patternfly/patternfly-a11y"
-      ]
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@patternfly/patternfly-a11y"]
     }
   ]
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8449

Updates syntax per the [renovate docs](https://docs.renovatebot.com/configuration-options/) and running `npx --package renovate renovate-config-validator` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated dependency update rules by switching to the recommended configuration.
  * Disabled broad npm updates by default and added explicit allowlisting for PatternFly-related packages.
  * Improved grouping for PatternFly dependencies and added more targeted handling for style-related packages.
  * Included a dedicated rule for the PatternFly accessibility package to ensure consistent update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->