### PR TITLE
fix(table): table thead background issue in safari

### DIFF
--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -4251,6 +4251,9 @@ For sticky columns to function correctly, the parent table's width must be contr
           Destination
         {{/table-th}}
       {{/table-tr}}
+      {{#> table-tr table-tr--modifier="pf-m-border-row" table-tr--attribute='aria-hidden="true"'}}
+        {{> table-td table-td--attribute='colspan="6"'}}
+      {{/table-tr}}
     {{/table-thead}}
 
     {{#> table-tbody}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -301,7 +301,7 @@
     table-layout: fixed;
   }
 
-  &.pf-m-sticky-header-base > .#{$table}__thead, &.pf-m-sticky-header-base .#{$table}__th {
+  &.pf-m-sticky-header-base > .#{$table}__thead, &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__th {
     &::before,
     &::after {
       opacity: 0;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -311,7 +311,7 @@
     }
   }
 
-  &.pf-m-sticky-header-stuck > .#{$table}__thead, &.pf-m-sticky-header-stuck .#{$table}__th {
+  &.pf-m-sticky-header-stuck > .#{$table}__thead, &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__th {
     &::before,
     &::after {
       opacity: 1;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -301,7 +301,7 @@
     table-layout: fixed;
   }
 
-  &.pf-m-sticky-header-base > .#{$table}__thead {
+  &.pf-m-sticky-header-base > .#{$table}__thead, &.pf-m-sticky-header-base .#{$table}__th {
     &::before,
     &::after {
       opacity: 0;
@@ -311,12 +311,7 @@
     }
   }
 
-  &.pf-m-sticky-header,
-  &.pf-m-sticky-header-stuck {
-    --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: 0;
-  }
-
-  &.pf-m-sticky-header-stuck > .#{$table}__thead {
+  &.pf-m-sticky-header-stuck > .#{$table}__thead, &.pf-m-sticky-header-stuck .#{$table}__th {
     &::before,
     &::after {
       opacity: 1;
@@ -338,26 +333,47 @@
         z-index: -1;
         pointer-events: none;
         content: '';
-        background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
         border-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         box-shadow: var(--#{$table}--m-sticky-header--BoxShadow);
+      }
+
+      .#{$table}__th::before,
+      .#{$table}__th::after {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        content: '';
+      }
+
+      .#{$table}__th::before {
+        z-index: -1;
+        background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
+      }
+
+      .#{$table}__th:first-child::before {
+        border-start-start-radius: var(--#{$table}--m-sticky-header--BorderRadius);
+        border-end-start-radius: var(--#{$table}--m-sticky-header--BorderRadius);
+      }
+
+      .#{$table}__th:last-child::before {
+        border-start-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
+        border-end-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
+      }
+
+      .#{$table}__th::after {
+        z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
+        border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
       }
 
       > :where(th, td) {
         z-index: var(--#{$table}--m-sticky-header--cell--ZIndex); // set z-index here to allow sticky column to override
       }
     }
-  }
 
-  &.pf-m-sticky-header,
-  &.pf-m-sticky-header-base {
-    > .#{$table}__thead::after {
-      position: absolute;
-      inset: 0;
-      z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
-      pointer-events: none;
-      content: '';
-      border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
+    :where(.pf-v6-theme-glass) & {
+      .pf-m-nested-column-header {
+        --#{$table}--m-sticky-header--BorderRadius: 0;
+      }
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -336,17 +336,14 @@
         border-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         box-shadow: var(--#{$table}--m-sticky-header--BoxShadow);
       }
-
-      .#{$table}__th::before,
-      .#{$table}__th::after {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        content: '';
-      }
+  
 
       .#{$table}__th::before {
+        position: absolute;
+        inset: 0;
         z-index: -1;
+        pointer-events: none;
+        content: '';
         background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
       }
 
@@ -360,8 +357,12 @@
         border-end-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
       }
 
-      .#{$table}__th::after {
+      .#{$table}__tr:last-child::after {
+        position: absolute;
+        inset: 0;
         z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
+        pointer-events: none;
+        content: '';
         border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
       }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -301,8 +301,9 @@
     table-layout: fixed;
   }
 
-  &.pf-m-sticky-header-base > .#{$table}__thead, &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__th {
-    &::before,
+  &.pf-m-sticky-header-base > .#{$table}__thead, 
+  &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__tr,
+  &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__th {
     &::after {
       opacity: 0;
       transition-timing-function: var(--#{$table}--m-sticky-header--TransitionTimingFunction--BackgroundColor);
@@ -311,8 +312,9 @@
     }
   }
 
-  &.pf-m-sticky-header-stuck > .#{$table}__thead, &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__th {
-    &::before,
+  &.pf-m-sticky-header-stuck > .#{$table}__thead, 
+  &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__tr,
+  &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__th {
     &::after {
       opacity: 1;
     }
@@ -327,7 +329,7 @@
       inset-block-start: 0;
       z-index: var(--#{$table}--m-sticky-header--ZIndex);
 
-      &::before {
+      &::after {
         position: absolute;
         inset: 0;
         z-index: -1;
@@ -338,7 +340,7 @@
       }
   
 
-      .#{$table}__th::before {
+      .#{$table}__th::after {
         position: absolute;
         inset: 0;
         z-index: -1;
@@ -347,12 +349,12 @@
         background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
       }
 
-      .#{$table}__th:first-child::before {
+      .#{$table}__th:first-child::after {
         border-start-start-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         border-end-start-radius: var(--#{$table}--m-sticky-header--BorderRadius);
       }
 
-      .#{$table}__th:last-child::before {
+      .#{$table}__th:last-child::after {
         border-start-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         border-end-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
       }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -241,7 +241,7 @@
   // * Table nested column header
   --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: var(--#{$table}--border-width--base);
   --#{$table}__thead--m-nested-column-header--BorderBlockEndColor: var(--#{$table}--BorderColor);
-  --#{$table}__thead--m-nested-column-header--after--ZIndex: calc(var(--pf-t--global--z-index--xs) + 2);
+  --#{$table}__thead--m-nested-column-header--after--ZIndex: initial;
   --#{$table}__thead--m-nested-column-header--button--OutlineOffset: #{pf-size-prem(-3px)};
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockStart: var(--pf-t--global--spacer--xs);
   --#{$table}__thead--m-nested-column-header__tr--PaddingBlockEnd: var(--pf-t--global--spacer--md);
@@ -302,7 +302,6 @@
   }
 
   &.pf-m-sticky-header-base > .#{$table}__thead, 
-  &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__tr,
   &.pf-m-sticky-header-base > .#{$table}__thead .#{$table}__th {
     &::after {
       opacity: 0;
@@ -313,7 +312,6 @@
   }
 
   &.pf-m-sticky-header-stuck > .#{$table}__thead, 
-  &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__tr,
   &.pf-m-sticky-header-stuck > .#{$table}__thead .#{$table}__th {
     &::after {
       opacity: 1;
@@ -347,6 +345,7 @@
         pointer-events: none;
         content: '';
         background-color: var(--#{$table}--m-sticky-header--BackgroundColor);
+        border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
       }
 
       .#{$table}__th:first-child::after {
@@ -357,15 +356,6 @@
       .#{$table}__th:last-child::after {
         border-start-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         border-end-end-radius: var(--#{$table}--m-sticky-header--BorderRadius);
-      }
-
-      .#{$table}__tr:last-child::after {
-        position: absolute;
-        inset: 0;
-        z-index: var(--#{$table}--m-sticky-header--border--ZIndex);
-        pointer-events: none;
-        content: '';
-        border-block-end: var(--#{$table}--m-sticky-header--BorderBlockEndWidth) solid var(--#{$table}--m-sticky-header--BorderBlockEndColor);
       }
 
       > :where(th, td) {
@@ -1308,14 +1298,13 @@
 
   // - Table nested column header button
   &.pf-m-nested-column-header {
+    --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
+
     position: relative;
 
-    &::after {
-      position: absolute;
-      inset: 0;
+    .#{$table}__tr:last-child:not(.pf-m-border-row) {
       z-index: var(--#{$table}__thead--m-nested-column-header--after--ZIndex);
       pointer-events: none;
-      content: '';
       border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
     }
 
@@ -1379,7 +1368,8 @@
   }
 
   &.pf-m-border-row {
-    border-block-end: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
+    height: var(--#{$table}--border-width--base);
+    background-color: var(--#{$table}--BorderColor);
   }
 }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -376,6 +376,7 @@
     :where(.pf-v6-theme-glass) & {
       .pf-m-nested-column-header {
         --#{$table}--m-sticky-header--BorderRadius: 0;
+        --#{$table}__thead--m-nested-column-header--BorderBlockEndWidth: 0;
       }
     }
   }


### PR DESCRIPTION
Closes #8453 
Move background and border ::before and ::after elements from thead to th for Safari support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Dock component: Updated desktop end-border width and color to use the standard border tokens for more consistent rendering.
  * Panel component: Adjusted default “before” border width to a high-contrast value and ensured the secondary modifier no longer overrides that border width.
  * Table component: Improved sticky header visuals by moving the background and border decoration from the header container pseudo-element to individual header cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->