### PR TITLE
fix(nav): update html examples to display indicator correctly.

### DIFF
--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -19,6 +19,8 @@
 }
 
 .ws-core-c-navigation .ws-preview-html {
+  padding-inline-start: var(--pf-t--global--spacer--md);
+  padding-inline-end: var(--pf-t--global--spacer--md);
   background: var(--pf-v6-c-page__sidebar--BackgroundColor); /* use sidebar background for vertical nav examples */
 }
 
@@ -28,8 +30,4 @@
 
 [id^="ws-core-c-navigation-horizontal-subnav"] .ws-preview-html {
   background: transparent; /* reset background for horizontal subnav examples */
-}
-
-.ws-core-c-navigation .ws-preview-html:not(:has(.pf-m-expanded, .pf-m-horizontal, .pf-m-drilldown)) {
-  margin-inline-start: var(--pf-t--global--spacer--md);
 }

--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -29,3 +29,7 @@
 [id^="ws-core-c-navigation-horizontal-subnav"] .ws-preview-html {
   background: transparent; /* reset background for horizontal subnav examples */
 }
+
+.ws-core-c-navigation .ws-preview-html:not(:has(.pf-m-expanded, .pf-m-horizontal, .pf-m-drilldown)) {
+  margin-inline-start: var(--pf-t--global--spacer--md);
+}

--- a/src/patternfly/components/Nav/examples/Navigation.css
+++ b/src/patternfly/components/Nav/examples/Navigation.css
@@ -25,7 +25,7 @@
 }
 
 [id^="ws-core-c-navigation-horizontal"] .ws-preview-html {
-  background: var(--pf-v6-c-masthead--BackgroundColor); /* use masthead background for horizontal nav examples */
+  background: var(--pf-t--global--background--color--secondary--default); /* use masthead background for horizontal nav examples */
 }
 
 [id^="ws-core-c-navigation-horizontal-subnav"] .ws-preview-html {


### PR DESCRIPTION
Fixes: #8489

Adds a margin to docked nav and other nav HTML examples so the current-page indicator isn’t clipped. Applies margin-inline-start on the preview container, and skips expanded, horizontal, and drilldown variants that don’t need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added consistent medium inline spacing to navigation previews.
  * Updated horizontal navigation previews with the secondary default background.
  * Improved alignment and visual consistency across navigation examples and previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->