### PR TITLE
feat(drawer): full height drawer with no content

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -373,6 +373,13 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       }
     }
   }
+
+  &:not(:has(.#{$drawer}__content)) {
+    > .#{$drawer}__main > .#{$drawer}__panel {
+      height: var(--#{$drawer}__panel--Height, auto);
+      margin-inline-start: var(--#{$drawer}__panel--MarginInlineStart, revert);
+    }
+  }
 }
 
 // Header area

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -379,6 +379,10 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       height: var(--#{$drawer}__panel--Height, auto);
       margin-inline-start: var(--#{$drawer}__panel--MarginInlineStart, revert);
     }
+
+    &.pf-m-panel-left {
+      --#{$drawer}__panel--MarginInlineStart: 0;
+    }
   }
 }
 

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -6,6 +6,13 @@ $pf-v6-c-drawer--breakpoint-map--width: build-breakpoint-map("base", "lg", "xl",
 $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 @include pf-root($drawer) {
+  // Drawer
+  --#{$drawer}--Height: 100%;
+  --#{$drawer}--OverflowX: hidden;
+
+  // Main
+  --#{$drawer}__main--Overflow: hidden;
+
   // Pill inline main
   --#{$drawer}--m-pill--m-inline__main--Gap: 0;
 
@@ -21,6 +28,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   --#{$drawer}__content--ZIndex: var(--pf-t--global--z-index--xs);
 
   // Panel
+  --#{$drawer}__panel--Position: relative;
   --#{$drawer}__panel--MinWidth: 50%; // change to __panel--md--MinWidth at breaking change
   --#{$drawer}__panel--MaxHeight: auto;
   --#{$drawer}__panel--ZIndex: var(--pf-t--global--z-index--sm);
@@ -249,8 +257,8 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   display: flex;
   flex-direction: column;
-  height: 100%;
-  overflow-x: hidden;
+  height: var(--#{$drawer}--Height);
+  overflow-x: var(--#{$drawer}--OverflowX);
 
   &.pf-m-inline,
   &.pf-m-static {
@@ -283,6 +291,60 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
   &.pf-m-panel-bottom > .#{$drawer}__main {
     flex-direction: column;
+  }
+
+  &:not(:has(.#{$drawer}__content)) {
+    --#{$drawer}--Height: unset;
+    --#{$drawer}--OverflowX: unset;
+    --#{$drawer}__panel--MaxHeight: 100dvh;
+    --#{$drawer}__main--Overflow: unset;
+    --#{$drawer}__panel--InsetInlineStart: auto;
+    --#{$drawer}__panel--InsetInlineEnd: var(--#{$drawer}--m-expanded__panel--inset);
+
+    position: fixed;
+    inset: 0;
+    z-index: var(--pf-t--global--z-index--md);
+    pointer-events: none;
+
+    > .#{$drawer}__main > .#{$drawer}__panel {
+      pointer-events: auto;
+    }
+
+    &.pf-m-panel-left {
+      --#{$drawer}__panel--InsetInlineStart: 0;
+      --#{$drawer}__panel--InsetInlineEnd: auto;
+    }
+
+    @media (min-width: $pf-v6-global--breakpoint--md) {
+      --#{$drawer}__panel--Position: fixed;
+      --#{$drawer}__panel--ZIndex: var(--pf-t--global--z-index--md);
+
+      > .#{$drawer}__main > .#{$drawer}__panel {
+        inset-block-start: 0;
+        inset-block-end: 0;
+        inset-inline-start: var(--#{$drawer}__panel--InsetInlineStart);
+        inset-inline-end: var(--#{$drawer}__panel--InsetInlineEnd);
+        inline-size: var(--#{$drawer}__panel--FlexBasis);
+
+        @include pf-v6-bidirectional-style(
+          $prop: transform,
+          $ltr-val: translateX(100%),
+          $rtl-val: translateX(#{pf-v6-calc-inverse(100%)}),
+        );
+      }
+
+      &.pf-m-panel-left  > .#{$drawer}__main > .#{$drawer}__panel {
+        @include pf-v6-bidirectional-style(
+          $prop: transform,
+          $ltr-val: translateX(-100%),
+          $rtl-val: translateX(#{pf-v6-calc-inverse(-100%)}),
+        );
+      }
+
+      &.pf-m-expanded > .#{$drawer}__main > .#{$drawer}__panel {
+        transform: translateX(0);
+      }
+    }
   }
 
   // Expanded
@@ -373,17 +435,6 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
       }
     }
   }
-
-  &:not(:has(.#{$drawer}__content)) {
-    > .#{$drawer}__main > .#{$drawer}__panel {
-      height: var(--#{$drawer}__panel--Height, auto);
-      margin-inline-start: var(--#{$drawer}__panel--MarginInlineStart, revert);
-    }
-
-    &.pf-m-panel-left {
-      --#{$drawer}__panel--MarginInlineStart: 0;
-    }
-  }
 }
 
 // Header area
@@ -407,7 +458,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
   display: flex;
   flex: 1;
   gap: var(--#{$drawer}__main--Gap, 0);
-  overflow: hidden;
+  overflow: var(--#{$drawer}__main--Overflow);
 }
 
 // Content / panel
@@ -445,7 +496,7 @@ $pf-v6-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
 
 // Panel
 .#{$drawer}__panel {
-  position: relative;
+  position: var(--#{$drawer}__panel--Position);
   z-index: var(--#{$drawer}__panel--ZIndex);
   visibility: hidden; // hidden by default
   flex-basis: var(--#{$drawer}__panel--FlexBasis);

--- a/src/patternfly/components/Drawer/examples/Drawer.md
+++ b/src/patternfly/components/Drawer/examples/Drawer.md
@@ -336,7 +336,7 @@ import './Drawer.css'
 | `.pf-v6-c-drawer` | `<div>` | Initiates the drawer container. **Required** |
 | `.pf-v6-c-drawer__section` | `<div>` | Initiates a drawer section area. This element can be used above or below `.pf-v6-c-drawer__main` for titles, toolbars, footers, etc. |
 | `.pf-v6-c-drawer__main` | `<div>` | Initiates the drawer main area. **Required** |
-| `.pf-v6-c-drawer__content` | `<div>` | Initiates the drawer content container. **Required** |
+| `.pf-v6-c-drawer__content` | `<div>` | Initiates the drawer content container. **Required** except when omitted to create a viewport overlay. Place that drawer after `.pf-v6-c-page` as a sibling. |
 | `.pf-v6-c-drawer__panel` | `<aside>` | Initiates the drawer panel container. **Required** |
 | `.pf-v6-c-drawer__panel-main` | `<div>` | Initiates the drawer panel main container for resizable drawers only. |
 | `.pf-v6-c-drawer__body` | `<div>` | Initiates a drawer body container and is the child of `.pf-v6-c-drawer__content`, `.pf-v6-c-drawer__panel` and `.pf-v6-c-drawer__panel-main`. **Required** |

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -233,19 +233,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--action--default);
 
   // Drawer section
-  --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--sm);
-  --#{$page}__drawer--Position: relative;
-  --#{$page}__drawer--InsetBlockStart: 0;
-  --#{$page}__drawer--InsetBlockEnd: 0;
-  --#{$page}__drawer--InsetInlineStart: 0;
-  --#{$page}__drawer--InsetInlineEnd: 0;
   --#{$page}__drawer--c-drawer--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}__drawer--c-drawer--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
-
-  @media (min-width: $pf-v6-global--breakpoint--md) {
-    --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--md);
-    --#{$page}__drawer--Position: fixed;
-  }
 
   // Glass theme
   --#{$page}--BackgroundColor--glass: transparent;
@@ -985,26 +974,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
     &.pf-m-fill {
       flex-grow: 1;
-    }
-  }
-
-  &:not(:has(.#{$drawer}__content)) {
-    --#{$drawer}__panel--MarginInlineStart: 100%;
-
-    position: var(--#{$page}__drawer--Position);
-    inset-block-start: var(--#{$page}__drawer--InsetBlockStart);
-    inset-block-end: var(--#{$page}__drawer--InsetBlockEnd);
-    inset-inline-start: var(--#{$page}__drawer--InsetInlineStart);
-    inset-inline-end: var(--#{$page}__drawer--InsetInlineEnd);
-    z-index: var(--#{$page}__drawer--ZIndex);
-    pointer-events: none;
-
-    @media (min-width: $pf-v6-global--breakpoint--md) {
-      --#{$drawer}__panel--Height: 100%;
-    }
-
-    > .#{$drawer} > .#{$drawer}__main > .#{$drawer}__panel {
-      pointer-events: auto;
     }
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -239,15 +239,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__drawer--InsetBlockEnd: 0;
   --#{$page}__drawer--InsetInlineStart: 0;
   --#{$page}__drawer--InsetInlineEnd: 0;
-  --#{$page}__drawer--c-drawer__panel--Height: auto;
-  --#{$page}__drawer--c-drawer__panel--MarginInlineStart: 100%;
   --#{$page}__drawer--c-drawer--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}__drawer--c-drawer--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
 
   @media (min-width: $pf-v6-global--breakpoint--md) {
     --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--md);
     --#{$page}__drawer--Position: fixed;
-    --#{$page}__drawer--c-drawer__panel--Height: 100%;
   }
 
   // Glass theme
@@ -992,6 +989,8 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   }
 
   &:not(:has(.#{$drawer}__content)) {
+    --#{$drawer}__panel--MarginInlineStart: 100%;
+
     position: var(--#{$page}__drawer--Position);
     inset-block-start: var(--#{$page}__drawer--InsetBlockStart);
     inset-block-end: var(--#{$page}__drawer--InsetBlockEnd);
@@ -1000,9 +999,11 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     z-index: var(--#{$page}__drawer--ZIndex);
     pointer-events: none;
 
+    @media (min-width: $pf-v6-global--breakpoint--md) {
+      --#{$drawer}__panel--Height: 100%;
+    }
+
     > .#{$drawer} > .#{$drawer}__main > .#{$drawer}__panel {
-      height: var(--#{$page}__drawer--c-drawer__panel--Height);
-      margin-inline-start: var(--#{$page}__drawer--c-drawer__panel--MarginInlineStart);
       pointer-events: auto;
     }
   }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -233,8 +233,22 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--action--default);
 
   // Drawer section
+   --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--sm);
+  --#{$page}__drawer--Position: relative;
+  --#{$page}__drawer--InsetBlockStart: 0;
+  --#{$page}__drawer--InsetBlockEnd: 0;
+  --#{$page}__drawer--InsetInlineStart: 0;
+  --#{$page}__drawer--InsetInlineEnd: 0;
+  --#{$page}__drawer--c-drawer__panel--Height: auto;
+  --#{$page}__drawer--c-drawer__panel--MarginInlineStart: 100%;
   --#{$page}__drawer--c-drawer--BorderBlockStartWidth: var(--pf-t--global--border--width--high-contrast--regular);
   --#{$page}__drawer--c-drawer--BorderBlockStartColor: var(--pf-t--global--border--color--high-contrast);
+
+  @media (min-width: $pf-v6-global--breakpoint--md) {
+    --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--md);
+    --#{$page}__drawer--Position: fixed;
+    --#{$page}__drawer--c-drawer__panel--Height: 100%;
+  }
 
   // Glass theme
   --#{$page}--BackgroundColor--glass: transparent;
@@ -974,6 +988,22 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
     &.pf-m-fill {
       flex-grow: 1;
+    }
+  }
+
+  &:not(:has(.#{$drawer}__content)) {
+    position: var(--#{$page}__drawer--Position);
+    inset-block-start: var(--#{$page}__drawer--InsetBlockStart);
+    inset-block-end: var(--#{$page}__drawer--InsetBlockEnd);
+    inset-inline-start: var(--#{$page}__drawer--InsetInlineStart);
+    inset-inline-end: var(--#{$page}__drawer--InsetInlineEnd);
+    z-index: var(--#{$page}__drawer--ZIndex);
+    pointer-events: none;
+
+    > .#{$drawer} > .#{$drawer}__main > .#{$drawer}__panel {
+      height: var(--#{$page}__drawer--c-drawer__panel--Height);
+      margin-inline-start: var(--#{$page}__drawer--c-drawer__panel--MarginInlineStart);
+      pointer-events: auto;
     }
   }
 }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -233,7 +233,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-wizard--BorderBlockStartWidth: var(--pf-t--global--border--width--action--default);
 
   // Drawer section
-   --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--sm);
+  --#{$page}__drawer--ZIndex: var(--pf-t--global--z-index--sm);
   --#{$page}__drawer--Position: relative;
   --#{$page}__drawer--InsetBlockStart: 0;
   --#{$page}__drawer--InsetBlockEnd: 0;

--- a/src/patternfly/demos/Drawer/examples/Drawer.md
+++ b/src/patternfly/demos/Drawer/examples/Drawer.md
@@ -28,6 +28,24 @@ wrapperTag: div
 {{/inline}}
 ```
 
+### Expanded without content
+```hbs isFullscreen
+{{> page-template
+      page-template--id="drawer-expanded-without-content-example"
+      page-template--IsDrawer="true"
+      page-template--HasNoDrawerContent="true"
+      page-template--drawer-panel--IsOpen="true"
+}}
+
+{{#*inline "page-template-drawer-panel"}}
+  {{#> drawer-panel}}
+    {{#> drawer-body}}
+      drawer panel
+    {{/drawer-body}}
+  {{/drawer-panel}}
+{{/inline}}
+```
+
 ### Expanded bottom
 ```hbs isFullscreen
 {{> page-template

--- a/src/patternfly/demos/Drawer/examples/Drawer.md
+++ b/src/patternfly/demos/Drawer/examples/Drawer.md
@@ -29,21 +29,18 @@ wrapperTag: div
 ```
 
 ### Expanded without content
-```hbs isFullscreen
-{{> page-template
-      page-template--id="drawer-expanded-without-content-example"
-      page-template--IsDrawer="true"
-      page-template--HasNoDrawerContent="true"
-      page-template--drawer-panel--IsOpen="true"
-}}
+```hbs isFullscreen isBeta
+{{> page-template page-template--id="drawer-expanded-without-content-example"}}
 
-{{#*inline "page-template-drawer-panel"}}
-  {{#> drawer-panel}}
-    {{#> drawer-body}}
-      drawer panel
-    {{/drawer-body}}
-  {{/drawer-panel}}
-{{/inline}}
+{{#> drawer drawer--id="drawer-expanded-without-content-example-drawer" drawer-panel--IsOpen="true"}}
+  {{#> drawer-main}}
+    {{#> drawer-panel}}
+      {{#> drawer-body}}
+        drawer panel
+      {{/drawer-body}}
+    {{/drawer-panel}}
+  {{/drawer-main}}
+{{/drawer}}
 ```
 
 ### Expanded bottom

--- a/src/patternfly/demos/Page/page-template-drawer.hbs
+++ b/src/patternfly/demos/Page/page-template-drawer.hbs
@@ -1,9 +1,11 @@
 {{#> page-drawer}}
   {{#> drawer drawer--id=(concat page-template--id '-drawer') drawer-panel--IsOpen=page-template--drawer-panel--IsOpen}}
     {{#> drawer-main}}
-      {{#> drawer-content}}
-        {{> page-template-main}}
-      {{/drawer-content}}
+      {{#unless page-template--HasNoDrawerContent}}
+        {{#> drawer-content}}
+          {{> page-template-main}}
+        {{/drawer-content}}
+      {{/unless}}
       {{> page-template-drawer-panel}}
     {{/drawer-main}}
   {{/drawer}}

--- a/src/patternfly/demos/Page/page-template.hbs
+++ b/src/patternfly/demos/Page/page-template.hbs
@@ -39,6 +39,9 @@
     {{/unless}}
   {{/unless}}
   {{#if page-template--IsDrawer}}
+    {{#if page-template--HasNoDrawerContent}}
+      {{> page-template-main}}
+    {{/if}}
     {{> page-template-drawer}}
   {{else}}
     {{> page-template-main}}


### PR DESCRIPTION
Closes: #8504

Based on the approaches discussed in #8504, this PR implements Option 1: removing `.pf-v6-c-drawer__content` from the page-level drawer so the panel can act as a standalone overlay rather than a layout participant sized by sibling content. At the md breakpoint and up, .pf-v6-c-page__drawer becomes position: fixed and the panel fills the full browser height, sitting above the page while pointer events pass through to the content scrolling behind it. Below md, the drawer remains in normal document flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for drawers without dedicated content areas, rendering as a full-viewport overlay.
  - Improved responsive drawer positioning and panel slide behavior across page layouts, including expanded/panel-left variants.
- **Documentation**
  - Updated Drawer demo to use the Drawer component directly and marked it as beta.
  - Clarified Drawer content-container guidance (including the sibling placement pattern for overlay drawers).
  - Updated page templates to conditionally render main and drawer content when no drawer content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->