### PR TITLE
fix(Menu): document listbox/option/aria-selected attributes for select menus

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -1666,6 +1666,10 @@ import './Menu.css'
 | `disabled` | `button.pf-v6-c-menu__item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus. |
 | `role="menuitem"` | `.pf-v6-c-menu__item`, `.pf-v6-c-menu__list-item` (checkbox) | Assigns `.pf-v6-c-menu__item` as an option in a set of choices contained by a menu. |
 | `role="none"` | `.pf-v6-c-menu__list-item` | Removes semantic meaning from `.pf-v6-c-menu__list-item`. |
+| `role="listbox"` | `.pf-v6-c-menu__list` | When the menu is used as a select (single or multi-select), replaces `role="menu"` to declare `.pf-v6-c-menu__list` as a listbox. |
+| `role="option"` | `.pf-v6-c-menu__item` | When the menu is used as a select, replaces `role="menuitem"` to assign `.pf-v6-c-menu__item` as a selectable option in the listbox. |
+| `aria-selected="true"` or `"false"` | `.pf-v6-c-menu__item` (`role="option"`) | **Required** on every option in a select listbox. Indicates whether that option is currently selected; must never be omitted, even for unselected options. |
+| `aria-multiselectable="true"` | `.pf-v6-c-menu__list` (`role="listbox"`) | Indicates that more than one option in the listbox can be selected at a time. Only applies to multi-select. |
 | `aria-disabled="true"` | `.pf-v6-c-menu__item` | Indicates to assistive technologies that the menu item is disabled, but still allows it to be focusable via keyboard. Additional click prevention may be required. |
 | `tabindex="-1"` | `a.pf-v6-c-menu__item` | When the menu item uses a link element and has `aria-disabled="true"` passed in, removes it from keyboard focus. This is similar to passing `disabled` to a menu item that uses a button element. |
 | `aria-hidden="true"` | `.pf-v6-c-menu__item-icon`, `.pf-v6-c-menu__item-action-icon`, `.pf-v6-c-menu__item-external-icon`, `.pf-v6-c-menu__item-toggle-icon`, `.pf-v6-c-menu__item-select-icon` | Hides the icon from assistive technologies. |


### PR DESCRIPTION
Closes #5799

The Menu HTML docs describe the select examples (single and multi-select) using `role="menu"` / `role="menuitem"`, but selects should use `role="listbox"` / `role="option"`, and every option needs `aria-selected="true"` or `"false"` (never omitted). Multi-select listboxes also need `aria-multiselectable="true"`.

I looked at actually rewriting the rendered examples first, but `menu-list.hbs` and `menu-item.hbs` hardcode `role="menu"` and `role="menuitem"` with no override param, only an append-only `--attribute` passthrough. Passing a role through that would just emit a second, duplicate `role` attribute, which is worse than what's there now. Reworking those partials to support a role override, then updating every example and any generated snapshot/backstop images that reference them, is a lot bigger than this issue and touches other menu examples that don't need it.

The issue's own updated criteria (from thatblindgeye's edit) says this is fine to handle in the accessibility docs instead of the HTML: "We can update the a11y docs to include the aria attributes here as well, rather than adding them to the HTML Accessibility table (which would be removed anyway in favor of the a11y docs)." So this PR adds four rows to the Accessibility table in `Menu.md` covering `role="listbox"`, `role="option"`, `aria-selected`, and `aria-multiselectable`, explaining when each replaces the default menu/menuitem roles and that `aria-selected` is required on every option.

Verified:
- Confirmed on current `main` that `menu-list.hbs` / `menu-item.hbs` still hardcode `role="menu"` / `role="menuitem"` and that the Menu.md examples and table have no listbox/option/aria-selected coverage.
- Checked the table structure by hand (column counts match the existing rows) since this repo doesn't have a markdown lint step for these doc tables.
- Did not run the full docs build (webpack/gulp) — repo has no installed deps in my environment and it's a big install for a docs-table-only change. Happy to add that verification if a maintainer wants it before merge.

Assisted-by: Claude Code (used for research and drafting this documentation fix; the underlying HTML/hbs investigation, issue re-read, and table content were reviewed before opening this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Menu accessibility guidance for select-style usage.
  * Clarified that single- and multi-select menus should use listbox semantics, with items exposed as options.
  * Added guidance to always set `aria-selected` on every option and to use `aria-multiselectable` for multi-select menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->