### PR TITLE
fix(tree-view): revert caret rotations

### DIFF
--- a/src/patternfly/components/TreeView/tree-view-node-toggle-icon.hbs
+++ b/src/patternfly/components/TreeView/tree-view-node-toggle-icon.hbs
@@ -2,5 +2,5 @@
   {{#if tree-view-node-toggle-icon--attribute}}
     {{{tree-view-node-toggle-icon--attribute}}}
   {{/if}}>
-  {{pfIcon "rh-microns-caret-down"}}
+  {{pfIcon "rh-microns-caret-right"}}
 </span>

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -90,9 +90,9 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   // Icon
   --#{$tree-view}__node-icon--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tree-view}__node-icon--Color: var(--pf-t--global--icon--color--subtle);
-  --#{$tree-view}__node-toggle-icon--base--Rotate: -90deg;
+  --#{$tree-view}__node-toggle-icon--base--Rotate: 0;
   --#{$tree-view}__node-toggle-icon--Rotate: var(--#{$tree-view}__node-toggle-icon--base--Rotate);
-  --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: 0;
+  --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: 90deg;
 
   // Disabled
   --#{$tree-view}__node--m-disabled--Color: var(--pf-t--global--text--color--disabled);

--- a/src/patternfly/components/TreeView/tree-view.scss
+++ b/src/patternfly/components/TreeView/tree-view.scss
@@ -90,9 +90,9 @@ $pf-v6-c-tree-view--MaxNesting: 10 !default;
   // Icon
   --#{$tree-view}__node-icon--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
   --#{$tree-view}__node-icon--Color: var(--pf-t--global--icon--color--subtle);
-  --#{$tree-view}__node-toggle-icon--base--Rotate: 0;
+  --#{$tree-view}__node-toggle-icon--base--Rotate: -90deg;
   --#{$tree-view}__node-toggle-icon--Rotate: var(--#{$tree-view}__node-toggle-icon--base--Rotate);
-  --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: -180deg;
+  --#{$tree-view}__list-item--m-expanded__node-toggle-icon--Rotate: 0;
 
   // Disabled
   --#{$tree-view}__node--m-disabled--Color: var(--pf-t--global--text--color--disabled);


### PR DESCRIPTION
Closes: #8474 

Reverted the expand/collapse pattern from down/up to right/down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the TreeView node toggle icon rotation to better reflect expanded vs. collapsed state.
  * Updated the TreeView toggle icon behavior so the appropriate caret direction is shown when the toggle attribute is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->