### PR TITLE
feat(page): adds plain variant

### DIFF
--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -353,8 +353,8 @@ import './Page.css'
     {{/masthead-main}}
     {{> masthead-content}}
   {{/masthead}}
-  {{#> page-main page-main-section--HasNoPadding=true}}
-    {{#> page-main-section page-main-section--IsLimitWidth="true"}}
+  {{#> page-main}}
+    {{#> page-main-section page-main-section--IsLimitWidth=true page-main-section--HasNoPadding=true}}
       Page content
     {{/page-main-section}}
   {{/page-main}}

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -295,15 +295,65 @@ import './Page.css'
 ```
 
 ### Custom header
-```hbs
+```hbs isBeta
 {{#> page}}
-  {{#> page-header page-header--IsHeader=true}}
+  {{#> page-header}}
     Custom header
   {{/page-header}}
   {{#> page-sidebar}}
     Navigation
   {{/page-sidebar}}
   {{#> page-main}}
+    {{#> page-main-section page-main-section--IsLimitWidth="true"}}
+      Page content
+    {{/page-main-section}}
+  {{/page-main}}
+{{/page}}
+```
+
+### Footer
+```hbs isBeta
+{{#> page}}
+  {{#> masthead}}
+    {{#> masthead-main}}
+      {{> masthead-toggle}}
+      {{#> masthead-brand}}
+        {{#> masthead-logo}}
+          Logo
+        {{/masthead-logo}}
+      {{/masthead-brand}}
+    {{/masthead-main}}
+    {{> masthead-content}}
+  {{/masthead}}
+  {{#> page-sidebar}}
+    Navigation
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-main-section page-main-section--IsLimitWidth="true"}}
+      Page content
+    {{/page-main-section}}
+  {{/page-main}}
+  {{#> page-footer}}
+    Page footer
+  {{/page-footer}}
+{{/page}}
+```
+
+### Plain
+```hbs isBeta
+{{#> page page--IsPlain=true}}
+  {{#> masthead}}
+    {{#> masthead-main}}
+      {{> masthead-toggle}}
+      {{#> masthead-brand}}
+        {{#> masthead-logo}}
+          Logo
+        {{/masthead-logo}}
+      {{/masthead-brand}}
+    {{/masthead-main}}
+    {{> masthead-content}}
+  {{/masthead}}
+  {{#> page-main page-main-section--HasNoPadding=true}}
     {{#> page-main-section page-main-section--IsLimitWidth="true"}}
       Page content
     {{/page-main-section}}
@@ -327,7 +377,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-v6-c-page` | `<div>` | Declares the page component. |
-| `.pf-v6-c-page__header` | `<div>`, `<header>` | Declares the page header. |
+| `.pf-v6-c-page__header` | `<header>`, `<div>` | Declares the page header. |
 | `.pf-v6-c-page__sidebar` | `<aside>` | Declares the page sidebar. |
 | `.pf-v6-c-page__sidebar-body` | `<div>` | Creates a wrapper within the sidebar to hold content. **Note: The last/only `.pf-v6-c-page__sidebar-body` element will grow to fill the available vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.** |
 | `.pf-v6-c-page__dock` | `<div>` | Creates a dock region for persisting navigation or other content at the edge of the page. |
@@ -340,7 +390,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-v6-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required** |
 | `.pf-v6-c-page__main-group` | `<div>` | Creates the group of `.pf-v6-c-page__main-*` sections. Can be used in combination with `.pf-m-sticky-[top/bottom]` to make multiple sections sticky. |
 | `.pf-v6-c-page__drawer` | `<div>` | Creates a container for the drawer component when placing the main page element in the drawer body. |
-| `.pf-v6-c-page__footer` | `<div>`, `<footer>` | Declares the page footer. |
+| `.pf-v6-c-page__footer` | `<footer>`, `<div>` | Declares the page footer. |
 | `.pf-m-docked` | `.pf-v6-c-page` | Modifies the page grid to have a dock. |
 | `.pf-m-plain` | `.pf-v6-c-page` | Modifies the page to remove the content area background and overflow scroll. |
 | `.pf-m-no-sidebar` | `.pf-v6-c-page` | Modifies the page grid for layouts without a sidebar. |

--- a/src/patternfly/components/Page/examples/Page.md
+++ b/src/patternfly/components/Page/examples/Page.md
@@ -330,6 +330,7 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-v6-c-page__header` | `<div>`, `<header>` | Declares the page header. |
 | `.pf-v6-c-page__sidebar` | `<aside>` | Declares the page sidebar. |
 | `.pf-v6-c-page__sidebar-body` | `<div>` | Creates a wrapper within the sidebar to hold content. **Note: The last/only `.pf-v6-c-page__sidebar-body` element will grow to fill the available vertical space. You can change this behavior using `.pf-m-fill` and `.pf-m-no-fill`, which are documented below.** |
+| `.pf-v6-c-page__dock` | `<div>` | Creates a dock region for persisting navigation or other content at the edge of the page. |
 | `.pf-v6-c-page__main` | `<main>` | Declares the main page area. |
 | `.pf-v6-c-page__main-subnav` | `<section>` | Creates a container to nest the horizontal subnav navigation component in the main page area. |
 | `.pf-v6-c-page__main-breadcrumb` | `<section>` | Creates a container to nest the breadcrumb component in the main page area. |
@@ -339,17 +340,18 @@ This component provides the basic chrome for a page, including sidebar and main 
 | `.pf-v6-c-page__main-body` | `<div>` | Creates the body section for a page section. **Required** |
 | `.pf-v6-c-page__main-group` | `<div>` | Creates the group of `.pf-v6-c-page__main-*` sections. Can be used in combination with `.pf-m-sticky-[top/bottom]` to make multiple sections sticky. |
 | `.pf-v6-c-page__drawer` | `<div>` | Creates a container for the drawer component when placing the main page element in the drawer body. |
+| `.pf-v6-c-page__footer` | `<div>`, `<footer>` | Declares the page footer. |
 | `.pf-m-docked` | `.pf-v6-c-page` | Modifies the page grid to have a dock. |
-| `.pf-v6-c-page__dock` | `<div>` | Creates a dock region for persisting navigation or other content at the edge of the page. |
-| `.pf-m-expanded` | `.pf-v6-c-page__dock` | Expands the dock as an overlay. On desktop, the dock returns to its collapsed, icon-only state. |
-| `.pf-m-expandable-expanded` | `.pf-v6-c-page__dock` | Expands the dock as an overlay on desktop instead of collapsing to an icon-only rail. Used when an expandable nav item opens a subnav overlay. |
-| `.pf-m-text-expanded` | `.pf-v6-c-page__dock` | Expands the dock so nav items show icon and text labels and reveals the masthead logo. |
+| `.pf-m-plain` | `.pf-v6-c-page` | Modifies the page to remove the content area background and overflow scroll. |
 | `.pf-m-no-sidebar` | `.pf-v6-c-page` | Modifies the page grid for layouts without a sidebar. |
 | `.pf-m-expanded` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the expanded state. |
 | `.pf-m-collapsed` | `.pf-v6-c-page__sidebar` | Modifies the sidebar for the collapsed state. |
 | `.pf-m-page-insets` | `.pf-v6-c-page__sidebar-body` | Modifies a sidebar body padding/inset to visually match padding of page elements. |
 | `.pf-m-context-selector` | `.pf-v6-c-page__sidebar-body` | Modifies a sidebar body to contain a context selector. |
 | `.pf-m-inset-none` | `.pf-v6-c-page__sidebar-body` | Removes a sidebar body left/right inset. |
+| `.pf-m-expanded` | `.pf-v6-c-page__dock` | Expands the dock as an overlay. On desktop, the dock returns to its collapsed, icon-only state. |
+| `.pf-m-expandable-expanded` | `.pf-v6-c-page__dock` | Expands the dock as an overlay on desktop instead of collapsing to an icon-only rail. Used when an expandable nav item opens a subnav overlay. |
+| `.pf-m-text-expanded` | `.pf-v6-c-page__dock` | Expands the dock so nav items show icon and text labels and reveals the masthead logo. |
 | `.pf-m-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Modifies the main page section to add padding back in at an optional [breakpoint](/foundations-and-styles/design-tokens/all-design-tokens). Should be used with pf-m-no-padding. |
 | `.pf-m-no-padding{-on-[breakpoint]}` | `.pf-v6-c-page__main-section` | Removes padding from the main page section at an optional [breakpoint](/foundations-and-styles/design-tokens/all-design-tokens). |
 | `.pf-m-fill` | `.pf-v6-c-page__main-container`, `.pf-v6-c-page__main-section`, `.pf-v6-c-page__main-group`, `.pf-v6-c-page__main-wizard`, `.pf-v6-c-page__sidebar-body` | Modifies the element to grow to fill the available space. Note that `.pf-v6-c-page__main-container` must also have `.pf-m-fill` applied in order for the section to have space to stretch to full height.|

--- a/src/patternfly/components/Page/page-footer.hbs
+++ b/src/patternfly/components/Page/page-footer.hbs
@@ -1,0 +1,8 @@
+<{{ternary page-footer--type page-footer--type 'footer'}} class="{{pfv}}page__footer{{#if page-footer--modifier}} {{page-footer--modifier}}{{/if}}"
+  {{#if page-footer--attribute}}
+    {{{page-footer--attribute}}}
+  {{/if}}>
+  {{#> page-main-body}}
+    {{> @partial-block}}
+  {{/page-main-body}}
+</{{ternary page-footer--type page-footer--type 'footer'}}>

--- a/src/patternfly/components/Page/page-header.hbs
+++ b/src/patternfly/components/Page/page-header.hbs
@@ -1,6 +1,6 @@
-<{{ternary page-header--IsHeader 'header' 'div'}} class="{{pfv}}page__header{{#if page-header--modifier}} {{page-header--modifier}}{{/if}}"
+<{{ternary page-header--type page-header--type 'header'}} class="{{pfv}}page__header{{#if page-header--modifier}} {{page-header--modifier}}{{/if}}"
   {{#if page-header--attribute}}
     {{{page-header--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</{{ternary page-header--IsHeader 'header' 'div'}}>
+</{{ternary page-header--type page-header--type 'header'}}>

--- a/src/patternfly/components/Page/page-main-section.hbs
+++ b/src/patternfly/components/Page/page-main-section.hbs
@@ -1,4 +1,8 @@
-<section class="{{pfv}}page__main-section{{#if page-main-section--IsLimitWidth}} pf-m-limit-width{{/if}}{{#if page-main-section--modifier}} {{page-main-section--modifier}}{{/if}}"
+<section class="{{pfv}}page__main-section
+  {{setModifiers
+    page-main-section--IsLimitWidth='pf-m-limit-width'
+    page-main-section--HasNoPadding='pf-m-no-padding'
+    page-main-section--modifier=page-main-section--modifier}}"
   {{#if page-main-section--attribute}}
     {{{page-main-section--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Page/page-main-section.hbs
+++ b/src/patternfly/components/Page/page-main-section.hbs
@@ -2,6 +2,7 @@
   {{setModifiers
     page-main-section--IsLimitWidth='pf-m-limit-width'
     page-main-section--HasNoPadding='pf-m-no-padding'
+    page-main-section--IsPlain='pf-m-plain'
     page-main-section--modifier=page-main-section--modifier}}"
   {{#if page-main-section--attribute}}
     {{{page-main-section--attribute}}}

--- a/src/patternfly/components/Page/page.hbs
+++ b/src/patternfly/components/Page/page.hbs
@@ -2,6 +2,7 @@
   {{setModifiers
     page--HasNoSidebar='pf-m-no-sidebar'
     page--HasDock='pf-m-docked'
+    page--IsPlain='pf-m-plain'
     page--modifier=page--modifier}}"
   {{#if page--attribute}}
     {{{page--attribute}}}

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -429,6 +429,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
     --#{$page}__main-container--MarginBlockEnd: var(--#{$page}--m-plain__main-container--MarginBlockEnd);
 
     height: revert;
+    min-height: 100dvh;
     max-height: revert;
 
     :is(.#{$page}__main, .#{$page}__main-container) {

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -334,7 +334,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
         "header header"
         "sidebar main"
         "footer footer";
-      grid-template-rows: max-content 1fr auto;
     }
   }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -267,6 +267,9 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--m-plain__main-container--MarginBlockEnd: var(--#{$page}--inset);
   --#{$page}--m-plain__main--RowGap: var(--pf-t--global--spacer--gutter--default);
 
+  // Footer
+  --#{$page}__footer--ZIndex: var(--#{$page}__main-container--ZIndex);
+
   :where(.pf-v6-theme-glass) & {
     --#{$page}--BackgroundColor: var(--#{$page}--BackgroundColor--glass);
     --#{$page}__sidebar--Width--base: var(--#{$page}__sidebar--Width--base--glass);
@@ -476,7 +479,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
 // Footer
 .#{$page}__footer {
-  z-index: var(--#{$page}__footer-ZIndex);
+  z-index: var(--#{$page}__footer--ZIndex);
   grid-area: footer;
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -476,7 +476,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
 // Footer
 .#{$page}__footer {
-  z-index: var(--#{$page}__header--ZIndex);
+  z-index: var(--#{$page}__footer-ZIndex);
   grid-area: footer;
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -172,7 +172,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}__main-section--m-secondary--BorderBlockEndWidth: var(--pf-t--global--border--width--glass--default, var(--pf-t--global--border--width--high-contrast--regular));
   --#{$page}__main-section--m-secondary--BorderBlockEndColor: var(--pf-t--global--border--color--subtle);
 
-
   // Limit width
   --#{$page}--section--m-limit-width--MaxWidth: calc(#{pf-size-prem(2000px)} - var(--#{$page}__sidebar--Width));
 
@@ -193,7 +192,6 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--section--m-sticky-top--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
   --#{$page}--section--m-sticky-bottom--TransitionDuration: var(--pf-t--global--motion--duration--fade--short);
   --#{$page}--section--m-sticky-bottom--TransitionTimingFunction: var(--pf-t--global--motion--timing-function--default);
-
 
   // Shadows
   --#{$page}--section--m-shadow-bottom--BoxShadow: var(--pf-t--global--box-shadow--sm--bottom);
@@ -265,6 +263,10 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   --#{$page}--m-dock__main-container--MaxHeight--glass: calc(100% - var(--pf-t--global--spacer--inset--page-chrome) - var(--pf-t--global--spacer--gutter--default));
   --#{$page}--m-dock__main-container--MarginBlockStart--glass: var(--pf-t--global--spacer--gutter--default);
 
+  // Plain
+  --#{$page}--m-plain__main-container--MarginBlockEnd: var(--#{$page}--inset);
+  --#{$page}--m-plain__main--RowGap: var(--pf-t--global--spacer--gutter--default);
+
   :where(.pf-v6-theme-glass) & {
     --#{$page}--BackgroundColor: var(--#{$page}--BackgroundColor--glass);
     --#{$page}__sidebar--Width--base: var(--#{$page}__sidebar--Width--base--glass);
@@ -311,6 +313,14 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   max-height: 100%;
   background-color: var(--#{$page}--BackgroundColor);
 
+  &:has(> .#{$page}__footer) {
+    grid-template-areas:
+      "header"
+      "main"
+      "footer";
+    grid-template-rows: max-content 1fr auto;
+  }
+
   @media (min-width: $pf-v6-global--breakpoint--xl) {
     --#{$page}__sidebar--Width: var(--#{$page}__sidebar--xl--Width); // TODO can remove at breaking change
 
@@ -318,6 +328,14 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       "header header"
       "sidebar main";
     grid-template-columns: var(--#{$page}__sidebar--Width) 1fr;
+
+    &:has(> .#{$page}__footer) {
+      grid-template-areas:
+        "header header"
+        "sidebar main"
+        "footer footer";
+      grid-template-rows: max-content 1fr auto;
+    }
   }
 
   &.pf-m-docked {
@@ -404,6 +422,35 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
       @include pf-v6-hamburger($collapse: true);
     }
   }
+
+  &.pf-m-plain {
+    --#{$page}__main-container--MarginBlockEnd: var(--#{$page}--m-plain__main-container--MarginBlockEnd);
+
+    height: revert;
+    max-height: revert;
+
+    :is(.#{$page}__main, .#{$page}__main-container) {
+      overflow: revert;
+    }
+
+    .#{$page}__main-container {
+      max-height: revert;
+      background: transparent;
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+      backdrop-filter: none;
+    }
+
+    .#{$page}__main {
+      gap: var(--#{$page}--m-plain__main--RowGap);
+    }
+
+    .#{$page}__main-breadcrumb,
+    .#{$page}__main-subnav {
+      padding: 0;
+    }
+  }
 }
 
 // Header
@@ -426,6 +473,12 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
 
 .#{$page}.pf-m-docked > .#{$masthead} {
   --#{$masthead}--m-display-inline--GridTemplateColumns: var(--#{$page}--m-dock--c-masthead--m-display-inline--GridTemplateColumns);
+}
+
+// Footer
+.#{$page}__footer {
+  z-index: var(--#{$page}__header--ZIndex);
+  grid-area: footer;
 }
 
 // Dock
@@ -780,6 +833,7 @@ $pf-page-v6--height-breakpoint-map: build-breakpoint-map("base", "sm", "md", "lg
   align-self: var(--#{$page}__main-container--AlignSelf);
   max-height: var(--#{$page}__main-container--MaxHeight);
   margin-block-start: var(--#{$page}__main-container--MarginBlockStart, 0);
+  margin-block-end: var(--#{$page}__main-container--MarginBlockEnd, 0);
   margin-inline-start: var(--#{$page}__main-container--MarginInlineStart);
   margin-inline-end: var(--#{$page}__main-container--MarginInlineEnd);
   background: var(--#{$page}__main-container--BackgroundColor);

--- a/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
+++ b/src/patternfly/demos/Card/templates/card-template-expandable-status.hbs
@@ -1,5 +1,5 @@
 {{#> reset grid--attribute=reset grid-item--attribute=reset grid--modifier=reset grid-item--modifier=reset l-l-flex--attribute=reset l-flex-item--attribute=reset l-flex--modifier=reset l-flex-item--modifier=reset}}
-  {{#> card card--modifier="pf-m-expanded"}}
+  {{#> card card--modifier="pf-m-expanded" card--IsGlass=card-template-expandable-status--IsGlass}}
     {{#> card-header card--id=card-template-expandable-status--id}}
       {{> card-header-toggle}}
       {{#> card-actions}}
@@ -12,7 +12,7 @@
       {{/card-title}}
     {{/card-header}}
     {{#> card-expandable-content}}
-      {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-md"}}
+      {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-md" card--IsGlass=false}}
         {{> card-template-expandable-status-card card-template-expandable-status-card--HasIncident=true}}
         {{> divider divider--modifier="pf-m-vertical-on-md pf-m-inset-3xl"}}
         {{> card-template-expandable-status-card

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -168,3 +168,33 @@ import './Page.css'
 ```hbs isFullscreen
 {{> page-template page-template--id="page-demo-no-sidebar-masthead" page-template--HasNoSidebar=true page-template--HasNoMasthead=true}}
 ```
+
+### Plain with custom header
+```hbs isFullscreen
+{{> page-template
+      page-template--id="page-demo-plain-custom-header"
+      page-template-gallery--IsLongGallery=true
+      page-template--ExcludeSidebar=true
+      page-template--modifier="pf-m-plain"
+      page-template--HasFooter=true
+}}
+
+{{#*inline "page-template-main-content"}}
+  {{#> page-main-section page-main-section--modifier="pf-m-no-padding"}}
+    {{#> panel panel--IsGlass=true}}
+      {{#> panel-main}}
+        {{#> panel-main-body}}
+          {{#> content}}
+            <h1>Page title</h1>
+            <p>This is a full page demo.</p>
+          {{/content}}
+        {{/panel-main-body}}
+      {{/panel-main}}
+    {{/panel}}
+  {{/page-main-section}}
+  {{#> page-main-section page-main-section--modifier="pf-m-no-padding"}}
+    {{> card-template-expandable-status card-template-expandable-status--id=(concat page-template--id '-expandable-status-card-1') card-template-expandable-status--IsGlass=true}}
+  {{/page-main-section}}
+  {{> card-template-gallery card-template-gallery--id="card-view-basic-example-gallery" card--IsGlass=true}}
+{{/inline}}
+```

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -180,8 +180,8 @@ import './Page.css'
 }}
 
 {{#*inline "page-template-main-content"}}
-  {{#> page-main-section page-main-section--HasNoPadding=true}}
-    {{#> panel panel--IsGlass=true}}
+  {{#> page-main-section page-main-section--HasNoPadding=true page-main-section--IsPlain=true}}
+    {{#> panel panel--IsGlass=true panel--IsBordered=true}}
       {{#> panel-main}}
         {{#> panel-main-body}}
           {{#> content}}
@@ -192,7 +192,7 @@ import './Page.css'
       {{/panel-main}}
     {{/panel}}
   {{/page-main-section}}
-  {{#> page-main-section page-main-section--HasNoPadding=true}}
+  {{#> page-main-section page-main-section--HasNoPadding=true page-main-section--IsPlain=true}}
     {{> card-template-expandable-status card-template-expandable-status--id=(concat page-template--id '-expandable-status-card-1') card-template-expandable-status--IsGlass=true}}
   {{/page-main-section}}
   {{> card-template-gallery card-template-gallery--id="card-view-basic-example-gallery" card--IsGlass=true}}

--- a/src/patternfly/demos/Page/examples/Page.md
+++ b/src/patternfly/demos/Page/examples/Page.md
@@ -169,18 +169,18 @@ import './Page.css'
 {{> page-template page-template--id="page-demo-no-sidebar-masthead" page-template--HasNoSidebar=true page-template--HasNoMasthead=true}}
 ```
 
-### Plain with custom header
+### Plain
 ```hbs isFullscreen
 {{> page-template
-      page-template--id="page-demo-plain-custom-header"
+      page-template--id="page-demo-plain"
       page-template-gallery--IsLongGallery=true
       page-template--ExcludeSidebar=true
-      page-template--modifier="pf-m-plain"
+      page--IsPlain=true
       page-template--HasFooter=true
 }}
 
 {{#*inline "page-template-main-content"}}
-  {{#> page-main-section page-main-section--modifier="pf-m-no-padding"}}
+  {{#> page-main-section page-main-section--HasNoPadding=true}}
     {{#> panel panel--IsGlass=true}}
       {{#> panel-main}}
         {{#> panel-main-body}}
@@ -192,7 +192,7 @@ import './Page.css'
       {{/panel-main}}
     {{/panel}}
   {{/page-main-section}}
-  {{#> page-main-section page-main-section--modifier="pf-m-no-padding"}}
+  {{#> page-main-section page-main-section--HasNoPadding=true}}
     {{> card-template-expandable-status card-template-expandable-status--id=(concat page-template--id '-expandable-status-card-1') card-template-expandable-status--IsGlass=true}}
   {{/page-main-section}}
   {{> card-template-gallery card-template-gallery--id="card-view-basic-example-gallery" card--IsGlass=true}}

--- a/src/patternfly/demos/Page/page-template-main-content.hbs
+++ b/src/patternfly/demos/Page/page-template-main-content.hbs
@@ -8,6 +8,3 @@
   {{> page-template-title}}
 {{/unless}}
 {{> page-template-section}}
-{{#if page-template--HasFooter}}
-  {{> page-template-footer}}
-{{/if}}

--- a/src/patternfly/demos/Page/page-template.hbs
+++ b/src/patternfly/demos/Page/page-template.hbs
@@ -33,14 +33,16 @@
       {{> masthead-template masthead-template--id=(concat page--id '-docked')}}
     {{/if}}
   {{/unless}}
-  {{#unless page-template--HasNoSidebar}}
-    {{#unless masthead-template--HasDockedNav}}
-      {{> page-template-sidebar}}
-    {{/unless}}
-  {{/unless}}
+  {{!-- page-template--HasNoSidebar applies the pf-m-no-sidebar variant class. page-template--ExcludeSidebar just removes the sidebar --}}
+  {{#ifAll (inverse page-template--HasNoSidebar) (inverse masthead-template--HasDockedNav) (inverse page-template--ExcludeSidebar)}}
+    {{> page-template-sidebar}}
+  {{/ifAll}}
   {{#if page-template--IsDrawer}}
     {{> page-template-drawer}}
   {{else}}
     {{> page-template-main}}
+  {{/if}}
+  {{#if page-template--HasFooter}}
+    {{#> page-footer}}custom footer{{/page-footer}}
   {{/if}}
 {{/page}}


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/8506 (JIRA https://redhat.atlassian.net/browse/PF-4449)

**PR preview - https://pf-pr-8571.surge.sh/components/page/html-demos/plain/**

The primary goal is to enable a layout similar to https://images.redhat.com/ that has
* Custom header
* Stacked sections with a gap between them that can optionally be wrapped in glass panels
* Custom footer

This demo only looks right in glass. Isn't clear what this should do in non-glass. Non-glass can be a follow up after this merges. 

New features
* Adds `.pf-m-plain` on `.pf-v6-c-page` for this new layout
* Adds `.pf-v6-c-page__footer` that defaults to `<footer>`. It's full-bleed and doesn't have padding. A RH global footer can be dropped inside. Compliments the new `.pf-v6-c-page__header`
  * Updated the page grid to support it behind `:has()` so we don't break anyone's existing grid.

Does these things
* Removes the main container styling (background color, border, padding, etc)
* Removes the height constraints on the page wrapper so it can grow beyond the viewport, and added a min-height of the viewport height.
* Removes overflow/scroll management from the content section so the window is what scrolls now
* Adds a gap on the main container to space the page sections. Gap token is `--pf-t--global--spacer--gutter--default`
* Removes padding from the breadcrumb and subnav sections. TBD on that, may add it back if the goal is to do something like group those in a panel with the page title.

Questions
* Should the footer always be at the bottom of the viewport or could it just end wherever the page content ends, even if that means the footer is floating in the middle of the viewport. 
* What should it look like in non-glass?
* Should the footer have any kind of default or optional styles? Background color, padding, divider, etc?
* Should we have a few demos with a few common layouts to show things like a toolbar + table, breadcrumbs, horizontal subnav, etc?
* Should we change chrome/layout spacers? Specifically the chrome around the main content area, gap between the header + content + footer, gap used between page sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added footer support with configurable markup and styling.
  - Added a plain Page variant with simplified styling and spacing.
  - Added configurable Page header element types.
  - Added sidebar exclusion and custom footer options.
  - Added no-padding and width-limiting options for main sections.
  - Added demos for plain pages, custom headers, footers, and glass content.

- **Bug Fixes**
  - Improved expandable status card rendering to preserve intended glass styling.

- **Documentation**
  - Updated Page examples and usage tables to reflect beta features and new layout options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->