### PR TITLE
fix(docked nav expandable): remove ellipsis on mobile

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -208,6 +208,7 @@
       position: absolute;
       inset-block-start: 50%;
       inset-inline-start: 50%;
+      display: none;
       color: var(--#{$nav}--m-docked__link-expandable-icon--Color);
       scale: var(--#{$nav}--m-docked__link-expandable-icon--Scale);
       translate: -50% calc(-50% + var(--#{$nav}--m-docked__link-expandable-icon--offset));
@@ -218,6 +219,10 @@
 
       .#{$nav}__link-text, .#{$nav}__toggle, .#{$nav}__subnav {
         display: none;
+      }
+
+      .#{$nav}__link-expandable-icon {
+        display: revert;
       }
     }
 


### PR DESCRIPTION
Fixes #8569

This fixes the expandable-item indicator icon (ellipsis) incorrectly showing in the docked nav on mobile view. Because the nav is fully expanded by default on mobile, this sets the display to none and reverts it in the desktop breakpoint (following a "mobile first" approach).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the docked navigation layout by hiding the expandable icon on smaller screens.
  - Restored the icon on desktop-width displays for a more appropriate responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->