### PR TITLE
chore(docs): Replace ActionGroup with ActionList

### DIFF
--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -91,8 +91,8 @@ Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum v
   Submit
 {{/button}}
 
-{{#> button button--IsPrimary=true button--IsReset=true}}
-  Reset
+{{#> button button--IsPrimary=true}}
+  Cancel
 {{/button}}
 
 {{#> button button--IsPrimary=true}}

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -248,7 +248,7 @@ cssPrefix: pf-v6-c-form
 {{/form}}
 ```
 
-### Action list
+### Action group
 ```hbs
 {{#> form}}
   {{#> form-group form-group--modifier="pf-m-action"}}
@@ -257,12 +257,12 @@ cssPrefix: pf-v6-c-form
         {{#> action-list-group}}
           {{#> action-list-item}}
             {{#> button button--IsPrimary=true button--IsSubmit=true}}
-              Submit form
+              Submit
             {{/button}}
           {{/action-list-item}}
           {{#> action-list-item}}
-            {{#> button button--IsLink=true button--IsReset=true}}
-              Reset form
+            {{#> button button--IsLink=true}
+              Cancel
             {{/button}}
           {{/action-list-item}}
         {{/action-list-group}}
@@ -272,18 +272,20 @@ cssPrefix: pf-v6-c-form
 {{/form}}
 ```
 
-### Action group
+### Action group (deprecated)
 ```hbs isDeprecated
 {{#> form}}
   {{#> form-group form-group--modifier="pf-m-action"}}
-    {{#> form-actions}}
-      {{#> button button--IsPrimary=true button--IsSubmit=true}}
-        Submit form
-      {{/button}}
-      {{#> button button--IsLink=true button--IsReset=true}}
-        Reset form
-      {{/button}}
-    {{/form-actions}}
+    {{#> form-group-control}}
+      {{#> form-actions}}
+        {{#> button button--IsPrimary=true button--IsSubmit=true}}
+          Submit
+        {{/button}}
+        {{#> button button--IsLink=true}
+          Cancel
+        {{/button}}
+      {{/form-actions}}
+    {{/form-group-control}}
   {{/form-group}}
 {{/form}}
 ```

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -248,8 +248,32 @@ cssPrefix: pf-v6-c-form
 {{/form}}
 ```
 
-### Action group
+### Action list
 ```hbs
+{{#> form}}
+  {{#> form-group form-group--modifier="pf-m-action"}}
+    {{#> form-group-control}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Submit form
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsLink=true button--IsReset=true}}
+              Reset form
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
+    {{/form-group-control}}
+  {{/form-group}}
+{{/form}}
+```
+
+### Action group
+```hbs isDeprecated
 {{#> form}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-actions}}
@@ -611,7 +635,7 @@ To avoid the form label's required indicator or help tooltip icon from wrapping 
 | `.pf-v6-c-form__group-label-info` | `<div>` |  Initiates a form group info label. |
 | `.pf-v6-c-form__group-label-help` | `<span>` | Initiates field level help. |
 | `.pf-v6-c-form__group-control` | `<div>` |  Initiates a form group control section. |
-| `.pf-v6-c-form__actions` | `<div>` | Iniates a row of actions. |
+| `.pf-v6-c-form__actions` | `<div>` | Initiates a row of actions. **Deprecated:** Use [Action list](/components/action-list) instead. **Note:** `.pf-v6-c-form__actions` will be removed in a future release. |
 | `.pf-v6-c-form__helper-text` | `<p>`, `<div>` |  Initiates a form helper text block. |
 | `.pf-v6-c-form__alert` | `<div>` | Initiates the form alert container for inline alerts. |
 | `.pf-v6-c-form__field-group` | `<div>` | Initiates a form field group. |

--- a/src/patternfly/components/Form/form-actions.hbs
+++ b/src/patternfly/components/Form/form-actions.hbs
@@ -1,3 +1,4 @@
+{{!-- Deprecated: Use action-list instead. --}}
 <div class="{{pfv}}form__actions{{#if form-actions--modifier}} {{form-actions--modifier}}{{/if}}"
   {{#if form-actions--attribute}}
     {{{form-actions--attribute}}}

--- a/src/patternfly/components/Form/form-actions.hbs
+++ b/src/patternfly/components/Form/form-actions.hbs
@@ -1,4 +1,4 @@
-{{!-- Deprecated: Use action-list instead. --}}
+{{!-- Deprecated: Use action-list instead. Remove in a breaking change. --}}
 <div class="{{pfv}}form__actions{{#if form-actions--modifier}} {{form-actions--modifier}}{{/if}}"
   {{#if form-actions--attribute}}
     {{{form-actions--attribute}}}

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -352,6 +352,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   border: 0;
 }
 
+// Deprecated: Use action-list instead.
 .#{$form}__actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -352,7 +352,7 @@ $pf-v6-c-form--m-horizontal--breakpoint-map: build-breakpoint-map("sm", "md", "l
   border: 0;
 }
 
-// Deprecated: Use action-list instead.
+// Deprecated: Use action-list instead. Remove in a breaking change.
 .#{$form}__actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -304,14 +304,20 @@ The React implementation can be found in the [search input](/components/search-i
           {{/form-group-control}}
         {{/form-group}}
         {{#> form-group form-group--modifier="pf-m-action"}}
-          {{#> form-actions}}
-            {{#> button button--id="submit-advanced-search-expanded" button--IsPrimary=true button--IsSubmit=true button--aria-labelledby="submit-advanced-search-expanded search-input-group-advanced-search-expanded"}}
-              Submit
-            {{/button}}
-            {{#> button button--id="reset-advanced-search-expanded" button--IsLink=true button--IsReset=true button--aria-labelledby="reset-advanced-search-expanded search-input-group-advanced-search-expanded"}}
-              Reset
-            {{/button}}
-          {{/form-actions}}
+          {{#> action-list}}
+            {{#> action-list-group}}
+              {{#> action-list-item}}
+                {{#> button button--id="submit-advanced-search-expanded" button--IsPrimary=true button--IsSubmit=true button--aria-labelledby="submit-advanced-search-expanded search-input-group-advanced-search-expanded"}}
+                  Submit
+                {{/button}}
+              {{/action-list-item}}
+              {{#> action-list-item}}
+                {{#> button button--id="reset-advanced-search-expanded" button--IsLink=true button--IsReset=true button--aria-labelledby="reset-advanced-search-expanded search-input-group-advanced-search-expanded"}}
+                  Reset
+                {{/button}}
+              {{/action-list-item}}
+            {{/action-list-group}}
+          {{/action-list}}
         {{/form-group}}
       {{/form}}
     {{/panel-main-body}}
@@ -459,14 +465,20 @@ The React implementation can be found in the [search input](/components/search-i
           {{/form-group-control}}
         {{/form-group}}
         {{#> form-group form-group--modifier="pf-m-action"}}
-          {{#> form-actions}}
-            {{#> button button--id="submit-advanced-search-expanded-with-autocomplete" button--IsPrimary=true button--IsSubmit=true button--aria-labelledby="submit-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
-              Submit
-            {{/button}}
-            {{#> button button--id="reset-advanced-search-expanded-with-autocomplete" button--IsLink=true button--IsReset=true button--IsSubmit=true button--aria-labelledby="reset-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
-              Reset
-            {{/button}}
-          {{/form-actions}}
+          {{#> action-list}}
+            {{#> action-list-group}}
+              {{#> action-list-item}}
+                {{#> button button--id="submit-advanced-search-expanded-with-autocomplete" button--IsPrimary=true button--IsSubmit=true button--aria-labelledby="submit-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
+                  Submit
+                {{/button}}
+              {{/action-list-item}}
+              {{#> action-list-item}}
+                {{#> button button--id="reset-advanced-search-expanded-with-autocomplete" button--IsLink=true button--IsReset=true button--IsSubmit=true button--aria-labelledby="reset-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
+                  Reset
+                {{/button}}
+              {{/action-list-item}}
+            {{/action-list-group}}
+          {{/action-list}}
         {{/form-group}}
       {{/form}}
     {{/panel-main-body}}

--- a/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
+++ b/src/patternfly/components/TextInputGroup/examples/TextInputGroup.md
@@ -312,8 +312,8 @@ The React implementation can be found in the [search input](/components/search-i
                 {{/button}}
               {{/action-list-item}}
               {{#> action-list-item}}
-                {{#> button button--id="reset-advanced-search-expanded" button--IsLink=true button--IsReset=true button--aria-labelledby="reset-advanced-search-expanded search-input-group-advanced-search-expanded"}}
-                  Reset
+                {{#> button button--id="reset-advanced-search-expanded" button--IsLink=true button--aria-labelledby="reset-advanced-search-expanded search-input-group-advanced-search-expanded"}}
+                  Cancel
                 {{/button}}
               {{/action-list-item}}
             {{/action-list-group}}
@@ -473,8 +473,8 @@ The React implementation can be found in the [search input](/components/search-i
                 {{/button}}
               {{/action-list-item}}
               {{#> action-list-item}}
-                {{#> button button--id="reset-advanced-search-expanded-with-autocomplete" button--IsLink=true button--IsReset=true button--IsSubmit=true button--aria-labelledby="reset-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
-                  Reset
+                {{#> button button--id="reset-advanced-search-expanded-with-autocomplete" button--IsLink=true  button--IsSubmit=true button--aria-labelledby="reset-advanced-search-expanded-with-autocomplete search-input-group-advanced-search-expanded-with-autocomplete"}}
+                  Cancel
                 {{/button}}
               {{/action-list-item}}
             {{/action-list-group}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -71,7 +71,7 @@
             {{/button}}
           {{/action-list-item}}
           {{#> action-list-item}}
-            {{#> button button--IsSecondary=true button--IsReset=true}}
+            {{#> button button--IsSecondary=true}}
               Cancel
             {{/button}}
           {{/action-list-item}}

--- a/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-horizontal-form.hbs
@@ -63,14 +63,20 @@
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-group-control}}
-      {{#> form-actions}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true}}
-          Submit
-        {{/button}}
-        {{#> button button--IsSecondary=true button--IsReset=true}}
-          Cancel
-        {{/button}}
-      {{/form-actions}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Submit
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsSecondary=true button--IsReset=true}}
+              Cancel
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -80,7 +80,7 @@
             {{/button}}
           {{/action-list-item}}
           {{#> action-list-item}}
-            {{#> button button--IsSecondary=true button--IsReset=true}}
+            {{#> button button--IsSecondary=true}}
               Cancel
             {{/button}}
           {{/action-list-item}}

--- a/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
+++ b/src/patternfly/demos/Alert/alert-template-stacked-form.hbs
@@ -72,14 +72,20 @@
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-group-control}}
-      {{#> form-actions}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true}}
-          Submit
-        {{/button}}
-        {{#> button button--IsSecondary=true button--IsReset=true}}
-          Cancel
-        {{/button}}
-      {{/form-actions}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Submit
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsSecondary=true button--IsReset=true}}
+              Cancel
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/demos/Button/button-template-form.hbs
+++ b/src/patternfly/demos/Button/button-template-form.hbs
@@ -20,20 +20,24 @@
     {{/form-group-control}}
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
-    {{#> form-actions}}
-      {{#if button-template-form--IsLoading}}
-        {{#> button button--IsPrimary=true button--IsProgress=true button--IsInProgress=true button--IsSubmit=true}}
-          Linking account
-        {{/button}}
-      {{else if button-template-form--IsComplete}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true button--icon="check-circle"}}
-          Logged in
-        {{/button}}
-      {{else}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true}}
-          Link account and log in
-        {{/button}}
-      {{/if}}
-    {{/form-actions}}
+    {{#> action-list}}
+      {{#> action-list-group}}
+        {{#> action-list-item}}
+          {{#if button-template-form--IsLoading}}
+            {{#> button button--IsPrimary=true button--IsProgress=true button--IsInProgress=true button--IsSubmit=true}}
+              Linking account
+            {{/button}}
+          {{else if button-template-form--IsComplete}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true button--icon="check-circle"}}
+              Logged in
+            {{/button}}
+          {{else}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Link account and log in
+            {{/button}}
+          {{/if}}
+        {{/action-list-item}}
+      {{/action-list-group}}
+    {{/action-list}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -91,14 +91,20 @@ subsection: forms
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-group-control}}
-      {{#> form-actions}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true}}
-          Submit
-        {{/button}}
-        {{#> button button--IsLink=true}}
-          Cancel
-        {{/button}}
-      {{/form-actions}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Submit
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsLink=true}}
+              Cancel
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -157,14 +163,20 @@ subsection: forms
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-group-control}}
-      {{#> form-actions}}
-        {{#> button button--IsPrimary=true button--IsSubmit=true}}
-          Submit
-        {{/button}}
-        {{#> button button--IsLink=true}}
-          Cancel
-        {{/button}}
-      {{/form-actions}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Submit
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsLink=true}}
+              Cancel
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
     {{/form-group-control}}
   {{/form-group}}
 {{/form}}
@@ -287,14 +299,20 @@ subsection: forms
     {{/grid}}
     {{#> form-group form-group--modifier="pf-m-action"}}
       {{#> form-group-control}}
-        {{#> form-actions}}
-          {{#> button button--IsPrimary=true button--IsSubmit=true}}
-            Submit
-          {{/button}}
-          {{#> button button--IsLink=true}}
-            Cancel
-          {{/button}}
-        {{/form-actions}}
+        {{#> action-list}}
+          {{#> action-list-group}}
+            {{#> action-list-item}}
+              {{#> button button--IsPrimary=true button--IsSubmit=true}}
+                Submit
+              {{/button}}
+            {{/action-list-item}}
+            {{#> action-list-item}}
+              {{#> button button--IsLink=true}}
+                Cancel
+              {{/button}}
+            {{/action-list-item}}
+          {{/action-list-group}}
+        {{/action-list}}
       {{/form-group-control}}
     {{/form-group}}
   {{/grid}}
@@ -716,14 +734,24 @@ subsection: forms
     {{/form-field-group-header}}
   {{/form-field-group}}
 
-  {{!-- Form action buttons --}}
-  {{#> form-actions}}
-    {{#> button button--IsPrimary=true button--IsSubmit=true}}
-      Save
-    {{/button}}
-    {{#> button button--IsSecondary=true button--IsReset=true}}
-      Cancel
-    {{/button}}
-  {{/form-actions}}
+  {{!-- Form action list buttons --}}
+  {{#> form-group form-group--modifier="pf-m-action"}}
+    {{#> form-group-control}}
+      {{#> action-list}}
+        {{#> action-list-group}}
+          {{#> action-list-item}}
+            {{#> button button--IsPrimary=true button--IsSubmit=true}}
+              Save
+            {{/button}}
+          {{/action-list-item}}
+          {{#> action-list-item}}
+            {{#> button button--IsSecondary=true button--IsReset=true}}
+              Cancel
+            {{/button}}
+          {{/action-list-item}}
+        {{/action-list-group}}
+      {{/action-list}}
+    {{/form-group-control}}
+  {{/form-group}}
 {{/form}}
 ```

--- a/src/patternfly/demos/Form/examples/BasicForms.md
+++ b/src/patternfly/demos/Form/examples/BasicForms.md
@@ -745,7 +745,7 @@ subsection: forms
             {{/button}}
           {{/action-list-item}}
           {{#> action-list-item}}
-            {{#> button button--IsSecondary=true button--IsReset=true}}
+            {{#> button button--IsSecondary=true}}
               Cancel
             {{/button}}
           {{/action-list-item}}


### PR DESCRIPTION
What: Part of https://github.com/patternfly/patternfly/issues/8486

I didn't see this being used outside of the examples.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Form examples and demos to use the Action list component for submit, cancel, and related action controls.
  - Refreshed advanced search and button template demonstrations to match the new action layout.
- **Bug Fixes**
  - Corrected a spelling error in the Form actions usage reference.
- **Documentation**
  - Marked the legacy Form actions pattern as deprecated, added guidance to use Action list instead, and noted upcoming removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->