### PR TITLE
fix: address word-break/overflow-wrap bug

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -176,7 +176,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   -webkit-overflow-scrolling: touch;
 
   @media screen and (min-width: $pf-v6-global--breakpoint--sm) {

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -205,7 +205,7 @@
   grid-area: title;
   font-weight: var(--#{$alert}__title--FontWeight);
   color: var(--#{$alert}__title--Color);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &.pf-m-truncate {
     @include pf-v6-line-clamp("var(--#{$alert}__title--max-lines)");
@@ -215,7 +215,7 @@
 .#{$alert}__description {
   grid-area: description;
   padding-block-start: var(--#{$alert}__description--PaddingBlockStart);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   + .#{$alert}__action-group {
     --#{$alert}__action-group--PaddingBlockStart: var(--#{$alert}__description--action-group--PaddingBlockStart);

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -83,7 +83,7 @@
   font-weight: var(--#{$breadcrumb}__link--FontWeight);
   line-height: inherit;
   color: var(--#{$breadcrumb}__link--Color);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   text-decoration-line: var(--#{$breadcrumb}__link--TextDecorationLine);
   text-decoration-style: var(--#{$breadcrumb}__link--TextDecorationStyle);
   text-decoration-color: var(--#{$breadcrumb}__link--TextDecorationColor);

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -108,7 +108,7 @@
 }
 
 .#{$clipboard-copy}__text {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   white-space: normal;
 
   &.pf-m-code {

--- a/src/patternfly/components/Menu/menu.scss
+++ b/src/patternfly/components/Menu/menu.scss
@@ -627,7 +627,7 @@
 .#{$menu}__item-description {
   font-size: var(--#{$menu}__item-description--FontSize);
   color: var(--#{$menu}__item-description--Color);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 // - Menu check

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -226,7 +226,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   -webkit-overflow-scrolling: touch;
 
   &:last-child {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -242,7 +242,7 @@
 
 .#{$notification-drawer}__list-item-header-title {
   font-weight: var(--#{$notification-drawer}__list-item-header-title--FontWeight);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &.pf-m-truncate {
     @include pf-v6-line-clamp("var(--#{$notification-drawer}__list-item-header-title--max-lines)");
@@ -263,7 +263,7 @@
   grid-row: 2 / 3;
   grid-column: 1 / 2;
   margin-block-end: var(--#{$notification-drawer}__list-item-description--MarginBlockEnd);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .#{$notification-drawer}__list-item-timestamp {
@@ -307,7 +307,7 @@
   margin-inline-end: var(--#{$notification-drawer}__group-toggle-title--MarginInlineEnd);
   font-size: var(--#{$notification-drawer}__group-toggle-title--FontSize);
   text-align: start;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .#{$notification-drawer}__group-toggle-count {

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -163,7 +163,7 @@
 // the progress__description is displayed above the progress bar on the left
 .#{$progress}__description {
   grid-column: 1 / 2;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &.pf-m-truncate {
     @include pf-v6-text-overflow;
@@ -179,7 +179,7 @@
   align-items: flex-start;
   justify-content: flex-end;
   text-align: end;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 // the progress__status-icon is an icon displayed always in the upper right

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -71,7 +71,7 @@
 
 .#{$title} {
   font-family: var(--#{$title}--FontFamily);
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &.pf-m-4xl {
     font-size: var(--#{$title}--m-4xl--FontSize);

--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -129,7 +129,7 @@
   font-size: var(--#{$tooltip}__content--FontSize);
   color: var(--#{$tooltip}__content--Color);
   text-align: center;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   background-color: var(--#{$tooltip}__content--BackgroundColor);
   border-radius: var(--#{$tooltip}__content--BorderRadius);
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -325,7 +325,7 @@
   align-items: baseline;
   margin-block-end: var(--#{$wizard}__toggle-list-item--MarginBlockEnd);
   text-align: start;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &:not(:last-child) {
     margin-inline-end: var(--#{$wizard}__toggle-list-item--not-last-child--MarginInlineEnd);
@@ -478,7 +478,7 @@
   padding-inline: 0;
   color: var(--#{$wizard}__nav-link--Color);
   text-align: start; // needed for when the item is a button
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   text-decoration-line: var(--#{$wizard}__nav-link--TextDecoration);
   counter-increment: wizard-nav-count;
   background-color: transparent;
@@ -614,7 +614,7 @@
   flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .#{$wizard}__main-body {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8484

Follow up to a bug from https://github.com/patternfly/patternfly/pull/8438. I incorrectly replaced `word-break: break-word` with `overflow-wrap: break-word`, when it should have been replaced with `overflow-wrap: anywhere`. This PR goes through all of the changes in #8438 and changes any rules that were `word-break: break-word` to `overflow-wrap: anywhere` instead.

**Note** - there are some instances of `word-wrap: break-word` (`word-wrap` vs `word-break`) replaced with `overflow-wrap: break-word` originally, which is correct, so I left those alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text wrapping across multiple UI elements, including modals, alerts, breadcrumbs, menus, tooltips, notifications, progress displays, and wizards.
  - Long or unbroken text now wraps more gracefully in tighter spaces, reducing overflow and layout issues.
  - Updated title and clipboard copy text behavior for better readability when content is constrained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->