### PR TITLE
chore(patterns): fix status labels in dashboard demo

### DIFF
--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -48,24 +48,24 @@
             {{#> l-flex-item l-flex-item--attribute='style="margin-block-end: -.25em"'}}
               {{> label label--status="danger" label-text--value="Incident"}}
             {{/l-flex-item}}
-          {{/if}}
-          {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
-            {{#if card-template-expandable-status-card--HasIncident}}
+            {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
               {{#> icon}}
                 {{#> icon-content icon-content--modifier="pf-m-danger"}}
                   {{pfIcon "rh-ui-connected"}}
                 {{/icon-content}}
               {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is</b> required</p>
-            {{else}}
+            {{/l-flex}}
+          {{else}}
+            {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
               {{#> icon}}
                 {{#> icon-content icon-content--modifier="pf-m-success"}}
                   {{pfIcon "rh-ui-connected"}}
                 {{/icon-content}}
               {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is not</b> required</p>
-            {{/if}}
-          {{/l-flex}}
+            {{/l-flex}}
+          {{/if}}
         {{/l-flex}}
       {{/l-flex}}
     {{/card-body}}

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -46,24 +46,24 @@
         {{#> l-flex l-flex--modifier="pf-m-grow pf-m-column pf-m-row-on-lg pf-m-justify-content-flex-end pf-m-justify-content-flex-start-on-lg pf-m-align-content-flex-end-on-lg" l-flex--attribute='style="row-gap: var(--pf-6-global--spacer--md);"'}}
           {{#if card-template-expandable-status-card--HasIncident}}
             {{#> l-flex-item l-flex-item--attribute='style="margin-block-end: -.25em"'}}
-              {{> label label--color="red" label-text--value="Incident"}}
+              {{> label label--status="danger" label-text--value="Incident"}}
             {{/l-flex-item}}
           {{/if}}
           {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
             {{#if card-template-expandable-status-card--RequiresReboot}}
-              {{#> icon}}
-                {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                  {{pfIcon "rh-ui-connected"}}
-                {{/icon-content}}
-              {{/icon}}
-              <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is</b> required</p>
-            {{else}}
               {{#> icon}}
                 {{#> icon-content icon-content--modifier="pf-m-success"}}
                   {{pfIcon "rh-ui-connected"}}
                 {{/icon-content}}
               {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is not</b> required</p>
+            {{else}}
+              {{#> icon}}
+                {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                  {{pfIcon "rh-ui-connected"}}
+                {{/icon-content}}
+              {{/icon}}
+              <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is </b> required</p>
             {{/if}}
           {{/l-flex}}
         {{/l-flex}}

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status-card.hbs
@@ -50,20 +50,20 @@
             {{/l-flex-item}}
           {{/if}}
           {{#> l-flex l-flex--modifier="pf-m-space-items-sm pf-m-align-items-center pf-m-nowrap"}}
-            {{#if card-template-expandable-status-card--RequiresReboot}}
+            {{#if card-template-expandable-status-card--HasIncident}}
+              {{#> icon}}
+                {{#> icon-content icon-content--modifier="pf-m-danger"}}
+                  {{pfIcon "rh-ui-connected"}}
+                {{/icon-content}}
+              {{/icon}}
+              <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is</b> required</p>
+            {{else}}
               {{#> icon}}
                 {{#> icon-content icon-content--modifier="pf-m-success"}}
                   {{pfIcon "rh-ui-connected"}}
                 {{/icon-content}}
               {{/icon}}
               <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is not</b> required</p>
-            {{else}}
-              {{#> icon}}
-                {{#> icon-content icon-content--modifier="pf-m-danger"}}
-                  {{pfIcon "rh-ui-connected"}}
-                {{/icon-content}}
-              {{/icon}}
-              <p class="{{pfv 'u'}}color-200">System reboot <b class="{{pfv 'u'}}color-100">is </b> required</p>
             {{/if}}
           {{/l-flex}}
         {{/l-flex}}

--- a/src/patternfly/demos/Card/templates/card-template-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-status.hbs
@@ -131,38 +131,27 @@
                       {{#> label-group-list label-group-list--attribute='aria-label="Group of labels"'}}
                         {{#> label-group-list-item}}
                           {{> label
-                              label--id="default-red-icon"
-                              label--color="red"
-                              label-text--value="1"
-                              label-icon--value="exclamation-circle"}}
+                              label--id="default-danger"
+                              label--status="danger"
+                              label-text--value="1"}}
                         {{/label-group-list-item}}
                         {{#> label-group-list-item}}
                           {{> label
-                              label--id="default-orange-icon"
-                              label--color="orange"
-                              label-text--value="1"
-                              label-icon--value="exclamation-circle"}}
+                              label--id="default-warning"
+                              label--status="warning"
+                              label-text--value="1"}}
                         {{/label-group-list-item}}
                         {{#> label-group-list-item}}
                           {{> label
-                              label--id="default-green-icon"
-                              label--color="green"
-                              label-text--value="3"
-                              label-icon--value="check-circle"}}
+                              label--id="default-success"
+                              label--status="success"
+                              label-text--value="3"}}
                         {{/label-group-list-item}}
                         {{#> label-group-list-item}}
                           {{> label
-                              label--id="default-blue-icon"
-                              label--color="blue"
-                              label-text--value="3"
-                              label-icon--value="info-circle"}}
-                        {{/label-group-list-item}}
-                        {{#> label-group-list-item}}
-                          {{> label
-                              label--id="default-teal-icon"
-                              label--color="teal"
-                              label-text--value="3"
-                              label-icon--value="bell"}}
+                              label--id="default-info"
+                              label--status="info"
+                              label-text--value="3"}}
                         {{/label-group-list-item}}
                       {{/label-group-list}}
                     {{/label-group-main}}


### PR DESCRIPTION
This PR addresses a comment from the  6.5 Staging review where the non-status labels are used for statuses. 
The labels on core don't seem to be using the new new icons so that should be done in a separate issue.
 
**Note:** This PR was vibe coded with Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated status-card label presentation to use status-based styling (danger/warning/success/info) instead of color-based variants, including the notification drawer.
  * Refined the “Incident” label and reworked the system reboot messaging so it consistently reflects whether an incident is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->