### PR TITLE
fix(a11y): ignore target-size rule for WCAG 2.2 bump

### DIFF
--- a/patternfly-a11y.config.js
+++ b/patternfly-a11y.config.js
@@ -75,7 +75,8 @@ module.exports = {
     'landmark-no-duplicate-main',
     'landmark-main-is-top-level',
     'scrollable-region-focusable',
-    'aria-required-children' // Remove once https://github.com/patternfly/patternfly-react/issues/9968 is resolved
+    'aria-required-children', // Remove once https://github.com/patternfly/patternfly-react/issues/9968 is resolved
+    'target-size' // See if we can remove once https://github.com/patternfly/patternfly/issues/8492 is resolved
   ].join(','),
   ignoreIncomplete: true,
   skip: '(mailto)|(/(developer-resources)/.+)'


### PR DESCRIPTION
Related to https://github.com/patternfly/patternfly/issues/8492. We want to temporarily ignore the target-size AA rule introduced in WCAG 2.2 until we can see whether we're able to resolve all violations (some might be false positives, however). We need to ignore the rule for now so that we can merge the a11y tool bump PR and not have every PR fail build processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated accessibility validation settings to exclude the target-size rule from reported results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->