### PR TITLE
fix(Menu): use listbox roles in select examples

### DIFF
--- a/src/patternfly/components/Menu/examples/Menu.md
+++ b/src/patternfly/components/Menu/examples/Menu.md
@@ -1317,9 +1317,9 @@ import './Menu.css'
 ```hbs
 {{#> menu}}
   {{#> menu-content}}
-    {{#> menu-list}}
+    {{#> menu-list menu-list--role="listbox"}}
       {{#> menu-list-item}}
-        {{#> menu-item}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="false"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
               Option 1
@@ -1329,7 +1329,7 @@ import './Menu.css'
         {{/menu-item}}
       {{/menu-list-item}}
       {{#> menu-list-item}}
-        {{#> menu-item}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="false"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
               Option 2
@@ -1339,7 +1339,7 @@ import './Menu.css'
         {{/menu-item}}
       {{/menu-list-item}}
       {{#> menu-list-item}}
-        {{#> menu-item menu-item--modifier="pf-m-selected"}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="true" menu-item--modifier="pf-m-selected"}}
           {{#> menu-item-main}}
             {{#> menu-item-icon}}
               {{pfIcon "rh-ui-table"}}
@@ -1363,9 +1363,9 @@ import './Menu.css'
 ```hbs
 {{#> menu}}
   {{#> menu-content}}
-    {{#> menu-list}}
+    {{#> menu-list menu-list--role="listbox" menu-list--attribute='aria-multiselectable="true"'}}
       {{#> menu-list-item}}
-        {{#> menu-item menu-item--modifier="pf-m-selected"}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="true" menu-item--modifier="pf-m-selected"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
               Option 1
@@ -1375,7 +1375,7 @@ import './Menu.css'
         {{/menu-item}}
       {{/menu-list-item}}
       {{#> menu-list-item}}
-        {{#> menu-item menu-item--modifier="pf-m-selected"}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="true" menu-item--modifier="pf-m-selected"}}
           {{#> menu-item-main}}
             {{#> menu-item-text}}
               Option 2
@@ -1385,7 +1385,7 @@ import './Menu.css'
         {{/menu-item}}
       {{/menu-list-item}}
       {{#> menu-list-item}}
-        {{#> menu-item menu-item--modifier="pf-m-selected"}}
+        {{#> menu-item menu-item--role="option" menu-item--aria-selected="true" menu-item--modifier="pf-m-selected"}}
           {{#> menu-item-main}}
             {{#> menu-item-icon}}
               {{pfIcon "rh-ui-table"}}

--- a/src/patternfly/components/Menu/menu-item.hbs
+++ b/src/patternfly/components/Menu/menu-item.hbs
@@ -20,7 +20,10 @@
         aria-disabled="true"
       {{/if}}
     {{/if}}
-    role="menuitem"
+    role="{{#if menu-item--role}}{{menu-item--role}}{{else}}menuitem{{/if}}"
+    {{#if menu-item--aria-selected}}
+      aria-selected="{{menu-item--aria-selected}}"
+    {{/if}}
   {{/if}}
   {{#if menu-item--attribute}}
     {{{menu-item--attribute}}}

--- a/src/patternfly/components/Menu/menu-list.hbs
+++ b/src/patternfly/components/Menu/menu-list.hbs
@@ -1,5 +1,5 @@
 <ul class="{{pfv}}menu__list{{#if menu-list--modifier}} {{menu-list--modifier}}{{/if}}"
-  role="menu"
+  role="{{#if menu-list--role}}{{menu-list--role}}{{else}}menu{{/if}}"
   {{#if menu-list--attribute}}
     {{{menu-list--attribute}}}
   {{/if}}>


### PR DESCRIPTION
## Summary
- Add optional role overrides to Menu list and item partials
- Update single- and multi-select HTML examples to use `listbox` / `option` semantics
- Set required `aria-selected` values and `aria-multiselectable="true"` for multi-select

Closes #5799

## Test plan
- [ ] Verify Option single select example renders `role="listbox"` and `role="option"` with `aria-selected`
- [ ] Verify Option multi-select example includes `aria-multiselectable="true"`
- [ ] Confirm other Menu examples still default to `menu` / `menuitem` roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved menu examples with appropriate listbox and option roles.
  * Added selected-state announcements for single- and multi-select menus.
  * Added support for configuring menu and menu-item roles and selected states.
  * Multi-select menus now indicate that multiple options can be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->