### PR TITLE
fix(tabs): update padding and subtab height

### DIFF
--- a/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
@@ -10,7 +10,7 @@ __tabs-item--NoText: bool
 ------------------------------------
 --}}
 
-{{#if __tabs-list--IsScrollable}}
+{{#if __tabs-list-secondary--IsScrollable}}
   {{#unless __tabs-list--NoScrollButtons}}
     {{#if __tabs-list--DisabledFirstScrollButton}}
       {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true"}}
@@ -101,7 +101,7 @@ __tabs-item--NoText: bool
   {{/unless}}
 {{/tabs-list}}
 
-{{#if __tabs-list--IsScrollable}}
+{{#if __tabs-list-secondary--IsScrollable}}
   {{#unless __tabs-list--NoScrollButtons}}
     {{#if __tabs-list--DisabledLastScrollButton}}
       {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true"}}

--- a/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list-secondary.hbs
@@ -10,15 +10,15 @@ __tabs-item--NoText: bool
 ------------------------------------
 --}}
 
-{{#unless __tabs-list-secondary--NoScrollButtons}}
-  {{#if __tabs-list-secondary--DisabledFirstScrollButton}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true"}}
-  {{else if __tabs-list-secondary--IsScrollable}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true"}}
-  {{else}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true" tabs-scroll-button--IsHidden="true"}}
-  {{/if}}
-{{/unless}}
+{{#if __tabs-list--IsScrollable}}
+  {{#unless __tabs-list--NoScrollButtons}}
+    {{#if __tabs-list--DisabledFirstScrollButton}}
+      {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true"}}
+    {{else}}
+      {{> tabs-scroll-button tabs-scroll-button--IsLeft="true"}}
+    {{/if}}
+  {{/unless}}
+{{/if}}
 
 {{#> tabs-list}}
   {{> __tabs-item
@@ -101,12 +101,12 @@ __tabs-item--NoText: bool
   {{/unless}}
 {{/tabs-list}}
 
-{{#unless __tabs-list-secondary--NoScrollButtons}}
-  {{#if __tabs-list-secondary--DisabledLastScrollButton}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true"}}
-  {{else if __tabs-list-secondary--IsScrollable}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true"}}
-  {{else}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true" tabs-scroll-button--IsHidden="true"}}
-  {{/if}}
-{{/unless}}
+{{#if __tabs-list--IsScrollable}}
+  {{#unless __tabs-list--NoScrollButtons}}
+    {{#if __tabs-list--DisabledLastScrollButton}}
+      {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true"}}
+    {{else}}
+      {{> tabs-scroll-button tabs-scroll-button--IsRight="true"}}
+    {{/if}}
+  {{/unless}}
+{{/if}}

--- a/src/patternfly/components/Tabs/__tabs-list.hbs
+++ b/src/patternfly/components/Tabs/__tabs-list.hbs
@@ -16,15 +16,15 @@ __tabs-list--IsCloseDisabled: bool
 ------------------------------------
 --}}
 
-{{#unless __tabs-list--NoScrollButtons}}
-  {{#if __tabs-list--DisabledFirstScrollButton}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true"}}
-  {{else if __tabs-list--IsScrollable}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true"}}
-  {{else}}
-    {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true" tabs-scroll-button--IsHidden="true"}}
-  {{/if}}
-{{/unless}}
+{{#if __tabs-list--IsScrollable}}
+  {{#unless __tabs-list--NoScrollButtons}}
+    {{#if __tabs-list--DisabledFirstScrollButton}}
+      {{> tabs-scroll-button tabs-scroll-button--IsLeft="true" tabs-scroll-button--IsDisabled="true"}}
+    {{else}}
+      {{> tabs-scroll-button tabs-scroll-button--IsLeft="true"}}
+    {{/if}}
+  {{/unless}}
+{{/if}}
 
 {{#> tabs-list tabs-item--IsAction=__tabs-list--IsAction tabs-item--HasClose=__tabs-list--HasClose tabs-item--HasHelp=__tabs-list--HasHelp}}
   {{> __tabs-item
@@ -154,15 +154,15 @@ __tabs-list--IsCloseDisabled: bool
   {{/unless}}
 {{/tabs-list}}
 
-{{#unless __tabs-list--NoScrollButtons}}
-  {{#if __tabs-list--DisabledLastScrollButton}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true"}}
-  {{else if __tabs-list--IsScrollable}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true"}}
-  {{else}}
-    {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true" tabs-scroll-button--IsHidden="true"}}
-  {{/if}}
-{{/unless}}
+{{#if __tabs-list--IsScrollable}}
+  {{#unless __tabs-list--NoScrollButtons}}
+    {{#if __tabs-list--DisabledLastScrollButton}}
+      {{> tabs-scroll-button tabs-scroll-button--IsRight="true" tabs-scroll-button--IsDisabled="true"}}
+    {{else}}
+      {{> tabs-scroll-button tabs-scroll-button--IsRight="true"}}
+    {{/if}}
+  {{/unless}}
+{{/if}}
 
 {{#if __tabs-list--HasAddTab}}
   {{> tabs-add}}

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -96,7 +96,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--TransitionTimingFunction--background-color: var(--pf-t--global--motion--timing-function--default);
 
   // Subtab link
-  --#{$tabs}--m-subtab__link--MarginBlock: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
+  --#{$tabs}--m-subtab__link--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
+  --#{$tabs}--m-subtab__link--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
@@ -527,7 +528,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__add--c-button--FontSize: var(--#{$tabs}--m-subtab__add--c-button--FontSize);
 
     .#{$tabs}__link {
-      margin-block: var(--#{$tabs}--m-subtab__link--MarginBlock);
+      margin-block-start: var(--#{$tabs}--m-subtab__link--MarginBlock);
+      margin-block-end: var(--#{$tabs}--m-subtab__link--MarginBlockEnd);
     }
   }
 

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -71,9 +71,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$tabs}__link--disabled--BorderColor: transparent;
   --#{$tabs}__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--plain);
-  --#{$tabs}__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
+  --#{$tabs}__link--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$tabs}__link--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--plain);
-  --#{$tabs}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
+  --#{$tabs}__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$tabs}__link--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--disabled--Color: var(--pf-t--global--text--color--disabled);
   --#{$tabs}__link--disabled--BackgroundColor: transparent;

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -96,6 +96,21 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--TransitionTimingFunction--background-color: var(--pf-t--global--motion--timing-function--default);
 
   // Subtab link
+  // This calc is __item--padding + __link--padding - __subtab__link--padding + (font-size difference) * (line-height / 2)
+  --#{$tabs}--m-subtab__item--PaddingBlockStart: calc(
+    var(--pf-t--global--spacer--sm)
+    + var(--pf-t--global--spacer--control--vertical--plain)
+    - var(--#{$tabs}--m-subtab__link--PaddingBlockStart)
+    + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs))
+    * (var(--pf-t--global--font--line-height--body) / 2)
+  );
+  --#{$tabs}--m-subtab__item--PaddingBlockEnd: calc(
+    var(--pf-t--global--spacer--sm)
+    + var(--pf-t--global--spacer--control--vertical--plain)
+    - var(--#{$tabs}--m-subtab__link--PaddingBlockStart)
+    + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs))
+    * (var(--pf-t--global--font--line-height--body) / 2)
+  );
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
@@ -517,6 +532,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 
   &.pf-m-subtab {
+    --#{$tabs}__item--PaddingBlockStart: var(--#{$tabs}--m-subtab__item--PaddingBlockStart);
+    --#{$tabs}__item--PaddingBlockEnd: var(--#{$tabs}--m-subtab__item--PaddingBlockEnd);
     --#{$tabs}__link--FontSize: var(--#{$tabs}--m-subtab__link--FontSize);
     --#{$tabs}__link--PaddingBlockStart: var(--#{$tabs}--m-subtab__link--PaddingBlockStart);
     --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-subtab__link--PaddingInlineStart);

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -96,9 +96,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--TransitionTimingFunction--background-color: var(--pf-t--global--motion--timing-function--default);
 
   // Subtab link
-  // This calc is __item--padding + __link--padding - __subtab__link--padding + (font-size difference) * (line-height / 2)
-  --#{$tabs}--m-subtab__item--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--control--vertical--plain) - var(--#{$tabs}--m-subtab__link--PaddingBlockStart) + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs)) * (var(--pf-t--global--font--line-height--body) / 2));
-  --#{$tabs}--m-subtab__item--PaddingBlockEnd: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--control--vertical--plain) - var(--#{$tabs}--m-subtab__link--PaddingBlockStart) + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs)) * (var(--pf-t--global--font--line-height--body) / 2));
+  --#{$tabs}--m-subtab__link--MarginBlock: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
@@ -520,8 +518,6 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   }
 
   &.pf-m-subtab {
-    --#{$tabs}__item--PaddingBlockStart: var(--#{$tabs}--m-subtab__item--PaddingBlockStart);
-    --#{$tabs}__item--PaddingBlockEnd: var(--#{$tabs}--m-subtab__item--PaddingBlockEnd);
     --#{$tabs}__link--FontSize: var(--#{$tabs}--m-subtab__link--FontSize);
     --#{$tabs}__link--PaddingBlockStart: var(--#{$tabs}--m-subtab__link--PaddingBlockStart);
     --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-subtab__link--PaddingInlineStart);
@@ -529,6 +525,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
     --#{$tabs}__link--PaddingInlineEnd: var(--#{$tabs}--m-subtab__link--PaddingInlineEnd);
     --#{$tabs}__item-action--c-button--FontSize: var(--#{$tabs}--m-subtab__item-action--c-button--FontSize);
     --#{$tabs}__add--c-button--FontSize: var(--#{$tabs}--m-subtab__add--c-button--FontSize);
+
+    .#{$tabs}__link {
+      margin-block: var(--#{$tabs}--m-subtab__link--MarginBlock);
+    }
   }
 
   &.pf-m-page-insets {

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -98,7 +98,7 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   // Subtab link
   --#{$tabs}--m-subtab__link--MarginBlockStart: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
   --#{$tabs}--m-subtab__link--MarginBlockEnd: calc(var(--pf-t--global--spacer--control--vertical--plain) - var(--pf-t--global--spacer--control--vertical--compact) + (var(--pf-t--global--font--size--body--default) * var(--pf-t--global--font--line-height--body) - 1lh) / 2);
-  --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
+  --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--body--sm);
   --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
   --#{$tabs}--m-subtab__link--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--compact);
@@ -521,14 +521,14 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   &.pf-m-subtab {
     --#{$tabs}__link--FontSize: var(--#{$tabs}--m-subtab__link--FontSize);
     --#{$tabs}__link--PaddingBlockStart: var(--#{$tabs}--m-subtab__link--PaddingBlockStart);
-    --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-subtab__link--PaddingInlineStart);
     --#{$tabs}__link--PaddingBlockEnd: var(--#{$tabs}--m-subtab__link--PaddingBlockEnd);
+    --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-subtab__link--PaddingInlineStart);
     --#{$tabs}__link--PaddingInlineEnd: var(--#{$tabs}--m-subtab__link--PaddingInlineEnd);
     --#{$tabs}__item-action--c-button--FontSize: var(--#{$tabs}--m-subtab__item-action--c-button--FontSize);
     --#{$tabs}__add--c-button--FontSize: var(--#{$tabs}--m-subtab__add--c-button--FontSize);
 
     .#{$tabs}__link {
-      margin-block-start: var(--#{$tabs}--m-subtab__link--MarginBlock);
+      margin-block-start: var(--#{$tabs}--m-subtab__link--MarginBlockStart);
       margin-block-end: var(--#{$tabs}--m-subtab__link--MarginBlockEnd);
     }
   }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -70,9 +70,9 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}__link--BorderColor: transparent;
   --#{$tabs}__link--hover--BorderColor: var(--pf-t--global--border--color--high-contrast);
   --#{$tabs}__link--disabled--BorderColor: transparent;
-  --#{$tabs}__link--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$tabs}__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--plain);
   --#{$tabs}__link--PaddingInlineEnd: var(--pf-t--global--spacer--sm);
-  --#{$tabs}__link--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
+  --#{$tabs}__link--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--plain);
   --#{$tabs}__link--PaddingInlineStart: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--ColumnGap: var(--pf-t--global--spacer--sm);
   --#{$tabs}__link--disabled--Color: var(--pf-t--global--text--color--disabled);
@@ -92,9 +92,15 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
   --#{$tabs}--m-box--m-secondary__link--disabled--BackgroundColor: transparent;
   --#{$tabs}--m-box--m-secondary__link--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
   --#{$tabs}--m-box--m-secondary__item--m-current__link--BackgroundColor: var(--pf-t--global--background--color--action--plain--default);
-  --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}__link--TransitionDuration--background-color: var(--pf-t--global--motion--duration--fade--short);
   --#{$tabs}__link--TransitionTimingFunction--background-color: var(--pf-t--global--motion--timing-function--default);
+
+  // Subtab link
+  --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
+  --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
+  --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);
+  --#{$tabs}--m-subtab__link--PaddingBlockEnd: var(--pf-t--global--spacer--control--vertical--compact);
+  --#{$tabs}--m-subtab__link--PaddingInlineEnd: var(--pf-t--global--spacer--action--horizontal--plain--default);
 
   // Link before
   --#{$tabs}__link--before--border-color--base: var(--pf-t--global--border--color--default);
@@ -512,6 +518,10 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   &.pf-m-subtab {
     --#{$tabs}__link--FontSize: var(--#{$tabs}--m-subtab__link--FontSize);
+    --#{$tabs}__link--PaddingBlockStart: var(--#{$tabs}--m-subtab__link--PaddingBlockStart);
+    --#{$tabs}__link--PaddingInlineStart: var(--#{$tabs}--m-subtab__link--PaddingInlineStart);
+    --#{$tabs}__link--PaddingBlockEnd: var(--#{$tabs}--m-subtab__link--PaddingBlockEnd);
+    --#{$tabs}__link--PaddingInlineEnd: var(--#{$tabs}--m-subtab__link--PaddingInlineEnd);
     --#{$tabs}__item-action--c-button--FontSize: var(--#{$tabs}--m-subtab__item-action--c-button--FontSize);
     --#{$tabs}__add--c-button--FontSize: var(--#{$tabs}--m-subtab__add--c-button--FontSize);
   }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -97,20 +97,8 @@ $pf-v6-c-tabs--spacer-map: build-spacer-map("none", "sm", "md", "lg", "xl", "2xl
 
   // Subtab link
   // This calc is __item--padding + __link--padding - __subtab__link--padding + (font-size difference) * (line-height / 2)
-  --#{$tabs}--m-subtab__item--PaddingBlockStart: calc(
-    var(--pf-t--global--spacer--sm)
-    + var(--pf-t--global--spacer--control--vertical--plain)
-    - var(--#{$tabs}--m-subtab__link--PaddingBlockStart)
-    + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs))
-    * (var(--pf-t--global--font--line-height--body) / 2)
-  );
-  --#{$tabs}--m-subtab__item--PaddingBlockEnd: calc(
-    var(--pf-t--global--spacer--sm)
-    + var(--pf-t--global--spacer--control--vertical--plain)
-    - var(--#{$tabs}--m-subtab__link--PaddingBlockStart)
-    + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs))
-    * (var(--pf-t--global--font--line-height--body) / 2)
-  );
+  --#{$tabs}--m-subtab__item--PaddingBlockStart: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--control--vertical--plain) - var(--#{$tabs}--m-subtab__link--PaddingBlockStart) + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs)) * (var(--pf-t--global--font--line-height--body) / 2));
+  --#{$tabs}--m-subtab__item--PaddingBlockEnd: calc(var(--pf-t--global--spacer--sm) + var(--pf-t--global--spacer--control--vertical--plain) - var(--#{$tabs}--m-subtab__link--PaddingBlockStart) + (var(--pf-t--global--font--size--sm) - var(--pf-t--global--font--size--xs)) * (var(--pf-t--global--font--line-height--body) / 2));
   --#{$tabs}--m-subtab__link--FontSize: var(--pf-t--global--font--size--xs);
   --#{$tabs}--m-subtab__link--PaddingBlockStart: var(--pf-t--global--spacer--control--vertical--compact);
   --#{$tabs}--m-subtab__link--PaddingInlineStart: var(--pf-t--global--spacer--action--horizontal--plain--default);


### PR DESCRIPTION
Fixes #8253 

Updates Tabs padding tokens and subtab.

- Tab link padding switched to `--pf-t--global--spacer--action--horizontal--plain--plain`.
- Subtab link padding updated with dedicated tokens using `--pf-t--global--spacer--control--vertical--compact`and `--pf-t--global--spacer--action--horizontal--plain--default`
- Subtab row height matches regular tab height with or without scroll buttons
- Scroll buttons render only in examples when tabs list is scrollable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tabs scrolling controls so navigation buttons render only when the tab list is scrollable.
  * Correctly shows disabled left/right controls at the start or end of scrollable tab lists.
  * Prevents hidden or extra scroll buttons from appearing in non-scrollable scenarios.
* **Style**
  * Refreshed Tabs and subtabs spacing/padding and adjusted subtab typography for more consistent alignment and visual rhythm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->