### PR TITLE
docs(misc): remove pf-d- prefix from demo docs

### DIFF
--- a/src/patternfly/demos/BackToTop/examples/BackToTop.md
+++ b/src/patternfly/demos/BackToTop/examples/BackToTop.md
@@ -1,7 +1,6 @@
 ---
 id: 'Back to top'
 section: components
-cssPrefix: pf-d-back-to-top
 ---
 
 ## Examples

--- a/src/patternfly/demos/Banner/examples/Banner.md
+++ b/src/patternfly/demos/Banner/examples/Banner.md
@@ -1,7 +1,6 @@
 ---
 id: 'Banner'
 section: components
-cssPrefix: pf-v6-c-banner
 wrapperTag: div
 ---
 

--- a/src/patternfly/demos/Button/examples/Button.md
+++ b/src/patternfly/demos/Button/examples/Button.md
@@ -1,7 +1,6 @@
 ---
 id: 'Button'
 section: components
-cssPrefix: pf-d-button
 ---
 
 ## Examples

--- a/src/patternfly/demos/Dashboard/examples/Dashboard.md
+++ b/src/patternfly/demos/Dashboard/examples/Dashboard.md
@@ -1,7 +1,6 @@
 ---
 id: 'Dashboard'
 section: patterns
-cssPrefix: pf-d-dashboard
 ---
 
 ## Examples

--- a/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
+++ b/src/patternfly/demos/DescriptionList/examples/DescriptionList.md
@@ -1,7 +1,6 @@
 ---
 id: 'Description list'
 section: components
-cssPrefix: pf-d-description-list
 ---
 
 ## Examples


### PR DESCRIPTION
Removes the css prefix from a couple demo md files. These were appearing in their own CSS variables table with no content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Back to top, Button, Dashboard, Description List, and Banner examples.
  * Removed obsolete styling metadata from these demos to keep their displayed configurations accurate and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->