### PR TITLE
fix(modal): footer action spacing

### DIFF
--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -76,7 +76,7 @@
 
   // Footer buttons
   --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--pf-t--global--spacer--gap--action-to-action--default);
-  --#{$modal-box}__footer--c-button--sm--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
+  --#{$modal-box}__footer--c-button--sm--MarginInlineEnd: var(--pf-t--global--spacer--gap--action-to-action--default);
 }
 
 .#{$modal-box} {

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -249,7 +249,7 @@
     margin-inline-end: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
 
     @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-      --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--MarginInlineEnd); // remove in breaking change
+      --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--sm--MarginInlineEnd); // remove in breaking change
     }
   }
 }

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -76,6 +76,7 @@
 
   // Footer buttons
   --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--pf-t--global--spacer--gap--action-to-action--default);
+  --#{$modal-box}__footer--c-button--sm--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
 }
 
 .#{$modal-box} {

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -75,8 +75,7 @@
   --#{$modal-box}__footer--PaddingInlineStart: var(--pf-t--global--spacer--lg);
 
   // Footer buttons
-  --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--pf-t--global--spacer--md); // Button spacer is used to manipulate margin-inline-start and/or margin-right values at various breakpoints, with a single value.
-  --#{$modal-box}__footer--c-button--sm--MarginInlineEnd: calc(var(--#{$modal-box}__footer--c-button--MarginInlineEnd) / 2);
+  --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--pf-t--global--spacer--gap--action-to-action--default);
 }
 
 .#{$modal-box} {
@@ -247,9 +246,5 @@
   // Base margin left and right equal for buttons when wrapped
   > .#{$button}:not(:last-child) {
     margin-inline-end: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
-
-    @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
-      --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--sm--MarginInlineEnd);
-    }
   }
 }

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -246,5 +246,9 @@
   // Base margin left and right equal for buttons when wrapped
   > .#{$button}:not(:last-child) {
     margin-inline-end: var(--#{$modal-box}__footer--c-button--MarginInlineEnd);
+
+    @media screen and (min-width: $pf-v6-global--breakpoint--sm) {
+      --#{$modal-box}__footer--c-button--MarginInlineEnd: var(--#{$modal-box}__footer--c-button--MarginInlineEnd); // remove in breaking change
+    }
   }
 }


### PR DESCRIPTION
Closes #7226

Updated Modal footer action spacing from t-shirt size to semantic token and removed unnecessary breakpoint override that was halving the spacer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized spacing for modal footer action buttons to use the default action-to-action gap.
  * Updated the small (`sm`) variant so its spacing matches the base footer button spacing.
  * Simplified small-screen breakpoint styling by removing a now-redundant footer spacing override for more consistent layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->