### PR TITLE
fix(table): hover and selected background color updated to action-plan tokens

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -226,10 +226,10 @@
   // * Table tr clickable
   --#{$table}__tr--m-clickable--BackgroundColor: transparent;
   --#{$table}__tr--m-clickable--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
-  --#{$table}__tr--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+  --#{$table}__tr--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--action--plain--hover);
 
   // * Table tr selected
-  --#{$table}__tr--m-selected--BackgroundColor: var(--pf-t--global--background--color--primary--clicked);
+  --#{$table}__tr--m-selected--BackgroundColor: var(--pf-t--global--background--color--action--plain--clicked);
   --#{$table}__tr--m-selected--OutlineOffset: calc(-1 * var(--pf-t--global--spacer--xs));
 
   // * Table tbody clickable


### PR DESCRIPTION
Fixes: #8562

Consulted with Design to change the hover/clicked states to action-plain tokens respectively in order to cover different backgrounds on the table component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated table control-row, expandable, hover, clickable, expanded, and selected-state backgrounds for more consistent styling.
  * Aligned clickable row hover and selected-row colors with global action color tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->