### PR TITLE
fix: disabled background flicker

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -15,6 +15,7 @@
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$button}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$button}--BackgroundColor: transparent;
+  --#{$button}--background--click: radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
   --#{$button}--BorderColor: transparent;
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
@@ -454,7 +455,7 @@
   -webkit-user-select: none;
   user-select: none;
   // stylelint-enable property-no-vendor-prefix
-  background: var(--#{$button}--BackgroundColor) radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
+  background: var(--#{$button}--BackgroundColor) var(--#{$button}--background--click);
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -559,7 +560,7 @@
     --#{$button}--m-clicked__icon--Color: var(--#{$button}--m-link--m-clicked__icon--Color);
     --#{$button}--m-small--PaddingInlineEnd: var(--#{$button}--m-link--m-small--PaddingInlineEnd);
     --#{$button}--m-small--PaddingInlineStart: var(--#{$button}--m-link--m-small--PaddingInlineStart);
-  
+
     &.pf-m-inline {
       @at-root span#{&} {
         --#{$button}--m-link--m-inline--Display: var(--#{$button}--span--m-link--m-inline--Display);
@@ -953,7 +954,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background: var(--#{$button}--disabled--BackgroundColor);
+    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--background--click);
 
     &::after {
       border-color: var(--#{$button}--disabled--BorderColor);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -15,7 +15,7 @@
   --#{$button}--FontWeight: var(--pf-t--global--font--weight--body--default);
   --#{$button}--FontSize: var(--pf-t--global--font--size--body--default);
   --#{$button}--BackgroundColor: transparent;
-  --#{$button}--background--click: radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
+  --#{$button}--Background--click: radial-gradient(circle, transparent 1%, color-mix(in srgb, currentcolor 15%, transparent) 2%) center/15000% 15000%;
   --#{$button}--BorderColor: transparent;
   --#{$button}--BorderWidth: var(--pf-t--global--border--width--action--default);
   --#{$button}--BorderRadius: var(--pf-t--global--border--radius--pill);
@@ -455,7 +455,7 @@
   -webkit-user-select: none;
   user-select: none;
   // stylelint-enable property-no-vendor-prefix
-  background: var(--#{$button}--BackgroundColor) var(--#{$button}--background--click);
+  background: var(--#{$button}--BackgroundColor) var(--#{$button}--Background--click);
   border: 0;
   border-start-start-radius: var(--#{$button}--BorderStartStartRadius, var(--#{$button}--BorderRadius));
   border-start-end-radius: var(--#{$button}--BorderStartEndRadius, var(--#{$button}--BorderRadius));
@@ -954,7 +954,7 @@
   &.pf-m-aria-disabled {
     color: var(--#{$button}--disabled--Color);
     text-decoration-color: var(--#{$button}--disabled--TextDecorationColor);
-    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--background--click);
+    background: var(--#{$button}--disabled--BackgroundColor) var(--#{$button}--Background--click);
 
     &::after {
       border-color: var(--#{$button}--disabled--BorderColor);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8535

The but comes from the click transition being removed on a disabled button. When the button goes from disabled to enabled, the transition is added back and runs.

This PR keeps the transition on disabled buttons, but the transition is disabled because the `background-position` change on `:active` (that gives the ripple effect) is overridden by the `background` declaration on `:disabed/.pf-m-disabled/.pf-m-aria-disabled`.

<img width="525" height="217" alt="Screenshot 2026-08-03 at 3 39 17 PM" src="https://github.com/user-attachments/assets/84618168-6950-49fa-ade1-eb3a752fe5dd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved button click ripple rendering across standard and disabled button states.
- Preserved button background colors while displaying the click interaction effect consistently.
- Ensured the click effect layers correctly with button themes and disabled styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->