### PR TITLE
chore: fix handlebars syntax

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -261,7 +261,7 @@ cssPrefix: pf-v6-c-form
             {{/button}}
           {{/action-list-item}}
           {{#> action-list-item}}
-            {{#> button button--IsLink=true}
+            {{#> button button--IsLink=true}}
               Cancel
             {{/button}}
           {{/action-list-item}}
@@ -281,7 +281,7 @@ cssPrefix: pf-v6-c-form
         {{#> button button--IsPrimary=true button--IsSubmit=true}}
           Submit
         {{/button}}
-        {{#> button button--IsLink=true}
+        {{#> button button--IsLink=true}}
           Cancel
         {{/button}}
       {{/form-actions}}


### PR DESCRIPTION
Syntax issue with one of the examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Cancel” link-style button examples in the Form documentation so they render correctly.
  * Updated both current and deprecated action group examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->