### PR TITLE
feat(table): add dynamic sticky footer styling

### DIFF
--- a/src/patternfly/components/Table/examples/Table.css
+++ b/src/patternfly/components/Table/examples/Table.css
@@ -13,13 +13,9 @@
 #ws-core-c-table-nested-column-headers-sticky-header .ws-preview-html,
 #ws-core-c-table-sticky-header .ws-preview-html,
 #ws-core-c-table-sticky-footer .ws-preview-html,
-#ws-core-c-table-sticky-header-with-base-and-stuck .ws-preview-html {
+#ws-core-c-table-sticky-header-with-base-and-stuck .ws-preview-html,
+#ws-core-c-table-sticky-footer-with-base-and-stuck .ws-preview-html {
   height: 400px;
-}
-
-#ws-core-c-table-sticky-header .ws-preview-html,
-#ws-core-c-table-sticky-footer .ws-preview-html {
-  overflow: auto;
 }
 
 .pf-v6-c-overflow-menu .pf-v6-c-menu {

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3785,6 +3785,7 @@ This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-heade
 
 ### Sticky footer
 ```hbs
+<div class="pf-v6-c-scroll-inner-wrapper">
 {{#> table table--id="table-sticky-footer" table--IsGrid=true table--modifier="pf-m-grid-md" table--HasStickyFooter=true table--attribute='aria-label="This is a table with a sticky footer"'}}
   {{#> table-thead}}
     {{#> table-tr}}
@@ -3963,25 +3964,193 @@ This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-heade
     {{/table-tr}}
   {{/table-tfoot}}
 {{/table}}
+</div>
 ```
 
 ### Sticky footer with base and stuck
 
-This example uses `.pf-m-sticky-footer-base` for sticky positioning without sticky styling. Apply `.pf-m-sticky-footer-stuck` dynamically while the footer is stuck and floating above the table content, and remove it when the footer reaches the bottom of the table so it returns to a normal row.
+This example uses `.pf-m-sticky-footer-base` and `.pf-m-sticky-footer-stuck` for sticky positioning. Apply `.pf-m-sticky-footer-stuck` dynamically while the footer is stuck and floating above the table content, and remove it when the footer reaches the bottom of the table so it returns to a normal row.
 
 ```hbs
+<div class="pf-v6-c-scroll-inner-wrapper">
 {{#> table table--IsGrid=true table--modifier="pf-m-grid-md" table--HasStickyFooterBase=true table--HasStickyFooterStuck=true table--attribute='aria-label="This is a table with a sticky footer using base and stuck"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Workspaces
+      {{/table-th}}
+      {{#> table-th table-th--attribute='scope="col"'}}
+        Last commit
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
   {{#> table-tbody}}
     {{#> table-tr}}
-      {{#> table-td}}Table content{{/table-td}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 4
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 6
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 7
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository name"}}
+        Repository 8
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last commit"}}
+        2 days ago
+      {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
   {{#> table-tfoot}}
     {{#> table-tr}}
-      {{#> table-th table-th--attribute='scope="row"'}}Total{{/table-th}}
+      {{#> table-th table-th--attribute='scope="row"'}}
+        Total
+      {{/table-th}}
+      {{#> table-td table-td--attribute='colspan="4"'}}
+        4
+      {{/table-td}}
     {{/table-tr}}
   {{/table-tfoot}}
 {{/table}}
+</div>
 ```
 
 ### Sticky column

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3967,7 +3967,7 @@ This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-heade
 
 ### Sticky footer with base and stuck
 
-This example uses `.pf-m-sticky-footer-base` for sticky positioning without sticky styling. `.pf-m-sticky-footer-stuck` can be applied dynamically as the table has scrolled to show the footer styling while it is stuck and floating above the table content.
+This example uses `.pf-m-sticky-footer-base` for sticky positioning without sticky styling. Apply `.pf-m-sticky-footer-stuck` dynamically while the footer is stuck and floating above the table content, and remove it when the footer reaches the bottom of the table so it returns to a normal row.
 
 ```hbs
 {{#> table table--IsGrid=true table--modifier="pf-m-grid-md" table--HasStickyFooterBase=true table--HasStickyFooterStuck=true table--attribute='aria-label="This is a table with a sticky footer using base and stuck"'}}
@@ -4040,7 +4040,7 @@ For sticky columns to function correctly, the parent table's width must be contr
 | `.pf-m-sticky-header-stuck` | `.pf-v6-c-table` | Applies sticky header styling to a table with `.pf-m-sticky-header-base`. |
 | `.pf-m-sticky-footer` | `.pf-v6-c-table` | Makes the `<tfoot>` sticky to the bottom of the table on scroll with sticky styling. |
 | `.pf-m-sticky-footer-base` | `.pf-v6-c-table` | Makes the `<tfoot>` sticky to the bottom of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-footer-stuck` should be used to apply sticky styling. |
-| `.pf-m-sticky-footer-stuck` | `.pf-v6-c-table` | Applies sticky footer styling to a table with `.pf-m-sticky-footer-base`. |
+| `.pf-m-sticky-footer-stuck` | `.pf-v6-c-table` | Applies sticky footer styling to a table with `.pf-m-sticky-footer-base`. Remove it when the footer reaches the bottom of the table to restore normal row styling. |
 | `.pf-v6-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-v6-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
 | `.pf-v6-c-table__sticky-cell` | `<th>`, `<td>` | Initiates a sticky table cell. |

--- a/src/patternfly/components/Table/examples/Table.md
+++ b/src/patternfly/components/Table/examples/Table.md
@@ -3965,6 +3965,25 @@ This example shows the use of `.pf-m-sticky-header-base` and `.pf-m-sticky-heade
 {{/table}}
 ```
 
+### Sticky footer with base and stuck
+
+This example uses `.pf-m-sticky-footer-base` for sticky positioning without sticky styling. `.pf-m-sticky-footer-stuck` can be applied dynamically as the table has scrolled to show the footer styling while it is stuck and floating above the table content.
+
+```hbs
+{{#> table table--IsGrid=true table--modifier="pf-m-grid-md" table--HasStickyFooterBase=true table--HasStickyFooterStuck=true table--attribute='aria-label="This is a table with a sticky footer using base and stuck"'}}
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td}}Table content{{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+  {{#> table-tfoot}}
+    {{#> table-tr}}
+      {{#> table-th table-th--attribute='scope="row"'}}Total{{/table-th}}
+    {{/table-tr}}
+  {{/table-tfoot}}
+{{/table}}
+```
+
 ### Sticky column
 ```hbs
 <div class="pf-v6-c-scroll-inner-wrapper">
@@ -4019,6 +4038,9 @@ For sticky columns to function correctly, the parent table's width must be contr
 | `.pf-m-sticky-header` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll. |
 | `.pf-m-sticky-header-base` | `.pf-v6-c-table` | Makes the table cells in `<thead>` sticky to the top of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-header-stuck` should be used to apply sticky styling. |
 | `.pf-m-sticky-header-stuck` | `.pf-v6-c-table` | Applies sticky header styling to a table with `.pf-m-sticky-header-base`. |
+| `.pf-m-sticky-footer` | `.pf-v6-c-table` | Makes the `<tfoot>` sticky to the bottom of the table on scroll with sticky styling. |
+| `.pf-m-sticky-footer-base` | `.pf-v6-c-table` | Makes the `<tfoot>` sticky to the bottom of the table on scroll, but does not apply sticky styling. `.pf-m-sticky-footer-stuck` should be used to apply sticky styling. |
+| `.pf-m-sticky-footer-stuck` | `.pf-v6-c-table` | Applies sticky footer styling to a table with `.pf-m-sticky-footer-base`. |
 | `.pf-v6-c-scroll-outer-wrapper` | `<div>` | Initiates a table container sticky columns outer wrapper. |
 | `.pf-v6-c-scroll-inner-wrapper` | `<div>` | Initiates a table container sticky columns inner wrapper. |
 | `.pf-v6-c-table__sticky-cell` | `<th>`, `<td>` | Initiates a sticky table cell. |

--- a/src/patternfly/components/Table/table.hbs
+++ b/src/patternfly/components/Table/table.hbs
@@ -9,6 +9,8 @@
     table--IsPlain='pf-m-plain'
     table--HasStickyHeader='pf-m-sticky-header'
     table--HasStickyFooter='pf-m-sticky-footer'
+    table--HasStickyFooterBase='pf-m-sticky-footer-base'
+    table--HasStickyFooterStuck='pf-m-sticky-footer-stuck'
     table--HasStickyHeaderBase='pf-m-sticky-header-base'
     table--HasStickyHeaderStuck='pf-m-sticky-header-stuck'
     table--HasMdGridBreakpoint='pf-m-grid-md'

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -287,6 +287,7 @@
   --#{$table}--m-sticky-footer--BoxShadow--glass: var(--pf-t--global--box-shadow--sm);
   --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--BorderColor);
   --#{$table}--m-sticky-footer-stuck--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor);
+  --#{$table}--m-sticky-footer-stuck--BorderBlockStartWidth: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth);
   --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow);
   --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius);
   --#{$table}--m-sticky-footer--ZIndex: calc(var(--pf-t--global--z-index--xs) + 1);
@@ -296,9 +297,9 @@
     --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
-    --#{$table}--m-sticky-footer--BorderBlockStartWidth: 0;
-    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
-    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
+    --#{$table}--m-sticky-footer-stuck--BorderBlockStartWidth: 0;
+    --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
+    --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
   }
 }
 
@@ -412,8 +413,8 @@
   &.pf-m-sticky-footer-base > .#{$table}__tfoot :is(.#{$table}__th, .#{$table}__td) {
     &::after {
       opacity: 0;
-      transition-timing-function: var(--#{$table}--m-sticky-header--TransitionTimingFunction--BackgroundColor);
-      transition-duration: var(--#{$table}--m-sticky-header--TransitionDuration--BackgroundColor);
+      transition-timing-function: var(--#{$table}--m-sticky-footer--TransitionTimingFunction--BackgroundColor);
+      transition-duration: var(--#{$table}--m-sticky-footer--TransitionDuration--BackgroundColor);
       transition-property: opacity;
     }
   }
@@ -423,6 +424,13 @@
     &::after {
       opacity: 1;
     }
+  }
+
+  &.pf-m-sticky-footer-stuck,
+  &.pf-m-sticky-footer:not(.pf-m-sticky-footer-base) {
+    --#{$table}--m-sticky-footer--BorderBlockStartWidth: var(--#{$table}--m-sticky-footer-stuck--BorderBlockStartWidth);
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
   }
 
   &.pf-m-sticky-footer,
@@ -464,13 +472,19 @@
         border-block-start: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth) solid var(--#{$table}--m-sticky-footer--BorderBlockStartColor);
       }
 
-      :is(.#{$table}__th, .#{$table}__td):first-child::after {
+      > .#{$table}__tr:first-child > :is(.#{$table}__th, .#{$table}__td):first-child::after {
         border-start-start-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+      }
+
+      > .#{$table}__tr:last-child > :is(.#{$table}__th, .#{$table}__td):first-child::after {
         border-end-start-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
       }
 
-      :is(.#{$table}__th, .#{$table}__td):last-child::after {
+      > .#{$table}__tr:first-child > :is(.#{$table}__th, .#{$table}__td):last-child::after {
         border-start-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+      }
+
+      > .#{$table}__tr:last-child > :is(.#{$table}__th, .#{$table}__td):last-child::after {
         border-end-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
       }
     }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -297,8 +297,8 @@
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
     --#{$table}--m-sticky-footer--BorderBlockStartWidth: 0;
-    --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
-    --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
   }
 }
 
@@ -357,7 +357,6 @@
         border-radius: var(--#{$table}--m-sticky-header--BorderRadius);
         box-shadow: var(--#{$table}--m-sticky-header--BoxShadow);
       }
-  
 
       .#{$table}__th::after {
         position: absolute;
@@ -427,6 +426,13 @@
   }
 
   &.pf-m-sticky-footer,
+  &.pf-m-sticky-footer-stuck {
+    > .#{$table}__tbody:last-of-type > .#{$table}__tr:last-of-type {
+      border-block-end-color: transparent;
+    }
+  }
+
+  &.pf-m-sticky-footer,
   &.pf-m-sticky-footer-base {
     > .#{$table}__tfoot {
       position: sticky;
@@ -434,7 +440,7 @@
       z-index: var(--#{$table}--m-sticky-footer--ZIndex);
       background: transparent;
 
-      &::before {
+      &::after {
         position: absolute;
         inset: 0;
         z-index: -1;
@@ -466,31 +472,6 @@
       :is(.#{$table}__th, .#{$table}__td):last-child::after {
         border-start-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
         border-end-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
-      }
-    }
-
-    > .#{$table}__tbody:last-of-type > .#{$table}__tr:last-of-type {
-      border-block-end: 0;
-    }
-  }
-
-  &.pf-m-sticky-footer-stuck {
-    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
-    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
-
-    > .#{$table}__tfoot::before {
-      opacity: 1;
-    }
-  }
-
-  &.pf-m-sticky-footer:not(.pf-m-sticky-footer-base) {
-    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
-    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
-
-    > .#{$table}__tfoot,
-    > .#{$table}__tfoot :is(.#{$table}__th, .#{$table}__td) {
-      &::after {
-        opacity: 1;
       }
     }
   }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -275,6 +275,22 @@
   --#{$table}--m-sticky-header--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--default);
     
   // * Table sticky footer
+  --#{$table}--m-sticky-footer--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
+  --#{$table}--m-sticky-footer--BoxShadow: 0;
+  --#{$table}--m-sticky-footer--BorderRadius: 0;
+  --#{$table}--m-sticky-footer--BorderBlockStartWidth: var(--#{$table}--border-width--base);
+  --#{$table}--m-sticky-footer--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
+  --#{$table}--m-sticky-footer--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--short);
+  --#{$table}--m-sticky-footer--BorderRadius--glass: var(--pf-t--global--border--radius--medium);
+  --#{$table}--m-sticky-footer--BoxShadow--glass: var(--pf-t--global--box-shadow--sm);
+  --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--BorderColor);
+  --#{$table}--m-sticky-footer--BackdropFilter: none;
+  --#{$table}--m-sticky-footer--BackgroundColor--glass: var(--pf-t--global--background--color--glass--primary--default, var(--pf-t--global--background--color--primary--default));
+  --#{$table}--m-sticky-footer--BorderColor--glass: var(--pf-t--global--border--color--glass--default, var(--pf-t--global--border--color--subtle));
+  --#{$table}--m-sticky-footer--BackdropFilter--glass: var(--pf-t--global--background--filter--glass--blur--primary);
+  --#{$table}--m-sticky-footer-stuck--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor);
+  --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow);
+  --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius);
   --#{$table}--m-sticky-footer--ZIndex: calc(var(--pf-t--global--z-index--xs) + 1);
   --#{$table}--m-sticky-footer--border--ZIndex: calc(var(--pf-t--global--z-index--xs) + 2);
 
@@ -282,6 +298,13 @@
     --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
+    --#{$table}--m-sticky-footer--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor--glass);
+    --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--m-sticky-footer--BorderColor--glass);
+    --#{$table}--m-sticky-footer--BackdropFilter: var(--#{$table}--m-sticky-footer--BackdropFilter--glass);
+    --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
+    --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
   }
 }
 
@@ -397,7 +420,9 @@
       position: sticky;
       inset-block-end: 0;
       z-index: var(--#{$table}--m-sticky-footer--ZIndex);
-      background: var(--#{$table}--BackgroundColor);
+      background: var(--#{$table}--m-sticky-footer--BackgroundColor);
+      backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
+      border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
 
       &::before {
         position: absolute;
@@ -405,12 +430,55 @@
         z-index: var(--#{$table}--m-sticky-footer--border--ZIndex);
         pointer-events: none;
         content: "";
-        border-block-start: var(--#{$table}--border-width--base) solid var(--#{$table}--BorderColor);
+        border-block-start: var(--#{$table}--border-width--base) solid var(--#{$table}--m-sticky-footer--BorderColor);
+        border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
       }
     }
 
     > .#{$table}__tbody:last-of-type > .#{$table}__tr:last-of-type {
       border-block-end: 0;
+    }
+  }
+
+  // - Table sticky footer base and stuck
+  &.pf-m-sticky-footer-base {
+    > .#{$table}__tfoot {
+      position: sticky;
+      inset-block-end: 0;
+      z-index: var(--#{$table}--m-sticky-footer--ZIndex);
+      background: transparent;
+      backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
+      border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+
+      &::before {
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        pointer-events: none;
+        content: '';
+        background: var(--#{$table}--m-sticky-footer--BackgroundColor);
+        border-block-start: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth) solid var(--#{$table}--m-sticky-footer--BorderColor);
+        border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+        box-shadow: var(--#{$table}--m-sticky-footer--BoxShadow);
+        opacity: 0;
+        transition-timing-function: var(--#{$table}--m-sticky-footer--TransitionTimingFunction--BackgroundColor);
+        transition-duration: var(--#{$table}--m-sticky-footer--TransitionDuration--BackgroundColor);
+        transition-property: opacity;
+      }
+    }
+
+    > .#{$table}__tbody:last-of-type > .#{$table}__tr:last-of-type {
+      border-block-end: 0;
+    }
+  }
+
+  &.pf-m-sticky-footer-stuck {
+    --#{$table}--m-sticky-footer--BackgroundColor: var(--#{$table}--m-sticky-footer-stuck--BackgroundColor);
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
+
+    > .#{$table}__tfoot::before {
+      opacity: 1;
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -276,18 +276,16 @@
     
   // * Table sticky footer
   --#{$table}--m-sticky-footer--BackgroundColor: var(--pf-t--global--background--color--sticky--default);
+  --#{$table}--m-sticky-footer--cell--ZIndex: var(--pf-t--global--z-index--xs);
   --#{$table}--m-sticky-footer--BoxShadow: 0;
   --#{$table}--m-sticky-footer--BorderRadius: 0;
   --#{$table}--m-sticky-footer--BorderBlockStartWidth: var(--#{$table}--border-width--base);
+  --#{$table}--m-sticky-footer--BorderBlockStartColor: var(--#{$table}--BorderColor);
   --#{$table}--m-sticky-footer--TransitionTimingFunction--BackgroundColor: var(--pf-t--global--motion--timing-function--default);
   --#{$table}--m-sticky-footer--TransitionDuration--BackgroundColor: var(--pf-t--global--motion--duration--fade--short);
   --#{$table}--m-sticky-footer--BorderRadius--glass: var(--pf-t--global--border--radius--medium);
   --#{$table}--m-sticky-footer--BoxShadow--glass: var(--pf-t--global--box-shadow--sm);
   --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--BorderColor);
-  --#{$table}--m-sticky-footer--BackdropFilter: none;
-  --#{$table}--m-sticky-footer--BackgroundColor--glass: var(--pf-t--global--background--color--glass--primary--default, var(--pf-t--global--background--color--primary--default));
-  --#{$table}--m-sticky-footer--BorderColor--glass: var(--pf-t--global--border--color--glass--default, var(--pf-t--global--border--color--subtle));
-  --#{$table}--m-sticky-footer--BackdropFilter--glass: var(--pf-t--global--background--filter--glass--blur--primary);
   --#{$table}--m-sticky-footer-stuck--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor);
   --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow);
   --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius);
@@ -298,9 +296,7 @@
     --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
-    --#{$table}--m-sticky-footer--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor--glass);
-    --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--m-sticky-footer--BorderColor--glass);
-    --#{$table}--m-sticky-footer--BackdropFilter: var(--#{$table}--m-sticky-footer--BackdropFilter--glass);
+    --#{$table}--m-sticky-footer--BorderBlockStartWidth: 0;
     --#{$table}--m-sticky-footer-stuck--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
     --#{$table}--m-sticky-footer-stuck--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
   }
@@ -413,42 +409,30 @@
   }
 
   // - Table sticky footer
-  &.pf-m-sticky-footer {
-    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
-    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
-
-    > .#{$table}__tfoot {
-      position: sticky;
-      inset-block-end: 0;
-      z-index: var(--#{$table}--m-sticky-footer--ZIndex);
-      background: var(--#{$table}--m-sticky-footer--BackgroundColor);
-      backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
-      border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
-
-      &::before {
-        position: absolute;
-        inset: 0;
-        z-index: var(--#{$table}--m-sticky-footer--border--ZIndex);
-        pointer-events: none;
-        content: "";
-        border-block-start: var(--#{$table}--border-width--base) solid var(--#{$table}--m-sticky-footer--BorderColor);
-        border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
-      }
-    }
-
-    > .#{$table}__tbody:last-of-type > .#{$table}__tr:last-of-type {
-      border-block-end: 0;
+  &.pf-m-sticky-footer-base > .#{$table}__tfoot,
+  &.pf-m-sticky-footer-base > .#{$table}__tfoot :is(.#{$table}__th, .#{$table}__td) {
+    &::after {
+      opacity: 0;
+      transition-timing-function: var(--#{$table}--m-sticky-header--TransitionTimingFunction--BackgroundColor);
+      transition-duration: var(--#{$table}--m-sticky-header--TransitionDuration--BackgroundColor);
+      transition-property: opacity;
     }
   }
 
-  // - Table sticky footer base and stuck
+  &.pf-m-sticky-footer-stuck > .#{$table}__tfoot,
+  &.pf-m-sticky-footer-stuck > .#{$table}__tfoot :is(.#{$table}__th, .#{$table}__td) {
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &.pf-m-sticky-footer,
   &.pf-m-sticky-footer-base {
     > .#{$table}__tfoot {
       position: sticky;
       inset-block-end: 0;
       z-index: var(--#{$table}--m-sticky-footer--ZIndex);
       background: transparent;
-      border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
 
       &::before {
         position: absolute;
@@ -456,15 +440,32 @@
         z-index: -1;
         pointer-events: none;
         content: '';
-        background: var(--#{$table}--m-sticky-footer--BackgroundColor);
-        backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
-        border-block-start: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth) solid var(--#{$table}--m-sticky-footer--BorderColor);
         border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
         box-shadow: var(--#{$table}--m-sticky-footer--BoxShadow);
-        opacity: 0;
-        transition-timing-function: var(--#{$table}--m-sticky-footer--TransitionTimingFunction--BackgroundColor);
-        transition-duration: var(--#{$table}--m-sticky-footer--TransitionDuration--BackgroundColor);
-        transition-property: opacity;
+      }
+
+      > .#{$table}__tr > :is(th, td) {
+        z-index: var(--#{$table}--m-sticky-footer--cell--ZIndex);
+      }
+
+      :is(.#{$table}__th, .#{$table}__td)::after {
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        pointer-events: none;
+        content: '';
+        background: var(--#{$table}--m-sticky-footer--BackgroundColor);
+        border-block-start: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth) solid var(--#{$table}--m-sticky-footer--BorderBlockStartColor);
+      }
+
+      :is(.#{$table}__th, .#{$table}__td):first-child::after {
+        border-start-start-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+        border-end-start-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+      }
+
+      :is(.#{$table}__th, .#{$table}__td):last-child::after {
+        border-start-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
+        border-end-end-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
       }
     }
 
@@ -474,12 +475,23 @@
   }
 
   &.pf-m-sticky-footer-stuck {
-    --#{$table}--m-sticky-footer--BackgroundColor: var(--#{$table}--m-sticky-footer-stuck--BackgroundColor);
     --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
     --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
 
     > .#{$table}__tfoot::before {
       opacity: 1;
+    }
+  }
+
+  &.pf-m-sticky-footer:not(.pf-m-sticky-footer-base) {
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
+
+    > .#{$table}__tfoot,
+    > .#{$table}__tfoot :is(.#{$table}__th, .#{$table}__td) {
+      &::after {
+        opacity: 1;
+      }
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -298,8 +298,6 @@
     --#{$table}--m-sticky-header--BorderBlockEndWidth: 0;
     --#{$table}--m-sticky-header--BoxShadow: var(--#{$table}--m-sticky-header--BoxShadow--glass);
     --#{$table}--m-sticky-header--BorderRadius: var(--#{$table}--m-sticky-header--BorderRadius--glass);
-    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer--BoxShadow--glass);
-    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer--BorderRadius--glass);
     --#{$table}--m-sticky-footer--BackgroundColor: var(--#{$table}--m-sticky-footer--BackgroundColor--glass);
     --#{$table}--m-sticky-footer--BorderColor: var(--#{$table}--m-sticky-footer--BorderColor--glass);
     --#{$table}--m-sticky-footer--BackdropFilter: var(--#{$table}--m-sticky-footer--BackdropFilter--glass);
@@ -416,6 +414,9 @@
 
   // - Table sticky footer
   &.pf-m-sticky-footer {
+    --#{$table}--m-sticky-footer--BoxShadow: var(--#{$table}--m-sticky-footer-stuck--BoxShadow);
+    --#{$table}--m-sticky-footer--BorderRadius: var(--#{$table}--m-sticky-footer-stuck--BorderRadius);
+
     > .#{$table}__tfoot {
       position: sticky;
       inset-block-end: 0;
@@ -447,7 +448,6 @@
       inset-block-end: 0;
       z-index: var(--#{$table}--m-sticky-footer--ZIndex);
       background: transparent;
-      backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
       border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
 
       &::before {
@@ -457,6 +457,7 @@
         pointer-events: none;
         content: '';
         background: var(--#{$table}--m-sticky-footer--BackgroundColor);
+        backdrop-filter: var(--#{$table}--m-sticky-footer--BackdropFilter);
         border-block-start: var(--#{$table}--m-sticky-footer--BorderBlockStartWidth) solid var(--#{$table}--m-sticky-footer--BorderColor);
         border-radius: var(--#{$table}--m-sticky-footer--BorderRadius);
         box-shadow: var(--#{$table}--m-sticky-footer--BoxShadow);


### PR DESCRIPTION
## What

- Add `pf-m-sticky-footer-base` and `pf-m-sticky-footer-stuck` table modifiers.
- Add `<tfoot>` template modifier support and documentation examples.
- Match sticky footer glass styling to the sticky header, including cell surfaces, z-index, shadow, and rounded corners.
- Keep the footer visually normal when the stuck modifier is removed at the table boundary.

## Related

- Resolves #8582 
- PF-3996
- PatternFly PR #8034

## Validation

- `./node_modules/.bin/sass src/patternfly/patternfly.scss /tmp/patternfly.css`
- `git diff --check`

The React layer should toggle `pf-m-sticky-footer-stuck` only while the footer is floating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sticky table footer base and stuck states.
  * Improved sticky footer styling across borders, shadows, rounded corners, backgrounds, and glass-theme presentation.
  * Updated sticky header and footer previews with consistent sizing.
* **Documentation**
  * Expanded sticky footer examples with realistic repository data, headers, and summary rows.
  * Clarified descriptions for base and stuck footer states.
  * Updated examples to demonstrate scrollable table content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->