### PR TITLE
fix(data-list): adjust draggable row icon alignment

### DIFF
--- a/src/patternfly/components/DataList/data-list-check.hbs
+++ b/src/patternfly/components/DataList/data-list-check.hbs
@@ -5,5 +5,5 @@
   {{> check
       check--IsStandalone=true
       check--IsLabelWrapped=true
-      check--id=(concat data-list--id '-' data-list-item--id '"' data-list-check-checkbox--attribute)}}
+      check--id=(concat data-list--id '-' data-list-item--id)}}
 </div>

--- a/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
+++ b/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
@@ -2,6 +2,7 @@
   button--IsPlain=true
   button--IsIcon=true
   button--aria-label='Drag button'
+  button--aria-describedby='draggable-help'
   button--modifier=(concat (pfv) 'data-list__item-draggable-button')
 }}
   {{> data-list-item-draggable-icon}}

--- a/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
+++ b/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
@@ -1,9 +1,8 @@
-<button class="{{pfv}}data-list__item-draggable-button{{#if data-list-item-draggable-button--modifier}} {{data-list-item-draggable-button--modifier}}{{/if}}"
-  type="button"
-  aria-label="Reorder"
-  aria-pressed="false"
-  {{#if data-list-item-draggable-button--attribute}}
-    {{{data-list-item-draggable-button--attribute}}}
-  {{/if}}>
+{{#> button
+  button--IsPlain=true
+  button--IsIcon=true
+  button--aria-label='Drag button'
+  button--modifier=(concat (pfv) 'data-list__item-draggable-button')
+}}
   {{> data-list-item-draggable-icon}}
-</button>
+{{/button}}

--- a/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
+++ b/src/patternfly/components/DataList/data-list-item-draggable-button.hbs
@@ -2,8 +2,10 @@
   button--IsPlain=true
   button--IsIcon=true
   button--aria-label='Drag button'
+  button--aria-labelledby=(concat button--id ' ' data-list--id '-' data-list-item--id)
   button--aria-describedby='draggable-help'
   button--modifier=(concat (pfv) 'data-list__item-draggable-button')
+  button--attribute='aria-pressed="false"'
 }}
   {{> data-list-item-draggable-icon}}
 {{/button}}

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -73,7 +73,7 @@
   --#{$data-list}__item-draggable-button--PaddingInlineEnd: var(--pf-t--global--spacer--md);
   --#{$data-list}__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--lg) * -1);
   --#{$data-list}__item-draggable-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--lg) * -1);
-  --#{$data-list}__item-draggable-button--PaddingBlockStart: var(--pf-t--global--spacer--lg);
+  --#{$data-list}__item-draggable-button--PaddingBlockStart: var(--#{$data-list}__cell--PaddingBlockStart);
   --#{$data-list}__item-draggable-button--PaddingBlockEnd: var(--pf-t--global--spacer--lg);
   --#{$data-list}__item-draggable-button--MarginInlineStart: calc(var(--pf-t--global--spacer--md) * -1);
   --#{$data-list}__item-draggable-button-icon--Color: var(--pf-t--global--icon--color--subtle);
@@ -92,7 +92,7 @@
 
   // check
   --#{$data-list}__check--Height: calc(var(--#{$data-list}--FontSize) * var(--#{$data-list}--LineHeight));
-  --#{$data-list}__check--MarginBlockStart: #{pf-size-prem(-1px)}; // slightly offset input
+  --#{$data-list}__check--MarginBlockStart: 0;
 
   // actions
   --#{$data-list}__item-action--Display: flex;
@@ -141,7 +141,7 @@
   --#{$data-list}--m-compact__item-content--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --#{$data-list}--m-compact__item-draggable-button--MarginBlockStart: calc(var(--pf-t--global--spacer--sm) * -1);
   --#{$data-list}--m-compact__item-draggable-button--MarginBlockEnd: calc(var(--pf-t--global--spacer--sm) * -1);
-  --#{$data-list}--m-compact__item-draggable-button--PaddingBlockStart: var(--pf-t--global--spacer--xs);
+  --#{$data-list}--m-compact__item-draggable-button--PaddingBlockStart: var(--#{$data-list}--m-compact__cell--PaddingBlockStart);
   --#{$data-list}--m-compact__item-draggable-button--PaddingBlockEnd: var(--pf-t--global--spacer--xs);
   --#{$data-list}--m-compact__cell--m-icon--cell--PaddingBlockStart: var(--pf-t--global--spacer--sm);
 }
@@ -288,9 +288,10 @@
   }
 }
 
-.#{$data-list}__item-draggable-button {
+.#{$data-list}__item-draggable-button.#{$button}.pf-m-plain {
   display: flex;
   flex-direction: column; // fixes safari alignment
+  justify-content: start;
   padding-block-start: var(--#{$data-list}__item-draggable-button--PaddingBlockStart);
   padding-block-end: var(--#{$data-list}__item-draggable-button--PaddingBlockEnd);
   padding-inline-start: var(--#{$data-list}__item-draggable-button--PaddingInlineStart);
@@ -298,6 +299,7 @@
   margin-block-start: var(--#{$data-list}__item-draggable-button--MarginBlockStart);
   margin-block-end: var(--#{$data-list}__item-draggable-button--MarginBlockEnd);
   margin-inline-start: var(--#{$data-list}__item-draggable-button--MarginInlineStart);
+  line-height: 1lh; // inherit line height from parent, fixes compact alignment
   background-color: var(--#{$data-list}__item-draggable-button--BackgroundColor);
   border: 0;
 
@@ -315,7 +317,7 @@
     cursor: grabbing;
   }
 
-  &.pf-m-disabled {
+  &:is(:disabled, .pf-m-disabled) {
     --#{$data-list}__item-draggable-button-icon--Color: var(--#{$data-list}__item-draggable-button--m-disabled__draggable-icon--Color);
 
     pointer-events: none;

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -940,7 +940,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button data-list-item-draggable-button--modifier="pf-m-disabled" data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-1" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-1 ' data-list--id '-item-1" disabled')}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-1")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -956,7 +956,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-2"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-2" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-2 ' data-list--id '-item-2"')}}
+        {{> data-list-item-draggable-button button--id=(concat ata-list--id "-draggable-button-2")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -972,7 +972,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-3" data-list-item--modifier="pf-m-ghost-row"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-         {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-3" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-3 ' data-list--id '-item-3" disabled')}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-3")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -988,7 +988,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-4"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button data-list-item-draggable-button--attribute=(concat 'id="' data-list--id '-draggable-button-4" aria-describedby="draggable-help" aria-labelledby="' data-list--id '-draggable-button-4 ' data-list--id '-item-4"')}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-4")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -1006,7 +1006,7 @@ When a list item includes more than one block of content, it can be difficult fo
 ### Draggable data list accessibility
 | Attribute | Applied to | Outcome |
 | -- | -- | -- |
-| `aria-pressed="true or false"` | `.pf-v6-c-data-list__item-draggable-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. |
+| `aria-pressed="true or false"` | `.pf-v6-c-data-list__item-draggable-button` | Indicates that the button is a toggle. |
 | `aria-live` | `[element with live text]` | Gives screen reader users live feedback about what's happening during interaction with the data list, both during drag and drop interactions and keyboard interactions. **Highly Recommended** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-v6-c-data-list__item-draggable-button` | Gives the draggable button an accessible description by referring to the textual content that describes how to use the button to drag elements. The example here uses a `<div id="draggable-help"></div>`. **Highly recommended** |
 | `aria-labelledby="[id value of .pf-v6-c-data-list__item-draggable-button] [id value of .pf-v6-c-data-list__cell-text]"` | `.pf-v6-c-data-list__item-draggable-button` | Provides an accessible name for the draggable button. |
@@ -1015,11 +1015,9 @@ When a list item includes more than one block of content, it can be difficult fo
 ### Draggable data list usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-v6-c-data-list__item-draggable-button` | `<button>` | Initiates the draggable button. Use for drag and drop. |
+| `.pf-v6-c-data-list__item-draggable-button` | `.pf-v6-c-button` | Initiates the draggable button. Use for drag and drop. |
 | `.pf-v6-c-data-list__item-draggable-icon` | `<span>` | Initiates the draggable button icon. |
-| `.pf-m-draggable` | `.pf-v6-c-data-list__item` | Modifies a data list item so that it is draggable. |
-| `.pf-m-ghost-row` | `.pf-v6-c-data-list__item.pf-m-draggable` | Modifies a draggable data list item to be the ghost row. |
-| `.pf-m-disabled` | `.pf-v6-c-data-list__item.pf-m-draggable` | Modifies a data list draggable item for the disabled state. |
+| `.pf-m-ghost-row` | `.pf-v6-c-data-list__item` | Modifies a draggable data list item to be the ghost row. |
 | `.pf-m-drag-over` | `.pf-v6-c-data-list` | Modifies the data list to indicate that a draggable item is being dragged over the data list. |
 
 

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -940,7 +940,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-1")}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat data-list--id "-draggable-button-1")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -956,7 +956,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-2"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button button--id=(concat ata-list--id "-draggable-button-2")}}
+        {{> data-list-item-draggable-button button--id=(concat data-list--id "-draggable-button-2")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -972,7 +972,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-3" data-list-item--modifier="pf-m-ghost-row"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-3")}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat data-list--id "-draggable-button-3")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -988,7 +988,7 @@ When a list item includes more than one block of content, it can be difficult fo
   {{#> data-list-item data-list-item--id="item-4"}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat ata-list--id "-draggable-button-4")}}
+        {{> data-list-item-draggable-button button--IsDisabled=true button--id=(concat data-list--id "-draggable-button-4")}}
         {{> data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
@@ -1001,8 +1001,8 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 {{/data-list}}
-<div class="{{pfv 'unset-prefix'}}screen-reader" aria-live="assertive">
-  This is the aria-live section that provides real-time feedback to the user.
+<div style="display: none;">
+  To pick up a draggable item, press the space bar. While dragging, use the arrow keys to move the item. Press space again to drop the item in its new position, or press escape to cancel.
 </div>
 ```
 

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -933,9 +933,6 @@ When a list item includes more than one block of content, it can be difficult fo
 ## Draggable data list
 ### Draggable data list example
 ```hbs
-<div id="draggable-help">
-  Activate the reorder button and use the arrow keys to reorder the list or use your mouse to drag/reorder. Press escape to cancel the reordering.
-</div>
 {{#> data-list data-list--id="data-list-draggable" data-list--attribute='aria-label="Draggable data list rows"' data-list--IsCompact=true}}
   {{#> data-list-item data-list-item--id="item-1"}}
     {{#> data-list-item-row}}
@@ -1001,7 +998,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 {{/data-list}}
-<div style="display: none;">
+<div id="draggable-help">
   To pick up a draggable item, press the space bar. While dragging, use the arrow keys to move the item. Press space again to drop the item in its new position, or press escape to cancel.
 </div>
 ```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly/issues/7579

Follow up to this PR that was closed https://github.com/patternfly/patternfly/pull/7582

What it does:
* Fixes drag button/icon alignment
* Updates the draggable buttons to match what is in react
  * Use button component
  * Update `aria-label`
  * Remove `aria-labelledby`

This is what regular/compact data-lists look like in chrome/ff/safari

<img width="1982" height="1218" alt="Screenshot 2026-08-11 at 3 52 07 PM" src="https://github.com/user-attachments/assets/fe19aa3a-65c2-41ea-93fe-cd66178c81fc" />

<img width="1960" height="1055" alt="Screenshot 2026-08-11 at 3 52 51 PM" src="https://github.com/user-attachments/assets/62e7cbbf-1665-4355-9e17-f3f105d4530e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draggable data list button styling, including padding, alignment, line height, and disabled states.
  * Reset checkbox spacing for more consistent data list layouts.
  * Improved checkbox identification for more reliable interactions.
  * Enhanced accessibility guidance and labeling for keyboard-based drag-and-drop interactions.

* **Refactor**
  * Updated draggable controls to use shared button styling for a more consistent experience.
  * Simplified draggable button configuration and removed outdated state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->