### PR TITLE
fix: make entire label clickable

### DIFF
--- a/src/patternfly/components/Label/label.hbs
+++ b/src/patternfly/components/Label/label.hbs
@@ -31,8 +31,14 @@
   {{/label-content}}
   {{#if label--IsRemovable}}
     {{#> label-actions}}
-      {{> button button--IsDisabled=label--IsDisabled button--IsIcon=true button--icon="rh-microns-close" button--IsPlain=true button--HasNoPadding=true button--attribute=(concat 'id="' label--id '-button"
-    aria-label="Remove" aria-labelledby="' label--id '-button ' label--id '-text"')}}
+      {{> button
+          button--IsDisabled=label--IsDisabled
+          button--IsIcon=true button--icon="rh-microns-close"
+          button--IsPlain=true button--HasNoPadding=true
+          button--id=(concat label--id '-button')
+          button--aria-label="Remove"
+          button--aria-labelledby=(concat label--id '-button ' label--id '-text')
+      }}
     {{/label-actions}}
   {{/if}}
 </{{#if label--type}}{{label--type}}{{else if label--IsOverflow}}button{{else if label--IsAdd}}button{{else}}span{{/if}}>

--- a/src/patternfly/components/Label/label.scss
+++ b/src/patternfly/components/Label/label.scss
@@ -567,7 +567,6 @@
     position: absolute;
     inset: 0;
     z-index: -1;
-    pointer-events: none;
     content: "";
     background-color: var(--#{$label}--BackgroundColor);
     border: var(--#{$label}--BorderWidth) solid var(--#{$label}--BorderColor);
@@ -588,8 +587,15 @@
   margin-inline-end: var(--#{$label}__actions--MarginInlineEnd);
 
   .#{$button} {
-    @at-root .#{$label}.pf-m-compact & {
-      --#{$button}--m-plain--m-no-padding--after--Inset: 0 calc(#{pf-size-prem(2px) * -1});
+    @at-root .#{$label} & {
+      padding-block-start: var(--#{$label}--PaddingBlockStart);
+      padding-block-end: var(--#{$label}--PaddingBlockEnd);
+      padding-inline-end: var(--#{$label}--PaddingInlineEnd);
+      margin-block-start: calc(var(--#{$label}--PaddingBlockStart) * -1);
+      margin-block-end: calc(var(--#{$label}--PaddingBlockEnd) * -1);
+      margin-inline-end: calc(var(--#{$label}--PaddingInlineEnd) * -1);
+      border-start-end-radius: var(--#{$label}--BorderRadius);
+      border-end-end-radius: var(--#{$label}--BorderRadius);
     }
 
     --#{$button}--FontSize: var(--#{$label}__actions--c-button--FontSize);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/8430

`pointer-events: none` was preventing the pseudo element from making the entire label clickable. Looks like it was added a while ago as part of the editable label enhancement https://github.com/patternfly/patternfly/pull/4097

After this change, I tested onclicks of all the action/link/removable variations, as well as editable and editable removable labels, and all of the clicks registered on the elements they're intended to. One side effect of this change is that the area above and to the right of the close button is now clickable, but the click event registers on the label, so I updated the close button padding/margin to extend to the top/bottom/right edges of the label.

For testing the close button clickable area, you can add something like this

```scss
.pf-v6-c-label .pf-v6-c-label__actions .pf-v6-c-button {
  background: red;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removable label close-button accessibility attributes and disabled-state handling.
  * Corrected action-button spacing, padding, and corner styling within labels.
  * Improved pointer interaction with label elements and compact label layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->