### PR TITLE
fix(table): nested table sorting

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1304,7 +1304,7 @@
 
     .#{$table}__tr:last-child:not(.pf-m-border-row) {
       z-index: var(--#{$table}__thead--m-nested-column-header--after--ZIndex);
-      pointer-events: none;
+      pointer-events: auto;
       border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
     }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1304,7 +1304,6 @@
 
     .#{$table}__tr:last-child:not(.pf-m-border-row) {
       z-index: var(--#{$table}__thead--m-nested-column-header--after--ZIndex);
-      pointer-events: auto;
       border-block-end: var(--#{$table}__thead--m-nested-column-header--BorderBlockEndWidth) solid var(--#{$table}__thead--m-nested-column-header--BorderBlockEndColor);
     }
 


### PR DESCRIPTION
Fixes: #8485 

Change :last tr pointer-events to auto to allow for click through with new background treatment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction for nested table column headers by enabling pointer events on the last nested header row, making it easier to interact with nested header layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->